### PR TITLE
feat: add procurement dashboard

### DIFF
--- a/buildsuite_core/api/procurement.py
+++ b/buildsuite_core/api/procurement.py
@@ -1,0 +1,181 @@
+import frappe
+from frappe.query_builder.functions import Count, Sum
+from frappe.utils import add_days, date_diff, flt, nowdate
+
+RM_THRESHOLD_PCT = 5  # keep in sync with public/js/purchase_order.js
+
+
+@frappe.whitelist()
+def get_dashboard() -> dict:
+	"""KPI figures for the Procurement dashboard (get_list applies user perms)."""
+	return {
+		"open_material_requests": _open_material_requests(),
+		"on_order": _on_order(),
+		"received_this_week": _received_this_week(),
+		"above_estimated_rate": _above_estimated_rate(),
+		"needs_action": _needs_action(),
+		"recent_receipts": _recent_receipts(),
+	}
+
+
+def _open_material_requests() -> dict:
+	"""Submitted MRs not fully ordered; value = the still-to-order portion."""
+	names = frappe.get_list(
+		"Material Request",
+		filters={"docstatus": 1, "material_request_type": "Purchase", "per_ordered": ["<", 100]},
+		pluck="name",
+	)
+	return {"count": len(names), "value": _pending_order_value(names)}
+
+
+def _pending_order_value(mr_names: list[str]) -> float:
+	"""Sum of (qty - ordered_qty) * rate over the given MRs' items."""
+	if not mr_names:
+		return 0.0
+	mri = frappe.qb.DocType("Material Request Item")
+	total = (
+		frappe.qb.from_(mri)
+		.select(Sum((mri.qty - mri.ordered_qty) * mri.rate))
+		.where(mri.parent.isin(mr_names))
+	).run()
+	return flt(total[0][0]) if total else 0.0
+
+
+def _on_order() -> dict:
+	"""Submitted POs awaiting delivery (per_received < 100): count + full value."""
+	row = frappe.get_list(
+		"Purchase Order",
+		filters={"docstatus": 1, "per_received": ["<", 100]},
+		fields=[{"COUNT": "name", "as": "count"}, {"SUM": "grand_total", "as": "value"}],
+	)[0]
+	return {"count": row.count or 0, "value": flt(row.value)}
+
+
+def _received_this_week() -> dict:
+	"""Purchase Receipts posted in the last 7 days."""
+	row = frappe.get_list(
+		"Purchase Receipt",
+		filters={"docstatus": 1, "posting_date": [">=", add_days(nowdate(), -7)]},
+		fields=[{"COUNT": "name", "as": "count"}],
+	)[0]
+	return {"count": row.count or 0}
+
+
+def _above_estimated_rate() -> dict:
+	"""Count PO lines priced > RM_THRESHOLD_PCT above their Rate Master rate."""
+	po_names = frappe.get_list("Purchase Order", filters={"docstatus": 1}, pluck="name")
+	return {"count": _over_rate_line_count(po_names)}
+
+
+def _over_rate_line_count(po_names: list[str]) -> int:
+	"""Count lines (within the given POs) priced above the Rate Master rate."""
+	if not po_names:
+		return 0
+	poi = frappe.qb.DocType("Purchase Order Item")
+	limit = 1 + RM_THRESHOLD_PCT / 100
+	return (
+		frappe.qb.from_(poi)
+		.select(Count(poi.name))
+		.where(poi.parent.isin(po_names))
+		.where(poi.custom_rate_master != "")
+		.where(poi.custom_rate_master_rate > 0)
+		.where(poi.rate > poi.custom_rate_master_rate * limit)
+	).run()[0][0]
+
+
+def _needs_action() -> dict:
+	"""The four procurement to-do signals."""
+	return {
+		"approved_to_order": _approved_to_order(),
+		"deliveries_overdue": _deliveries_overdue(),
+		"partial_deliveries": _partial_deliveries(),
+		"received_not_billed": _received_not_billed(),
+	}
+
+
+def _approved_to_order() -> dict:
+	"""Submitted MRs not fully ordered, plus the oldest wait in days."""
+	rows = frappe.get_list(
+		"Material Request",
+		filters={"docstatus": 1, "material_request_type": "Purchase", "per_ordered": ["<", 100]},
+		fields=["transaction_date"],
+		order_by="transaction_date asc",
+	)
+	oldest_days = date_diff(nowdate(), rows[0].transaction_date) if rows else 0
+	return {"count": len(rows), "oldest_days": oldest_days}
+
+
+def _deliveries_overdue() -> dict:
+	"""Submitted POs past schedule_date and not fully received."""
+	pos = frappe.get_list(
+		"Purchase Order",
+		filters={"docstatus": 1, "per_received": ["<", 100], "schedule_date": ["<", nowdate()]},
+		fields=["name", "supplier", "schedule_date"],
+		order_by="schedule_date asc",
+	)
+	return {"count": len(pos), "first": _overdue_first(pos[0]) if pos else None}
+
+
+def _overdue_first(po: dict) -> dict:
+	"""First line item (idx 1) of an overdue PO, for the sub-line."""
+	item = frappe.db.get_value("Purchase Order Item", {"parent": po["name"], "idx": 1}, "item_name")
+	return {
+		"item": item,
+		"supplier": po["supplier"],
+		"required_by": po["schedule_date"],
+	}
+
+
+def _partial_deliveries() -> dict:
+	"""Submitted POs between 1% and 99% received."""
+	row = frappe.get_list(
+		"Purchase Order",
+		filters=[["docstatus", "=", 1], ["per_received", ">", 0], ["per_received", "<", 100]],
+		fields=[{"COUNT": "name", "as": "count"}],
+	)[0]
+	return {"count": row.count or 0}
+
+
+def _received_not_billed() -> dict:
+	"""Submitted Purchase Receipts not yet fully billed."""
+	row = frappe.get_list(
+		"Purchase Receipt",
+		filters={"docstatus": 1, "per_billed": ["<", 100]},
+		fields=[{"COUNT": "name", "as": "count"}],
+	)[0]
+	return {"count": row.count or 0}
+
+
+def _recent_receipts() -> list[dict]:
+	"""The 5 latest submitted Purchase Receipts, with items and a status."""
+	prs = frappe.get_list(
+		"Purchase Receipt",
+		filters={"docstatus": 1},
+		fields=["name", "supplier", "project", "posting_date"],
+		order_by="posting_date desc, creation desc",
+		limit=5,
+	)
+	for pr in prs:
+		_attach_items(pr)
+	return prs
+
+
+def _attach_items(pr: dict) -> None:
+	"""Attach the receipt's items, item_count and a Short/Full status."""
+	items = frappe.get_all(
+		"Purchase Receipt Item",
+		filters={"parent": pr["name"], "parenttype": "Purchase Receipt"},
+		fields=["item_name", "received_qty", "rejected_qty", "uom"],
+	)
+	pr["items"] = [{"item": i.item_name, "qty": i.received_qty, "uom": i.uom} for i in items]
+	pr["item_count"] = len(items)
+	pr["status"] = _receipt_status(items)
+
+
+def _receipt_status(items: list[dict]) -> str:
+	"""Full (clean) / Partial (some rejected) / Short (all rejected)."""
+	received = sum(flt(i.received_qty) for i in items)
+	rejected = sum(flt(i.rejected_qty) for i in items)
+	if rejected <= 0:
+		return "Full"
+	return "Short" if rejected >= received else "Partial"

