### PR TITLE
feat: Planned Progress (%) label, milestone is_milestone sync, BOQ diagrams

### DIFF
--- a/buildsuite_core/api/schedule.py
+++ b/buildsuite_core/api/schedule.py
@@ -213,11 +213,14 @@ def remove_task_predecessor(task: str, predecessor: str):
 
 
 def normalize_milestone_task(doc, method=None):
-	"""A Milestone is a point in time (zero-duration) — collapse its dates to a
+	"""A Milestone is a point in time (zero-duration): keep ERPNext's native
+	`is_milestone` flag in sync with the task's `type`, and collapse its dates to a
 	single day so the engine + Gantt render it as a diamond, not a bar.
 
-	Scheduling type now lives on the native `type` Link (-> Task Type master)."""
-	if getattr(doc, "type", None) != "Milestone":
+	Scheduling type lives on the native `type` Link (-> Task Type master)."""
+	is_milestone = getattr(doc, "type", None) == "Milestone"
+	doc.is_milestone = 1 if is_milestone else 0
+	if not is_milestone:
 		return
 	if doc.exp_start_date:
 		doc.exp_end_date = doc.exp_start_date

--- a/buildsuite_core/buildsuite_core/doctype/stage_planning_task/stage_planning_task.json
+++ b/buildsuite_core/buildsuite_core/doctype/stage_planning_task/stage_planning_task.json
@@ -40,7 +40,7 @@
    "fieldname": "planned_qty",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Planned Qty"
+   "label": "Planned Progress (%)"
   },
   {
    "allow_in_quick_entry": 1,

--- a/buildsuite_core/tests/test_schedule_engine.py
+++ b/buildsuite_core/tests/test_schedule_engine.py
@@ -138,6 +138,16 @@ class TestScheduleEngineIntegration(BuildSuiteTestCase):
 			}
 		).insert(ignore_permissions=True)
 
+	def test_milestone_type_sets_native_is_milestone(self):
+		# A Milestone-type task gets ERPNext's native is_milestone flag on save, and
+		# it clears again when the type changes away from Milestone.
+		p = self._make_project(company=self.company)
+		t = self._task(p.name, f"MS {self._n}", "2026-01-05", "2026-01-05", type="Milestone")
+		self.assertEqual(t.is_milestone, 1)
+		t.type = "Activity"
+		t.save(ignore_permissions=True)
+		self.assertEqual(t.is_milestone, 0)
+
 	def test_hook_flags_then_cascade_clears(self):
 		p = self._make_project(company=self.company)
 		a = self._task(p.name, f"A {self._n}", "2026-01-01", "2026-01-10")

