### PR TITLE
M2 access control: workspace visibility + DocType permission matrix

### DIFF
--- a/buildsuite_core/api/rate_master.py
+++ b/buildsuite_core/api/rate_master.py
@@ -10,6 +10,17 @@ def update_rates_from_po(purchase_order, updates, supplier=None):
 	if isinstance(updates, str):
 		updates = json.loads(updates)
 
+	# The PO-submit rate-update dialog is gated to governance roles + the empowered
+	# Procurement Officer (who is read-only on the Rate Master form). Enforced
+	# server-side so it holds independent of the UI (PERM-013).
+	from buildsuite_core.permissions.setup import RATE_UPDATE_GOVERNANCE_ROLES
+
+	if not set(frappe.get_roles()) & set(RATE_UPDATE_GOVERNANCE_ROLES):
+		frappe.throw(
+			_("You are not permitted to update Rate Master rates."),
+			frappe.PermissionError,
+		)
+
 	changed = []
 	for row in updates:
 		rate_master = row.get("rate_master")
@@ -18,17 +29,14 @@ def update_rates_from_po(purchase_order, updates, supplier=None):
 			continue
 
 		doc = frappe.get_doc("Construction Rate Master", rate_master)
-		if not frappe.has_permission("Construction Rate Master", "write", doc=doc):
-			frappe.throw(
-				_("Not permitted to update Rate Master {0}.").format(rate_master),
-				frappe.PermissionError,
-			)
 		if flt(doc.current_rate) == new_rate:
 			continue
 
 		doc.flags.rate_source = {"purchase_order": purchase_order, "supplier": supplier}
 		doc.current_rate = new_rate
-		doc.save()
+		# The governance gate above authorises the write; the Rate Master form perm
+		# (Procurement Officer = read-only) is deliberately bypassed for this path.
+		doc.save(ignore_permissions=True)
 		changed.append(rate_master)
 
 	return changed

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -75,21 +75,22 @@ TASK_ROLE_PERMS = {
 	"BuildSuite HR Manager": {"read": 1, "report": 1, "print": 1},
 }
 
-# BOQ (Bill of Quantities) — estimation is the Estimator's and QS's job, so they get
-# full CRUD alongside Director / PM / Administrator. Everyone else is read-only.
+# The estimation write roles: BuildSuite Administrator + Director + PM + Estimator +
+# QS. System Manager is omitted here — it keeps native full perms on custom doctypes.
+_ESTIMATION_ROLES = (
+	"BuildSuite Administrator",
+	"BuildSuite Director",
+	"BuildSuite PM",
+	"BuildSuite Estimator",
+	"BuildSuite QS",
+)
+
+# BOQ (Bill of Quantities) — full CRUD for the estimation roles; everyone else has
+# NO access (the Estimation workspace is hidden from them). M2 tightened this from
+# the earlier "read for Site Engineer / Foreman / Accountant / HR".
 _BOQ_FULL = {"read": 1, "write": 1, "create": 1, "delete": 1, "report": 1, "export": 1, "print": 1}
 _BOQ_READ = {"read": 1, "report": 1, "export": 1, "print": 1}
-BOQ_ROLE_PERMS = {
-	"BuildSuite Director": _BOQ_FULL,
-	"BuildSuite PM": _BOQ_FULL,
-	"BuildSuite Administrator": _BOQ_FULL,
-	"BuildSuite Estimator": _BOQ_FULL,
-	"BuildSuite QS": _BOQ_FULL,
-	"BuildSuite Site Engineer": _BOQ_READ,
-	"BuildSuite Foreman": _BOQ_READ,
-	"BuildSuite Accountant": _BOQ_READ,
-	"BuildSuite HR Manager": _BOQ_READ,
-}
+BOQ_ROLE_PERMS = {role: _BOQ_FULL for role in _ESTIMATION_ROLES}
 BOQ_DOCTYPES = ("BOQ", "BOQ Group", "BOQ Item", "BOQ Sub Item")
 
 # Only these roles may approve a BOQ (mirrors the prototype BOQ_APPROVE_ROLES). The