--- a/frontend/src/data/procurementApi.js
+++ b/frontend/src/data/procurementApi.js
@@ -1,0 +1,14 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+async function call(method) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.procurement.${method}`,
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const getProcurementDashboard = () => call("get_dashboard");

--- a/frontend/src/views/workspaces/ProcurementDashboardView.vue
+++ b/frontend/src/views/workspaces/ProcurementDashboardView.vue
@@ -1,10 +1,113 @@
 <script setup>
-import { computed } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { RouterLink } from "vue-router";
+import { fmtCompactINR, fmtDate } from "@/utils/format";
+import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
+import { getProcurementDashboard } from "@/data/procurementApi";
 
 const today = computed(() =>
 	new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
 );
+
+const loading = ref(true);
+const error = ref("");
+const kpis = ref(null);
+
+onMounted(loadDashboard);
+
+async function loadDashboard() {
+	loading.value = true;
+	error.value = "";
+	try {
+		kpis.value = await getProcurementDashboard();
+	} catch (e) {
+		error.value = e.message || "Could not load the dashboard.";
+	} finally {
+		loading.value = false;
+	}
+}
+
+function plural(n) {
+	return n === 1 ? "" : "s";
+}
+
+// Needs-action rows, composed from the API's needs_action block.
+const actionRows = computed(() => {
+	const na = kpis.value?.needs_action;
+	if (!na) return [];
+	const overdue = na.deliveries_overdue;
+	let overdueSub = "—";
+	if (overdue.count && overdue.first) {
+		const f = overdue.first;
+		overdueSub = `${f.item || "material"} from ${f.supplier} · req. ${fmtDate(f.required_by)}`;
+	}
+	return [
+		{
+			key: "approved",
+			tone: "info",
+			icon: "check-circle",
+			label: "Approved requests to order",
+			sub: na.approved_to_order.count
+				? `Oldest waiting ${na.approved_to_order.oldest_days} day${plural(
+						na.approved_to_order.oldest_days
+				  )}`
+				: "All caught up",
+			count: na.approved_to_order.count,
+		},
+		{
+			key: "overdue",
+			tone: "danger",
+			icon: "refresh-ccw",
+			label: "Deliveries overdue",
+			sub: overdueSub,
+			count: overdue.count,
+		},
+		{
+			key: "partial",
+			tone: "warning",
+			icon: "chart-bar",
+			label: "Partial deliveries",
+			sub: na.partial_deliveries.count
+				? `${na.partial_deliveries.count} PO${plural(
+						na.partial_deliveries.count
+				  )} between 1–99% received`
+				: "No partial deliveries pending",
+			count: na.partial_deliveries.count,
+		},
+		{
+			key: "unbilled",
+			tone: "ink",
+			icon: "file-text",
+			label: "Received, not billed",
+			sub: na.received_not_billed.count
+				? `${na.received_not_billed.count} GRN${plural(
+						na.received_not_billed.count
+				  )} awaiting supplier invoice`
+				: "All receipts billed",
+			count: na.received_not_billed.count,
+		},
+	];
+});
+
+function toneClasses(tone) {
+	switch (tone) {
+		case "danger":
+			return { chip: "bg-danger-50 text-danger-700", count: "text-danger-700" };
+		case "warning":
+			return { chip: "bg-warning-50 text-warning-700", count: "text-warning-700" };
+		case "info":
+			return { chip: "bg-info-50 text-info-700", count: "text-info-700" };
+		default:
+			return { chip: "bg-ink-100 text-ink-700", count: "text-ink-700" };
+	}
+}
+
+function grnTone(status) {
+	if (status === "Full") return "bg-success-50 text-success-700";
+	if (status === "Partial") return "bg-warning-50 text-warning-700";
+	if (status === "Short") return "bg-danger-50 text-danger-700";
+	return "bg-ink-100 text-ink-700";
+}
 </script>
 
 <template>
@@ -27,6 +130,218 @@ const today = computed(() =>
 					glance.
 				</p>
 			</div>
+
+			<!-- Loading / error states -->
+			<div v-if="loading" class="text-sm text-ink-500 py-8">Loading…</div>
+			<div v-else-if="error" class="text-sm text-danger-700 py-8">{{ error }}</div>
+
+			<template v-else-if="kpis">
+				<!-- ===== KPI strip ===== -->
+				<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+					<!-- 1 — Open material requests -->
+					<div class="card p-4 bg-white border border-ink-200">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+							Open material requests
+						</div>
+						<div class="flex items-baseline gap-2 mt-1.5">
+							<div class="text-2xl font-semibold text-ink-900 tabular-nums">
+								{{ kpis.open_material_requests.count }}
+							</div>
+							<div class="text-xs text-ink-500 tabular-nums">
+								{{ fmtCompactINR(kpis.open_material_requests.value) }}
+							</div>
+						</div>
+						<div class="text-[10px] text-ink-400 mt-1">
+							Pending + Approved + Partially Ordered
+						</div>
+					</div>
+
+					<!-- 2 — On order · awaiting delivery -->
+					<div class="card p-4 bg-white border border-ink-200">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+							On order · awaiting delivery
+						</div>
+						<div class="flex items-baseline gap-2 mt-1.5">
+							<div class="text-2xl font-semibold text-ink-900 tabular-nums">
+								{{ kpis.on_order.count }}
+							</div>
+							<div class="text-xs text-ink-500 tabular-nums">
+								{{ fmtCompactINR(kpis.on_order.value) }}
+							</div>
+						</div>
+						<div class="text-[10px] text-ink-400 mt-1">POs not yet fully received</div>
+					</div>
+
+					<!-- 3 — Received this week -->
+					<div class="card p-4 bg-white border border-ink-200">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+							Received this week
+						</div>
+						<div class="text-2xl font-semibold text-success-700 tabular-nums mt-1.5">
+							{{ kpis.received_this_week.count }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-1">
+							Goods receipts in last 7 days
+						</div>
+					</div>
+
+					<!-- 4 — Above estimated rate -->
+					<div class="card p-4 bg-white border border-ink-200">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+							Above estimated rate
+						</div>
+						<div
+							class="text-2xl font-semibold tabular-nums mt-1.5"
+							:class="
+								kpis.above_estimated_rate.count > 0
+									? 'text-warning-700'
+									: 'text-ink-900'
+							"
+						>
+							{{ kpis.above_estimated_rate.count }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-1">
+							PO line items priced above Rate Master
+						</div>
+					</div>
+				</div>
+
+				<!-- ===== Needs action + Recent receipts band ===== -->
+				<div class="grid grid-cols-1 lg:grid-cols-[1.35fr_1fr] gap-4 mb-6">
+					<!-- Left — Needs action -->
+					<div
+						class="card p-0 bg-white border border-ink-200 overflow-hidden rounded-xl"
+					>
+						<div
+							class="px-4 py-3 border-b border-ink-100 flex items-center gap-2 bg-gradient-to-r from-success-50 to-white"
+						>
+							<svg
+								class="w-4 h-4 text-success-700"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.75"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-hidden="true"
+								v-html="getWorkspaceIconPath('check-circle')"
+							/>
+							<h2 class="text-sm font-semibold text-ink-900">Needs action</h2>
+							<span class="ml-auto text-[11px] text-ink-500">Today</span>
+						</div>
+						<ul class="divide-y divide-ink-100">
+							<li
+								v-for="row in actionRows"
+								:key="row.key"
+								class="px-4 py-3 flex items-center gap-3"
+							>
+								<span
+									:class="[
+										'w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0',
+										toneClasses(row.tone).chip,
+									]"
+								>
+									<svg
+										class="w-4 h-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.75"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										aria-hidden="true"
+										v-html="getWorkspaceIconPath(row.icon)"
+									/>
+								</span>
+								<div class="flex-1 min-w-0">
+									<div class="text-sm font-medium text-ink-900 truncate">
+										{{ row.label }}
+									</div>
+									<div class="text-[11px] text-ink-500 truncate mt-0.5">
+										{{ row.sub }}
+									</div>
+								</div>
+								<span
+									:class="[
+										'text-base font-semibold tabular-nums flex-shrink-0',
+										toneClasses(row.tone).count,
+									]"
+									>{{ row.count }}</span
+								>
+								<span class="text-ink-300">›</span>
+							</li>
+						</ul>
+					</div>
+
+					<!-- Right — Recent site receipts -->
+					<div
+						class="card p-0 bg-white border border-ink-200 overflow-hidden rounded-xl"
+					>
+						<div class="px-4 py-3 border-b border-ink-100 flex items-center gap-2">
+							<svg
+								class="w-4 h-4 text-ink-500"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.75"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								aria-hidden="true"
+								v-html="getWorkspaceIconPath('paperclip')"
+							/>
+							<h2 class="text-sm font-semibold text-ink-900">
+								Recent site receipts
+							</h2>
+							<a
+								href="/app/purchase-receipt"
+								class="ml-auto text-xs text-brand-700 hover:underline"
+								>View all →</a
+							>
+						</div>
+						<ul v-if="kpis.recent_receipts.length" class="divide-y divide-ink-100">
+							<li
+								v-for="grn in kpis.recent_receipts"
+								:key="grn.name"
+								class="px-4 py-3 flex items-center gap-3"
+							>
+								<div class="flex-1 min-w-0">
+									<div
+										class="text-sm font-medium flex items-center gap-1.5 min-w-0"
+									>
+										<span class="text-ink-900 truncate">
+											{{ grn.items[0]?.item || "—" }}
+											<span class="text-ink-500 font-normal">·</span>
+											<span class="text-ink-500 font-normal tabular-nums"
+												>{{ grn.items[0]?.qty }}
+												{{ grn.items[0]?.uom }}</span
+											>
+										</span>
+										<span
+											v-if="grn.item_count > 1"
+											class="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-ink-100 text-ink-700 whitespace-nowrap"
+											>+{{ grn.item_count - 1 }} more</span
+										>
+									</div>
+									<div class="text-[11px] text-ink-500 mt-0.5 truncate">
+										{{ grn.project }} · {{ grn.supplier }} ·
+										{{ fmtDate(grn.posting_date) }} · {{ grn.name }}
+									</div>
+								</div>
+								<span
+									:class="[
+										'text-[10px] px-2 py-0.5 rounded-full font-medium flex-shrink-0',
+										grnTone(grn.status),
+									]"
+									>{{ grn.status }}</span
+								>
+							</li>
+						</ul>
+						<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
+							No goods receipts recorded yet.
+						</div>
+					</div>
+				</div>
+			</template>
 		</div>
 	</div>
 </template>

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -13,7 +13,11 @@ const shortcuts = [
 	{ label: "Material Requests", icon: "clipboard-list", href: "/app/material-request" },
 	{ label: "Purchase Orders", icon: "file-text", href: "/app/purchase-order" },
 	{ label: "Purchase Receipts", icon: "check-circle", href: "/app/purchase-receipt" },
-	{ label: "Material Consumption", icon: "stock", prevent: true },
+	{
+		label: "Material Consumption",
+		icon: "stock",
+		href: "/app/stock-entry?stock_entry_type=Material Consumption for Manufacture",
+	},
 	{ label: "Suppliers", icon: "building-2", href: "/app/supplier" },
 	{ label: "Items & Rates", icon: "tag", to: "/rate-master" },
 ];


### PR DESCRIPTION
PR description
Adds the Procurement Dashboard (frappe-ui Vue) backed by one permission-aware API (get_dashboard).

- KPI cards: Open Material Requests, On order, Received this week, Above estimated rate
- Needs action: approved-to-order, overdue, partial, received-not-billed
- Recent site receipts: latest 5 GRNs with Full/Partial/Short status
- Material Consumption link a filtered Stock Entry list