--- a/docs/images/mermaid/boq-er.mmd
+++ b/docs/images/mermaid/boq-er.mmd
@@ -1,0 +1,122 @@
+erDiagram
+    PROJECT ||--o{ BOQ : "revisions"
+    PROJECT ||--o{ WORK_PACKAGE : has
+    PROJECT ||--o{ TASK : has
+    PROJECT_TYPE ||--o{ ESTIMATE_TEMPLATE : "scopes"
+
+    BOQ ||--o| BOQ : "base_revision (self)"
+    BOQ ||--o{ BOQ_GROUP : contains
+    BOQ ||--o{ BOQ_ITEM : contains
+    BOQ ||--o{ BOQ_WP_SUMMARY : "rolls up (child table)"
+    BOQ_GROUP ||--o{ BOQ_ITEM : groups
+    BOQ_ITEM ||--o{ BOQ_SUB_ITEM : "breaks down to"
+
+    BOQ_ITEM }o--o| ASSEMBLY : "explodes from"
+    BOQ_ITEM }o--o| TASK : "actuals from"
+    BOQ_ITEM }o--o| WORK_PACKAGE : "tagged to"
+    BOQ_ITEM }o--o| UOM : unit
+    BOQ_SUB_ITEM }o--|| CONSTRUCTION_RATE_MASTER : "priced by"
+    BOQ_SUB_ITEM }o--o| ASSEMBLY : source_assembly
+    BOQ_SUB_ITEM }o--o| WORK_PACKAGE : "tagged to"
+    BOQ_WP_SUMMARY }o--|| WORK_PACKAGE : "per-WP bucket"
+
+    ASSEMBLY ||--o{ ASSEMBLY_COMPONENT : "recipe of"
+    ASSEMBLY ||--o| UOM : uom
+    ASSEMBLY_COMPONENT }o--|| CONSTRUCTION_RATE_MASTER : "resource"
+
+    CONSTRUCTION_RATE_MASTER ||--o{ CONSTRUCTION_RATE_HISTORY : "audit trail"
+    CONSTRUCTION_RATE_MASTER ||--o| UOM : uom
+
+    ESTIMATE_TEMPLATE ||--o{ ESTIMATE_TEMPLATE_ROW : rows
+    ESTIMATE_TEMPLATE_ROW }o--o| ASSEMBLY : "Assembly line"
+    ESTIMATE_TEMPLATE_ROW }o--o| CONSTRUCTION_RATE_MASTER : "Resource line"
+
+    BOQ {
+        Link project FK
+        Int revision
+        Link base_revision FK
+        Select status "Draft|Submitted|Approved|Superseded"
+        Percent margin_rate
+        Percent tax_rate
+        Currency planned_amount
+        Currency actual_amount
+        Currency total
+    }
+    BOQ_GROUP {
+        Link boq FK
+        Data code
+        Data group_name
+        Int idx_order
+    }
+    BOQ_ITEM {
+        Link boq FK
+        Link boq_group FK
+        Float planned_qty
+        Float driving_qty
+        Currency rate
+        Currency planned_amount
+        Float actual_qty
+        Select cost_head
+        Select quantity_source "Manual|Assembly|Template|Takeoff"
+        Link assembly FK
+        Link task FK
+        Link work_package FK
+    }
+    BOQ_SUB_ITEM {
+        Link boq FK
+        Link boq_item FK
+        Link rate_master FK
+        Float qty_per_unit
+        Float qty
+        Currency rate
+        Currency amount
+        Select cost_head
+        Link source_assembly FK
+    }
+    BOQ_WP_SUMMARY {
+        Link work_package FK
+        Currency planned_amount
+        Currency margin_amount
+        Currency tax_amount
+        Currency total
+    }
+    ASSEMBLY {
+        Data assembly_code PK
+        Select category
+        Currency rate_per_unit
+        Int component_count
+    }
+    ASSEMBLY_COMPONENT {
+        Link resource FK
+        Float coefficient
+        Currency rate
+        Currency amount
+    }
+    CONSTRUCTION_RATE_MASTER {
+        Data rate_code PK
+        Select category "Material|Labour|Equipment"
+        Currency current_rate
+        Currency previous_rate
+        Date effective_date
+    }
+    CONSTRUCTION_RATE_HISTORY {
+        Currency rate
+        Date effective_from
+        Date effective_to
+        Select reason
+        Link purchase_order FK
+        Link supplier FK
+    }
+    ESTIMATE_TEMPLATE {
+        Data template_code PK
+        Link project_type FK
+        Currency estimated_total
+    }
+    ESTIMATE_TEMPLATE_ROW {
+        Data group_name
+        Select line_type "Assembly|Resource"
+        Link assembly FK
+        Link resource FK
+        Float placeholder_qty
+        Select cost_head
+    }

--- a/docs/images/mermaid/boq-flowchart.mmd
+++ b/docs/images/mermaid/boq-flowchart.mmd
@@ -1,0 +1,69 @@
+flowchart TB
+    subgraph MASTERS["🧱 Estimation Masters (org-wide, reusable)"]
+        direction TB
+        RM["<b>Construction Rate Master</b><br/>rate_code · category M/L/E<br/>current_rate · UOM<br/><i>the atomic price source</i>"]
+        RH["Construction Rate History<br/><i>every rate change: PO / supplier / market</i>"]
+        ASM["<b>Assembly</b><br/>assembly_code · rate_per_unit<br/><i>a composite 'recipe'</i>"]
+        AC["Assembly Component<br/>resource → Rate Master<br/>coefficient (qty per unit)"]
+        ET["<b>Estimate Template</b><br/>template_code · project_type<br/><i>reusable BOQ skeleton</i>"]
+        ETR["Estimate Template Row<br/>line_type = Assembly | Resource<br/>group_name · placeholder_qty"]
+
+        RM -- "logs changes" --> RH
+        ASM -- "bundles" --> AC
+        AC -- "priced by" --> RM
+        ET -- "rows" --> ETR
+        ETR -. "Assembly row" .-> ASM
+        ETR -. "Resource row" .-> RM
+    end
+
+    subgraph BUILD["📋 Build a project BOQ (Draft)"]
+        direction TB
+        NEW["New BOQ on a Project<br/>(revision = max+1)"]
+        IMPORT{{"import_template(boq, template)"}}
+        GRP["BOQ Group<br/>code · group_name"]
+        ITEM["BOQ Item<br/>planned_qty · rate · cost_head<br/>quantity_source = Manual/Assembly/Template/Takeoff<br/>→ work_package, → task"]
+        EXPLODE{{"explode_item(boq_item)"}}
+        SUB["BOQ Sub Item<br/>rate_master · qty_per_unit<br/>qty = coefficient × driving_qty"]
+    end
+
+    subgraph COST["💰 Roll-up & lifecycle"]
+        direction TB
+        ROLLUP["recompute_boq()<br/>planned = Σ item amounts<br/>margin = planned × margin_rate%<br/>tax = (planned+margin) × tax_rate%<br/>total → split into BOQ WP Summary"]
+        SUBMIT(["Submitted"])
+        APPROVE(["Approved<br/><i>supersedes prior Approved rev</i>"])
+        SUPER(["Superseded"])
+        ACTUALS{{"recalculate_actuals(boq)<br/>actual_qty = planned_qty × Task.progress%"}}
+    end
+
+    %% template seeding
+    ET ==> IMPORT
+    IMPORT --> GRP
+    IMPORT --> ITEM
+    IMPORT -- "Assembly row auto-explodes" --> EXPLODE
+    IMPORT -- "Resource row → 1 sub-item" --> SUB
+
+    %% manual build path
+    NEW --> GRP --> ITEM
+    ITEM -- "links an Assembly,<br/>then explode" --> EXPLODE
+    ASM ==> EXPLODE
+    EXPLODE -- "snapshot rows<br/>(item.rate = assembly.rate_per_unit)" --> SUB
+    RM ==> SUB
+    ITEM -- "manual rate analysis" --> SUB
+
+    %% costing + lifecycle
+    SUB --> ROLLUP
+    ITEM --> ROLLUP
+    ROLLUP --> SUBMIT
+    SUBMIT -- "approve_boq()<br/>(Director/PM/Admin/SysMgr)" --> APPROVE
+    APPROVE -. "older approved rev" .-> SUPER
+    APPROVE -- "create_revision()<br/>clone → new Draft" --> NEW
+    APPROVE -- "site progress feeds back" --> ACTUALS
+    Task[("native Task<br/>.progress")] ==> ACTUALS
+    ACTUALS --> ROLLUP
+
+    classDef master fill:#ecfdf5,stroke:#10b981,color:#064e3b;
+    classDef api fill:#eff6ff,stroke:#3b82f6,color:#1e3a8a;
+    classDef state fill:#fff7ed,stroke:#f59e0b,color:#7c2d12;
+    class RM,RH,ASM,AC,ET,ETR master;
+    class IMPORT,EXPLODE,ACTUALS api;
+    class SUBMIT,APPROVE,SUPER state;

--- a/frontend/src/views/StagePlanningDetailView.vue
+++ b/frontend/src/views/StagePlanningDetailView.vue
@@ -1144,7 +1144,7 @@ usePageTitle(() => stage.value?.stageName);
 						<div class="px-3 py-1.5">Task</div>
 						<div class="px-3 py-1.5">Planned Start</div>
 						<div class="px-3 py-1.5">Planned End</div>
-						<div class="px-3 py-1.5 text-right">Planned Qty (%)</div>
+						<div class="px-3 py-1.5 text-right">Planned Progress (%)</div>
 						<div class="px-3 py-1.5">Status</div>
 					</div>
 					<div


### PR DESCRIPTION
Three small, independent changes (one commit each):

- **Stage planning label** — the stage task's planned field is now labelled **"Planned Progress (%)"** (was "Planned Qty") in both the doctype and the Stage detail table header, matching how it's used (a 0–100% planned progress).
- **Milestone sync** — a Task's ERPNext-native `is_milestone` flag is now kept in sync with its `type`: set when the type is "Milestone", cleared otherwise. Folded into the existing `normalize_milestone_task` validate hook. (Note: `is_milestone` is a Task field and "Milestone" is a Task Type — so this applies to tasks.)
- **Docs** — added the BOQ mermaid ER + flowchart diagrams under `docs/images/mermaid/`.

Verified: 11 schedule-engine tests pass (added coverage that Milestone→is_milestone=1 and back to 0). Frontend builds clean.