### PR TITLE
feat: user management — match demo UI, add delete + email actions

### DIFF
--- a/buildsuite_core/api/users.py
+++ b/buildsuite_core/api/users.py
@@ -13,22 +13,9 @@ import frappe
 from frappe import _
 from frappe.utils import cint
 
-# Persona labels = the options on the User.persona Select field (and the role
-# names in the frontend roles.js). Source of truth for role mapping is the hook.
-PERSONA_OPTIONS = [
-	"Director / Owner",
-	"Project Manager",
-	"Estimator",
-	"Quantity Surveyor",
-	"Site Engineer",
-	"Foreman / Supervisor",
-	"Procurement Officer",
-	"Store Keeper",
-	"Accountant",
-	"HR Manager",
-	"System Manager (Admin)",
-	"BuildSuite Administrator",
-]
+from buildsuite_core.permissions.setup import PERSONA_TO_ROLE
+
+PERSONA_OPTIONS = list(PERSONA_TO_ROLE)
 ADMIN_ROLES = {"System Manager", "BuildSuite Administrator"}
 SYSTEM_ACCOUNTS = ["Administrator", "Guest"]
 
@@ -50,7 +37,7 @@ def list_buildsuite_users():
 	return frappe.get_all(
 		"User",
 		filters={"persona": ["in", PERSONA_OPTIONS], "name": ["not in", SYSTEM_ACCOUNTS]},
-		fields=["name", "full_name", "email", "enabled", "persona", "last_login"],
+		fields=["name", "full_name", "email", "enabled", "persona"],
 		order_by="full_name asc",
 	)
 
@@ -130,3 +117,22 @@ def send_user_password_reset(email):
 	# Administrator accounts.
 	reset_password(email)
 	return {"ok": True}
+
+
+@frappe.whitelist()
+def delete_buildsuite_user(email):
+	_require_admin()
+	if email in SYSTEM_ACCOUNTS:
+		frappe.throw(_("This account can't be deleted."))
+	if email == frappe.session.user:
+		frappe.throw(_("You can't delete your own account."))
+	if not frappe.db.exists("User", email):
+		frappe.throw(_("User not found."))
+	frappe.delete_doc("User", email)
+	return {"ok": True}
+
+
+@frappe.whitelist()
+def outgoing_email_configured():
+	_require_admin()
+	return bool(frappe.db.exists("Email Account", {"default_outgoing": 1, "awaiting_password": 0}))

--- a/frontend/src/components/ConfirmDialog.vue
+++ b/frontend/src/components/ConfirmDialog.vue
@@ -29,7 +29,7 @@ function confirm() { emit('confirm') }
   <Teleport to="body">
     <div
       v-if="open"
-      class="fixed inset-0 bg-ink-900/40 z-40 flex items-center justify-center p-6"
+      class="fixed inset-0 bg-ink-900/40 z-[70] flex items-center justify-center p-6"
       @click.self="close"
     >
       <div

--- a/frontend/src/data/usersApi.js
+++ b/frontend/src/data/usersApi.js
@@ -1,31 +1,15 @@
-// Thin wrappers around the buildsuite_core.api.users whitelisted methods.
-
-function serverMessage(data, status) {
-  if (data?._server_messages) {
-    try {
-      const first = JSON.parse(data._server_messages)[0]
-      const parsed = JSON.parse(first)
-      if (parsed?.message) return String(parsed.message).replace(/<[^>]*>/g, '')
-    } catch {
-      /* fall through */
-    }
-  }
-  return data?.exception || data?.exc_type || `Request failed (${status})`
-}
+import { frappeRequest } from 'frappe-ui-frappe-request'
+import { parseFrappeError } from '@/utils/frappeError'
 
 async function call(method, args) {
-  const res = await fetch(`/api/method/buildsuite_core.api.users.${method}`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Frappe-CSRF-Token': window.csrf_token || '',
-    },
-    body: JSON.stringify(args || {}),
-  })
-  const data = await res.json().catch(() => ({}))
-  if (!res.ok) throw new Error(serverMessage(data, res.status))
-  return data.message
+  try {
+    return await frappeRequest({
+      url: `buildsuite_core.api.users.${method}`,
+      params: args || {},
+    })
+  } catch (err) {
+    throw new Error(parseFrappeError(err).summary || 'Request failed.')
+  }
 }
 
 export const listBuildsuiteUsers = () => call('list_buildsuite_users')
