### PR TITLE
BOQ estimation: list/detail UI parity + cross-project link validation

### DIFF
--- a/buildsuite_core/api/boq.py
+++ b/buildsuite_core/api/boq.py
@@ -139,9 +139,11 @@ def recalculate_actuals(boq):
 # --- clone / revisions ----------------------------------------------------
 
 
-def _clone_tree(src_boq, dst_boq, reset_actuals=True, src_wp=None, wp_override=None):
+def _clone_tree(src_boq, dst_boq, reset_actuals=True, src_wp=None, wp_override=None, drop_wp=False):
 	"""Clone groups/items/sub-items from src_boq into dst_boq. `src_wp` limits the
-	source to items tagged to that Work Package; `wp_override` retags the copies."""
+	source to items tagged to that Work Package; `wp_override` retags the copies.
+	`drop_wp` clears the Work Package on the copies (used for a cross-project clone,
+	where the source project's Work Packages don't belong to the target project)."""
 	group_map = {}
 	for g in frappe.get_all(
 		"BOQ Group", filters={"boq": src_boq}, fields=["name", "code", "group_name", "idx_order"]
@@ -175,7 +177,7 @@ def _clone_tree(src_boq, dst_boq, reset_actuals=True, src_wp=None, wp_override=N
 				"rate": it.rate,
 				"task": None if reset_actuals else it.task,
 				"quantity_source": it.quantity_source,
-				"work_package": wp_override or it.work_package,
+				"work_package": wp_override or (None if drop_wp else it.work_package),
 				"cost_head": it.cost_head,
 				"assembly": it.assembly,
 				"driving_qty": it.driving_qty,
@@ -194,7 +196,7 @@ def _clone_tree(src_boq, dst_boq, reset_actuals=True, src_wp=None, wp_override=N
 					"qty_per_unit": si.qty_per_unit,
 					"rate": si.rate,
 					"qty": si.qty,
-					"work_package": wp_override or si.work_package,
+					"work_package": wp_override or (None if drop_wp else si.work_package),
 					"cost_head": si.cost_head,
 					"source_assembly": si.source_assembly,
 				}
@@ -273,7 +275,7 @@ def clone_boq(from_project, to_project, from_work_package=None, to_work_package=
 	).insert(ignore_permissions=True)
 	frappe.flags.boq_skip_rollup = True
 	try:
-		count = _clone_tree(src, new.name, wp_override=to_work_package)
+		count = _clone_tree(src, new.name, wp_override=to_work_package, drop_wp=True)
 	finally:
 		frappe.flags.boq_skip_rollup = False
 	recompute_boq(new.name)

--- a/buildsuite_core/api/estimation_seed.py
+++ b/buildsuite_core/api/estimation_seed.py
@@ -1,0 +1,400 @@
+"""Seed a realistic Estimation demo: users -> project -> work packages ->
+rate master -> assemblies -> estimate template -> BOQ master (groups/items/
+sub-items), wired end to end so /core shows a full, dependency-linked estimate.
+
+Dev/demo only (guarded on developer_mode). Idempotent: masters are
+get-or-create by code, and the demo project's BOQ tree is rebuilt on every run.
+
+Run:
+    bench --site bs.local execute buildsuite_core.api.estimation_seed.seed_estimation_demo
+Tear down:
+    bench --site bs.local execute buildsuite_core.api.estimation_seed.unseed_estimation_demo
+"""
+
+import frappe
+from frappe.utils import add_months, today
+
+from buildsuite_core.api import boq as boq_api
+
+DEMO_PASSWORD = "BuildSuite-Demo-2026!"
+PROJECT_CODE = "DEMO-EST-001"
+
+# --- persona users (persona must match PERSONA_TO_ROLE keys) ------------------
+DEMO_USERS = {
+	"director": ("demo-director@buildsuite.demo", "Dana Director", "Director / Owner"),
+	"pm": ("demo-pm@buildsuite.demo", "Paul Manager", "Project Manager"),
+	"estimator": ("demo-estimator@buildsuite.demo", "Esther Estimator", "Estimator"),
+	"qs": ("demo-qs@buildsuite.demo", "Quinn Surveyor", "Quantity Surveyor"),
+}
+
+UOMS = ["Cubic Meter", "Square Meter", "Kg", "Bag", "Nos", "Day"]
+
+# rate_code -> (name, category, uom, current_rate)
+RATES = {
+	"CEM-OPC": ("Cement OPC 42.5 (50kg)", "Material", "Bag", 5.50),
+	"SAND-SHARP": ("Sharp Sand", "Material", "Cubic Meter", 18.00),
+	"AGG-20": ("Coarse Aggregate 20mm", "Material", "Cubic Meter", 22.00),
+	"REBAR-Y16": ("Reinforcement Bar Y16", "Material", "Kg", 0.95),
+	"PLY-18": ("Formwork Plywood 18mm", "Material", "Square Meter", 12.00),
+	"BLK-200": ("Hollow Block 200mm", "Material", "Nos", 1.20),
+	"LAB-MASON": ("Mason", "Labour", "Day", 35.00),
+	"LAB-STEEL": ("Steel Fixer", "Labour", "Day", 38.00),
+	"LAB-CARP": ("Carpenter (Formwork)", "Labour", "Day", 36.00),
+	"LAB-GEN": ("General Labourer", "Labour", "Day", 22.00),
+	"EQ-MIXER": ("Concrete Mixer 0.5m3", "Equipment", "Day", 45.00),
+	"EQ-VIB": ("Poker Vibrator", "Equipment", "Day", 15.00),
+}
+
+# assembly_code -> (name, category, uom, [(resource_code, coefficient), ...])
+ASSEMBLIES = {
+	"ASM-C25": (
+		"In-situ Concrete C25/30",
+		"Concrete",
+		"Cubic Meter",
+		[("CEM-OPC", 7.0), ("SAND-SHARP", 0.5), ("AGG-20", 0.8),
+		 ("LAB-MASON", 0.3), ("LAB-GEN", 0.8), ("EQ-MIXER", 0.15), ("EQ-VIB", 0.1)],
+	),
+	"ASM-REBAR": (
+		"Reinforcement Fixing (Y16)",
+		"Reinforcement",
+		"Kg",
+		[("REBAR-Y16", 1.05), ("LAB-STEEL", 0.02)],
+	),
+	"ASM-FORM": (
+		"Formwork to Columns & Beams",
+		"General",
+		"Square Meter",
+		[("PLY-18", 0.30), ("LAB-CARP", 0.25), ("LAB-GEN", 0.10)],
+	),
+	"ASM-BLK": (
+		"Blockwork 200mm",
+		"Masonry",
+		"Square Meter",
+		[("BLK-200", 12.5), ("LAB-MASON", 0.20), ("LAB-GEN", 0.15)],
+	),
+}
+
+# work_package_name -> code
+WORK_PACKAGES = [
+	("Substructure", "WP-SUB"),
+	("Superstructure", "WP-SUP"),
+	("Finishes", "WP-FIN"),
+]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def _ensure_uoms():
+	for name in UOMS:
+		if not frappe.db.exists("UOM", name):
+			frappe.get_doc({"doctype": "UOM", "uom_name": name}).insert(ignore_permissions=True)
+
+
+def _ensure_user(email, full_name, persona):
+	first, _, last = full_name.partition(" ")
+	if frappe.db.exists("User", email):
+		doc = frappe.get_doc("User", email)
+		doc.enabled = 1
+		doc.persona = persona
+	else:
+		doc = frappe.get_doc({
+			"doctype": "User",
+			"email": email,
+			"first_name": first,
+			"last_name": last,
+			"enabled": 1,
+			"send_welcome_email": 0,
+			"persona": persona,
+			"new_password": DEMO_PASSWORD,
+		})
+	doc.flags.ignore_password_policy = True
+	doc.save(ignore_permissions=True)
+	return email
+
+
+def _ensure_rate(code):
+	name, category, uom, rate = RATES[code]
+	if frappe.db.exists("Construction Rate Master", code):
+		return code
+	frappe.get_doc({
+		"doctype": "Construction Rate Master",
+		"rate_code": code,
+		"rate_name": name,
+		"category": category,
+		"uom": uom,
+		"current_rate": rate,
+	}).insert(ignore_permissions=True)
+	return code
+
+
+def _ensure_assembly(code):
+	name, category, uom, comps = ASSEMBLIES[code]
+	if frappe.db.exists("Assembly", code):
+		return code
+	doc = frappe.get_doc({
+		"doctype": "Assembly",
+		"assembly_code": code,
+		"assembly_name": name,
+		"category": category,
+		"uom": uom,
+	})
+	for resource_code, coeff in comps:
+		doc.append("components", {
+			"resource": resource_code,
+			"resource_name": RATES[resource_code][0],
+			"coefficient": coeff,
+			"uom": RATES[resource_code][2],
+		})
+	doc.insert(ignore_permissions=True)  # validate() prices components + rate_per_unit
+	return code
+
+
+def _ensure_template():
+	code = "TPL-COMM-SHELL"
+	if frappe.db.exists("Estimate Template", code):
+		return code
+	project_type = "Commercial" if frappe.db.exists("Project Type", "Commercial") else None
+	doc = frappe.get_doc({
+		"doctype": "Estimate Template",
+		"template_code": code,
+		"template_name": "Commercial RC Frame — Shell & Core",
+		"description": "Reusable shell-and-core skeleton for a commercial RC-frame building.",
+		"project_type": project_type,
+		"enabled": 1,
+		"rows": [
+			{"group_name": "Substructure", "line_type": "Assembly", "assembly": "ASM-C25",
+			 "description": "Foundation concrete C25/30", "placeholder_qty": 120, "uom": "Cubic Meter", "cost_head": "Material"},
+			{"group_name": "Substructure", "line_type": "Assembly", "assembly": "ASM-REBAR",
+			 "description": "Reinforcement to foundations", "placeholder_qty": 9000, "uom": "Kg", "cost_head": "Material"},
+			{"group_name": "Superstructure", "line_type": "Assembly", "assembly": "ASM-C25",
+			 "description": "Columns, beams & slabs concrete", "placeholder_qty": 480, "uom": "Cubic Meter", "cost_head": "Material"},
+			{"group_name": "Superstructure", "line_type": "Assembly", "assembly": "ASM-FORM",
+			 "description": "Formwork to frame", "placeholder_qty": 2600, "uom": "Square Meter", "cost_head": "Material"},
+			{"group_name": "Finishes", "line_type": "Assembly", "assembly": "ASM-BLK",
+			 "description": "200mm blockwork walls", "placeholder_qty": 3400, "uom": "Square Meter", "cost_head": "Material"},
+			{"group_name": "Finishes", "line_type": "Resource", "resource": "LAB-GEN",
+			 "description": "General site cleaning & handover", "placeholder_qty": 200, "uom": "Day", "cost_head": "Labour"},
+		],
+	})
+	doc.insert(ignore_permissions=True)
+	return code
+
+
+def _ensure_project(company, pm):
+	name = frappe.db.get_value("Project", {"custom_project_id": PROJECT_CODE}, "name")
+	if name:
+		return frappe.get_doc("Project", name)
+	start = today()
+	doc = frappe.get_doc({
+		"doctype": "Project",
+		"project_name": "Riverside Commercial Tower",
+		"custom_project_id": PROJECT_CODE,
+		"project_status": "Ongoing",
+		"company": company,
+		"is_group": 0,
+		"expected_start_date": start,
+		"expected_end_date": add_months(start, 18),
+		"project_manager": pm,          # auto-adds PM to the team
+	})
+	doc.insert(ignore_permissions=True)
+	return doc
+
+
+def _ensure_team(project_doc, members):
+	existing = {r.user for r in (project_doc.custom_team_members or [])}
+	changed = False
+	for user in members:
+		if user not in existing:
+			project_doc.append("custom_team_members", {"user": user})
+			changed = True
+	if changed:
+		project_doc.save(ignore_permissions=True)
+
+
+def _ensure_work_packages(project):
+	wp_by_name = {}
+	start = frappe.db.get_value("Project", project, "expected_start_date")
+	for i, (wp_name, code) in enumerate(WORK_PACKAGES):
+		existing = frappe.db.get_value("Work Package", {"project": project, "work_package_name": wp_name}, "name")
+		if existing:
+			wp_by_name[wp_name] = existing
+			continue
+		doc = frappe.get_doc({
+			"doctype": "Work Package",
+			"project": project,
+			"work_package_name": wp_name,
+			"code": code,
+			"status": "Planned",
+			"start_date": add_months(start, i * 4),
+			"end_date": add_months(start, i * 4 + 5),
+		}).insert(ignore_permissions=True)
+		wp_by_name[wp_name] = doc.name
+	return wp_by_name
+
+
+def _ensure_task(project, wp, subject, pct):
+	name = frappe.db.get_value("Task", {"project": project, "subject": subject}, "name")
+	if not name:
+		name = frappe.get_doc({
+			"doctype": "Task",
+			"subject": subject,
+			"project": project,
+			"work_package": wp,
+			"task_status": "In Progress",
+		}).insert(ignore_permissions=True).name
+	if not frappe.db.exists("Task Progress Entry", {"task": name}):
+		frappe.get_doc({
+			"doctype": "Task Progress Entry",
+			"task": name,
+			"entry_date": today(),
+			"cumulative_progress": pct,
+		}).insert(ignore_permissions=True)
+	return name
+
+
+def _rebuild_boq(project, company, prepared_by, wp_by_name, task_for_columns):
+	# Wipe any prior demo BOQ so re-runs are clean (on_trash cascades the tree).
+	for old in frappe.get_all("BOQ", filters={"project": project}, pluck="name"):
+		frappe.delete_doc("BOQ", old, force=True, ignore_permissions=True)
+
+	boq = frappe.get_doc({
+		"doctype": "BOQ",
+		"project": project,
+		"company": company,
+		"title": "Tender BOQ — Rev 1",
+		"revision": 1,
+		"status": "Draft",
+		"prepared_by": prepared_by,
+		"prepared_date": today(),
+		"margin_rate": 15.0,
+		"tax_rate": 7.5,
+	}).insert(ignore_permissions=True)
+
+	# groups: code -> (name, group doc)
+	groups = {}
+	for code, gname in [("A", "Substructure"), ("B", "Superstructure"), ("C", "Finishes")]:
+		g = frappe.get_doc({
+			"doctype": "BOQ Group",
+			"boq": boq.name,
+			"code": code,
+			"group_name": gname,
+			"idx_order": ord(code) - ord("A") + 1,
+		}).insert(ignore_permissions=True)
+		groups[code] = g.name
+
+	def assembly_item(group_code, code, desc, assembly, driving_qty, wp, task=None):
+		item = frappe.get_doc({
+			"doctype": "BOQ Item",
+			"boq": boq.name,
+			"boq_group": groups[group_code],
+			"code": code,
+			"description": desc,
+			"unit": ASSEMBLIES[assembly][2],
+			"planned_qty": driving_qty,
+			"driving_qty": driving_qty,
+			"quantity_source": "Assembly",
+			"assembly": assembly,
+			"work_package": wp,
+			"task": task,
+			"cost_head": "Material",
+		}).insert(ignore_permissions=True)
+		boq_api.explode_item(item.name)  # snapshots sub-items + sets item.rate
+		return item.name
+
+	def manual_item(group_code, code, desc, unit, qty, rate, wp, cost_head="Material"):
+		frappe.get_doc({
+			"doctype": "BOQ Item",
+			"boq": boq.name,
+			"boq_group": groups[group_code],
+			"code": code,
+			"description": desc,
+			"unit": unit,
+			"planned_qty": qty,
+			"rate": rate,
+			"quantity_source": "Manual",
+			"work_package": wp,
+			"cost_head": cost_head,
+		}).insert(ignore_permissions=True)
+
+	sub = wp_by_name["Substructure"]
+	sup = wp_by_name["Superstructure"]
+	fin = wp_by_name["Finishes"]
+
+	assembly_item("A", "A1", "Foundation & pile-cap concrete C25/30", "ASM-C25", 120, sub)
+	assembly_item("A", "A2", "Reinforcement to foundations", "ASM-REBAR", 9000, sub)
+	manual_item("A", "A3", "Blinding concrete under footings", "Cubic Meter", 40, 85.0, sub)
+
+	assembly_item("B", "B1", "Columns, beams & slabs concrete C25/30", "ASM-C25", 480, sup, task=task_for_columns)
+	assembly_item("B", "B2", "Reinforcement to frame", "ASM-REBAR", 52000, sup)
+	assembly_item("B", "B3", "Formwork to frame", "ASM-FORM", 2600, sup)
+
+	assembly_item("C", "C1", "200mm blockwork walls", "ASM-BLK", 3400, fin)
+	manual_item("C", "C2", "Allowance — external works & landscaping", "Nos", 1, 45000.0, fin, cost_head="Other")
+
+	# Pull actuals from the linked task's live progress.
+	boq_api.recalculate_actuals(boq.name)
+	boq.reload()
+	return boq
+
+
+# ---------------------------------------------------------------------------
+# entry points
+# ---------------------------------------------------------------------------
+def _guard():
+	if not (frappe.conf.developer_mode or frappe.conf.allow_tests or frappe.flags.in_test):
+		frappe.throw(frappe._("This seed helper is only available in developer / test mode"))
+
+
+@frappe.whitelist()
+def seed_estimation_demo():
+	_guard()
+
+	company = frappe.db.get_value("Company", {}, "name")
+	if not company:
+		frappe.throw(frappe._("No Company found — install ERPNext and create a Company first."))
+
+	_ensure_uoms()
+	users = {k: _ensure_user(*v) for k, v in DEMO_USERS.items()}
+	for code in RATES:
+		_ensure_rate(code)
+	for code in ASSEMBLIES:
+		_ensure_assembly(code)
+	template = _ensure_template()
+
+	project = _ensure_project(company, users["pm"])
+	_ensure_team(project, [users["director"], users["estimator"], users["qs"]])
+	wp_by_name = _ensure_work_packages(project.name)
+	task = _ensure_task(project.name, wp_by_name["Superstructure"], "Cast columns — Level 1", 25)
+	boq = _rebuild_boq(project.name, company, users["estimator"], wp_by_name, task)
+
+	frappe.db.commit()  # nosemgrep - dev helper run via bench execute
+	summary = {
+		"company": company,
+		"users": users,
+		"project": project.name,
+		"work_packages": wp_by_name,
+		"rate_master": len(RATES),
+		"assemblies": {c: frappe.db.get_value("Assembly", c, "rate_per_unit") for c in ASSEMBLIES},
+		"estimate_template": template,
+		"boq": boq.name,
+		"boq_planned_amount": boq.planned_amount,
+		"boq_margin_amount": boq.margin_amount,
+		"boq_tax_amount": boq.tax_amount,
+		"boq_total": boq.total,
+		"boq_actual_amount": boq.actual_amount,
+		"password": DEMO_PASSWORD,
+	}
+	print(frappe.as_json(summary))  # noqa: T201 - visible in bench execute output
+	return summary
+
+
+@frappe.whitelist()
+def unseed_estimation_demo():
+	"""Remove the demo project (cascades BOQ/WP/Task). Leaves shared masters + users."""
+	_guard()
+	name = frappe.db.get_value("Project", {"custom_project_id": PROJECT_CODE}, "name")
+	if name:
+		frappe.delete_doc("Project", name, force=True, ignore_permissions=True)
+	frappe.db.commit()  # nosemgrep - dev helper run via bench execute
+	return {"deleted_project": name}

--- a/buildsuite_core/buildsuite_core/doctype/boq_item/boq_item.py
+++ b/buildsuite_core/buildsuite_core/doctype/boq_item/boq_item.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
 
@@ -18,6 +19,32 @@ class BOQItem(Document):
 			self.driving_qty = self.planned_qty
 		if self.quantity_source not in _QUANTITY_SOURCES:
 			self.quantity_source = "Manual"
+		self._validate_project_scope()
+
+	def _validate_project_scope(self):
+		"""A BOQ Item's Task and Work Package must belong to the BOQ's own project —
+		you can't cost work from another project into this BOQ."""
+		if not (self.task or self.work_package):
+			return
+		boq_project = frappe.db.get_value("BOQ", self.boq, "project")
+		if not boq_project:
+			return
+		if self.task:
+			task_project = frappe.db.get_value("Task", self.task, "project")
+			if task_project and task_project != boq_project:
+				frappe.throw(
+					_("Task {0} belongs to project {1}, not this BOQ's project {2}.").format(
+						self.task, task_project, boq_project
+					)
+				)
+		if self.work_package:
+			wp_project = frappe.db.get_value("Work Package", self.work_package, "project")
+			if wp_project and wp_project != boq_project:
+				frappe.throw(
+					_("Work Package {0} belongs to project {1}, not this BOQ's project {2}.").format(
+						self.work_package, wp_project, boq_project
+					)
+				)
 
 	def on_update(self):
 		# Propagate WP / cost-head stamps to child sub-items (denormalized join keys).