@@ -104,6 +105,97 @@ BOQ_APPROVE_ROLES = (
 # Masters the BOQ tree's link pickers resolve. Any BOQ-readable role needs read on
 # these or the pickers 403 (read-only mirror — never write).
 BOQ_LINKED_MASTER_DOCTYPES = ("UOM", "Construction Rate Master", "Assembly", "Estimate Template")
+
+# --- M2 estimation masters + Purchase & Stock matrices ----------------------
+# Permission-code shorthands (readme: C R W D S X — Create/Read/Write/Delete/Submit/
+# Cancel-Amend). CRWDSX = full on a submittable doctype; CRWD = full non-submittable.
+_READ = {"read": 1, "report": 1, "export": 1, "print": 1}  # R
+_FULL = {"read": 1, "write": 1, "create": 1, "delete": 1, "report": 1, "export": 1, "print": 1}  # CRWD
+_FULL_SUB = {**_FULL, "submit": 1, "cancel": 1, "amend": 1}  # CRWDSX
+_RAISE = {"read": 1, "create": 1, "print": 1}  # CR — raise own records only
+_CRWS = {"read": 1, "write": 1, "create": 1, "submit": 1, "report": 1, "print": 1}  # CRWS
+
+# Assembly + Estimate Template: full for the estimation roles, hidden for the rest.
+ASSEMBLY_TEMPLATE_ROLE_PERMS = {role: _FULL for role in _ESTIMATION_ROLES}
+# Rate Master: full for the estimation roles; Procurement Officer is READ-ONLY here
+# (the ruling) — it writes to the catalog only via the gated PO-submit dialog, never
+# this form. Rate History is the parent's child table, so its read follows Rate Master.
+RATE_MASTER_ROLE_PERMS = {
+	**{role: _FULL for role in _ESTIMATION_ROLES},
+	"BuildSuite Procurement Officer": _READ,
+}
+# UOM is resolved by the BOQ / Rate Master link pickers, so those roles need read.
+_UOM_READ_ROLES = _ESTIMATION_ROLES + ("BuildSuite Procurement Officer",)
+
+# Purchase & Stock (native ERPNext doctypes). `project` is required per config and
+# drives warehouse defaulting; the rate-update prompt on PO submit is gated
+# separately (RATE_UPDATE_GOVERNANCE_ROLES).
+MATERIAL_REQUEST_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _CRWS,  # PM authors + submits; approval is the workflow action
+	"BuildSuite Site Engineer": _RAISE,  # raise own MR only
+	"BuildSuite Foreman": _RAISE,  # raise own MR only
+	"BuildSuite Procurement Officer": _FULL_SUB,
+	"BuildSuite Store Keeper": _READ,
+	"BuildSuite Accountant": _READ,
+}
+PURCHASE_ORDER_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _READ,
+	"BuildSuite Procurement Officer": _FULL_SUB,
+	"BuildSuite Store Keeper": _READ,
+	"BuildSuite Accountant": _READ,
+}
+PURCHASE_RECEIPT_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _READ,
+	"BuildSuite Procurement Officer": _FULL_SUB,
+	"BuildSuite Store Keeper": _FULL_SUB,  # Store Keeper posts receipts
+	"BuildSuite Accountant": _READ,
+}
+PURCHASE_INVOICE_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _READ,
+	"BuildSuite Procurement Officer": _READ,
+	"BuildSuite Accountant": _FULL_SUB,  # Accountant owns invoicing
+}
+STOCK_ENTRY_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _READ,
+	"BuildSuite Site Engineer": _CRWS,  # posts Material Issue for consumption
+	"BuildSuite Procurement Officer": _FULL_SUB,
+	"BuildSuite Store Keeper": _FULL_SUB,
+	"BuildSuite Accountant": _READ,
+}
+ITEM_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _READ,
+	"BuildSuite Estimator": _READ,
+	"BuildSuite QS": _READ,
+	"BuildSuite Procurement Officer": _FULL,  # maintains Item.rate_master
+	"BuildSuite Store Keeper": _FULL,
+	"BuildSuite Accountant": _READ,
+}
+
+# Roles that may confirm a Rate Master rate update from the PO-submit dialog. The
+# Procurement Officer is empowered-with-guardrails here even though it is READ-ONLY
+# on the Rate Master form. Enforced server-side in buildsuite_core.api.rate_master.
+RATE_UPDATE_GOVERNANCE_ROLES = (
+	"BuildSuite Director",
+	"BuildSuite PM",
+	"BuildSuite Estimator",
+	"BuildSuite QS",
+	"BuildSuite Procurement Officer",
+	"BuildSuite Administrator",
+	"System Manager",
+	"Administrator",
+)
 
 # Per-role base permissions on Work Package — read-only for everyone except the
 # full-CRUD roles; scope inherits the parent project. No own-scope rules.
