### PR TITLE
fix: repair disabled default personas and prevent admin lockout

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/persona/seed_personas.py
+++ b/buildsuite_core/buildsuite_core/doctype/persona/seed_personas.py
@@ -32,6 +32,8 @@ PERSONAS = (
 
 
 def seed_personas():
+	"""Create any missing default persona. Idempotent; leaves existing personas
+	(and any admin edits to them) untouched."""
 	created = []
 	for persona_name, slug, order, roles in PERSONAS:
 		if frappe.db.exists("Persona", persona_name):
@@ -53,3 +55,67 @@ def seed_personas():
 		doc.insert(ignore_permissions=True)
 		created.append(persona_name)
 	return created
+
+
+def _add_missing_roles(doc, roles):
+	"""Append any default role the persona is missing (existing role rows kept)."""
+	have = {r.role for r in doc.roles}
+	added = False
+	for role in roles:
+		if role not in have and frappe.db.exists("Role", role):
+			doc.append("roles", {"role": role})
+			added = True
+	return added
+
+
+def _repair_existing(persona_name, slug, roles):
+	"""Re-enable a default persona and restore its default roles. Returns True if it
+	changed. Never removes an admin's extra roles."""
+	doc = frappe.get_doc("Persona", persona_name)
+	changed = False
+	if not doc.enabled:
+		doc.enabled = 1
+		changed = True
+	if not doc.is_default:
+		doc.is_default = 1
+		changed = True
+	if not (doc.slug or "").strip():
+		doc.slug = slug
+		changed = True
+	changed = _add_missing_roles(doc, roles) or changed
+	if changed:
+		doc.flags.ignore_permissions = True
+		doc.save()
+	return changed
+
+
+def repair_default_personas():
+	"""Restore the default personas to a working state: create any that are missing,
+	re-enable any that were left disabled, and add back any default role rows that
+	went missing. This recovers sites where the two admin personas ended up disabled
+	(dropping them from the user-form picker and locking admins out of Settings).
+
+	Only ever creates, enables and ADDS roles — never removes an admin's extra roles
+	or personas — so it's safe to re-run."""
+	repaired = []
+	for persona_name, slug, order, roles in PERSONAS:
+		if frappe.db.exists("Persona", persona_name):
+			if _repair_existing(persona_name, slug, roles):
+				repaired.append(persona_name)
+			continue
+		doc = frappe.get_doc(
+			{
+				"doctype": "Persona",
+				"persona_name": persona_name,
+				"slug": slug,
+				"sort_order": order,
+				"enabled": 1,
+				"is_default": 1,
+			}
+		)
+		for role in roles:
+			if frappe.db.exists("Role", role):
+				doc.append("roles", {"role": role})
+		doc.insert(ignore_permissions=True)
+		repaired.append(persona_name)
+	return repaired

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -11,3 +11,4 @@ buildsuite_core.patches.migrate_task_type_to_native_type
 buildsuite_core.patches.backfill_stage_aggregates
 buildsuite_core.patches.migrate_project_type_to_category
 buildsuite_core.patches.remove_legacy_project_template_doctypes
+buildsuite_core.patches.repair_default_personas

--- a/buildsuite_core/patches/repair_default_personas.py
+++ b/buildsuite_core/patches/repair_default_personas.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Repair the default Personas on sites where the two admin personas ended up
+disabled — which dropped them from the user-form persona picker (an enabled-only
+list) and could leave an admin without the BuildSuite Administrator role, locking
+them out of Settings. Ensures all default personas exist, are enabled and carry
+their default roles. Safe and idempotent."""
+
+import frappe
+
+
+def execute():
+	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import (
+		repair_default_personas,
+	)
+
+	repair_default_personas()
+	frappe.db.commit()

--- a/buildsuite_core/tests/test_user.py
+++ b/buildsuite_core/tests/test_user.py
@@ -69,3 +69,28 @@ class TestUserPersona(BuildSuiteTestCase):
 		u.persona = "Estimator"
 		u.save(ignore_permissions=True)
 		self.assertIn("System Manager", self._roles(u.name))
+
+	def test_unknown_persona_is_rejected(self):
+		# Frappe's Link validation blocks assigning a persona that doesn't exist, so a
+		# user can never be left pointing at a missing persona (and thus silently
+		# stripped of their roles). The sync hook also guards against it defensively.
+		u = self._make_user("BuildSuite Administrator")
+		u.persona = "No Such Persona"
+		with self.assertRaises(frappe.LinkValidationError):
+			u.save(ignore_permissions=True)
+
+	def test_repair_reenables_disabled_default_personas(self):
+		# The repair restores a default persona that was left disabled — so it
+		# reappears in the enabled-only user-form picker.
+		from buildsuite_core.api.users import list_personas
+		from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import (
+			repair_default_personas,
+		)
+
+		frappe.db.set_value("Persona", "BuildSuite Administrator", "enabled", 0)
+		self.assertNotIn(
+			"BuildSuite Administrator", [p["name"] for p in list_personas()]
+		)
+		repair_default_personas()
+		self.assertEqual(frappe.db.get_value("Persona", "BuildSuite Administrator", "enabled"), 1)
+		self.assertIn("BuildSuite Administrator", [p["name"] for p in list_personas()])

--- a/buildsuite_core/utils/user.py
+++ b/buildsuite_core/utils/user.py
@@ -48,6 +48,12 @@ def sync_persona_roles(doc, method=None):
 	if not frappe.db.table_exists("Persona Role"):
 		return
 
+	# A set-but-unknown persona (dangling link to a Persona that isn't there) must
+	# not strip the user's roles — that could silently unmake an admin. Leave roles
+	# untouched until the persona resolves.
+	if doc.persona and not frappe.db.exists("Persona", doc.persona):
+		return
+
 	desired = _persona_roles(doc.persona)
 
 	# Roles to keep/grant for the current persona (grants may include a protected

--- a/frontend/src/views/settings/UsersView.vue
+++ b/frontend/src/views/settings/UsersView.vue
@@ -102,6 +102,14 @@ listPersonas()
 		personaOptions.value = [];
 	});
 
+// Always include the user's current persona in the edit dropdown, even if it's
+// disabled/absent from the enabled list — otherwise editing would silently blank it.
+const editPersonaOptions = computed(() => {
+	const opts = [...personaOptions.value];
+	if (editForm.persona && !opts.includes(editForm.persona)) opts.unshift(editForm.persona);
+	return opts;
+});
+
 function openEdit(row) {
 	editForm.email = row.email || row.name;
 	editForm.fullName = row.full_name || "";
@@ -362,7 +370,11 @@ async function deleteUser() {
 									"
 								>
 									<option value="">— Select persona —</option>
-									<option v-for="opt in personaOptions" :key="opt" :value="opt">
+									<option
+										v-for="opt in editPersonaOptions"
+										:key="opt"
+										:value="opt"
+									>
 										{{ opt }}
 									</option>
 								</DeskSelect>


### PR DESCRIPTION
Fixes a state where the two admin personas ("System Manager (Admin)" and "BuildSuite Administrator") ended up **disabled**, which dropped them from the user-form persona picker (an enabled-only list of 10) and could leave an admin without the BuildSuite Administrator role — locking them out of Settings.

## Changes
- **Repair** (`repair_default_personas`) + a one-time post-model-sync patch: ensures all default personas exist, are enabled, and carry their default roles. Only ever creates/enables/adds — never removes admin edits — so it's safe to re-run. Runs automatically on `bench migrate`.
- **Harden `sync_persona_roles`**: never strip a user's roles when their persona link can't be resolved (defensive against silently unmaking an admin). Frappe's own link validation already rejects an unknown persona on save.
- **Edit picker resilience**: the Users edit modal always includes the user's current persona in the dropdown, even if it's disabled/absent from the enabled list, so editing can't silently blank it.

## Verification
- Reproduced the exact symptom (2 admin personas disabled → picker shows 10) and confirmed the repair restores it to 12 with roles + enabled intact.
- 118 backend tests pass (repair + unknown-persona-rejection covered). Frontend builds clean. The patch runs cleanly on migrate.

## Recovery on an affected site
`bench --site <site> migrate` runs the repair. If an admin was already locked out, restore access with `bench --site <site> add-system-manager <email>`, then reassign the persona in the UI.