### PR TITLE
feat: persona link picker in user forms, hiding backend-only admin personas

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/persona/persona.json
+++ b/buildsuite_core/buildsuite_core/doctype/persona/persona.json
@@ -12,6 +12,7 @@
   "enabled",
   "sort_order",
   "is_default",
+  "backend_only",
   "section_break_roles",
   "roles",
   "section_break_desc",
@@ -58,6 +59,14 @@
    "fieldtype": "Check",
    "label": "Seeded Default",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "description": "Only assignable from the Frappe desk (backend), not the BuildSuite app's user forms.",
+   "fieldname": "backend_only",
+   "fieldtype": "Check",
+   "label": "Backend Only",
+   "in_list_view": 1
   },
   {
    "fieldname": "section_break_roles",

--- a/buildsuite_core/buildsuite_core/doctype/persona/seed_personas.py
+++ b/buildsuite_core/buildsuite_core/doctype/persona/seed_personas.py
@@ -12,22 +12,24 @@ missing persona; it never overwrites an admin's later edits to an existing one.
 
 import frappe
 
-# (persona_name, slug, sort_order, (roles…))
+# (persona_name, slug, sort_order, (roles…), backend_only)
 # persona_name doubles as the record name (autoname field:persona_name), so existing
 # User.persona string values resolve straight to these Link targets — no data migration.
+# backend_only=1 personas are assignable only from the Frappe desk, never the app's
+# user forms (the two admin personas — they grant platform-admin access).
 PERSONAS = (
-	("Director / Owner", "director", 1, ("BuildSuite Director",)),
-	("Project Manager", "pm", 2, ("BuildSuite PM",)),
-	("Estimator", "estimator", 3, ("BuildSuite Estimator",)),
-	("Quantity Surveyor", "qs", 4, ("BuildSuite QS",)),
-	("Site Engineer", "site-engineer", 5, ("BuildSuite Site Engineer",)),
-	("Foreman / Supervisor", "foreman", 6, ("BuildSuite Foreman",)),
-	("Procurement Officer", "procurement", 7, ("BuildSuite Procurement Officer",)),
-	("Store Keeper", "store-keeper", 8, ("BuildSuite Store Keeper",)),
-	("Accountant", "accountant", 9, ("BuildSuite Accountant",)),
-	("HR Manager", "hr-manager", 10, ("BuildSuite HR Manager",)),
-	("System Manager (Admin)", "admin", 11, ("System Manager",)),
-	("BuildSuite Administrator", "bsa", 12, ("BuildSuite Administrator",)),
+	("Director / Owner", "director", 1, ("BuildSuite Director",), 0),
+	("Project Manager", "pm", 2, ("BuildSuite PM",), 0),
+	("Estimator", "estimator", 3, ("BuildSuite Estimator",), 0),
+	("Quantity Surveyor", "qs", 4, ("BuildSuite QS",), 0),
+	("Site Engineer", "site-engineer", 5, ("BuildSuite Site Engineer",), 0),
+	("Foreman / Supervisor", "foreman", 6, ("BuildSuite Foreman",), 0),
+	("Procurement Officer", "procurement", 7, ("BuildSuite Procurement Officer",), 0),
+	("Store Keeper", "store-keeper", 8, ("BuildSuite Store Keeper",), 0),
+	("Accountant", "accountant", 9, ("BuildSuite Accountant",), 0),
+	("HR Manager", "hr-manager", 10, ("BuildSuite HR Manager",), 0),
+	("System Manager (Admin)", "admin", 11, ("System Manager",), 1),
+	("BuildSuite Administrator", "bsa", 12, ("BuildSuite Administrator",), 1),
 )
 
 
@@ -35,7 +37,7 @@ def seed_personas():
 	"""Create any missing default persona. Idempotent; leaves existing personas
 	(and any admin edits to them) untouched."""
 	created = []
-	for persona_name, slug, order, roles in PERSONAS:
+	for persona_name, slug, order, roles, backend_only in PERSONAS:
 		if frappe.db.exists("Persona", persona_name):
 			continue
 		doc = frappe.get_doc(
@@ -46,6 +48,7 @@ def seed_personas():
 				"sort_order": order,
 				"enabled": 1,
 				"is_default": 1,
+				"backend_only": backend_only,
 			}
 		)
 		for role in roles:
@@ -68,9 +71,10 @@ def _add_missing_roles(doc, roles):
 	return added
 
 
-def _repair_existing(persona_name, slug, roles):
-	"""Re-enable a default persona and restore its default roles. Returns True if it
-	changed. Never removes an admin's extra roles."""
+def _repair_existing(persona_name, slug, roles, backend_only):
+	"""Re-enable a default persona, restore its default roles and enforce its
+	backend-only flag. Returns True if it changed. Never removes an admin's extra
+	roles."""
 	doc = frappe.get_doc("Persona", persona_name)
 	changed = False
 	if not doc.enabled:
@@ -82,6 +86,9 @@ def _repair_existing(persona_name, slug, roles):
 	if not (doc.slug or "").strip():
 		doc.slug = slug
 		changed = True
