### PR TITLE
Update Rate Master rate from Purchase Order on submit

### DIFF
--- a/buildsuite_core/api/rate_master.py
+++ b/buildsuite_core/api/rate_master.py
@@ -1,0 +1,34 @@
+import json
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+
+@frappe.whitelist()
+def update_rates_from_po(purchase_order, updates, supplier=None):
+	if isinstance(updates, str):
+		updates = json.loads(updates)
+
+	changed = []
+	for row in updates:
+		rate_master = row.get("rate_master")
+		new_rate = flt(row.get("new_rate"))
+		if not rate_master or new_rate <= 0:
+			continue
+
+		doc = frappe.get_doc("Construction Rate Master", rate_master)
+		if not frappe.has_permission("Construction Rate Master", "write", doc=doc):
+			frappe.throw(
+				_("Not permitted to update Rate Master {0}.").format(rate_master),
+				frappe.PermissionError,
+			)
+		if flt(doc.current_rate) == new_rate:
+			continue
+
+		doc.flags.rate_source = {"purchase_order": purchase_order, "supplier": supplier}
+		doc.current_rate = new_rate
+		doc.save()
+		changed.append(rate_master)
+
+	return changed

--- a/buildsuite_core/buildsuite_core/doctype/construction_rate_master/construction_rate_master.py
+++ b/buildsuite_core/buildsuite_core/doctype/construction_rate_master/construction_rate_master.py
@@ -46,22 +46,27 @@ class ConstructionRateMaster(Document):
 				self.previous_rate = before.current_rate
 			self.effective_date = today
 			self._close_open_row(today)
-			self._append_rate_row("Manual revision", today)
+			source = self.flags.get("rate_source") or {}
+			reason = "Purchase-driven" if source.get("purchase_order") else "Manual revision"
+			self._append_rate_row(reason, today, source)
 
 	def _close_open_row(self, effective_to):
 		for row in self.rate_history:
 			if not row.effective_to:
 				row.effective_to = effective_to
 
-	def _append_rate_row(self, reason, effective_from):
-		self.append(
-			"rate_history",
-			{
-				"rate": self.current_rate,
-				"effective_from": effective_from,
-				"effective_to": None,
-				"reason": reason,
-				"changed_by": frappe.session.user,
-				"changed_on": now_datetime(),
-			},
-		)
+	def _append_rate_row(self, reason, effective_from, source=None):
+		source = source or {}
+		row = {
+			"rate": self.current_rate,
+			"effective_from": effective_from,
+			"effective_to": None,
+			"reason": reason,
+			"changed_by": frappe.session.user,
+			"changed_on": now_datetime(),
+		}
+		if source.get("purchase_order"):
+			row["purchase_order"] = source["purchase_order"]
+		if source.get("supplier"):
+			row["supplier"] = source["supplier"]
+		self.append("rate_history", row)

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -272,28 +272,77 @@ CUSTOM_FIELD = {
 			"module": "BuildSuite Core",
 		},
 	],
-  "Stock Entry":[
-         {
-            "fieldname": "custom_section_break_o8nvm",
-            "fieldtype": "Section Break",
-            "insert_after": "source_stock_entry",
-            "is_system_generated": 0,
-            "label": None,
-            "depends_on":"eval:doc.stock_entry_type&&doc.purpose!=\"Material Transfer\"",
-            "read_only": 0
-        },
-    ],
-    "Material Request":[
-        {
-            "fieldname": "project",
-            "fieldtype": "Link",
-            "insert_after": "naming_series",
-            "is_system_generated": 0,
-            "label": "Project",
-            "options":"Project",
-            "in_standard_filter":1,
-            "reqd":1,
-            "read_only": 0
-        }
-    ],
+	"Stock Entry": [
+		{
+			"fieldname": "custom_section_break_o8nvm",
+			"fieldtype": "Section Break",
+			"insert_after": "source_stock_entry",
+			"is_system_generated": 0,
+			"label": None,
+			"depends_on": 'eval:doc.stock_entry_type&&doc.purpose!="Material Transfer"',
+			"read_only": 0,
+		},
+	],
+	"Material Request": [
+		{
+			"fieldname": "project",
+			"fieldtype": "Link",
+			"insert_after": "naming_series",
+			"is_system_generated": 0,
+			"label": "Project",
+			"options": "Project",
+			"in_standard_filter": 1,
+			"reqd": 1,
+			"read_only": 0,
+		}
+	],
+	"Item": [
+		{
+			"fieldname": "custom_rate_master",
+			"fieldtype": "Link",
+			"label": "Rate Master",
+			"options": "Construction Rate Master",
+			"insert_after": "image",
+			"module": "BuildSuite Core",
+		},
+	],
+	"Purchase Order": [
+		{
+			"fieldname": "custom_rate_master_banner",
+			"fieldtype": "HTML",
+			"label": "Rate Master Preview",
+			"insert_after": "items_section",
+			"module": "BuildSuite Core",
+		},
+	],
+	"Purchase Order Item": [
+		{
+			"fieldname": "custom_rate_master",
+			"fieldtype": "Link",
+			"label": "Rate Master",
+			"options": "Construction Rate Master",
+			"fetch_from": "item_code.custom_rate_master",
+			"insert_after": "item_group",
+			"in_list_view": 1,
+			"module": "BuildSuite Core",
+		},
+		{
+			"fieldname": "custom_rate_master_name",
+			"fieldtype": "Data",
+			"label": "RM Name",
+			"fetch_from": "custom_rate_master.rate_name",
+			"read_only": 1,
+			"insert_after": "custom_rate_master",
+			"module": "BuildSuite Core",
+		},
+		{
+			"fieldname": "custom_rate_master_rate",
+			"fieldtype": "Currency",
+			"label": "RM Rate",
+			"fetch_from": "custom_rate_master.current_rate",
+			"read_only": 1,
+			"insert_after": "custom_rate_master_name",
+			"module": "BuildSuite Core",
+		},
+	],
 }

