### PR TITLE
feat: format currency from site default instead of hardcoded ₹

### DIFF
--- a/buildsuite_core/www/core.py
+++ b/buildsuite_core/www/core.py
@@ -51,10 +51,16 @@ def get_boot():
 		except Exception:
 			csrf_token = ""
 
+	defaults = frappe.defaults.get_defaults()
+
 	return frappe._dict(
 		{
 			"frappe_version": frappe.__version__,
 			"session_user": frappe.session.user,
+			"sysdefaults": {
+				"currency": defaults.get("currency"),
+				"currency_precision": defaults.get("currency_precision"),
+			},
 			"default_route": f"/{APP_ROUTE}",
 			"site_name": frappe.local.site,
 			"read_only_mode": frappe.flags.read_only,

--- a/frontend/src/utils/format.js
+++ b/frontend/src/utils/format.js
@@ -1,22 +1,41 @@
 // Formatting helpers used across views.
 
-export function fmt(n) {
-	if (n == null || n === "") return "";
-	return Number(n).toLocaleString("en-IN");
+// Site currency + decimals from the boot payload (set in www/core.py).
+function defs() {
+  return (typeof window !== 'undefined' && window.sysdefaults) || {}
 }
 
-export function fmtINR(n) {
-	if (n == null) return "₹0";
-	return "₹" + fmt(n);
+// fmtCurrency(150000) -> ₹1,50,000.00 ; fmtCurrency(150000, 'USD') -> $150,000.00
+export function fmtCurrency(value, currency = defs().currency || 'INR', precision) {
+  if (value == null || value === '') value = 0
+  if (precision == null || precision === '') {
+    const p = Number(defs().currency_precision)
+    precision = p > 0 ? p : 2
+  }
+  const locale = currency === 'INR' ? 'en-IN' : 'en-US'
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  }).format(Number(value) || 0)
 }
 
-export function fmtCompactINR(n) {
-	if (n == null) return "₹0";
-	if (n >= 10000000) return `₹${(n / 10000000).toFixed(2)} Cr`;
-	if (n >= 100000) return `₹${(n / 100000).toFixed(2)} L`;
-	if (n >= 1000) return `₹${(n / 1000).toFixed(1)} k`;
-	return `₹${n}`;
+// Compact: ₹1.5Cr / $1.5M etc.
+export function fmtCompactCurrency(value, currency = defs().currency || 'INR') {
+  if (value == null || value === '') value = 0
+  const locale = currency === 'INR' ? 'en-IN' : 'en-US'
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(Number(value) || 0)
 }
+
+// Legacy aliases — now follow the site currency, not hardcoded ₹.
+export const fmtINR = fmtCurrency
+export const fmtCompactINR = fmtCompactCurrency
 
 export function fmtDate(d) {
 	if (!d) return "—";


### PR DESCRIPTION
Currency was hardcoded to the INR symbol in the frontend. Now it uses the site's default currency from the boot settings.

- Backend (core.py): send the site currency and precision to the frontend.
- format.js: new fmtCurrency(value, currency) - symbol and decimals come from the site.
- Old fmtINR / fmtCompactINR kept as aliases, so no other files change.