+	if int(doc.backend_only or 0) != backend_only:
+		doc.backend_only = backend_only
+		changed = True
 	changed = _add_missing_roles(doc, roles) or changed
 	if changed:
 		doc.flags.ignore_permissions = True
@@ -91,16 +98,17 @@ def _repair_existing(persona_name, slug, roles):
 
 def repair_default_personas():
 	"""Restore the default personas to a working state: create any that are missing,
-	re-enable any that were left disabled, and add back any default role rows that
-	went missing. This recovers sites where the two admin personas ended up disabled
-	(dropping them from the user-form picker and locking admins out of Settings).
+	re-enable any that were left disabled, add back any default role rows that went
+	missing, and enforce the admin personas' backend-only flag. Recovers sites where
+	the two admin personas ended up disabled (dropping them from the user-form picker
+	and locking admins out of Settings).
 
-	Only ever creates, enables and ADDS roles — never removes an admin's extra roles
-	or personas — so it's safe to re-run."""
+	Only ever creates, enables, adds roles and fixes the backend-only flag — never
+	removes an admin's extra roles or personas — so it's safe to re-run."""
 	repaired = []
-	for persona_name, slug, order, roles in PERSONAS:
+	for persona_name, slug, order, roles, backend_only in PERSONAS:
 		if frappe.db.exists("Persona", persona_name):
-			if _repair_existing(persona_name, slug, roles):
+			if _repair_existing(persona_name, slug, roles, backend_only):
 				repaired.append(persona_name)
 			continue
 		doc = frappe.get_doc(
@@ -111,6 +119,7 @@ def repair_default_personas():
 				"sort_order": order,
 				"enabled": 1,
 				"is_default": 1,
+				"backend_only": backend_only,
 			}
 		)
 		for role in roles:

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -12,3 +12,4 @@ buildsuite_core.patches.backfill_stage_aggregates
 buildsuite_core.patches.migrate_project_type_to_category
 buildsuite_core.patches.remove_legacy_project_template_doctypes
 buildsuite_core.patches.repair_default_personas
+buildsuite_core.patches.enforce_persona_backend_only

--- a/buildsuite_core/patches/enforce_persona_backend_only.py
+++ b/buildsuite_core/patches/enforce_persona_backend_only.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Mark the two admin personas ("System Manager (Admin)", "BuildSuite Administrator")
+as backend-only so the BuildSuite app's user forms stop offering them — they grant
+platform-admin access and should only be assigned from the Frappe desk. Reuses the
+idempotent default-persona repair, which now also enforces the backend_only flag."""
+
+import frappe
+
+
+def execute():
+	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import (
+		repair_default_personas,
+	)
+
+	repair_default_personas()
+	frappe.db.commit()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -311,6 +311,7 @@ LINKED_MASTER_DOCTYPES = (
 	"Project Category",  # New Project -> Category picker (drives templating)
 	"Employee",  # PM / owner / assignee pickers
 	"Task Type",  # New Task -> Task Type picker
+	"Persona",  # Users settings -> persona link picker
 )
 _READONLY_PTYPES = ("read", "report", "export", "print")
 

--- a/buildsuite_core/tests/test_user.py
+++ b/buildsuite_core/tests/test_user.py
@@ -79,6 +79,19 @@ class TestUserPersona(BuildSuiteTestCase):
 		with self.assertRaises(frappe.LinkValidationError):
 			u.save(ignore_permissions=True)
 
+	def test_admin_personas_are_backend_only(self):
+		# The two admin personas are flagged backend-only, so they're excluded from
+		# the app's assignable set (enabled + not backend_only) that the user-form
+		# link picker queries — they can only be assigned from the Frappe desk.
+		for name in ("System Manager (Admin)", "BuildSuite Administrator"):
+			self.assertEqual(frappe.db.get_value("Persona", name, "backend_only"), 1)
+		assignable = frappe.get_all(
+			"Persona", filters={"enabled": 1, "backend_only": 0}, pluck="name"
+		)
+		self.assertNotIn("BuildSuite Administrator", assignable)
+		self.assertNotIn("System Manager (Admin)", assignable)
+		self.assertIn("Project Manager", assignable)
+
 	def test_repair_reenables_disabled_default_personas(self):
 		# The repair restores a default persona that was left disabled — so it
 		# reappears in the enabled-only user-form picker.

--- a/frontend/src/data/usersApi.js
+++ b/frontend/src/data/usersApi.js
@@ -12,7 +12,6 @@ async function call(method, args) {
 	}
 }
 
-export const listPersonas = () => call("list_personas");
 export const listBuildsuiteUsers = () => call("list_buildsuite_users");
 export const createBuildsuiteUser = (args) => call("create_buildsuite_user", args);
 export const updateBuildsuiteUser = (args) => call("update_buildsuite_user", args);

--- a/frontend/src/views/settings/NewUserView.vue
+++ b/frontend/src/views/settings/NewUserView.vue
@@ -10,7 +10,6 @@ import {
 	createBuildsuiteUser,
 	sendUserPasswordReset,
 	outgoingEmailConfigured,
-	listPersonas,
 } from "@/data/usersApi";
 import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -19,7 +18,7 @@ import DeskActionBar from "@/components/desk/DeskActionBar.vue";
 import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