@@ -251,6 +343,9 @@ PERSONA_TO_ROLE = {
 
 # Every flag we may set on a DocPerm — anything not granted is explicitly cleared.
 _PTYPES = ("read", "write", "create", "delete", "report", "export", "print")
+# Submittable doctypes (Material Request, Purchase Order, Stock Entry, …) also carry
+# the transition ptypes.
+_SUBMIT_PTYPES = _PTYPES + ("submit", "cancel", "amend")
 
 
 def _ensure_role(role_name):
@@ -264,13 +359,21 @@ def _ensure_role(role_name):
 		).insert(ignore_permissions=True)
 
 
-def _apply_role_perms(doctype, role_perms):
+def _apply_role_perms(doctype, role_perms, ptypes=_PTYPES):
+	if not frappe.db.exists("DocType", doctype):
+		return
 	from frappe.permissions import add_permission, update_permission_property
+
+	# The matrix is the single source of truth: drop any stale custom grant for a
+	# BuildSuite role no longer listed (e.g. a role dropped from an earlier read
+	# mirror), so removing a role from a matrix actually revokes its access.
+	for role in set(BUILDSUITE_ROLES) - set(role_perms):
+		frappe.db.delete("Custom DocPerm", {"parent": doctype, "role": role})
 
 	for role, perms in role_perms.items():
 		_ensure_role(role)
 		add_permission(doctype, role, 0)