--- a/buildsuite_core/tests/test_boq.py
+++ b/buildsuite_core/tests/test_boq.py
@@ -63,6 +63,53 @@ class TestBOQ(BuildSuiteTestCase):
 		self.assertTrue(b.wp_summaries)
 		self.assertAlmostEqual(sum(r.total for r in b.wp_summaries), 2596, places=2)
 
+	# --- project-scope guard on Task / Work Package links ----------------
+	def _other_project(self):
+		# A second project with a distinct name (base `_make_project` reuses one
+		# hash per test, which would collide on the unique project_name).
+		h = frappe.generate_hash(length=6)
+		return frappe.get_doc(
+			{
+				"doctype": "Project",
+				"project_name": f"UAT {h}",
+				"custom_project_id": f"UAT-{h}",
+				"project_status": "Ongoing",
+				"company": self.company,
+			}
+		).insert(ignore_permissions=True)
+
+	def _work_package(self, project, name="WP"):
+		return frappe.get_doc(
+			{
+				"doctype": "Work Package",
+				"project": project,
+				"work_package_name": name,
+				"code": f"{name}-{frappe.generate_hash(length=4)}",
+			}
+		).insert(ignore_permissions=True)
+
+	def test_item_rejects_cross_project_work_package(self):
+		# A BOQ Item may only tag a Work Package from the BOQ's own project.
+		pa = self._make_project(company=self.company)
+		pb = self._other_project()
+		b = self._boq(pa.name)
+		g = self._group(b.name)
+		with self.assertRaises(frappe.ValidationError):
+			self._item(b.name, g.name, 1, 1, work_package=self._work_package(pb.name).name)
+		# same-project Work Package is accepted
+		self._item(b.name, g.name, 1, 1, work_package=self._work_package(pa.name).name)
+
+	def test_item_rejects_cross_project_task(self):
+		# A BOQ Item may only link a Task from the BOQ's own project.
+		pa = self._make_project(company=self.company)
+		pb = self._other_project()
+		b = self._boq(pa.name)
+		g = self._group(b.name)
+		with self.assertRaises(frappe.ValidationError):
+			self._item(b.name, g.name, 1, 1, task=self._make_task(pb.name).name)
+		# same-project Task is accepted
+		self._item(b.name, g.name, 1, 1, task=self._make_task(pa.name).name)
+
 	def test_cascade_delete(self):
 		p = self._make_project(company=self.company)
 		b = self._boq(p.name)

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -6,6 +6,14 @@ const props = defineProps({
 	size: { type: String, default: "sm" },
 });
 