@@ -33,3 +17,5 @@ export const createBuildsuiteUser = (args) => call('create_buildsuite_user', arg
 export const updateBuildsuiteUser = (args) => call('update_buildsuite_user', args)
 export const sendUserWelcome = (email) => call('send_user_welcome', { email })
 export const sendUserPasswordReset = (email) => call('send_user_password_reset', { email })
+export const deleteBuildsuiteUser = (email) => call('delete_buildsuite_user', { email })
+export const outgoingEmailConfigured = () => call('outgoing_email_configured')

--- a/frontend/src/views/settings/NewUserView.vue
+++ b/frontend/src/views/settings/NewUserView.vue
@@ -3,11 +3,11 @@
 // drives the BuildSuite role via the server-side sync hook. Optional welcome /
 // password-reset emails use Frappe's native flows.
 
-import { ref, reactive } from 'vue'
+import { ref, reactive, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDataStore } from '@/stores'
-import { ROLES } from '@/data/roles'
-import { createBuildsuiteUser, sendUserWelcome, sendUserPasswordReset } from '@/data/usersApi'
+import { createBuildsuiteUser, sendUserPasswordReset, outgoingEmailConfigured } from '@/data/usersApi'
+import { useDoctypeMeta } from '@/composables/useDoctypeMeta'
 import { showToast } from '@/utils/appToast'
 import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskForm from '@/components/desk/DeskForm.vue'
@@ -29,7 +29,19 @@ const form = reactive({
   sendReset: false,
 })
 const errors = ref({})
+const formError = ref('')
 const saving = ref(false)
+const mailConfigured = ref(null)
+
+onMounted(() => {
+  outgoingEmailConfigured()
+    .then((ok) => { mailConfigured.value = !!ok })
+    .catch(() => { mailConfigured.value = null })
+})
+
+
+const { selectOptions } = useDoctypeMeta('User')
+const personaOptions = computed(() => selectOptions('persona'))
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -52,6 +64,7 @@ function validate() {
 
 async function save() {
   if (!validate()) return
+  formError.value = ''
   saving.value = true
   try {
     const user = await createBuildsuiteUser({
@@ -68,7 +81,7 @@ async function save() {
     showToast(`User ${user.full_name} created`)
     router.push({ path: '/settings/users', query: { created: user.name } })
   } catch (err) {
-    errors.value = { email: err.message || 'Could not create the user.' }
+    formError.value = err.message || 'Could not create the user.'
     saving.value = false
   }
 }
@@ -91,45 +104,56 @@ async function save() {
         />
       </template>
 
-      <DeskSection title="Account">
-        <DeskField label="Full name" required :error="errors.fullName">
-          <DeskInput v-model="form.fullName" placeholder="e.g. Asha Menon" @input="errors.fullName = ''" />
-        </DeskField>
-        <DeskField label="Email" required :error="errors.email" hint="Becomes the login id. The welcome email goes here.">
-          <DeskInput v-model="form.email" type="email" placeholder="name@company.com" @input="errors.email = ''" />
-        </DeskField>
-        <DeskField label="Account status">
-          <label class="inline-flex items-center gap-2 text-sm text-ink-700 dark:text-ink-200">
-            <input v-model="form.enabled" type="checkbox" class="accent-brand-600" />
-            Enabled
-          </label>
-        </DeskField>
-      </DeskSection>
+      <div class="max-w-3xl mx-auto">
+        <div v-if="formError" class="mb-4 px-3 py-2 bg-danger-50 border border-danger-100 text-xs text-danger-700 dark:bg-ink-800 dark:border-ink-700" style="border-radius: 6px;">
+          {{ formError }}
+        </div>
+        <DeskSection title="Account">
+          <DeskField label="Full name" required :error="errors.fullName">
+            <DeskInput v-model="form.fullName" placeholder="e.g. Asha Menon" @input="errors.fullName = ''; formError = ''" />
+          </DeskField>
+          <DeskField label="Email" required :error="errors.email" hint="Used as the login id + destination for the welcome and password-reset emails.">
+            <DeskInput v-model="form.email" type="email" placeholder="name@company.com" @input="errors.email = ''; formError = ''" />
+          </DeskField>
+          <DeskField label="Account status" hint="Disabled users keep their record but cannot log in.">
+            <label class="inline-flex items-center gap-2 cursor-pointer select-none text-sm text-ink-700 dark:text-ink-200">
+              <input v-model="form.enabled" type="checkbox" class="accent-brand-600" />
+              Enabled — user can log in immediately
+            </label>
+          </DeskField>
+        </DeskSection>
 
-      <DeskSection title="Persona">
-        <DeskField label="Persona" required :error="errors.persona" hint="Drives the user's BuildSuite role and access.">
-          <DeskSelect v-model="form.persona" @change="errors.persona = ''">
-            <option value="">— Select persona —</option>
-            <option v-for="r in ROLES" :key="r.id" :value="r.name">{{ r.name }}</option>
-          </DeskSelect>
-        </DeskField>
-      </DeskSection>
+        <DeskSection title="Persona">
+          <DeskField label="Persona" required :error="errors.persona" hint="Frappe Roles are auto-assigned from the persona on the production side. Pick the one that matches the user's day-to-day work.">
+            <DeskSelect v-model="form.persona" @change="errors.persona = ''; formError = ''">
+              <option value="">— Select persona —</option>
+              <option v-for="opt in personaOptions" :key="opt" :value="opt">{{ opt }}</option>
+            </DeskSelect>
+          </DeskField>
+        </DeskSection>
 
-      <DeskSection title="Onboarding">
-        <DeskField label="Emails">
-          <label class="flex items-center gap-2 text-sm text-ink-700 dark:text-ink-200">
-            <input v-model="form.sendWelcome" type="checkbox" class="accent-brand-600" />
-            Send welcome email (account setup link)
-          </label>
-          <label class="flex items-center gap-2 text-sm text-ink-700 mt-2 dark:text-ink-200">
-            <input v-model="form.sendReset" type="checkbox" class="accent-brand-600" />
-            Also send a password-reset link
-          </label>
-          <div class="text-[11px] text-ink-500 mt-1.5">
-            Emails use the site's mail settings. If mail isn't configured they wait in the Email Queue.
-          </div>
-        </DeskField>
-      </DeskSection>
+        <DeskSection title="Onboarding">
+          <DeskField label="Emails">
+            <div v-if="mailConfigured === false" class="mb-2 px-3 py-2 bg-warning-50 border border-warning-100 text-[11px] text-warning-700 dark:bg-ink-800 dark:border-ink-700" style="border-radius: 6px;">
+              Outgoing email isn't configured — these emails won't be sent until an outgoing Email Account is set up.
+            </div>
+            <label class="flex items-start gap-2 cursor-pointer select-none">
+              <input v-model="form.sendWelcome" type="checkbox" class="accent-brand-600 mt-0.5" />
+              <div>
+                <div class="text-sm text-ink-900 dark:text-[#F5F5F5]">Send welcome email</div>
+                <div class="text-[11px] text-ink-500">Brief intro to BuildSuite Core, link to set up their profile.</div>
+              </div>
+            </label>
+            <label class="flex items-start gap-2 cursor-pointer select-none mt-3">
+              <input v-model="form.sendReset" type="checkbox" class="accent-brand-600 mt-0.5" />
+              <div>
+                <div class="text-sm text-ink-900 dark:text-[#F5F5F5]">Send password reset link</div>
+                <div class="text-[11px] text-ink-500">Lets the user set their own password instead of you assigning one.</div>
+              </div>
+            </label>
+          </DeskField>
+        </DeskSection>
+      </div>
     </DeskForm>
   </DeskPage>
 </template>

--- a/frontend/src/views/settings/UsersView.vue
+++ b/frontend/src/views/settings/UsersView.vue
@@ -7,15 +7,19 @@
 import { computed, ref, reactive, onMounted } from 'vue'
 import { useRouter, useRoute, RouterLink } from 'vue-router'
 import { useDataStore } from '@/stores'
-import { ROLES } from '@/data/roles'
 import {
   listBuildsuiteUsers,
   updateBuildsuiteUser,
   sendUserWelcome,
   sendUserPasswordReset,
+  deleteBuildsuiteUser,
+  outgoingEmailConfigured,
 } from '@/data/usersApi'
+import { useDoctypeMeta } from '@/composables/useDoctypeMeta'
+import { useConfirm } from '@/composables/useConfirm'
 import { showToast } from '@/utils/appToast'
 import StatusBadge from '@/components/StatusBadge.vue'
+import FrappeUserBadge from '@/components/FrappeUserBadge.vue'
 import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskList from '@/components/desk/DeskList.vue'
 import DeskSection from '@/components/desk/DeskSection.vue'
@@ -26,6 +30,7 @@ import DeskSelect from '@/components/desk/DeskSelect.vue'
 const store = useDataStore()
 const router = useRouter()
 const route = useRoute()
+const confirmDialog = useConfirm()
 
 const PERSONA_PILL = 'bg-ink-100 text-ink-700'
 
@@ -64,11 +69,11 @@ const items = computed(() => {
   )
 })
 
-const fieldOrder = ['full_name', 'persona', 'email', 'enabled', 'name']
 const columns = [
+  { key: 'avatar', label: '' },
   { key: 'full_name', label: 'Name' },
-  { key: 'email', label: 'Email' },
   { key: 'persona', label: 'Persona' },
+  { key: 'email', label: 'Email' },
   { key: 'enabled', label: 'Status' },
 ]
 
@@ -82,8 +87,13 @@ const breadcrumbs = [
 const editOpen = ref(false)
 const editForm = reactive({ email: '', fullName: '', persona: '', enabled: true })
 const editErrors = ref({})
+const editError = ref('')
 const editSaving = ref(false)
 const emailActing = ref('') // '' | 'welcome' | 'reset'
+const mailConfigured = ref(null)
+
+const { selectOptions } = useDoctypeMeta('User')
+const personaOptions = computed(() => selectOptions('persona'))
 
 function openEdit(row) {
   editForm.email = row.email || row.name
@@ -91,7 +101,11 @@ function openEdit(row) {
   editForm.persona = row.persona || ''
   editForm.enabled = !!row.enabled
   editErrors.value = {}
+  editError.value = ''
   editOpen.value = true
+  outgoingEmailConfigured()
+    .then((ok) => { mailConfigured.value = !!ok })
+    .catch(() => { mailConfigured.value = null })
 }
 
 async function saveEdit() {
@@ -100,6 +114,7 @@ async function saveEdit() {
   if (!editForm.persona) e.persona = 'Pick a persona.'
   editErrors.value = e
   if (Object.keys(e).length) return
+  editError.value = ''
   editSaving.value = true
   try {
     await updateBuildsuiteUser({
@@ -112,7 +127,7 @@ async function saveEdit() {
     editOpen.value = false
     await loadUsers()
   } catch (err) {
-    editErrors.value = { persona: err.message || 'Could not save.' }
+    editError.value = err.message || 'Could not save.'
   } finally {
     editSaving.value = false
   }
@@ -138,6 +153,28 @@ async function sendReset() {
     showToast(err.message || 'Could not send reset link', 'error')
   } finally {
     emailActing.value = ''
+  }
+}
+
+async function deleteUser() {
+  const ok = await confirmDialog({
+    title: 'Delete user',
+    message: `Delete ${editForm.fullName || editForm.email}? They can no longer log in or be assigned new work.`,
+    confirmLabel: 'Delete user',
+    destructive: true,
+  })
+  if (!ok) return
+  editError.value = ''
+  editSaving.value = true
+  try {
+    await deleteBuildsuiteUser(editForm.email)
+    showToast('User deleted')
+    editOpen.value = false
+    await loadUsers()
+  } catch (err) {
+    editError.value = err.message || 'Could not delete user.'
+  } finally {
+    editSaving.value = false
   }
 }
 </script>
@@ -168,6 +205,9 @@ async function sendReset() {
       search-placeholder="Search by name, email, persona…"
       @row-click="openEdit"
     >
+      <template #cell-avatar="{ row }">
+        <FrappeUserBadge :user-id="row.name" :show-name="false" size="sm" />
+      </template>
       <template #cell-full_name="{ row }">
         <span class="text-sm font-medium text-ink-900 dark:text-[#F5F5F5]">{{ row.full_name || row.name }}</span>
       </template>
@@ -179,7 +219,7 @@ async function sendReset() {
         <span v-else class="text-[10px] text-ink-400">—</span>
       </template>
       <template #cell-enabled="{ row }">
-        <StatusBadge :status="row.enabled ? 'Active' : 'Cancelled'" size="xs" />
+        <StatusBadge :status="row.enabled ? 'Active' : 'Disabled'" size="xs" />
       </template>
 
       <template #empty>
@@ -197,28 +237,34 @@ async function sendReset() {
         @click.self="editOpen = false"
       >
         <div
-          class="bg-white border border-ink-200 w-full max-w-lg shadow-fp-lg flex flex-col dark:bg-[#242424] dark:border-ink-700"
+          class="bg-white border border-ink-200 w-full max-w-2xl shadow-fp-lg flex flex-col dark:bg-[#242424] dark:border-ink-700"
           style="border-radius: 12px; max-height: calc(100vh - 3rem);"
           @click.stop
         >
-          <header class="px-5 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0 dark:border-ink-700" style="border-radius: 12px 12px 0 0;">
-            <div class="min-w-0 flex-1">
-              <h2 class="text-sm font-semibold text-ink-900 dark:text-[#F5F5F5]">Edit user</h2>
-              <p class="text-[11px] text-ink-500 mt-0.5 truncate">{{ editForm.email }}</p>
+          <header class="px-5 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0 bg-white dark:bg-[#242424] dark:border-ink-700" style="border-radius: 12px 12px 0 0;">
+            <div class="flex items-center gap-3 min-w-0 flex-1">
+              <FrappeUserBadge :user-id="editForm.email" :show-name="false" size="sm" />
+              <div class="min-w-0">
+                <h2 class="text-sm font-semibold text-ink-900 truncate dark:text-[#F5F5F5]">{{ editForm.fullName || editForm.email }}</h2>
+                <p class="text-[11px] text-ink-500 mt-0.5 truncate">{{ editForm.email }}</p>
+              </div>
             </div>
             <button type="button" class="text-ink-500 hover:text-ink-900 text-lg leading-none flex-shrink-0 ml-3 dark:text-ink-400 dark:hover:text-ink-200" aria-label="Close" @click="editOpen = false">×</button>
           </header>
 
           <div class="p-5 overflow-y-auto flex-1">
+            <div v-if="editError" class="mb-4 px-3 py-2 bg-danger-50 border border-danger-100 text-xs text-danger-700 dark:bg-ink-800 dark:border-ink-700" style="border-radius: 6px;">
+              {{ editError }}
+            </div>
             <DeskSection title="Account">
               <DeskField label="Full name" required :error="editErrors.fullName">
-                <DeskInput v-model="editForm.fullName" @input="editErrors.fullName = ''" />
+                <DeskInput v-model="editForm.fullName" @input="editErrors.fullName = ''; editError = ''" />
               </DeskField>
-              <DeskField label="Email">
+              <DeskField label="Email" hint="Login id — cannot be changed after the user is created.">
                 <DeskInput :model-value="editForm.email" disabled />
               </DeskField>
-              <DeskField label="Account status">
-                <label class="inline-flex items-center gap-2 text-sm text-ink-700 dark:text-ink-200">
+              <DeskField label="Account status" hint="Disabled users keep their record but cannot log in.">
+                <label class="inline-flex items-center gap-2 cursor-pointer select-none text-sm text-ink-700 dark:text-ink-200">
                   <input v-model="editForm.enabled" type="checkbox" class="accent-brand-600" />
                   Enabled
                 </label>
@@ -226,43 +272,61 @@ async function sendReset() {
             </DeskSection>
 
             <DeskSection title="Persona">
-              <DeskField label="Persona" required :error="editErrors.persona" hint="Drives the user's BuildSuite role.">
-                <DeskSelect v-model="editForm.persona" @change="editErrors.persona = ''">
+              <DeskField label="Persona" required :error="editErrors.persona" hint="Frappe Roles are auto-assigned from the persona on the production side.">
+                <DeskSelect v-model="editForm.persona" @change="editErrors.persona = ''; editError = ''">
                   <option value="">— Select persona —</option>
-                  <option v-for="r in ROLES" :key="r.id" :value="r.name">{{ r.name }}</option>
+                  <option v-for="opt in personaOptions" :key="opt" :value="opt">{{ opt }}</option>
                 </DeskSelect>
               </DeskField>
             </DeskSection>
 
             <DeskSection title="Email actions">
-              <div class="md:col-span-2 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
-                  style="border-radius: 6px;"
-                  :disabled="!!emailActing"
-                  @click="resendWelcome"
-                >{{ emailActing === 'welcome' ? 'Sending…' : 'Resend welcome email' }}</button>
-                <button
-                  type="button"
-                  class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
-                  style="border-radius: 6px;"
-                  :disabled="!!emailActing"
-                  @click="sendReset"
-                >{{ emailActing === 'reset' ? 'Sending…' : 'Send password-reset link' }}</button>
+              <div class="md:col-span-2 space-y-2">
+                <div v-if="mailConfigured === false" class="px-3 py-2 bg-warning-50 border border-warning-100 text-[11px] text-warning-700 dark:bg-ink-800 dark:border-ink-700" style="border-radius: 6px;">
+                  Outgoing email isn't configured — these emails won't be sent until an outgoing Email Account is set up.
+                </div>
+                <div class="flex items-center justify-between gap-3 px-3 py-2 border border-ink-100 bg-ink-50 dark:bg-ink-800 dark:border-ink-700" style="border-radius: 6px;">
+                  <div class="text-sm text-ink-900 dark:text-[#F5F5F5]">Welcome email</div>
+                  <button
+                    type="button"
+                    class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 flex-shrink-0 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
+                    style="border-radius: 6px;"
+                    :disabled="!!emailActing"
+                    @click="resendWelcome"
+                  >{{ emailActing === 'welcome' ? 'Sending…' : 'Send welcome' }}</button>
+                </div>
+                <div class="flex items-center justify-between gap-3 px-3 py-2 border border-ink-100 bg-ink-50 dark:bg-ink-800 dark:border-ink-700" style="border-radius: 6px;">
+                  <div class="text-sm text-ink-900 dark:text-[#F5F5F5]">Password reset link</div>
+                  <button
+                    type="button"
+                    class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 flex-shrink-0 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
+                    style="border-radius: 6px;"
+                    :disabled="!!emailActing"
+                    @click="sendReset"
+                  >{{ emailActing === 'reset' ? 'Sending…' : 'Send reset link' }}</button>
+                </div>
               </div>
             </DeskSection>
           </div>
 
-          <footer class="px-5 py-3 border-t border-ink-200 flex items-center justify-end gap-2 flex-shrink-0 dark:border-ink-700" style="border-radius: 0 0 12px 12px;">
+          <footer class="px-5 py-3 border-t border-ink-200 flex items-center justify-between gap-2 flex-shrink-0 bg-white dark:bg-[#242424] dark:border-ink-700" style="border-radius: 0 0 12px 12px;">
             <button
               type="button"
-              class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
+              class="text-xs px-3 py-1.5 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700 dark:bg-ink-800 dark:border-ink-700 dark:hover:bg-ink-700"
               style="border-radius: 6px;"
               :disabled="editSaving"
-              @click="editOpen = false"
-            >Cancel</button>
-            <button type="button" class="desk-save-btn" :disabled="editSaving" @click="saveEdit">{{ editSaving ? 'Saving…' : 'Save' }}</button>
+              @click="deleteUser"
+            >Delete user</button>
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
+                style="border-radius: 6px;"
+                :disabled="editSaving"
+                @click="editOpen = false"
+              >Cancel</button>
+              <button type="button" class="desk-save-btn" :disabled="editSaving" @click="saveEdit">{{ editSaving ? 'Saving…' : 'Save' }}</button>
+            </div>
           </footer>
         </div>
       </div>


### PR DESCRIPTION
Brings the Users settings up to the demo and wires the remaining actions.
  
  **What changed:**
  - UI/UX of the Users list, New User form, and Edit dialog matched to the demo
  - Add Delete user (with confirm dialog)
  - Send welcome email and password-reset link now working
  - Persona options now load from the backend (no hardcoded list)
  - Errors shown in a clear banner; small cleanup of dead code
  
  **Test:**
  - Create / edit / delete a user from /client/settings/users
  - Send welcome + reset from the edit dialog
  - A warning shows if no outgoing email account is configured