--- a/buildsuite_core/public/js/purchase_order.js
+++ b/buildsuite_core/public/js/purchase_order.js
@@ -93,10 +93,16 @@ frappe.ui.form.on('Purchase Order', {
                     filters: filters
                 }
             }
-                
 		});
-    }
-})
+		render_banner(frm);
+	},
+	before_submit(frm) {
+		if (frm.__rm_handled) return; // already decided this submit; let it through
+		if (!above_threshold_lines(frm).length) return;
+		frappe.validated = false;
+		show_rate_master_dialog(frm);
+	},
+});
 
 frappe.ui.form.on("Purchase Order Item", {
     amount: function (frm, cdt, cdn) {
@@ -106,5 +112,210 @@ frappe.ui.form.on("Purchase Order Item", {
             frappe.model.set_value(cdt, cdn, "rate", flt(item.amount / item.qty, precision("rate", item)));
             frappe.model.set_value(cdt, cdn, "custom_amout", item.amount);
         }
-    }
+    },
+	rate: render_banner,
+	item_code: render_banner,
+	items_remove: render_banner,
 });
+
+// ---------------------------------------------------------------------------
+// Rate Master sync: warn on submit when a PO line's rate is above the linked
+// Construction Rate Master, and offer to update the master.
+// ---------------------------------------------------------------------------
+const RM_THRESHOLD_PCT = 5; // TODO: move to BuildSuite Core Settings.
+const esc = frappe.utils.escape_html;
+
+function above_threshold_lines(frm) {
+	const limit = 1 + RM_THRESHOLD_PCT / 100;
+	return (frm.doc.items || []).filter(
+		(row) =>
+			row.custom_rate_master &&
+			flt(row.custom_rate_master_rate) > 0 &&
+			flt(row.rate) > flt(row.custom_rate_master_rate) * limit
+	);
+}
+
+// Several PO lines can share one Rate Master — keep just the highest-rate line
+// per master, so each master shows once.
+function dialog_rows(frm) {
+	const by_rm = {};
+	for (const row of above_threshold_lines(frm)) {
+		const code = row.custom_rate_master;
+		const best = by_rm[code];
+		if (!best || flt(row.rate) > flt(best.new_rate)) {
+			const old_rate = flt(row.custom_rate_master_rate);
+			const new_rate = flt(row.rate);
+			by_rm[code] = {
+				rm_code: code,
+				rm: row.custom_rate_master_name || code,
+				items: row.item_code,
+				old_rate: old_rate,
+				new_rate: new_rate,
+				delta: old_rate
+					? `${(((new_rate - old_rate) / old_rate) * 100).toFixed(1)}%`
+					: "—",
+			};
+		}
+	}
+	return Object.values(by_rm);
+}
+
+function render_banner(frm) {
+	const field = frm.get_field("custom_rate_master_banner");
+	if (!field) return;
+
+	// one entry per Rate Master (deduped), same as the dialog
+	const rows = frm.doc.docstatus === 0 ? dialog_rows(frm) : [];
+	if (!rows.length) {
+		field.$wrapper.empty();
+		return;
+	}
+
+	const items = rows
+		.map(
+			(r) =>
+				`<li>• <b>${esc(r.rm)}</b> (${esc(r.rm_code)}) · ${format_currency(
+					r.old_rate
+				)} → ` +
+				`<b style="color:var(--orange-600);">${format_currency(r.new_rate)}</b></li>`
+		)
+		.join("");
+
+	field.$wrapper.html(`
+		<div style="padding:12px 16px;border:1px solid var(--yellow-200);background:var(--yellow-50);border-radius:8px;">
+			<b>⚠ On Submit: ${rows.length} Rate Master update(s) will be proposed</b>
+			<ul style="margin:6px 0 0;padding-left:0;list-style:none;">${items}</ul>
+			<div style="margin-top:8px;font-size:11px;color:var(--text-muted);font-style:italic;">
+				Rates above ${RM_THRESHOLD_PCT}% of the Rate Master rate trigger the prompt at submit.
+				Updating affects future estimates only.
+			</div>
+		</div>
+	`);
+}
+
+function show_rate_master_dialog(frm) {
+	const d = new frappe.ui.Dialog({
+		title: __("Update Rate Master rates?"),
+		size: "large",
+		fields: [
+			{ fieldtype: "HTML", fieldname: "intro" },
+			{
+				fieldtype: "Table",
+				fieldname: "rows",
+				cannot_add_rows: 1,
+				cannot_delete_rows: 1,
+				in_place_edit: 1,
+				fields: [
+					{
+						fieldname: "rm_code",
+						fieldtype: "Data",
+						label: __("RM Code"),
+						hidden: 1,
+					},
+					{
+						fieldname: "rm",
+						fieldtype: "Data",
+						label: __("Rate Master"),
+						read_only: 1,
+						in_list_view: 1,
+					},
+					{
+						fieldname: "items",
+						fieldtype: "Data",
+						label: __("Items in PO"),
+						read_only: 1,
+						in_list_view: 1,
+					},
+					{
+						fieldname: "old_rate",
+						fieldtype: "Currency",
+						label: __("Old rate"),
+						read_only: 1,
+						in_list_view: 1,
+					},
+					{
+						fieldname: "new_rate",
+						fieldtype: "Currency",
+						label: __("New rate"),
+						in_list_view: 1,
+					},
+					{
+						fieldname: "delta",
+						fieldtype: "Data",
+						label: "Δ",
+						read_only: 1,
+						in_list_view: 1,
+					},
+				],
+			},
+		],
+		primary_action_label: __("Update rates"),
+		primary_action() {
+			const selected = d.fields_dict.rows.grid.get_selected_children();
+			if (!selected.length) {
+				frappe.msgprint(__("Tick at least one row to update."));
+				return;
+			}
+
+			// checked rows, each carries a clean { rate_master, new_rate } for the server
+			const updates = selected.map((r) => ({
+				rate_master: r.rm_code,
+				new_rate: flt(r.new_rate),
+			}));
+
+			d.hide();
+			frm.__rm_handled = true;
+
+			// submit first — rates change only if the PO actually goes through,
+			// and the submitted PO can be linked in the rate history.
+			frm.save("Submit")
+				.then(() =>
+					frappe.call({
+						method: "buildsuite_core.api.rate_master.update_rates_from_po",
+						args: {
+							purchase_order: frm.doc.name,
+							supplier: frm.doc.supplier,
+							updates,
+						},
+						freeze: true,
+						freeze_message: __("Updating Rate Masters…"),
+					})
+				)
+				.then((r) => {
+					const changed = (r && r.message) || [];
+					if (changed.length) {
+						frappe.show_alert({
+							message: __("Updated {0} Rate Master(s).", [changed.length]),
+							indicator: "green",
+						});
+					}
+				})
+				.catch(() => {
+					// submit failed → let the user retry the whole flow (dialog + update)
+					frm.__rm_handled = false;
+				});
+		},
+		secondary_action_label: __("Skip"),
+		secondary_action() {
+			d.hide();
+		},
+	});
+
+	d.fields_dict.intro.$wrapper.html(`
+		<div style="padding:10px 12px;border:1px solid var(--border-color);background:var(--bg-light-gray);border-radius:6px;font-size:12px;">
+			<b>${__("What this does")}</b>
+			<ul style="margin:6px 0 0;padding-left:16px;">
+				<li>${__("Updates the current Rate Master rate for each ticked row to the new value.")}</li>
+				<li>${__("Records an audit row (old → new, source PO, user) in the rate history.")}</li>
+				<li>${__("Affects future estimates only — existing BOQs keep their snapshot rates.")}</li>
+				<li>${__("Untick a row to skip it; edit New rate if you don't want the full PO rate.")}</li>
+			</ul>
+		</div>
+	`);
+
+	d.fields_dict.rows.df.data = dialog_rows(frm);
+
+	d.fields_dict.rows.grid.refresh();
+
+	d.show();
+}


### PR DESCRIPTION
**PR description**
When a PO line's rate is more than 5% above its linked Construction Rate Master, a dialog on submit lets the user pick which masters to update to the new rate.

- Banner on the draft PO shows the affected masters
- One row per Rate Master (highest rate wins if items repeat)
- On confirm: submit the PO, then update current_rate and add a "Purchase-driven" row in the rate history (with PO + supplier)
- New custom fields on Item / PO / PO Item to link the rate master