+// The BOQ status is stored as "Superseded" on the backend, but the prototype
+// renamed it to "Replaced" (reads less like document-control jargon). Alias it
+// at render time so the label matches the prototype without a backend change.
+const STATUS_ALIASES = {
+	Superseded: "Replaced",
+};
+const displayStatus = computed(() => STATUS_ALIASES[props.status] || props.status);
+
 const classes = computed(() => {
 	const map = {
 		Active: "bg-success-50 text-success-700",
@@ -26,6 +34,10 @@ const classes = computed(() => {
 		Approved: "bg-success-50 text-success-700",
 		Rejected: "bg-danger-50 text-danger-700",
 		Cancelled: "bg-ink-100 text-ink-500",
+		// BOQ superseded revision — muted ink chip. Keyed on the stored value
+		// ("Superseded"); rendered as "Replaced" via STATUS_ALIASES above.
+		Superseded: "bg-ink-100 text-ink-500",
+		Replaced: "bg-ink-100 text-ink-500",
 		High: "bg-danger-50 text-danger-700",
 		Medium: "bg-warning-50 text-warning-700",
 		Low: "bg-info-50 text-info-700",
@@ -46,5 +58,5 @@ const classes = computed(() => {
 </script>
 
 <template>
-	<span :class="classes">{{ status }}</span>
+	<span :class="classes">{{ displayStatus }}</span>
 </template>

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -534,31 +534,34 @@ const itemForm = ref({
 	costHead: "",
 	assemblyId: null,
 });
-const availableTasks = computed(() => {
-	const pid = boq.value?.projectId;
-	return pid
-		? (tasksRes.data || []).map((t) => ({ id: t.name, name: t.subject || t.name }))
-		: [];
-});
-const tasksRes = useDocTypeList("Task", {
-	filters: [["project", "=", props.id ? undefined : ""]],
-	fields: ["name", "subject"],
-	pageLength: 0,
-	auto: false,
-});
-watch(
-	() => boq.value?.projectId,
-	(pid) => {
-		if (pid) {
-			tasksRes.filters = [["project", "=", pid]];
-			tasksRes.reload?.();
-		}
-	},
-	{ immediate: true }
-);
+// The BOQ's project — scopes the Work Package + Task pickers in the item modal
+// so you can only link records that belong to this BOQ's project.
+const boqProjectId = computed(() => boq.value?.projectId || "");
 const itemPlannedAmountPreview = computed(
 	() => (Number(itemForm.value.plannedQty) || 0) * (Number(itemForm.value.rate) || 0)
 );
+// Assemblies for the "Source" picker — pick one to auto-fill unit / rate /
+// description (the save handler then auto-explodes the line into sub-items).
+const assembliesRes = useDocTypeList("Assembly", {
+	fields: ["name", "assembly_name", "uom", "rate_per_unit"],
+	pageLength: 5000,
+	cache: "buildsuite-boq-item-assemblies",
+});
+const assembliesMap = computed(() => {
+	const m = {};
+	for (const a of assembliesRes.data || [])
+		m[a.name] = { name: a.assembly_name || a.name, uom: a.uom || "", rate: a.rate_per_unit || 0 };
+	return m;
+});
+function onAssemblyPicked(id) {
+	itemForm.value.assemblyId = id || null;
+	if (!id) return;
+	const a = assembliesMap.value[id];
+	if (!a) return;
+	if (a.uom) itemForm.value.unit = a.uom;
+	itemForm.value.rate = a.rate;
+	if (!itemForm.value.description.trim()) itemForm.value.description = a.name;
+}
 function blankItemForm() {
 	return {
 		code: "",
@@ -606,19 +609,34 @@ async function saveItem() {
 		work_package: f.workPackageId || null,
 		cost_head: f.costHead || null,
 		assembly: f.assemblyId || null,
+		quantity_source: f.assemblyId ? "Assembly" : "Manual",
 	};
 	try {
 		if (itemModal.value.mode === "add") {
-			await adapter.create("BOQ Item", {
+			const created = await adapter.create("BOQ Item", {
 				boq: boq.value.id,
 				boq_group: itemModal.value.groupId,
 				...payload,
 			});
+			itemModal.value = null;
+			// An Assembly-sourced line auto-explodes so its snapshot sub-items
+			// appear in the tree immediately (mirrors the prototype's save flow).
+			if (f.assemblyId && created?.name) {
+				try {
+					await boqApi.explodeItem(created.name);
+				} catch (e) {
+					showToast(
+						parseFrappeError(e).summary ?? "Item saved, but explode failed",
+						"error"
+					);
+				}
+			}
+			reloadTree();
 		} else {
 			await adapter.update("BOQ Item", itemModal.value.id, payload);
+			itemModal.value = null;
+			reloadTree();
 		}
-		itemModal.value = null;
-		reloadTree();
 	} catch (err) {
 		showToast(parseFrappeError(err).summary ?? "Failed to save item", "error");
 	}
@@ -1529,6 +1547,20 @@ const breadcrumbs = computed(() => {
 						</button>
 					</div>
 					<div class="p-4 space-y-3">
+						<DeskField
+							label="Source — Assembly"
+							hint="Pick an Assembly to auto-fill unit / rate and explode into snapshot sub-items on save. Leave blank for a manual line."
+						>
+							<DeskLinkPicker
+								v-model="itemForm.assemblyId"
+								doctype="Assembly"
+								label-field="assembly_name"
+								value-field="name"
+								:search-fields="['assembly_code', 'assembly_name', 'name']"
+								placeholder="— Manual line —"
+								@change="onAssemblyPicked"
+							/>
+						</DeskField>
 						<div class="grid grid-cols-3 gap-3">
 							<DeskField label="Code" required hint="e.g. A.05, B.12">
 								<DeskInput v-model="itemForm.code" />
@@ -1557,7 +1589,10 @@ const breadcrumbs = computed(() => {
 							<DeskField label="Planned qty">
 								<DeskInput v-model="itemForm.plannedQty" type="number" />
 							</DeskField>
-							<DeskField label="Rate (₹)">
+							<DeskField
+								label="Rate (₹)"
+								:hint="itemForm.assemblyId ? 'Auto from Assembly' : ''"
+							>
 								<DeskInput v-model="itemForm.rate" type="number" />
 							</DeskField>
 							<DeskField label="Planned amount" hint="qty × rate (auto)">
@@ -1566,31 +1601,27 @@ const breadcrumbs = computed(() => {
 								</div>
 							</DeskField>
 						</div>
-						<DeskField
-							label="Link to task"
-							hint="Optional · drives live actuals from task progress"
-						>
-							<DeskSelect v-model="itemForm.taskId">
-								<option :value="null">— Not linked —</option>
-								<option v-for="t in availableTasks" :key="t.id" :value="t.id">
-									{{ t.id.slice(-4) }} · {{ t.name }}
-								</option>
-							</DeskSelect>
-						</DeskField>
-						<div class="grid grid-cols-3 gap-3">
-							<DeskField label="Work Package" hint="Optional · per-WP rollup">
+						<div class="grid grid-cols-2 gap-3">
+							<DeskField
+								label="Work Package (tag)"
+								hint="Optional. Drives per-WP roll-up in the BOQ summary."
+							>
 								<DeskLinkPicker
 									v-model="itemForm.workPackageId"
 									doctype="Work Package"
 									label-field="work_package_name"
 									value-field="name"
 									:search-fields="['work_package_name', 'code', 'name']"
-									placeholder="— None —"
+									:filters="boqProjectId ? [['project', '=', boqProjectId]] : []"
+									placeholder="— Unscoped —"
 								/>
 							</DeskField>
-							<DeskField label="Cost head">
+							<DeskField
+								label="Cost head"
+								hint="Material / Labour / Equipment / Subcontract / Preliminaries / Other"
+							>
 								<DeskSelect v-model="itemForm.costHead">
-									<option value="">— None —</option>
+									<option value="">—</option>
 									<option>Material</option>
 									<option>Labour</option>
 									<option>Equipment</option>
@@ -1599,17 +1630,21 @@ const breadcrumbs = computed(() => {
 									<option>Other</option>
 								</DeskSelect>
 							</DeskField>
-							<DeskField label="Assembly" hint="Then ‘Explode’ on the row">
-								<DeskLinkPicker
-									v-model="itemForm.assemblyId"
-									doctype="Assembly"
-									label-field="assembly_name"
-									value-field="name"
-									:search-fields="['assembly_code', 'assembly_name', 'name']"
-									placeholder="— None —"
-								/>
-							</DeskField>
 						</div>
+						<DeskField
+							label="Link to task"
+							hint="Optional · drives live actuals from task progress"
+						>
+							<DeskLinkPicker
+								v-model="itemForm.taskId"
+								doctype="Task"
+								label-field="subject"
+								value-field="name"
+								:search-fields="['subject', 'name']"
+								:filters="boqProjectId ? [['project', '=', boqProjectId]] : []"
+								placeholder="— Not linked —"
+							/>
+						</DeskField>
 					</div>
 					<div
 						class="px-4 py-2 border-t border-ink-200 flex items-center justify-end gap-2"

--- a/frontend/src/views/BoqView.vue
+++ b/frontend/src/views/BoqView.vue
@@ -34,7 +34,10 @@ const creating = ref(false);
 const projectsRes = useDocTypeList("Project", {
 	fields: ["name", "project_name", "custom_project_id", "parent_project"],
 	orderBy: "project_name asc",
-	pageLength: 0,
+	// Fetch all projects so every BOQ row resolves its project name + code (a
+	// `pageLength: 0` is treated as the default page of 20, which left rows
+	// falling back to the raw project id). Explicit high cap = "effectively all".
+	pageLength: 5000,
 	cache: "buildsuite-boq-projects",
 });
 const projectsMap = computed(() => {
@@ -44,11 +47,6 @@ const projectsMap = computed(() => {
 	}
 	return map;
 });
-const rootProjects = computed(() =>
-	(projectsRes.data || [])
-		.filter((p) => !p.parent_project)
-		.map((p) => ({ id: p.name, name: p.project_name || p.name }))
-);
 function projectName(id) {
 	return projectsMap.value[id]?.name || id;
 }
@@ -65,7 +63,9 @@ const boqRes = useDocTypeList("BOQ", {
 		"prepared_date",
 	],
 	orderBy: "creation desc",
-	pageLength: 0,
+	// Show every BOQ (client-side search/filter over the fetched rows); a
+	// `pageLength: 0` capped the list at 20. Explicit high cap = "effectively all".
+	pageLength: 5000,
 	cache: "buildsuite-boq-list",
 	transform: (data) =>
 		data.map((b) => {
@@ -126,6 +126,11 @@ const kpis = computed(() => {
 function variancePill(pct) {
 	if (Math.abs(pct) < 0.5) return "text-ink-500";
 	return pct > 0 ? "text-danger-700" : "text-success-700";
+}
+
+// Backend stores "Superseded"; the prototype renames it to "Replaced" for display.
+function statusLabel(s) {
+	return s === "Superseded" ? "Replaced" : s;
 }
 
 function openNew() {
@@ -238,12 +243,16 @@ const subtitle = computed(
 			@row-click="onRowClick"
 		>
 			<template #filter-chips>
-				<DeskSelect v-if="!projectFilter" v-model="projectFilter" class="!w-48">
-					<option value="">Project: Any</option>
-					<option v-for="p in rootProjects" :key="p.id" :value="p.id">
-						{{ p.name }}
-					</option>
-				</DeskSelect>
+				<div v-if="!projectFilter" class="w-48">
+					<DeskLinkPicker
+						v-model="projectFilter"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						:search-fields="['project_name', 'custom_project_id', 'name']"
+						placeholder="Project: Any"
+					/>
+				</div>
 				<DeskFilterChip
 					v-else
 					label="Project"
@@ -256,12 +265,12 @@ const subtitle = computed(
 					<option>Draft</option>
 					<option>Submitted</option>
 					<option>Approved</option>
-					<option>Superseded</option>
+					<option value="Superseded">Replaced</option>
 				</DeskSelect>
 				<DeskFilterChip
 					v-else
 					label="Status"
-					:value="statusFilter"
+					:value="statusLabel(statusFilter)"
 					@remove="statusFilter = ''"
 				/>
 			</template>


### PR DESCRIPTION
## Summary
Fixes the BOQ Estimation screens to match the prototype and adds server-side integrity on BOQ item links.

### BOQ list
- Resolve each row's **project name + code** (the list was showing the raw project id because the projects/BOQs fetch was capped at 20).
- Show **all** BOQs, and use a **searchable** project filter (DeskLinkPicker).
- Display the BOQ **"Superseded"** status as **"Replaced"** (render-time alias; backend value unchanged).

### BOQ item dialog
- Lead with a **"Source — Assembly"** picker that auto-fills unit/rate/description and **auto-explodes** the line into snapshot sub-items on save.
- Scope the **Work Package** and **Task** pickers to the **BOQ's project**; Task is now a searchable DeskLinkPicker.

### Backend
- Reject a **BOQ Item whose Task or Work Package belongs to another project** (authoritative `validate`), with a test.
- Cross-project **clone** now nulls out source Work Packages so it stays valid under the new rule.

### Tooling
- Add a dev-only **estimation demo seed** script (users → project → rate master → assemblies → template → BOQ).

Backend tests: BOQ suite green (9/9).