### PR TITLE
fix: template seed modes, nested task count, seeded planned_qty, stage task status

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/buildsuite_project_template/buildsuite_project_template.py
+++ b/buildsuite_core/buildsuite_core/doctype/buildsuite_project_template/buildsuite_project_template.py
@@ -44,17 +44,25 @@ def create_erpnext_project_from_template(template):
 
     return project.name
 
-def create_stage_plan(project_name, stage_plan_doc):
+def create_stage_plan(project_name, stage_plan_doc, with_tasks=True):
     stage_plan = frappe.new_doc('Stage Planning')
     stage_plan.project = project_name
     stage_plan.stage_name = stage_plan_doc.stage_name
     stage_plan.insert(ignore_permissions=True)
 
-    for task_row in stage_plan_doc.tasks:
-        task_name = create_task(project_name, task_row)
-        stage_plan.append('stage_planning_tasks', {'task': task_name})
-
-    stage_plan.save(ignore_permissions=True)
+    # with_tasks=False creates an empty stage (the "Stage Planning only" seed
+    # mode). When True, each template task becomes a live Task linked into the
+    # stage's child table with a default planned qty of 100% — matching what the
+    # frontend stage-create form sets (StageTaskPicker defaults plannedQty: 100).
+    if with_tasks:
+        for task_row in stage_plan_doc.tasks:
+            task_name = create_task(project_name, task_row)
+            stage_plan.append('stage_planning_tasks', {
+                'task': task_name,
+                'planned_qty': 100,
+                'qty_unit': '%',
+            })
+        stage_plan.save(ignore_permissions=True)
 
 def create_task(project_name, task_row):
     # task_row.task links to a template Task — copy its properties into a new live Task

--- a/buildsuite_core/utils/project.py
+++ b/buildsuite_core/utils/project.py
@@ -182,18 +182,26 @@ def seed_from_template_on_insert(doc, method=None):
         create_task,
     )
 
-    if doc.custom_seed_default_stages:
+    seed_stages = bool(doc.custom_seed_default_stages)
+    seed_tasks = bool(doc.custom_seed_default_tasks)
+
+    # Three seed modes:
+    #   Stages + Tasks -> stages created WITH their nested tasks, plus project-level tasks.
+    #   Stages only    -> empty stages (no tasks created at all).
+    #   Tasks only     -> no stages; every template task (project-level AND the ones
+    #                     nested in stage plans) created as a plain project task.
+    if seed_stages:
         for row in template.stage_plans:
             try:
                 stage_plan_doc = frappe.get_doc('Stage Plan Template', row.stage_plan)
-                create_stage_plan(doc.name, stage_plan_doc)
+                create_stage_plan(doc.name, stage_plan_doc, with_tasks=seed_tasks)
             except Exception:
                 frappe.log_error(
                     frappe.get_traceback(),
                     f'BuildSuite: seed stage plan "{row.stage_plan}" for project "{doc.name}"'
                 )
 
-    if doc.custom_seed_default_tasks:
+    if seed_tasks:
         for row in template.project_task:
             try:
                 create_task(doc.name, row)
@@ -202,6 +210,53 @@ def seed_from_template_on_insert(doc, method=None):
                     frappe.get_traceback(),
                     f'BuildSuite: seed task "{row.task}" for project "{doc.name}"'
                 )
+        # Tasks-only: the tasks that would otherwise be nested under stage plans
+        # are still wanted — create them as project-level tasks (no stage).
+        if not seed_stages:
+            for row in template.stage_plans:
+                try:
+                    stage_plan_doc = frappe.get_doc('Stage Plan Template', row.stage_plan)
+                    for task_row in stage_plan_doc.tasks:
+                        create_task(doc.name, task_row)
+                except Exception:
+                    frappe.log_error(
+                        frappe.get_traceback(),
+                        f'BuildSuite: seed nested tasks from stage plan "{row.stage_plan}" for project "{doc.name}"'
+                    )
+
+
+@frappe.whitelist()
+def get_project_template_summary(project_type):
+    """Preview summary of the template for a Project Type (used by the create form).
+
+    Returns the stage names and the TOTAL task count — the flat project-level
+    `project_task` rows PLUS every task nested inside the template's stage plans.
+    The task count is what the "Import default tasks" option will seed.
+    """
+    if not project_type:
+        return {'exists': False}
+
+    template_name = frappe.db.get_value(
+        'BuildSuite Project Template', {'project_type': project_type}, 'name'
+    )
+    if not template_name:
+        return {'exists': False}
+
+    template = frappe.get_doc('BuildSuite Project Template', template_name)
+
+    stage_names = []
+    nested_task_count = 0
+    for row in template.stage_plans:
+        stage_plan_doc = frappe.get_doc('Stage Plan Template', row.stage_plan)
+        stage_names.append(stage_plan_doc.stage_name)
+        nested_task_count += len(stage_plan_doc.tasks or [])
+
+    return {
+        'exists': True,
+        'stage_names': stage_names,
+        'stage_count': len(stage_names),
+        'task_count': len(template.project_task or []) + nested_task_count,
+    }
 
 
 @frappe.whitelist()