-import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 
 const router = useRouter();
 const store = useDataStore();
@@ -46,16 +45,6 @@ onMounted(() => {
 			mailConfigured.value = null;
 		});
 });
-
-// Persona options come from the Persona master (a Link now, not a hardcoded Select).
-const personaOptions = ref([]);
-listPersonas()
-	.then((rows) => {
-		personaOptions.value = (rows || []).map((p) => p.name);
-	})
-	.catch(() => {
-		personaOptions.value = [];
-	});
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -185,18 +174,21 @@ async function save() {
 						:error="errors.persona"
 						hint="Frappe Roles are auto-assigned from the persona on the production side. Pick the one that matches the user's day-to-day work."
 					>
-						<DeskSelect
+						<DeskLinkPicker
 							v-model="form.persona"
+							doctype="Persona"
+							placeholder="Select persona"
+							label-field="persona_name"
+							value-field="name"
+							:search-fields="['persona_name', 'name']"
+							:filters="{ enabled: 1, backend_only: 0 }"
+							order-by="sort_order asc"
+							:error="errors.persona"
 							@change="
 								errors.persona = '';
 								formError = '';
 							"
-						>
-							<option value="">— Select persona —</option>
-							<option v-for="opt in personaOptions" :key="opt" :value="opt">
-								{{ opt }}
-							</option>
-						</DeskSelect>
+						/>
 					</DeskField>
 				</DeskSection>
 

--- a/frontend/src/views/settings/UsersView.vue
+++ b/frontend/src/views/settings/UsersView.vue
@@ -14,7 +14,6 @@ import {
 	sendUserPasswordReset,
 	deleteBuildsuiteUser,
 	outgoingEmailConfigured,
-	listPersonas,
 } from "@/data/usersApi";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
@@ -25,7 +24,7 @@ import DeskList from "@/components/desk/DeskList.vue";
 import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
-import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 
 const store = useDataStore();
 const router = useRouter();
@@ -91,24 +90,6 @@ const editError = ref("");
 const editSaving = ref(false);
 const emailActing = ref(""); // '' | 'welcome' | 'reset'
 const mailConfigured = ref(null);
-
-// Persona options come from the Persona master (a Link now, not a hardcoded Select).
-const personaOptions = ref([]);
-listPersonas()
-	.then((rows) => {
-		personaOptions.value = (rows || []).map((p) => p.name);
-	})
-	.catch(() => {
-		personaOptions.value = [];
-	});
-
-// Always include the user's current persona in the edit dropdown, even if it's
-// disabled/absent from the enabled list — otherwise editing would silently blank it.
-const editPersonaOptions = computed(() => {
-	const opts = [...personaOptions.value];
-	if (editForm.persona && !opts.includes(editForm.persona)) opts.unshift(editForm.persona);
-	return opts;
-});
 
 function openEdit(row) {
 	editForm.email = row.email || row.name;
@@ -362,22 +343,21 @@ async function deleteUser() {
 								:error="editErrors.persona"
 								hint="Frappe Roles are auto-assigned from the persona on the production side."
 							>
-								<DeskSelect
+								<DeskLinkPicker
 									v-model="editForm.persona"
+									doctype="Persona"
+									placeholder="Select persona"
+									label-field="persona_name"
+									value-field="name"
+									:search-fields="['persona_name', 'name']"
+									:filters="{ enabled: 1, backend_only: 0 }"
+									order-by="sort_order asc"
+									:error="editErrors.persona"
 									@change="
 										editErrors.persona = '';
 										editError = '';
 									"
-								>
-									<option value="">— Select persona —</option>
-									<option
-										v-for="opt in editPersonaOptions"
-										:key="opt"
-										:value="opt"
-									>
-										{{ opt }}
-									</option>
-								</DeskSelect>
+								/>
 							</DeskField>
 						</DeskSection>
 


### PR DESCRIPTION
The user create/edit forms now use a searchable **link picker** for the persona field, and the two admin personas are hidden from it — they can only be assigned from the Frappe desk (backend).

## Changes
- New **backend_only** flag on Persona (default 0). The seed/repair set it to 1 for "System Manager (Admin)" and "BuildSuite Administrator"; a patch enforces it on existing sites.
- The New User and Users-edit persona fields are now `DeskLinkPicker` (searchable), filtered to `enabled = 1 AND backend_only = 0` — so the admin personas never appear. A user who already holds an admin persona still shows it (the picker fetches the current value independently) and keeps it on save.
- Granted app **read** on Persona (added to the linked-master permission set) so the picker works for BuildSuite Administrator users, not just System Manager.

## Verification
- The assignable set is exactly the 10 non-admin personas; a real BuildSuite Administrator user can list them.
- 118 backend tests pass (added coverage that the admin personas are backend-only and excluded). Frontend builds clean; the enforce patch runs cleanly on migrate.