### PR TITLE
Make company optional for users with a persona

### DIFF
--- a/buildsuite_core/api/users.py
+++ b/buildsuite_core/api/users.py
@@ -64,9 +64,9 @@ def create_buildsuite_user(full_name, email, persona, enabled=1, send_welcome=1)
 	doc.enabled = 1 if cint(enabled) else 0
 	doc.user_type = "System User"
 	doc.persona = persona  # the validate hook assigns the matching BuildSuite role
-	# Company isn't shown in the Vue user form — inherit the creator's company so
-	# the persona's mandatory-company rule is satisfied. Fall back to the site
-	# default (e.g. when the creator is Administrator with no company set).
+	# Company is optional. It isn't shown in the Vue user form, but when one can be
+	# inferred we stamp it (best-effort) since it feeds project company inference —
+	# new projects inherit the creator's company. Left blank when none is available.
 	doc.company = (
 		frappe.db.get_value("User", frappe.session.user, "company")
 		or frappe.defaults.get_global_default("company")

--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -7,7 +7,6 @@ from buildsuite_core.custom_property_list.property_field import get_property_set
 from buildsuite_core.permissions.setup import setup_record_permissions
 from buildsuite_core.utils.task import backfill_task_status, backfill_task_type
 from buildsuite_core.utils.project import backfill_project_status
-from buildsuite_core.utils.user import backfill_user_company
 
 
 def after_install():
@@ -26,7 +25,6 @@ def after_migrate():
     backfill_task_status()
     backfill_task_type()
     backfill_project_status()
-    backfill_user_company()
     seed_master_data()
     setup_record_permissions()
 

--- a/buildsuite_core/utils/user.py
+++ b/buildsuite_core/utils/user.py
@@ -10,7 +10,6 @@ deleted.
 """
 
 import frappe
-from frappe import _
 
 from buildsuite_core.permissions.setup import (
     PERSONA_TO_ROLE,
@@ -29,12 +28,6 @@ _MANAGED_ROLES = set(BUILDSUITE_ROLES) | {WORKFLOW_EDITOR_ROLE}
 def sync_persona_roles(doc, method=None):
     if doc.name in ("Administrator", "Guest"):
         return
-
-    # A persona'd user must carry a company — it's the source of truth for project
-    # company inference. Server-side only: the Vue user form never shows company;
-    # the create API stamps the creator's company onto the new user.
-    if (doc.persona or "").strip() and not doc.get("company"):
-        frappe.throw(_("Company is required for a user with a persona."))
 
     desired = PERSONA_TO_ROLE.get((doc.persona or "").strip())
 
@@ -57,34 +50,3 @@ def sync_persona_roles(doc, method=None):
     for role in keep - present:
         if frappe.db.exists("Role", role):
             doc.append("roles", {"role": role})
-
-
-def backfill_user_company(doc=None, method=None):
-    """Stamp the default company onto persona'd users missing one (idempotent).
-
-    Existing persona users predate the company field; without this, the validate
-    rule above would block their next save. Wired into after_migrate so the field
-    self-heals on deploy. Returns the number of rows updated.
-    """
-    default_company = (
-        frappe.defaults.get_global_default("company")
-        or frappe.db.get_single_value("Global Defaults", "default_company")
-        or frappe.db.get_value("Company", {}, "name")
-    )
-    if not default_company:
-        return 0
-
-    rows = frappe.get_all(
-        "User",
-        filters={"persona": ("is", "set"), "company": ("in", ("", None))},
-        pluck="name",
-    )
-    updated = 0
-    for name in rows:
-        if name in ("Administrator", "Guest"):
-            continue
-        frappe.db.set_value("User", name, "company", default_company, update_modified=False)
-        updated += 1
-    if updated:
-        frappe.db.commit()
-    return updated


### PR DESCRIPTION
## What

Removes the requirement that a persona'd User must have a company.

- **utils/user.py** — drop the `frappe.throw("Company is required…")` check in `sync_persona_roles`; remove the now-purposeless `backfill_user_company()` (it only existed to keep that rule from blocking saves). Role-sync logic unchanged.
- **install.py** — drop the `backfill_user_company` import + its `after_migrate()` call.
- **api/users.py** — keep best-effort company stamping on create (still feeds project company inference) but it's no longer mandatory; blank company is now valid.

The `company` custom field on User is kept (now optional). The Vue user forms never showed company, so no frontend changes were needed.

The prior state (mandatory company) is tagged `user-company` for easy restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)