-		for ptype in _PTYPES:
+		for ptype in ptypes:
 			update_permission_property(
 				doctype,
 				role,
@@ -304,10 +407,25 @@ def setup_stage_planning_permissions():
 def setup_boq_permissions():
 	for doctype in BOQ_DOCTYPES:
 		_apply_role_perms(doctype, BOQ_ROLE_PERMS)
-	mirror = _readonly_mirror(BOQ_ROLE_PERMS)
-	for doctype in BOQ_LINKED_MASTER_DOCTYPES:
-		if frappe.db.exists("DocType", doctype):
-			_apply_role_perms(doctype, mirror)
+
+
+def setup_estimation_master_permissions():
+	"""Assembly / Estimate Template / Rate Master (+ UOM read for their link pickers).
+	Rate Master's Rate History is a child table, so its read follows the parent."""
+	for doctype in ("Assembly", "Estimate Template"):
+		_apply_role_perms(doctype, ASSEMBLY_TEMPLATE_ROLE_PERMS)
+	_apply_role_perms("Construction Rate Master", RATE_MASTER_ROLE_PERMS)
+	_apply_role_perms("UOM", {role: _READ for role in _UOM_READ_ROLES})
+
+
+def setup_purchase_stock_permissions():
+	"""BuildSuite-role DocPerms on the native ERPNext buying / stock doctypes."""
+	_apply_role_perms("Material Request", MATERIAL_REQUEST_ROLE_PERMS, _SUBMIT_PTYPES)
+	_apply_role_perms("Purchase Order", PURCHASE_ORDER_ROLE_PERMS, _SUBMIT_PTYPES)
+	_apply_role_perms("Purchase Receipt", PURCHASE_RECEIPT_ROLE_PERMS, _SUBMIT_PTYPES)
+	_apply_role_perms("Purchase Invoice", PURCHASE_INVOICE_ROLE_PERMS, _SUBMIT_PTYPES)
+	_apply_role_perms("Stock Entry", STOCK_ENTRY_ROLE_PERMS, _SUBMIT_PTYPES)
+	_apply_role_perms("Item", ITEM_ROLE_PERMS)
 
 
 def _readonly_mirror(role_perms):
@@ -398,6 +516,8 @@ def setup_record_permissions():
 	setup_task_progress_entry_permissions()
 	setup_stage_planning_permissions()
 	setup_boq_permissions()
+	setup_estimation_master_permissions()
+	setup_purchase_stock_permissions()
 	setup_linked_master_permissions()
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()

--- a/buildsuite_core/tests/test_permissions.py
+++ b/buildsuite_core/tests/test_permissions.py
@@ -210,3 +210,83 @@ class TestPermissions(BuildSuiteTestCase):
 			self.assertTrue(doc.has_permission("read"))
 		finally:
 			frappe.set_user("Administrator")
+
+	# --- M2 access control (Estimation / Rate Master / Purchase & Stock) -----
+	def _as(self, persona, prefix):
+		user = self._make_persona_user(persona, prefix)
+		frappe.set_user(user)
+		return user
+
+	def test_estimator_full_estimation_crud(self):
+		# PERM-001 — Estimator has full CRUD across the estimation DocTypes.
+		self._as("Estimator", "est")
+		try:
+			for dt in ("BOQ", "Assembly", "Estimate Template", "Construction Rate Master"):
+				self.assertTrue(frappe.has_permission(dt, "create"), dt)
+				self.assertTrue(frappe.has_permission(dt, "write"), dt)
+				self.assertTrue(frappe.has_permission(dt, "delete"), dt)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_procurement_rate_master_read_only(self):
+		# PERM-004 / PERM-006 — Procurement Officer reads Rate Master but cannot write
+		# it from the form; PERM-003 — Estimation (BOQ) is hidden.
+		self._as("Procurement Officer", "proc")
+		try:
+			self.assertTrue(frappe.has_permission("Construction Rate Master", "read"))
+			self.assertFalse(frappe.has_permission("Construction Rate Master", "write"))
+			self.assertFalse(frappe.has_permission("BOQ", "read"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_procurement_full_buying(self):
+		# PERM-007 — Procurement Officer: create + submit on the buying transactions.
+		self._as("Procurement Officer", "proc")
+		try:
+			for dt in ("Material Request", "Purchase Order", "Purchase Receipt"):
+				self.assertTrue(frappe.has_permission(dt, "create"), dt)
+				self.assertTrue(frappe.has_permission(dt, "submit"), dt)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_site_engineer_mr_raise_only(self):
+		# PERM-008 — Site Engineer can create a Material Request but not delete it,
+		# and has no estimation access.
+		self._as("Site Engineer", "se")
+		try:
+			self.assertTrue(frappe.has_permission("Material Request", "create"))
+			self.assertFalse(frappe.has_permission("Material Request", "delete"))
+			self.assertFalse(frappe.has_permission("Assembly", "read"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_hr_no_procurement_or_estimation(self):
+		# PERM-015 — HR Manager sees neither procurement nor estimation DocTypes.
+		self._as("HR Manager", "hrm")
+		try:
+			self.assertFalse(frappe.has_permission("Construction Rate Master", "read"))
+			self.assertFalse(frappe.has_permission("Material Request", "read"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_rate_update_guard_rejects_non_governance(self):
+		# PERM-013 — the PO-submit rate-update endpoint rejects a non-governance role
+		# and accepts the empowered Procurement Officer.
+		from buildsuite_core.api import rate_master as rm
+
+		self._as("Foreman / Supervisor", "fm")
+		try:
+			self.assertRaises(
+				frappe.PermissionError,
+				rm.update_rates_from_po,
+				purchase_order="PO-TEST",
+				updates=[],
+			)
+		finally:
+			frappe.set_user("Administrator")
+
+		self._as("Procurement Officer", "proc")
+		try:
+			self.assertEqual(rm.update_rates_from_po(purchase_order="PO-TEST", updates=[]), [])
+		finally:
+			frappe.set_user("Administrator")

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -122,11 +122,8 @@ export const ROLES = [
 //    null          — —   hidden
 // =====================================================================
 export const WORKSPACE_VISIBILITY = {
-	// Session 33 — Scope Change merged into Site Execution. Estimator + Accountant
-	// gain read access here so they can still reach SCOs (which moved under this
-	// workspace from the dropped Scope Change workspace). Previously they had no
-	// Site Execution access; the SCO-visibility gap was the explicit reason for
-	// this matrix revision.
+	// M2 (Roles & Permissions spec) — Estimator + QS read here (Schedule/Gantt lives
+	// under Site Execution); Foreman create-own; Accountant is now hidden.
 	"site-execution": {
 		director: "full",
 		pm: "full",
@@ -136,14 +133,15 @@ export const WORKSPACE_VISIBILITY = {
 		foreman: "create-own",
 		procurement: null,
 		"store-keeper": null,
-		accountant: "read",
+		accountant: null,
 		"hr-manager": null,
 		admin: "full",
 		bsa: "full",
 	},
+	// M2 — PM now full on Estimation. Procurement Officer hidden (the ruling).
 	estimation: {
 		director: "full",
-		pm: "read",
+		pm: "full",
 		estimator: "full",
 		qs: "full",
 		"site-engineer": null,
@@ -155,13 +153,14 @@ export const WORKSPACE_VISIBILITY = {
 		admin: "full",
 		bsa: "full",
 	},
+	// M2 — Foreman can raise MRs (like Site Engineer). PM approve-only.
 	procurement: {
 		director: "full",
 		pm: "approve",
 		estimator: null,
 		qs: null,
 		"site-engineer": "mr-only",
-		foreman: null,
+		foreman: "mr-only",
 		procurement: "full",
 		"store-keeper": "full",
 		accountant: "read",
@@ -228,8 +227,9 @@ export const WORKSPACE_VISIBILITY = {
 		admin: "full",
 		bsa: "full",
 	},
+	// M2 — Director/PM read-only on the inherited ERPNext Buying surface.
 	buying: {
-		director: "full",
+		director: "read",
 		pm: "read",
 		estimator: null,
 		qs: null,
@@ -242,14 +242,16 @@ export const WORKSPACE_VISIBILITY = {
 		admin: "full",
 		bsa: "full",
 	},
+	// M2 — Procurement now full on Stock; Director read-only; Estimator read;
+	// Site Engineer hidden here (posts issues via Desk, not this workspace).
 	stock: {
-		director: "full",
+		director: "read",
 		pm: "read",
-		estimator: null,
+		estimator: "read",
 		qs: null,
-		"site-engineer": "read",
+		"site-engineer": null,
 		foreman: null,
-		procurement: "read",
+		procurement: "full",
 		"store-keeper": "full",
 		accountant: "read",
 		"hr-manager": null,


### PR DESCRIPTION
## Summary
Implements the M2 Roles & Permissions spec (BuildSuite_Core_M2_Roles_Permissions.xlsx).

### Workspace visibility (frontend, `roles.js`)
- **Estimation**: PM now **full**.
- **Site Execution**: Accountant now **hidden**.
- **Procurement**: **Foreman** can raise MRs (mr-only), like Site Engineer.
- **Buying**: Director now **read-only**.
- **Stock**: Procurement now **full**; Director **read-only**; Estimator **read**; Site Engineer hidden (posts issues via Desk).

### DocType permissions (backend, `permissions/setup.py`)
- **Estimation** — BOQ/Assembly/Estimate Template = full for the estimation roles only (BA/Dir/PM/Est/QS); read for others **revoked**.
- **Rate Master** — full for estimation roles; **Procurement Officer = READ-ONLY** (the ruling — it writes the catalog only via the gated PO dialog). UOM read for the pickers.
- **Purchase & Stock** — BuildSuite-role DocPerms (incl. submit/cancel/amend) on Material Request, Purchase Order, Purchase Receipt, Purchase Invoice, Stock Entry, and Item, per the matrix (Procurement full buying; Store Keeper posts receipts/issues; Site Engineer raise-MR / post-issue only; Accountant owns invoices).
- The permission applier is now **authoritative**: a role dropped from a matrix has its stale custom grant removed (this fixed HR/SE still reading Rate Master/Assembly).

### Governance (backend, `api/rate_master.py`)
- `update_rates_from_po` now rejects any non-governance caller (**PERM-013**) and lets the empowered Procurement Officer confirm updates via the PO dialog (form stays read-only). The save bypasses the form perm since the governance gate authorises it.

### Deferred (noted, not in this PR)
Schedule Task/Stage DocPerm tightening (M1-core, left stable); Rate Master Rate Log doctype, `cost_code`/`delivery_type`/`issue_purpose`, and Procurement dashboard — feature work that doesn't exist yet.

**Tests:** full backend suite green (108), incl. 6 new M2 permission tests (Estimator full CRUD, Procurement read-only Rate Master + hidden BOQ, Procurement full buying, Site Engineer MR-raise-only, HR no proc/estimation, rate-update governance guard).