--- a/frontend/src/views/NewProjectView.vue
+++ b/frontend/src/views/NewProjectView.vue
@@ -135,44 +135,29 @@ const parentProject = computed(() =>
 // selected Project Type. Since Stage Plan Template is autonamed by stage_name,
 // each stage_plans row's `stage_plan` field value IS the stage name.
 const templateLoading = ref(false)
-const bsTemplate = ref(null)
+// Summary from the backend: { exists, stage_names, stage_count, task_count }.
+// task_count is the TOTAL — project-level tasks PLUS tasks nested in every
+// stage plan — which is exactly what "Import default tasks" seeds.
+const templateSummary = ref(null)
 
-const templateStageNames = computed(() =>
-  (bsTemplate.value?.stage_plans || []).map(row => row.stage_plan)
-)
-const templateTaskCount = computed(() =>
-  (bsTemplate.value?.project_task || []).length
-)
+const templateStageNames = computed(() => templateSummary.value?.stage_names || [])
+const templateTaskCount = computed(() => templateSummary.value?.task_count || 0)
 
 async function loadTemplateForType(projectType) {
-  bsTemplate.value = null
+  templateSummary.value = null
   if (!projectType) return
   templateLoading.value = true
   try {
-    const listRes = await fetch(
-      '/api/method/frappe.client.get_list?' + new URLSearchParams({
-        doctype: 'BuildSuite Project Template',
-        fields: JSON.stringify(['name']),
-        filters: JSON.stringify([['project_type', '=', projectType]]),
-        limit_page_length: 1,
-      }),
+    const res = await fetch(
+      '/api/method/buildsuite_core.utils.project.get_project_template_summary?' +
+        new URLSearchParams({ project_type: projectType }),
       { credentials: 'include', headers: { 'X-Frappe-CSRF-Token': window.csrf_token || '' } }
     )
-    const listData = await listRes.json()
-    const rows = listData?.message || []
-    if (!rows.length) return
-
-    const docRes = await fetch(
-      '/api/method/frappe.client.get?' + new URLSearchParams({
-        doctype: 'BuildSuite Project Template',
-        name: rows[0].name,
-      }),
-      { credentials: 'include', headers: { 'X-Frappe-CSRF-Token': window.csrf_token || '' } }
-    )
-    const docData = await docRes.json()
-    bsTemplate.value = docData?.message || null
+    const data = await res.json()
+    const summary = data?.message || null
+    templateSummary.value = summary && summary.exists ? summary : null
   } catch (err) {
-    console.warn('[NewProjectView] Failed to load template for type', projectType, err)
+    console.warn('[NewProjectView] Failed to load template summary for type', projectType, err)
   } finally {
     templateLoading.value = false
   }
@@ -318,7 +303,7 @@ const breadcrumbs = computed(() => {
           <div v-if="templateLoading" class="mt-1.5 px-2 py-1.5 bg-ink-50 border border-ink-200 text-[11px] text-ink-500 italic" style="border-radius: 6px;">
             Loading template…
           </div>
-          <div v-else-if="bsTemplate" class="mt-1.5 px-2 py-1.5 bg-ink-50 border border-ink-200 text-[11px] text-ink-700 space-y-1.5" style="border-radius: 6px;">
+          <div v-else-if="templateSummary" class="mt-1.5 px-2 py-1.5 bg-ink-50 border border-ink-200 text-[11px] text-ink-700 space-y-1.5" style="border-radius: 6px;">
             <div class="flex items-center justify-between gap-2 flex-wrap">
               <div>
                 Template seeds <span class="font-medium text-ink-900">{{ templateStageNames.length }} default stages</span>:

--- a/frontend/src/views/StagePlanningDetailView.vue
+++ b/frontend/src/views/StagePlanningDetailView.vue
@@ -258,15 +258,18 @@ function loadTasksResource(projectId) {
     return
   }
   tasksResource.value = adapter.list('Task', {
-    fields: ['name', 'subject', 'status', 'progress'],
+    // Use the BuildSuite custom `task_status` (Yet To Start / In Progress /
+    // In Delay / Completed / Blocked) — the ideal status the rest of the app
+    // shows — not the native ERPNext `status` (Open / Working / …).
+    fields: ['name', 'subject', 'task_status', 'progress'],
     filters: [['project', '=', projectId]],
     pageLength: 500,
-    cache: `buildsuite-stage-detail-tasks:${projectId}`,
+    cache: `buildsuite-stage-detail-tasks-v2:${projectId}`,
     transform(rows) {
       return rows.map((row) => ({
         id: row?.name || '',
         name: row?.subject || row?.name || '',
-        status: row?.status || 'Open',
+        status: row?.task_status || 'Yet To Start',
         progress: Number(row?.progress) || 0,
       }))
     },


### PR DESCRIPTION
## Fixes

1. **Three template seed modes on project create** (`seed_from_template_on_insert`):
   - SP + Tasks → stage plans **with** nested tasks + project-level tasks
   - SP only → **empty** stage plans (no tasks)
   - Tasks only → no stages; every template task (project-level **and** nested-in-SP) created as a plain project task

2. **Template task count includes nested-SP tasks** — new whitelisted `get_project_template_summary(project_type)` returns stage names + total task count (flat `project_task` + tasks nested in each stage plan). NewProjectView's "Import default tasks" count now reflects the true total instead of project-level tasks only.

3. **Seeded `planned_qty` = 100%** — `create_stage_plan` now sets `planned_qty: 100, qty_unit: '%'` on seeded `stage_planning_tasks` (was defaulting to 0), matching the frontend stage-create default.

4. **Stage task status uses `task_status`** — StagePlanningDetailView fetched the native ERPNext `status` (Open/Working/…); switched to the BuildSuite custom `task_status` (Yet To Start / In Progress / In Delay / Completed / Blocked), the field the rest of the app uses.

Backend `py_compile` + frontend `yarn build` clean. Requires `bench migrate` + a browser check of the three seed modes.