### PR TITLE
feat: make Persona a DocType with an editable role mapping

### DIFF
--- a/buildsuite_core/api/cypress_setup.py
+++ b/buildsuite_core/api/cypress_setup.py
@@ -13,8 +13,8 @@ or with a custom password (matching Cypress `adminPassword` / CYPRESS_ADMIN_PWD)
 
 import frappe
 
-# persona id (Cypress `loginAs`) -> (email, full_name, User.persona Select value).
-# The persona values must match PERSONA_TO_ROLE keys in permissions/setup.py.
+# persona id (Cypress `loginAs`) -> (email, full_name, User.persona value).
+# The persona values must match a Persona record name (see the Persona master).
 CYPRESS_USERS = {
 	"admin": ("cypress-admin@buildsuite.test", "Cypress Admin", "BuildSuite Administrator"),
 	"pm": ("cypress-pm@buildsuite.test", "Cypress PM", "Project Manager"),

--- a/buildsuite_core/api/estimation_seed.py
+++ b/buildsuite_core/api/estimation_seed.py
@@ -19,7 +19,7 @@ from buildsuite_core.api import boq as boq_api
 DEMO_PASSWORD = "BuildSuite-Demo-2026!"
 PROJECT_CODE = "DEMO-EST-001"
 
-# --- persona users (persona must match PERSONA_TO_ROLE keys) ------------------
+# --- persona users (persona must match a Persona record name) -----------------
 DEMO_USERS = {
 	"director": ("demo-director@buildsuite.demo", "Dana Director", "Director / Owner"),
 	"pm": ("demo-pm@buildsuite.demo", "Paul Manager", "Project Manager"),

--- a/buildsuite_core/api/persona.py
+++ b/buildsuite_core/api/persona.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Whitelisted admin CRUD for the Persona master and its role mapping.
+
+The Vue Settings → Personas screen edits personas here rather than through the
+generic client adapter, because a persona's `roles` child table can't be written
+reliably via frappe.client.set_value. Only an administrator (System Manager /
+BuildSuite Administrator) may manage personas — the same gate as user admin.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint
+
+ADMIN_ROLES = {"System Manager", "BuildSuite Administrator"}
+
+
+def _require_admin():
+	if not (set(frappe.get_roles()) & ADMIN_ROLES):
+		frappe.throw(_("Only an administrator can manage personas."), frappe.PermissionError)
+
+
+def _serialize(doc):
+	return {
+		"name": doc.name,
+		"persona_name": doc.persona_name,
+		"slug": doc.slug,
+		"description": doc.description,
+		"enabled": doc.enabled,
+		"sort_order": doc.sort_order,
+		"is_default": doc.is_default,
+		"roles": [r.role for r in doc.roles],
+	}
+
+
+@frappe.whitelist()
+def list_personas():
+	"""All personas with their mapped roles, for the settings list."""
+	_require_admin()
+	rows = frappe.get_all(
+		"Persona",
+		fields=["name", "persona_name", "slug", "enabled", "sort_order"],
+		order_by="sort_order asc",
+	)
+	for row in rows:
+		row["roles"] = frappe.get_all("Persona Role", filters={"parent": row["name"]}, pluck="role")
+	return rows
+
+
+@frappe.whitelist()
+def get_persona(name: str):
+	"""One persona with its full role list."""
+	_require_admin()
+	if not frappe.db.exists("Persona", name):
+		frappe.throw(_("Persona not found."))
+	return _serialize(frappe.get_doc("Persona", name))
+
+
+@frappe.whitelist()
+def list_assignable_roles():
+	"""Roles a persona may grant — the BuildSuite roles plus native System Manager.
+	Excludes the workflow-editor marker, which the sync hook grants automatically."""
+	_require_admin()
+	from buildsuite_core.permissions.setup import WORKFLOW_EDITOR_ROLE
+
+	roles = frappe.get_all("Role", filters={"name": ["like", "BuildSuite %"]}, pluck="name")
+	if frappe.db.exists("Role", "System Manager"):
+		roles.append("System Manager")
+	return sorted(set(roles) - {WORKFLOW_EDITOR_ROLE})
+
+
+@frappe.whitelist()
+def save_persona(
+	name=None,
+	persona_name=None,
+	slug=None,
+	description=None,
+	enabled=1,
+	sort_order=0,
+	roles=None,
+):
+	"""Create or update a persona. The persona_name is the record key and is only
+	settable on create (renaming would orphan the User.persona links that point at
+	it). Roles are replaced wholesale from the payload."""
+	_require_admin()
+	roles = frappe.parse_json(roles) or []
+
+	if name and frappe.db.exists("Persona", name):
+		doc = frappe.get_doc("Persona", name)
+	else:
+		doc = frappe.new_doc("Persona")
+		doc.persona_name = (persona_name or "").strip()
+		if not doc.persona_name:
+			frappe.throw(_("Persona name is required."))
+		if frappe.db.exists("Persona", doc.persona_name):
+			frappe.throw(_("A persona with that name already exists."))
+
+	if slug is not None:
+		doc.slug = (slug or "").strip()
+	if description is not None:
+		doc.description = description
+	doc.enabled = 1 if cint(enabled) else 0
+	doc.sort_order = cint(sort_order)
+
+	doc.set("roles", [])
+	for role in roles:
+		if frappe.db.exists("Role", role):
+			doc.append("roles", {"role": role})
+
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def delete_persona(name: str):
+	"""Delete a persona once no user is assigned it."""
+	_require_admin()
+	if not frappe.db.exists("Persona", name):
+		frappe.throw(_("Persona not found."))
+	in_use = frappe.db.count("User", {"persona": name})
+	if in_use:
+		frappe.throw(
+			_("{0} user(s) are still assigned this persona — reassign them first.").format(in_use)
+		)
+	frappe.delete_doc("Persona", name, ignore_permissions=True)
+	return {"ok": True}

--- a/buildsuite_core/api/users.py
+++ b/buildsuite_core/api/users.py
@@ -3,19 +3,16 @@
 
 """BuildSuite user administration — real Frappe User CRUD from the Vue app.
 
-People are Frappe Users. A user's "persona" is the `persona` Select custom field
-on User; the buildsuite_core.utils.user.sync_persona_roles validate hook keeps
-exactly one BuildSuite role in sync with it. So we only ever set `persona` here —
-never touch roles directly.
+People are Frappe Users. A user's "persona" is the `persona` Link custom field on
+User, pointing at the Persona master; the buildsuite_core.utils.user.sync_persona_roles
+validate hook keeps their BuildSuite roles in sync with the persona's role mapping.
+So we only ever set `persona` here — never touch roles directly.
 """
 
 import frappe
 from frappe import _
 from frappe.utils import cint
 
-from buildsuite_core.permissions.setup import PERSONA_TO_ROLE
-
-PERSONA_OPTIONS = list(PERSONA_TO_ROLE)
 ADMIN_ROLES = {"System Manager", "BuildSuite Administrator"}
 SYSTEM_ACCOUNTS = ["Administrator", "Guest"]
 
@@ -26,8 +23,20 @@ def _require_admin():
 
 
 def _validate_persona(persona):
-	if persona not in PERSONA_OPTIONS:
+	if not frappe.db.get_value("Persona", persona, "enabled"):
 		frappe.throw(_("Invalid persona."))
+
+
+@frappe.whitelist()
+def list_personas():
+	"""Enabled personas for the user-admin picker (name doubles as the label)."""
+	_require_admin()
+	return frappe.get_all(
+		"Persona",
+		filters={"enabled": 1},
+		fields=["name", "slug", "description"],
+		order_by="sort_order asc",
+	)
 
 
 @frappe.whitelist()
@@ -36,7 +45,7 @@ def list_buildsuite_users():
 	_require_admin()
 	return frappe.get_all(
 		"User",
-		filters={"persona": ["in", PERSONA_OPTIONS], "name": ["not in", SYSTEM_ACCOUNTS]},
+		filters={"persona": ["is", "set"], "name": ["not in", SYSTEM_ACCOUNTS]},
 		fields=["name", "full_name", "email", "enabled", "persona"],
 		order_by="full_name asc",
 	)

--- a/buildsuite_core/buildsuite_core/doctype/persona/persona.json
+++ b/buildsuite_core/buildsuite_core/doctype/persona/persona.json
@@ -1,0 +1,110 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:persona_name",
+ "creation": "2026-07-06 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "persona_name",
+  "slug",
+  "column_break_meta",
+  "enabled",
+  "sort_order",
+  "is_default",
+  "section_break_roles",
+  "roles",
+  "section_break_desc",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "persona_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Persona Name",
+   "placeholder": "Project Manager",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "description": "Frontend id used by the role switcher / gating (e.g. pm).",
+   "fieldname": "slug",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Slug"
+  },
+  {
+   "fieldname": "column_break_meta",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "1",
+   "fieldname": "enabled",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Enabled"
+  },
+  {
+   "default": "0",
+   "fieldname": "sort_order",
+   "fieldtype": "Int",
+   "label": "Sort Order"
+  },
+  {
+   "default": "0",
+   "description": "Set on the personas seeded by BuildSuite. Informational only.",
+   "fieldname": "is_default",
+   "fieldtype": "Check",
+   "label": "Seeded Default",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_roles",
+   "fieldtype": "Section Break",
+   "label": "Roles"
+  },
+  {
+   "description": "Roles granted to a user assigned this persona.",
+   "fieldname": "roles",
+   "fieldtype": "Table",
+   "label": "Roles",
+   "options": "Persona Role"
+  },
+  {
+   "fieldname": "section_break_desc",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-06 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Persona",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "sort_order",
+ "sort_order": "ASC",
+ "states": [],
+ "track_changes": 1
+}

--- a/buildsuite_core/buildsuite_core/doctype/persona/persona.py
+++ b/buildsuite_core/buildsuite_core/doctype/persona/persona.py
@@ -1,0 +1,12 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+
+
+class Persona(Document):
+	def validate(self):
+		# Default the slug from the name so the frontend always has a stable id.
+		if not (self.slug or "").strip():
+			self.slug = frappe.scrub(self.persona_name or "").replace("_", "-")

--- a/buildsuite_core/buildsuite_core/doctype/persona/seed_personas.py
+++ b/buildsuite_core/buildsuite_core/doctype/persona/seed_personas.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Seed the default BuildSuite Personas and their role mappings.
+
+Replaces the hardcoded PERSONA_TO_ROLE dict: each persona is now a Persona record
+whose `roles` child table drives which roles a user with that persona is granted
+(the User.validate hook reads it). Idempotent — run from install.after_install /
+after_migrate, after the roles themselves are ensured. Re-running only fills in a
+missing persona; it never overwrites an admin's later edits to an existing one.
+"""
+
+import frappe
+
+# (persona_name, slug, sort_order, (roles…))
+# persona_name doubles as the record name (autoname field:persona_name), so existing
+# User.persona string values resolve straight to these Link targets — no data migration.
+PERSONAS = (
+	("Director / Owner", "director", 1, ("BuildSuite Director",)),
+	("Project Manager", "pm", 2, ("BuildSuite PM",)),
+	("Estimator", "estimator", 3, ("BuildSuite Estimator",)),
+	("Quantity Surveyor", "qs", 4, ("BuildSuite QS",)),
+	("Site Engineer", "site-engineer", 5, ("BuildSuite Site Engineer",)),
+	("Foreman / Supervisor", "foreman", 6, ("BuildSuite Foreman",)),
+	("Procurement Officer", "procurement", 7, ("BuildSuite Procurement Officer",)),
+	("Store Keeper", "store-keeper", 8, ("BuildSuite Store Keeper",)),
+	("Accountant", "accountant", 9, ("BuildSuite Accountant",)),
+	("HR Manager", "hr-manager", 10, ("BuildSuite HR Manager",)),
+	("System Manager (Admin)", "admin", 11, ("System Manager",)),
+	("BuildSuite Administrator", "bsa", 12, ("BuildSuite Administrator",)),
+)
+
+
+def seed_personas():
+	created = []
+	for persona_name, slug, order, roles in PERSONAS:
+		if frappe.db.exists("Persona", persona_name):
+			continue
+		doc = frappe.get_doc(
+			{
+				"doctype": "Persona",
+				"persona_name": persona_name,
+				"slug": slug,
+				"sort_order": order,
+				"enabled": 1,
+				"is_default": 1,
+			}
+		)
+		for role in roles:
+			# Guard so a not-yet-seeded role can't block persona creation.
+			if frappe.db.exists("Role", role):
+				doc.append("roles", {"role": role})
+		doc.insert(ignore_permissions=True)
+		created.append(persona_name)
+	return created

--- a/buildsuite_core/buildsuite_core/doctype/persona_role/persona_role.json
+++ b/buildsuite_core/buildsuite_core/doctype/persona_role/persona_role.json
@@ -1,0 +1,33 @@
+{
+ "actions": [],
+ "creation": "2026-07-06 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "role"
+ ],
+ "fields": [
+  {
+   "columns": 6,
+   "fieldname": "role",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Role",
+   "options": "Role",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-06 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Persona Role",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/buildsuite_core/buildsuite_core/doctype/persona_role/persona_role.py
+++ b/buildsuite_core/buildsuite_core/doctype/persona_role/persona_role.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class PersonaRole(Document):
+	pass

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -271,10 +271,14 @@ CUSTOM_FIELD = {
 	],
 	"User": [
 		{
+			# A Link to the Persona master (was a hardcoded Select). The Persona's
+			# `roles` child table drives which roles a user is granted — see
+			# utils.user.sync_persona_roles. Persona records are named after their
+			# label, so existing Select values resolve as Link targets unchanged.
 			"fieldname": "persona",
-			"fieldtype": "Select",
+			"fieldtype": "Link",
 			"label": "Persona",
-			"options": "Director / Owner\nProject Manager\nEstimator\nQuantity Surveyor\nSite Engineer\nForeman / Supervisor\nProcurement Officer\nStore Keeper\nAccountant\nHR Manager\nSystem Manager (Admin)\nBuildSuite Administrator",
+			"options": "Persona",
 			"insert_after": "username",
 			"module": "BuildSuite Core",
 		},

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -510,6 +510,8 @@ def setup_stage_planning_workflow():
 
 def setup_record_permissions():
 	"""Seed roles + DocPerms for every BuildSuite-scoped doctype."""
+	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import seed_personas
+
 	setup_project_permissions()
 	setup_task_permissions()
 	setup_work_package_permissions()
@@ -521,3 +523,5 @@ def setup_record_permissions():
 	setup_linked_master_permissions()
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()
+	# Personas map to the roles ensured above — seed them once the roles exist.
+	seed_personas()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -322,24 +322,9 @@ WORKFLOW_EDITOR_ROLE = "BuildSuite Project User"
 # All BuildSuite roles, for the app-level access gate (api.permission).
 BUILDSUITE_ROLES = tuple(PROJECT_ROLE_PERMS.keys())
 
-# User.persona Select value -> the role that persona grants. The persona option
-# strings mirror the `name` fields in frontend/src/data/roles.js so the frontend
-# and backend agree on one vocabulary. "System Manager (Admin)" maps to Frappe's
-# native System Manager role (not a BuildSuite role).
-PERSONA_TO_ROLE = {
-	"Director / Owner": "BuildSuite Director",
-	"Project Manager": "BuildSuite PM",
-	"Estimator": "BuildSuite Estimator",
-	"Quantity Surveyor": "BuildSuite QS",
-	"Site Engineer": "BuildSuite Site Engineer",
-	"Foreman / Supervisor": "BuildSuite Foreman",
-	"Procurement Officer": "BuildSuite Procurement Officer",
-	"Store Keeper": "BuildSuite Store Keeper",
-	"Accountant": "BuildSuite Accountant",
-	"HR Manager": "BuildSuite HR Manager",
-	"System Manager (Admin)": "System Manager",
-	"BuildSuite Administrator": "BuildSuite Administrator",
-}
+# The persona -> role mapping now lives in the Persona master (seeded from
+# buildsuite_core.buildsuite_core.doctype.persona.seed_personas). utils.user reads
+# a user's Persona.roles to keep their BuildSuite roles in sync.
 
 # Every flag we may set on a DocPerm — anything not granted is explicitly cleared.
 _PTYPES = ("read", "write", "create", "delete", "report", "export", "print")

--- a/buildsuite_core/tests/test_user.py
+++ b/buildsuite_core/tests/test_user.py
@@ -1,36 +1,71 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
-"""Tests for the User persona / company behaviour. Company is optional for a
-persona'd user (the earlier mandatory-company rule was dropped)."""
+"""Tests for the User persona / company behaviour. Persona is a Link to the Persona
+master; its roles child table drives the user's BuildSuite roles. Company is
+optional for a persona'd user (the earlier mandatory-company rule was dropped)."""
 
 import frappe
 
 from buildsuite_core.tests.base import BuildSuiteTestCase
 
+WORKFLOW_EDITOR_ROLE = "BuildSuite Project User"
+
 
 class TestUserPersona(BuildSuiteTestCase):
-	def test_user_persona_company_optional(self):
-		u = frappe.new_doc("User")
-		u.email = f"uat-{self._n}@example.com"
-		u.first_name = "UAT"
-		u.user_type = "System User"
-		u.send_welcome_email = 0
-		u.persona = "Project Manager"
-		u.company = ""
-		u.insert(ignore_permissions=True)  # must not raise
-		self.assertEqual(u.persona, "Project Manager")
-
-	def test_user_persona_with_company_ok(self):
+	def _make_user(self, persona, company=None):
 		u = frappe.get_doc(
 			{
 				"doctype": "User",
-				"email": f"uat-ok-{self._n}@example.com",
+				"email": f"uat-{persona[:3].lower()}-{self._n}@example.com",
 				"first_name": "UAT",
 				"user_type": "System User",
 				"send_welcome_email": 0,
-				"persona": "Project Manager",
-				"company": self.company,
+				"persona": persona,
+				"company": company or "",
 			}
 		)
 		u.insert(ignore_permissions=True)
+		return u
+
+	def _roles(self, user):
+		return {r.role for r in frappe.get_doc("User", user).roles}
+
+	def test_user_persona_company_optional(self):
+		u = self._make_user("Project Manager")  # must not raise with no company
+		self.assertEqual(u.persona, "Project Manager")
+
+	def test_user_persona_with_company_ok(self):
+		u = self._make_user("Project Manager", company=self.company)
 		self.assertEqual(u.company, self.company)
+
+	# --- doctype-driven persona -> role sync ---------------------------------
+	def test_default_personas_seeded(self):
+		# The 12 defaults exist and the admin persona maps to the native role.
+		self.assertGreaterEqual(frappe.db.count("Persona"), 12)
+		self.assertEqual(
+			frappe.db.get_value("Persona Role", {"parent": "System Manager (Admin)"}, "role"),
+			"System Manager",
+		)
+
+	def test_persona_grants_its_roles(self):
+		u = self._make_user("Project Manager")
+		roles = self._roles(u.name)
+		self.assertIn("BuildSuite PM", roles)
+		self.assertIn(WORKFLOW_EDITOR_ROLE, roles)
+
+	def test_switching_persona_swaps_the_managed_role(self):
+		u = self._make_user("Project Manager")
+		self.assertIn("BuildSuite PM", self._roles(u.name))
+		u.persona = "Estimator"
+		u.save(ignore_permissions=True)
+		roles = self._roles(u.name)
+		self.assertIn("BuildSuite Estimator", roles)
+		self.assertNotIn("BuildSuite PM", roles)  # stale managed role dropped
+
+	def test_system_manager_is_never_revoked_by_persona(self):
+		# A persona may grant System Manager, but switching persona must not strip it.
+		u = self._make_user("Project Manager")
+		u.append("roles", {"role": "System Manager"})
+		u.persona = "Estimator"
+		u.save(ignore_permissions=True)
+		self.assertIn("System Manager", self._roles(u.name))

--- a/buildsuite_core/utils/user.py
+++ b/buildsuite_core/utils/user.py
@@ -1,9 +1,16 @@
-"""Keep a User's BuildSuite role in sync with their persona custom field.
+"""Keep a User's BuildSuite roles in sync with their Persona.
 
-Persona is a single-select, so exactly one BuildSuite role should follow it. We
-run on `validate` (which fires on both insert and update) and mutate `doc.roles`
-in place — that saves atomically with the user and avoids the recursive-save trap
-that `add_roles`/`remove_roles` (which save the doc themselves) would cause.
+Persona is now a Link to the Persona master, whose `roles` child table lists the
+roles a user with that persona should hold. We run on `validate` (which fires on
+both insert and update) and mutate `doc.roles` in place — that saves atomically
+with the user and avoids the recursive-save trap that `add_roles`/`remove_roles`
+(which save the doc themselves) would cause.
+
+The persona owns the roles it grants: any persona-managed role that no longer
+matches the current persona is stripped, so the persona stays the single source of
+truth. Protected native roles (System Manager, Administrator) are never stripped —
+a persona may GRANT System Manager, but platform admins hold it for other reasons
+and this hook must not revoke it.
 
 Delete needs no handler: Frappe cascades the Has Role child rows when the User is
 deleted.
@@ -11,36 +18,51 @@ deleted.
 
 import frappe
 
-from buildsuite_core.permissions.setup import (
-	BUILDSUITE_ROLES,
-	PERSONA_TO_ROLE,
-	WORKFLOW_EDITOR_ROLE,
-)
+from buildsuite_core.permissions.setup import WORKFLOW_EDITOR_ROLE
 
-# Roles fully owned by the persona field — stripped when they no longer match the
-# persona so it stays the single source of truth. The workflow-editor marker role
-# rides along with any persona (needed for Stage Planning workflow editing).
-# System Manager is deliberately excluded: a persona can GRANT it, but this hook
-# must never REVOKE it (it's assigned for platform-admin reasons too).
-_MANAGED_ROLES = set(BUILDSUITE_ROLES) | {WORKFLOW_EDITOR_ROLE}
+# Native roles a persona may grant but this hook must never revoke.
+PROTECTED_ROLES = {"System Manager", "Administrator", "All", "Guest"}
+
+
+def _persona_roles(persona):
+	"""Roles granted by a persona (its Persona Role child rows)."""
+	if not persona:
+		return set()
+	return set(frappe.get_all("Persona Role", filters={"parent": persona}, pluck="role"))
+
+
+def _managed_roles():
+	"""Every role any persona grants (plus the workflow-editor marker), minus the
+	protected native roles. These are the roles the persona field owns and may
+	strip when they no longer match."""
+	roles = set(frappe.get_all("Persona Role", pluck="role"))
+	roles.add(WORKFLOW_EDITOR_ROLE)
+	return roles - PROTECTED_ROLES
 
 
 def sync_persona_roles(doc, method=None):
 	if doc.name in ("Administrator", "Guest"):
 		return
 
-	desired = PERSONA_TO_ROLE.get((doc.persona or "").strip())
+	# During install/migrate the Persona table may not exist yet — skip quietly.
+	if not frappe.db.table_exists("Persona Role"):
+		return
 
-	# Roles to keep/grant for the current persona.
+	desired = _persona_roles(doc.persona)
+
+	# Roles to keep/grant for the current persona (grants may include a protected
+	# role like System Manager; stripping below never touches protected roles).
 	keep = set()
 	if desired:
-		keep.add(desired)
+		keep |= desired
 		keep.add(WORKFLOW_EDITOR_ROLE)
+
+	managed = _managed_roles()
 
 	kept, present = [], set()
 	for row in doc.roles:
-		if row.role in _MANAGED_ROLES and row.role not in keep:
-			continue  # stale managed role — drop it
+		if row.role in managed and row.role not in keep:
+			continue  # stale persona-managed role — drop it
 		kept.append(row)
 		present.add(row.role)
 	doc.roles = kept

--- a/frontend/src/components/PersonaRolesField.vue
+++ b/frontend/src/components/PersonaRolesField.vue
@@ -1,0 +1,56 @@
+<script setup>
+// Editor for a persona's roles: selected roles as removable pills + an "add role"
+// dropdown of the still-assignable roles. v-model is an array of role names.
+
+import { computed } from "vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+
+const props = defineProps({
+	modelValue: { type: Array, default: () => [] },
+	available: { type: Array, default: () => [] },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const addable = computed(() => props.available.filter((r) => !props.modelValue.includes(r)));
+
+function addRole(role) {
+	if (role && !props.modelValue.includes(role)) {
+		emit("update:modelValue", [...props.modelValue, role]);
+	}
+}
+function removeRole(role) {
+	emit(
+		"update:modelValue",
+		props.modelValue.filter((r) => r !== role),
+	);
+}
+</script>
+
+<template>
+	<div>
+		<div v-if="modelValue.length" class="flex flex-wrap gap-1.5 mb-2">
+			<span
+				v-for="role in modelValue"
+				:key="role"
+				class="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-full bg-ink-100 text-ink-700"
+			>
+				{{ role }}
+				<button
+					type="button"
+					class="text-ink-400 hover:text-danger-600 leading-none"
+					aria-label="Remove role"
+					@click="removeRole(role)"
+				>
+					×
+				</button>
+			</span>
+		</div>
+		<p v-else class="text-xs text-ink-400 mb-2">No roles yet — add at least one below.</p>
+
+		<DeskSelect v-if="addable.length" :model-value="''" @update:model-value="addRole">
+			<option value="">+ Add role…</option>
+			<option v-for="role in addable" :key="role" :value="role">{{ role }}</option>
+		</DeskSelect>
+		<p v-else class="text-xs text-ink-400">All assignable roles added.</p>
+	</div>
+</template>

--- a/frontend/src/data/personaApi.js
+++ b/frontend/src/data/personaApi.js
@@ -1,0 +1,23 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Thin wrappers over buildsuite_core.api.persona.* — admin CRUD for the Persona
+// master and its role mapping (Settings → Personas).
+
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.persona.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const listPersonas = () => call("list_personas");
+export const getPersona = (name) => call("get_persona", { name });
+export const listAssignableRoles = () => call("list_assignable_roles");
+export const deletePersona = (name) => call("delete_persona", { name });
+export const savePersona = (args) =>
+	call("save_persona", { ...args, roles: JSON.stringify(args.roles || []) });

--- a/frontend/src/data/usersApi.js
+++ b/frontend/src/data/usersApi.js
@@ -12,6 +12,7 @@ async function call(method, args) {
 	}
 }
 
+export const listPersonas = () => call("list_personas");
 export const listBuildsuiteUsers = () => call("list_buildsuite_users");
 export const createBuildsuiteUser = (args) => call("create_buildsuite_user", args);
 export const updateBuildsuiteUser = (args) => call("update_buildsuite_user", args);

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -65,6 +65,9 @@ const PAGE_TITLES = {
 	"settings-project-category-new": "New Project Category",
 	"settings-project-category-detail": "Project Category",
 	"settings-project-category-template": "Project Template",
+	"settings-personas": "Personas",
+	"settings-persona-new": "New Persona",
+	"settings-persona-detail": "Persona",
 	forbidden: "Access Denied",
 };
 
@@ -449,6 +452,22 @@ const routes = [
 				path: "settings/project-categories/:id/template",
 				name: "settings-project-category-template",
 				component: () => import("@/views/settings/ProjectTemplateEditorView.vue"),
+				props: true,
+			},
+			{
+				path: "settings/personas",
+				name: "settings-personas",
+				component: () => import("@/views/settings/PersonasView.vue"),
+			},
+			{
+				path: "settings/personas/new",
+				name: "settings-persona-new",
+				component: () => import("@/views/settings/NewPersonaView.vue"),
+			},
+			{
+				path: "settings/personas/:id",
+				name: "settings-persona-detail",
+				component: () => import("@/views/settings/PersonaDetailView.vue"),
 				props: true,
 			},
 		],

--- a/frontend/src/views/settings/NewPersonaView.vue
+++ b/frontend/src/views/settings/NewPersonaView.vue
@@ -1,0 +1,150 @@
+<script setup>
+// New Persona — create a Persona and its role mapping (backend-backed via
+// buildsuite_core.api.persona). Admin / BSA only.
+
+import { reactive, ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useDataStore } from "@/stores";
+import { showToast } from "@/utils/appToast";
+import { savePersona, listAssignableRoles } from "@/data/personaApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import PersonaRolesField from "@/components/PersonaRolesField.vue";
+
+const router = useRouter();
+const store = useDataStore();
+
+const form = reactive({
+	personaName: "",
+	slug: "",
+	sortOrder: "",
+	enabled: true,
+	description: "",
+	roles: [],
+});
+const errors = ref({});
+const saving = ref(false);
+const assignableRoles = ref([]);
+
+function validate() {
+	const e = {};
+	if (!form.personaName.trim()) e.personaName = "Name is required";
+	if (!form.roles.length) e.roles = "Add at least one role";
+	errors.value = e;
+	return Object.keys(e).length === 0;
+}
+
+async function save() {
+	if (!validate() || saving.value) return;
+	saving.value = true;
+	try {
+		const res = await savePersona({
+			persona_name: form.personaName.trim(),
+			slug: form.slug.trim(),
+			description: form.description.trim(),
+			enabled: form.enabled ? 1 : 0,
+			sort_order: Number(form.sortOrder) || 0,
+			roles: form.roles,
+		});
+		showToast("Persona created");
+		router.push(`/settings/personas/${encodeURIComponent(res.name)}`);
+	} catch (err) {
+		showToast(err.message || "Failed to create persona", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+function cancel() {
+	router.push("/settings/personas");
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Settings", to: "/settings" },
+	{ label: "Personas", to: "/settings/personas" },
+	{ label: "New" },
+];
+
+onMounted(async () => {
+	if (!store.isAdmin && !store.isBSA) {
+		router.replace("/settings");
+		return;
+	}
+	try {
+		assignableRoles.value = await listAssignableRoles();
+	} catch {
+		assignableRoles.value = [];
+	}
+});
+</script>
+
+<template>
+	<DeskPage title="New Persona" :breadcrumbs="breadcrumbs">
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="saving ? 'Creating…' : 'Create persona'"
+					:saving="saving"
+					@save="save"
+					@cancel="cancel"
+				/>
+			</template>
+
+			<div class="max-w-3xl mx-auto">
+				<DeskSection title="Basic">
+					<DeskField
+						label="Persona name"
+						required
+						:error="errors.personaName"
+						hint="The label users pick. Can't be changed later."
+					>
+						<DeskInput v-model="form.personaName" placeholder="e.g. Planner" />
+					</DeskField>
+					<DeskField
+						label="Slug"
+						hint="Frontend id (auto-filled from the name if left blank)."
+					>
+						<DeskInput v-model="form.slug" placeholder="e.g. planner" />
+					</DeskField>
+					<DeskField label="Sort order" hint="Position in the persona dropdown.">
+						<DeskInput v-model="form.sortOrder" type="number" placeholder="auto" />
+					</DeskField>
+					<DeskField label="Enabled">
+						<label class="flex items-center gap-2 py-1 text-sm cursor-pointer">
+							<input
+								type="checkbox"
+								v-model="form.enabled"
+								class="accent-brand-600"
+							/>
+							<span>{{ form.enabled ? "Enabled" : "Disabled" }}</span>
+						</label>
+					</DeskField>
+				</DeskSection>
+
+				<DeskSection title="Roles" :cols="1">
+					<DeskField
+						label="Granted roles"
+						required
+						:error="errors.roles"
+						hint="Assigning this persona to a user grants these Frappe roles."
+					>
+						<PersonaRolesField v-model="form.roles" :available="assignableRoles" />
+					</DeskField>
+				</DeskSection>
+
+				<DeskSection title="Description" :cols="1">
+					<DeskField label="Notes">
+						<DeskInput
+							v-model="form.description"
+							placeholder="What this persona is for"
+						/>
+					</DeskField>
+				</DeskSection>
+			</div>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/settings/NewUserView.vue
+++ b/frontend/src/views/settings/NewUserView.vue
@@ -3,15 +3,15 @@
 // drives the BuildSuite role via the server-side sync hook. Optional welcome /
 // password-reset emails use Frappe's native flows.
 
-import { ref, reactive, computed, onMounted } from "vue";
+import { ref, reactive, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import {
 	createBuildsuiteUser,
 	sendUserPasswordReset,
 	outgoingEmailConfigured,
+	listPersonas,
 } from "@/data/usersApi";
-import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
 import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -47,8 +47,15 @@ onMounted(() => {
 		});
 });
 
-const { selectOptions } = useDoctypeMeta("User");
-const personaOptions = computed(() => selectOptions("persona"));
+// Persona options come from the Persona master (a Link now, not a hardcoded Select).
+const personaOptions = ref([]);
+listPersonas()
+	.then((rows) => {
+		personaOptions.value = (rows || []).map((p) => p.name);
+	})
+	.catch(() => {
+		personaOptions.value = [];
+	});
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 

--- a/frontend/src/views/settings/PersonaDetailView.vue
+++ b/frontend/src/views/settings/PersonaDetailView.vue
@@ -1,0 +1,209 @@
+<script setup>
+// Persona detail — edit a persona's slug, roles, order and status, or delete it
+// (backend-backed via buildsuite_core.api.persona). The persona name is the record
+// key and is locked. Admin / BSA only.
+
+import { reactive, ref, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useDataStore } from "@/stores";
+import { showToast } from "@/utils/appToast";
+import { useConfirm } from "@/composables/useConfirm";
+import { getPersona, savePersona, deletePersona, listAssignableRoles } from "@/data/personaApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import PersonaRolesField from "@/components/PersonaRolesField.vue";
+
+const props = defineProps({ id: { type: String, required: true } });
+const router = useRouter();
+const store = useDataStore();
+const confirmDialog = useConfirm();
+
+const form = reactive({
+	slug: "",
+	sortOrder: 0,
+	enabled: true,
+	description: "",
+	roles: [],
+});
+const errors = ref({});
+const isDefault = ref(false);
+const saving = ref(false);
+const loading = ref(true);
+const loadError = ref("");
+const assignableRoles = ref([]);
+
+async function load() {
+	loading.value = true;
+	loadError.value = "";
+	try {
+		const [data, roles] = await Promise.all([getPersona(props.id), listAssignableRoles()]);
+		assignableRoles.value = roles || [];
+		form.slug = data.slug || "";
+		form.sortOrder = data.sort_order || 0;
+		form.enabled = !!data.enabled;
+		form.description = data.description || "";
+		form.roles = data.roles || [];
+		isDefault.value = !!data.is_default;
+	} catch (err) {
+		loadError.value = err.message || "Could not load persona.";
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function save() {
+	if (saving.value) return;
+	if (!form.roles.length) {
+		errors.value = { roles: "Add at least one role" };
+		return;
+	}
+	errors.value = {};
+	saving.value = true;
+	try {
+		await savePersona({
+			name: props.id,
+			slug: form.slug.trim(),
+			description: form.description.trim(),
+			enabled: form.enabled ? 1 : 0,
+			sort_order: Number(form.sortOrder) || 0,
+			roles: form.roles,
+		});
+		showToast("Persona saved");
+		router.push("/settings/personas");
+	} catch (err) {
+		showToast(err.message || "Failed to save persona", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+function cancel() {
+	router.push("/settings/personas");
+}
+
+async function remove() {
+	const ok = await confirmDialog({
+		title: "Delete persona",
+		message: `Delete "${props.id}"? Users must be reassigned first.`,
+		confirmLabel: "Delete persona",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await deletePersona(props.id);
+		showToast("Persona deleted");
+		router.push("/settings/personas");
+	} catch (err) {
+		showToast(err.message || "Could not delete persona", "error");
+	}
+}
+
+const breadcrumbs = () => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Settings", to: "/settings" },
+	{ label: "Personas", to: "/settings/personas" },
+	{ label: props.id },
+];
+
+onMounted(() => {
+	if (!store.isAdmin && !store.isBSA) {
+		router.replace("/settings");
+		return;
+	}
+	load();
+});
+</script>
+
+<template>
+	<DeskPage :title="props.id" subtitle="Persona" :breadcrumbs="breadcrumbs()">
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="saving ? 'Saving…' : 'Save changes'"
+					:saving="saving"
+					@save="save"
+					@cancel="cancel"
+				/>
+			</template>
+
+			<div v-if="loading" class="py-12 text-center text-sm text-ink-500">
+				Loading persona…
+			</div>
+
+			<div
+				v-else-if="loadError"
+				class="mb-3 px-3 py-2 bg-danger-50 border border-danger-100 text-xs text-danger-700"
+				style="border-radius: 6px"
+			>
+				{{ loadError }}
+			</div>
+
+			<div v-else class="max-w-3xl mx-auto">
+				<DeskSection title="Basic">
+					<DeskField
+						label="Persona name"
+						hint="The name is the key and can't be changed."
+					>
+						<DeskInput :model-value="props.id" disabled />
+					</DeskField>
+					<DeskField label="Slug">
+						<DeskInput v-model="form.slug" placeholder="e.g. planner" />
+					</DeskField>
+					<DeskField label="Sort order">
+						<DeskInput v-model="form.sortOrder" type="number" />
+					</DeskField>
+					<DeskField label="Enabled">
+						<label class="flex items-center gap-2 py-1 text-sm cursor-pointer">
+							<input
+								type="checkbox"
+								v-model="form.enabled"
+								class="accent-brand-600"
+							/>
+							<span>{{ form.enabled ? "Enabled" : "Disabled" }}</span>
+						</label>
+					</DeskField>
+				</DeskSection>
+
+				<DeskSection title="Roles" :cols="1">
+					<DeskField
+						label="Granted roles"
+						required
+						:error="errors.roles"
+						hint="Assigning this persona to a user grants these Frappe roles."
+					>
+						<PersonaRolesField v-model="form.roles" :available="assignableRoles" />
+					</DeskField>
+				</DeskSection>
+
+				<DeskSection title="Description" :cols="1">
+					<DeskField label="Notes">
+						<DeskInput
+							v-model="form.description"
+							placeholder="What this persona is for"
+						/>
+					</DeskField>
+				</DeskSection>
+
+				<DeskSection title="Danger zone" :cols="1">
+					<div class="flex items-center justify-between gap-3 flex-wrap">
+						<p class="text-xs text-ink-500">
+							<span v-if="isDefault">This is a BuildSuite default persona. </span
+							>Deleting a persona is permanent and only allowed when no user is
+							assigned it.
+						</p>
+						<button
+							class="text-sm px-3 py-1.5 border border-danger-200 text-danger-700 hover:bg-danger-50"
+							style="border-radius: 6px"
+							@click="remove"
+						>
+							Delete persona
+						</button>
+					</div>
+				</DeskSection>
+			</div>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/settings/PersonasView.vue
+++ b/frontend/src/views/settings/PersonasView.vue
@@ -1,0 +1,123 @@
+<script setup>
+// Personas — settings list (backend-backed via the Persona master). Admin / BSA
+// gated. A persona maps to one or more Frappe roles; assigning it to a user grants
+// those roles (sync_persona_roles hook).
+
+import { ref, computed, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { useDataStore } from "@/stores";
+import { listPersonas } from "@/data/personaApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+
+const store = useDataStore();
+const router = useRouter();
+
+const personas = ref([]);
+const loading = ref(true);
+const loadError = ref("");
+const search = ref("");
+
+const columns = [
+	{ key: "persona_name", label: "Persona" },
+	{ key: "slug", label: "Slug" },
+	{ key: "roles", label: "Roles" },
+	{ key: "enabled", label: "Status" },
+];
+
+const items = computed(() => {
+	const term = search.value.trim().toLowerCase();
+	if (!term) return personas.value;
+	return personas.value.filter((p) =>
+		`${p.persona_name} ${p.slug} ${(p.roles || []).join(" ")}`.toLowerCase().includes(term),
+	);
+});
+
+async function load() {
+	loading.value = true;
+	loadError.value = "";
+	try {
+		personas.value = await listPersonas();
+	} catch (err) {
+		loadError.value = err.message || "Could not load personas.";
+	} finally {
+		loading.value = false;
+	}
+}
+
+function onRowClick(row) {
+	router.push(`/settings/personas/${encodeURIComponent(row.name)}`);
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Settings", to: "/settings" },
+	{ label: "Personas" },
+];
+
+onMounted(() => {
+	if (!store.isAdmin && !store.isBSA) {
+		router.replace("/settings");
+		return;
+	}
+	load();
+});
+</script>
+
+<template>
+	<DeskPage title="Personas" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<DeskLink to="/settings/personas/new" class="desk-save-btn">+ New Persona</DeskLink>
+		</template>
+
+		<div
+			v-if="loadError"
+			class="mb-3 px-3 py-2 bg-danger-50 border border-danger-100 text-xs text-danger-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			{{ loadError }}
+		</div>
+
+		<DeskList
+			v-model="search"
+			:rows="items"
+			:columns="columns"
+			row-key="name"
+			search-placeholder="Search personas…"
+			@row-click="onRowClick"
+		>
+			<template #cell-persona_name="{ row }">
+				<span class="text-sm font-medium text-ink-900 dark:text-[#F5F5F5]">{{
+					row.persona_name
+				}}</span>
+			</template>
+			<template #cell-slug="{ row }">
+				<span class="text-xs text-ink-500 font-mono">{{ row.slug || "—" }}</span>
+			</template>
+			<template #cell-roles="{ row }">
+				<span class="flex flex-wrap gap-1">
+					<span
+						v-for="role in row.roles"
+						:key="role"
+						class="text-[10px] px-1.5 py-0.5 rounded-full font-medium bg-ink-100 text-ink-700"
+						>{{ role }}</span
+					>
+					<span v-if="!row.roles || !row.roles.length" class="text-[10px] text-ink-400"
+						>No roles</span
+					>
+				</span>
+			</template>
+			<template #cell-enabled="{ row }">
+				<span
+					class="text-[10px] px-1.5 py-0.5 font-medium"
+					:class="
+						row.enabled ? 'bg-success-50 text-success-700' : 'bg-ink-100 text-ink-500'
+					"
+					style="border-radius: 9999px"
+					>{{ row.enabled ? "Enabled" : "Disabled" }}</span
+				>
+			</template>
+		</DeskList>
+	</DeskPage>
+</template>

--- a/frontend/src/views/settings/SettingsHubView.vue
+++ b/frontend/src/views/settings/SettingsHubView.vue
@@ -45,6 +45,14 @@ const groups = computed(() => [
 				adminOnly: true,
 			},
 			{
+				slug: "personas",
+				icon: "shield",
+				label: "Personas",
+				desc: "Job roles users pick from, each mapping to the Frappe roles it grants.",
+				to: "/settings/personas",
+				adminOnly: true,
+			},
+			{
 				slug: "roles",
 				icon: "shield",
 				label: "Roles & Permissions",
@@ -187,7 +195,7 @@ const visibleGroups = computed(() =>
 				return true;
 			}),
 		}))
-		.filter((g) => g.tiles.length)
+		.filter((g) => g.tiles.length),
 );
 
 function onTileClick(tile) {

--- a/frontend/src/views/settings/UsersView.vue
+++ b/frontend/src/views/settings/UsersView.vue
@@ -14,8 +14,8 @@ import {
 	sendUserPasswordReset,
 	deleteBuildsuiteUser,
 	outgoingEmailConfigured,
+	listPersonas,
 } from "@/data/usersApi";
-import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import StatusBadge from "@/components/StatusBadge.vue";
@@ -65,7 +65,7 @@ const items = computed(() => {
 	const term = search.value.trim().toLowerCase();
 	if (!term) return users.value;
 	return users.value.filter((u) =>
-		`${u.full_name} ${u.email} ${u.persona}`.toLowerCase().includes(term)
+		`${u.full_name} ${u.email} ${u.persona}`.toLowerCase().includes(term),
 	);
 });
 
@@ -92,8 +92,15 @@ const editSaving = ref(false);
 const emailActing = ref(""); // '' | 'welcome' | 'reset'
 const mailConfigured = ref(null);
 
-const { selectOptions } = useDoctypeMeta("User");
-const personaOptions = computed(() => selectOptions("persona"));
+// Persona options come from the Persona master (a Link now, not a hardcoded Select).
+const personaOptions = ref([]);
+listPersonas()
+	.then((rows) => {
+		personaOptions.value = (rows || []).map((p) => p.name);
+	})
+	.catch(() => {
+		personaOptions.value = [];
+	});
 
 function openEdit(row) {
 	editForm.email = row.email || row.name;


### PR DESCRIPTION
Replaces the hardcoded persona → role mapping (a Python dict + a Select custom field) with an editable **Persona** master, so admins can manage personas and the roles they grant from the UI — no code change.

## Backend
- New **Persona** master (name, slug, enabled, sort_order, description) + **Persona Role** child table; the 12 defaults are seeded from `seed_personas` (wired into `setup_record_permissions`).
- `User.persona` is now a **Link → Persona** (was a Select). Persona records are named after their labels, so existing values resolve with **no data migration**.
- `sync_persona_roles` (User.validate) now reads the persona's `roles` table instead of the `PERSONA_TO_ROLE` dict, which is removed. Protected native roles (System Manager, Administrator) are granted but never revoked.
- `api/users.py` validates against the Persona master and serves a persona list; new `api/persona.py` provides admin CRUD for personas + their roles.

## Frontend
- The New User / Users persona pickers now load personas from the Persona master.
- New **Settings → Personas** screen: list, create, edit (roles editor with add/remove pills), and delete — admin/BSA gated. Delete is blocked while a user still holds the persona.

## Verification
- `bench migrate` seeds the 12 personas and converts the field with no data loss; existing users keep their personas and roles.
- Live checks: assigning a persona grants its roles + the workflow marker; switching persona swaps the managed role while keeping a manually-granted System Manager; admin CRUD round-trips.
- 116 backend tests pass (4 new for doctype-driven sync), no data leak. Frontend builds clean.