### PR TITLE
Progress-entry guards, project-scoped TPE form, and warehouse cleanup

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/task_progress_entry/task_progress_entry.py
+++ b/buildsuite_core/buildsuite_core/doctype/task_progress_entry/task_progress_entry.py
@@ -84,6 +84,7 @@ class TaskProgressEntry(Document):
 	def validate(self):
 		# A task can't log progress while a Finish-to-Start predecessor is still open.
 		self._block_if_predecessor_incomplete()
+		self._reject_if_task_completed()
 
 		# Blocker flag requires a note. Server-side so the rule holds on both the
 		# File-Progress-Entry dialog and the TPE edit screen (the dialog enforces it
@@ -104,6 +105,20 @@ class TaskProgressEntry(Document):
 					"You can't log progress on this task yet — its Finish-to-Start "
 					'predecessor "{0}" isn\'t Completed.'
 				).format(pred)
+			)
+
+	def _reject_if_task_completed(self):
+		# A completed task takes no further progress entries. Guards NEW entries only
+		# (editing the entry that completed the task must still be allowed). Enforced
+		# in the controller so it holds from the form, the TPE list, and the API alike.
+		if not self.is_new():
+			return
+		task = frappe.db.get_value("Task", self.task, ["task_status", "progress"], as_dict=True)
+		if task and (task.task_status == "Completed" or flt(task.progress) >= 100):
+			frappe.throw(
+				_("Task {0} is already Completed — no further progress entries can be added.").format(
+					self.task
+				)
 			)
 
 	# Fields a user can change on a progress entry; if none differ from the stored

--- a/buildsuite_core/buildsuite_core/doctype/task_progress_entry/test_task_progress_entry.py
+++ b/buildsuite_core/buildsuite_core/doctype/task_progress_entry/test_task_progress_entry.py
@@ -85,6 +85,19 @@ class TestTaskProgressEntry(BuildSuiteTestCase):
 		self.assertEqual(t.progress, 100)
 		self.assertEqual(t.task_status, "Completed")
 
+	def test_completed_task_rejects_new_entry(self):
+		# A completed task takes no further progress entries — enforced in the
+		# controller so it holds from the form, the TPE list, and the API alike.
+		p = self._make_project(company=self.company)
+		t = self._make_task(p.name)
+		self._file_tpe(t.name, 100)
+		t.reload()
+		self.assertEqual(t.task_status, "Completed")
+		before = frappe.db.count("Task Progress Entry", {"task": t.name})
+		with self.assertRaises(frappe.ValidationError):
+			self._file_tpe(t.name, 100)
+		self.assertEqual(frappe.db.count("Task Progress Entry", {"task": t.name}), before)
+
 	def test_delete_latest_tpe_reverts_to_previous(self):
 		# TPE-009
 		p = self._make_project(company=self.company)

--- a/buildsuite_core/tests/test_project.py
+++ b/buildsuite_core/tests/test_project.py
@@ -169,6 +169,24 @@ class TestProject(BuildSuiteTestCase):
 		self.assertFalse(frappe.db.exists("Work Package", wp.name))
 		self.assertFalse(frappe.db.exists("Stage Planning", stage.name))
 
+	def test_delete_removes_project_warehouses(self):
+		# The delete cascade must not leave orphan warehouses: both the "<project>
+		# Store" leaf and its "<project>" group parent are removed; the shared
+		# company-level "Projects" group survives.
+		p = self._make_project(company=self.company)
+		store = {"warehouse_name": f"{p.project_name} Store", "company": self.company}
+		group = {"warehouse_name": p.project_name, "company": self.company, "is_group": 1}
+		self.assertTrue(frappe.db.exists("Warehouse", store))
+		self.assertTrue(frappe.db.exists("Warehouse", group))
+
+		frappe.delete_doc("Project", p.name, ignore_permissions=True)
+
+		self.assertFalse(frappe.db.exists("Warehouse", store))
+		self.assertFalse(frappe.db.exists("Warehouse", group))
+		self.assertTrue(
+			frappe.db.exists("Warehouse", {"warehouse_name": "Projects", "company": self.company})
+		)
+
 	# --- team membership (custom_team_members) --------------------------
 	def test_project_team_add_and_remove(self):
 		from buildsuite_core.api.project_team import (

--- a/buildsuite_core/utils/project.py
+++ b/buildsuite_core/utils/project.py
@@ -385,11 +385,22 @@ def create_warehouse_for_project(doc: Document, method: str | None = None):
 
 @frappe.whitelist()
 def delete_warehouse_for_project(doc: Document, method: str | None = None):
-	project_warehouse = f"{doc.project_name} Store"
-
-	warehouse_name = frappe.db.get_value(
-		"Warehouse", {"warehouse_name": project_warehouse, "company": doc.company}, "name"
+	"""Remove the per-project warehouses created in create_warehouse_for_project so a
+	project delete leaves no orphans: the "<project> Store" leaf first, then its
+	"<project>" group parent once empty. The shared company-level "Projects" group is
+	left intact — other projects hang off it."""
+	store = frappe.db.get_value(
+		"Warehouse", {"warehouse_name": f"{doc.project_name} Store", "company": doc.company}, "name"
 	)
+	if store:
+		frappe.delete_doc("Warehouse", store, ignore_permissions=True, force=True)
 
-	if warehouse_name:
-		frappe.delete_doc("Warehouse", warehouse_name, ignore_permissions=True)
+	# The per-project group warehouse (parent of the Store) was previously left
+	# orphaned. Remove it too, but only once it has no remaining child warehouses.
+	group = frappe.db.get_value(
+		"Warehouse",
+		{"warehouse_name": doc.project_name, "company": doc.company, "is_group": 1},
+		"name",
+	)
+	if group and not frappe.db.count("Warehouse", {"parent_warehouse": group}):
+		frappe.delete_doc("Warehouse", group, ignore_permissions=True, force=True)

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -76,17 +76,36 @@ const boq = computed(() => {
 
 usePageTitle(() => boq.value?.id);
 
-const projectsRes = useDocTypeList("Project", {
-	fields: ["name", "project_name", "custom_project_id"],
-	pageLength: 0,
-	cache: "buildsuite-boq-projects",
-});
-const project = computed(() => {
-	const pid = boq.value?.projectId;
-	if (!pid) return null;
-	const p = (projectsRes.data || []).find((x) => x.name === pid);
-	return p ? { id: p.name, name: p.project_name || p.name } : { id: pid, name: pid };
-});
+// Resolve just this BOQ's project (its name feeds the breadcrumb) with a single
+// document read — not a scan over a capped project list, which left the raw
+// project id (e.g. "PROJ-0260") in the breadcrumb. Mirrors TaskDetailView.
+const projectResource = ref(null);
+function loadProjectResource(projectId) {
+	if (!projectId) {
+		projectResource.value = null;
+		return;
+	}
+	projectResource.value = adapter.read("Project", projectId, {
+		fields: ["name", "project_name"],
+		transform(rows) {
+			return rows.map((row) => ({
+				id: row?.name || "",
+				name: row?.project_name || row?.name || "",
+			}));
+		},
+	});
+}
+watch(() => boq.value?.projectId, loadProjectResource, { immediate: true });
+const project = computed(() => firstResourceRow(projectResource.value));
+
+function firstResourceRow(resource) {
+	if (resource?.doc) return resource.doc;
+	const raw = resource?.data;
+	if (Array.isArray(raw)) return raw[0] || null;
+	if (Array.isArray(raw?.value)) return raw.value[0] || null;
+	if (raw && typeof raw === "object" && "value" in raw) return raw.value || null;
+	return raw || null;
+}
 
 // Sibling revisions (for baseBoq label) + base-revision items (for compare mode).
 const projectBoqsRes = useDocTypeList("BOQ", {
@@ -763,6 +782,12 @@ function primaryAction() {
 	else if (canApprove.value) approve();
 }
 
+// The BOQ id + revision live in the subtitle (as in the prototype), so the
+// breadcrumb trail ends at the project — not a raw BOQ-id crumb.
+const subtitle = computed(() =>
+	boq.value ? `${boq.value.id} · R${boq.value.revision}` : ""
+);
+
 const breadcrumbs = computed(() => {
 	const out = [
 		{ label: "BuildSuite Core", to: "/" },
@@ -770,7 +795,6 @@ const breadcrumbs = computed(() => {
 	];
 	if (project.value)
 		out.push({ label: project.value.name, to: `/projects/${project.value.id}` });
-	out.push({ label: boq.value?.id || props.id });
 	return out;
 });
 </script>

--- a/frontend/src/views/NewTaskProgressEntryView.vue
+++ b/frontend/src/views/NewTaskProgressEntryView.vue
@@ -3,6 +3,7 @@ import { reactive, ref, computed, watch } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import { useDataStore } from "@/stores";
 import { createDataAdapter } from "@/data/adapters";
+import { useDocTypeList } from "@/composables/useDocTypeList";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { usePermissions } from "@/composables/usePermissions";
@@ -25,6 +26,7 @@ const adapter = createDataAdapter(store);
 const cameFromTaskId = route.query.taskId || null;
 
 const form = reactive({
+	projectId: "",
 	taskId: cameFromTaskId || "",
 	entryDate: new Date().toISOString().slice(0, 10),
 	progressPct: 0,
@@ -43,6 +45,40 @@ const { errors, applyServerErrors, setErrors, clearError } = useFormErrors({
 });
 const saving = ref(false);
 
+// Project → its whole sub-tree (self + every nested sub-project). The Task picker
+// below is scoped with a `project in [...]` filter, so you can only pick a task
+// that belongs to the chosen project or one of its sub-projects.
+const allProjectsRes = useDocTypeList("Project", {
+	fields: ["name", "parent_project"],
+	pageLength: 5000,
+	cache: "buildsuite-tpe-project-tree",
+});
+const projectScope = computed(() => {
+	const pid = form.projectId;
+	if (!pid) return [];
+	const byParent = {};
+	for (const p of allProjectsRes.data || []) {
+		const parent = p.parent_project;
+		if (!byParent[parent]) byParent[parent] = [];
+		byParent[parent].push(p.name);
+	}
+	const out = [];
+	const stack = [pid];
+	while (stack.length) {
+		const cur = stack.pop();
+		out.push(cur);
+		for (const c of byParent[cur] || []) stack.push(c);
+	}
+	return out;
+});
+const taskFilters = computed(() =>
+	projectScope.value.length ? [["project", "in", projectScope.value]] : []
+);
+function onProjectChange() {
+	// A task from the previously-selected project no longer applies.
+	form.taskId = "";
+}
+
 // Load the selected task to show the info banner and pre-fill progress.
 const taskResource = ref(null);
 
@@ -53,13 +89,14 @@ function loadTaskResource(taskId) {
 	}
 	taskResource.value = adapter.read("Task", taskId, {
 		nameField: "name",
-		fields: ["name", "subject", "status", "progress"],
+		fields: ["name", "subject", "status", "progress", "project"],
 		transform(rows) {
 			return rows.map((row) => ({
 				id: row?.name || "",
 				name: row?.subject || row?.name || "",
 				status: row?.status || "",
 				progress: Number(row?.progress) || 0,
+				project: row?.project || "",
 			}));
 		},
 	});
@@ -89,8 +126,18 @@ const selectedTask = computed(() => {
 		name: row.subject || row.name || "",
 		status: row.status || "",
 		progress: Number(row.progress) || 0,
+		project: row.project || "",
 	};
 });
+
+// When arriving from a task (route ?taskId=), back-fill the Project picker from
+// that task so the picker + the task scope stay consistent.
+watch(
+	() => selectedTask.value?.project,
+	(proj) => {
+		if (proj && !form.projectId) form.projectId = proj;
+	}
+);
 
 // The task's current cumulative progress is the monotonic floor — a new entry
 // can never go below it.
@@ -144,7 +191,10 @@ function clampProgress() {
 
 function validate() {
 	const e = {};
+	if (!form.projectId) e.projectId = "Project is required";
 	if (!form.taskId) e.taskId = "Task is required";
+	else if (selectedTask.value && Number(selectedTask.value.progress) >= 100)
+		e.taskId = "This task is already Completed — no further progress entries can be added.";
 	const pct = Number(form.progressPct);
 	if (Number.isNaN(pct) || pct > 100) {
 		e.progressPct = "Progress must be between 0 and 100";
@@ -223,7 +273,19 @@ const breadcrumbs = [
 			</template>
 
 			<div class="max-w-3xl mx-auto">
-				<DeskSection title="Task &amp; date" :cols="2">
+				<DeskSection title="Project, task &amp; date" :cols="2">
+					<DeskField label="Project" required :error="errors.projectId">
+						<DeskLinkPicker
+							v-model="form.projectId"
+							doctype="Project"
+							label-field="project_name"
+							value-field="name"
+							:search-fields="['project_name', 'custom_project_id', 'name']"
+							:page-length="20"
+							placeholder="— Select project —"
+							@change="onProjectChange"
+						/>
+					</DeskField>
 					<DeskField label="Task" required :error="errors.taskId">
 						<DeskLinkPicker
 							v-model="form.taskId"
@@ -231,8 +293,10 @@ const breadcrumbs = [
 							label-field="subject"
 							value-field="name"
 							:search-fields="['subject', 'name']"
+							:filters="taskFilters"
+							:disabled="!form.projectId"
 							:page-length="20"
-							placeholder="— Select task —"
+							:placeholder="form.projectId ? '— Select task —' : '— Select a project first —'"
 						/>
 					</DeskField>
 					<DeskField label="Entry date">

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -795,7 +795,11 @@ usePageTitle(() => task.value?.name);
 							<h3 class="text-sm font-semibold text-ink-900">Progress</h3>
 						</div>
 						<button
-							v-if="canCreate('taskProgressEntry')"
+							v-if="
+								canCreate('taskProgressEntry') &&
+								task.progress < 100 &&
+								task.status !== 'Completed'
+							"
 							type="button"
 							data-test="file-progress-entry"
 							class="desk-save-btn text-xs"


### PR DESCRIPTION
## Summary
Three fixes plus a carried-over BOQ breadcrumb fix.

### Progress entries
- **Standalone New Progress Entry form** now has a **Project** picker (DeskLinkPicker); the **Task** picker is scoped to that project **and all its sub-projects** (`project in [...]`), so you can only pick tasks in the chosen project's tree. Arriving from a task back-fills the project automatically.
- **"+ File Progress Entry" is hidden on a completed task** (progress ≥ 100 or status Completed).
- **Backend guard**: a completed task rejects any new progress entry — enforced in the Task Progress Entry controller, so it holds from the form, the **TPE list**, and the API alike (+ test).

### Project delete cascade
- Removing a project left its **per-project group warehouse orphaned** (only the "<project> Store" leaf was deleted). Now the group parent is removed too, once empty; the shared company-level **"Projects"** group is preserved (+ test).

### BOQ detail (carried over)
- Breadcrumb showed the raw project id; now resolves the **project name** via a single `adapter.read("Project", …)` (mirrors TaskDetailView), ends the trail at the project, and restores the **subtitle** (`BOQ id · R{n}`).

Backend: Task Progress Entry (17) and Project (14) suites green, incl. the two new tests.