### PR TITLE
fix: project + task form fixes (naming, milestone dates, project type, WP list, defaults)

### DIFF
--- a/buildsuite_core/hooks.py
+++ b/buildsuite_core/hooks.py
@@ -156,8 +156,12 @@ has_permission = {
 }
 
 # Override the Project controller so its record name honours the BuildSuite Core
-# Settings "Project Naming" option (Project ID vs an ERPNext naming series).
-override_doctype_class = {"Project": "buildsuite_core.overrides.project.BuildSuiteProject"}
+# Settings "Project Naming" option (Project ID vs an ERPNext naming series), and the
+# Task controller so it never auto-fills the end date from expected_time.
+override_doctype_class = {
+	"Project": "buildsuite_core.overrides.project.BuildSuiteProject",
+	"Task": "buildsuite_core.overrides.task.BuildSuiteTask",
+}
 
 # Document Events
 # ---------------

--- a/buildsuite_core/overrides/task.py
+++ b/buildsuite_core/overrides/task.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Task controller override.
+
+ERPNext's Task.set_default_end_date_if_missing() auto-fills exp_end_date from
+exp_start_date + expected_time (hours) whenever the end is empty. Tasks seeded from
+a template carry expected_time, so editing one and saving with a start but no end
+would fabricate a "random" end date — while a freshly-created task (no expected_time)
+correctly keeps its end empty. BuildSuite wants the end date to stay empty unless the
+user enters one, regardless of how the task was created, so we no-op that auto-fill.
+"""
+
+from erpnext.projects.doctype.task.task import Task as _ERPNextTask
+
+
+class BuildSuiteTask(_ERPNextTask):
+	def set_default_end_date_if_missing(self):
+		# Intentionally a no-op — never derive the end date from expected_time.
+		pass

--- a/buildsuite_core/tests/test_schedule_engine.py
+++ b/buildsuite_core/tests/test_schedule_engine.py
@@ -138,6 +138,24 @@ class TestScheduleEngineIntegration(BuildSuiteTestCase):
 			}
 		).insert(ignore_permissions=True)
 
+	def test_end_date_not_auto_filled_from_expected_time(self):
+		# A task carrying expected_time (as template-seeded tasks do) must NOT get an
+		# auto-generated end date when saved with a start but no end.
+		p = self._make_project(company=self.company)
+		t = frappe.get_doc(
+			{
+				"doctype": "Task",
+				"project": p.name,
+				"subject": f"ET {self._n}",
+				"expected_time": 240,
+				"task_status": "Yet To Start",
+			}
+		).insert(ignore_permissions=True)
+		t.exp_start_date = "2026-02-01"
+		t.save(ignore_permissions=True)
+		t.reload()
+		self.assertIsNone(t.exp_end_date)
+
 	def test_milestone_type_sets_native_is_milestone(self):
 		# A Milestone-type task gets ERPNext's native is_milestone flag on save, and
 		# it clears again when the type changes away from Milestone.

--- a/frontend/src/components/TaskFormModal.vue
+++ b/frontend/src/components/TaskFormModal.vue
@@ -38,7 +38,13 @@ const { errors, applyServerErrors, setErrors, clearError } = useFormErrors({
 });
 
 const projectsResource = adapter.list("Project", {
-	fields: ["name", "project_name", "project_category", "expected_start_date", "expected_end_date"],
+	fields: [
+		"name",
+		"project_name",
+		"project_category",
+		"expected_start_date",
+		"expected_end_date",
+	],
 	orderBy: "modified desc",
 	pageLength: 200,
 });
@@ -77,15 +83,15 @@ watch(
 		form.startDate = new Date().toISOString().slice(0, 10);
 		form.endDate = "";
 		setErrors({});
-	}
+	},
 );
 
 const selectedProject = computed(() =>
-	projectsResource.data.find((p) => p.name === form.projectId)
+	projectsResource.data.find((p) => p.name === form.projectId),
 );
 const selectedWP = computed(() => wpsResource.data.find((wp) => wp.name === form.workPackageId));
 const availableWPs = computed(() =>
-	wpsResource.data.filter((wp) => wp.project === form.projectId)
+	wpsResource.data.filter((wp) => wp.project === form.projectId),
 );
 // Project is locked when the parent supplied it. WP is locked when both
 // project + WP are supplied (work-package-scoped entry). When the parent
@@ -104,7 +110,7 @@ watch(
 		) {
 			form.workPackageId = null;
 		}
-	}
+	},
 );
 
 function close() {
@@ -122,7 +128,7 @@ function validate() {
 		form.endDate,
 		selectedProject.value?.expected_start_date,
 		selectedProject.value?.expected_end_date,
-		"project"
+		"project",
 	);
 	if (boundsErr) {
 		if (boundsErr.startsWith("Start")) e.startDate = boundsErr;
@@ -144,7 +150,7 @@ async function save() {
 			description: form.description,
 			task_status: form.status,
 			priority: form.priority,
-			exp_start_date: form.startDate,
+			exp_start_date: form.task_type === "Milestone" ? form.endDate : form.startDate,
 			exp_end_date: form.endDate,
 		});
 		// Assignee is Frappe-native `_assign`, set after insert (single-assignee).
@@ -274,14 +280,22 @@ async function save() {
 					</DeskSection>
 
 					<DeskSection title="Schedule">
-						<DeskField label="Start date" :error="errors.startDate">
+						<!-- Milestone = a point in time: only a Due date, no start. -->
+						<DeskField
+							v-if="form.task_type !== 'Milestone'"
+							label="Start date"
+							:error="errors.startDate"
+						>
 							<DeskInput
 								v-model="form.startDate"
 								type="date"
 								@change="clearError('startDate')"
 							/>
 						</DeskField>
-						<DeskField label="End date" :error="errors.endDate">
+						<DeskField
+							:label="form.task_type === 'Milestone' ? 'Due date' : 'End date'"
+							:error="errors.endDate"
+						>
 							<DeskInput
 								v-model="form.endDate"
 								type="date"

--- a/frontend/src/views/NewProjectView.vue
+++ b/frontend/src/views/NewProjectView.vue
@@ -64,7 +64,7 @@ const parentResource = parentId
 					id: r?.name,
 					name: r?.project_name || r?.name || "",
 				})),
-	  })
+		})
 	: null;
 const fetchedParent = computed(() => firstResourceRow(parentResource));
 
@@ -76,6 +76,8 @@ const form = reactive({
 	status: "New",
 	priority: "Medium",
 	type: "",
+	// Native ERPNext Project Type (Internal / External) — distinct from Category.
+	projectType: "",
 	startDate: new Date().toISOString().slice(0, 10),
 	endDate: "",
 	budget: "",
@@ -83,17 +85,13 @@ const form = reactive({
 	location: "",
 	description: "",
 	parentId: route.query.parentId || null,
-	// Group project by default. Turning this off makes the project a child
-	// record under a selected parent (is_group = 0).
-	allowSubprojects: !route.query.parentId,
-	// Seed stages from the matching BuildSuite Project Template on create.
-	// Default ON for top-level projects, OFF for subprojects.
+	// Sub-project capability is opt-in: off by default so a new project is a leaf
+	// unless the user deliberately allows children (is_group = 1).
+	allowSubprojects: false,
+	// Template import toggles — kept consistent with each other: all default ON for
+	// top-level projects and OFF for subprojects (the parent owns the breakdown).
 	seedDefaultStages: !route.query.parentId,
-	// Import project-level tasks from the template. Off by default; disabled
-	// entirely for subprojects since the parent owns the breakdown.
-	seedDefaultTasks: false,
-	// Import the template's work packages (tasks link to them). Default ON for
-	// top-level projects, off for subprojects.
+	seedDefaultTasks: !route.query.parentId,
 	seedDefaultWorkPackages: !route.query.parentId,
 });
 const { errors, applyServerErrors, setErrors, clearError } = useFormErrors({
@@ -128,7 +126,7 @@ async function loadDefaultCompany() {
 loadDefaultCompany();
 
 const parentProject = computed(
-	() => fetchedParent.value || (form.parentId ? store.projectById(form.parentId) : null)
+	() => fetchedParent.value || (form.parentId ? store.projectById(form.parentId) : null),
 );
 
 // The "Allow subprojects" toggle only controls is_group on a top-level project —
@@ -156,7 +154,10 @@ async function loadTemplateForCategory(category) {
 		const res = await fetch(
 			"/api/method/buildsuite_core.utils.project.get_project_template_summary?" +
 				new URLSearchParams({ project_category: category }),
-			{ credentials: "include", headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" } }
+			{
+				credentials: "include",
+				headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+			},
 		);
 		const data = await res.json();
 		const summary = data?.message || null;
@@ -165,7 +166,7 @@ async function loadTemplateForCategory(category) {
 		console.warn(
 			"[NewProjectView] Failed to load template summary for category",
 			category,
-			err
+			err,
 		);
 	} finally {
 		templateLoading.value = false;
@@ -174,7 +175,7 @@ async function loadTemplateForCategory(category) {
 
 watch(
 	() => form.type,
-	(category) => loadTemplateForCategory(category)
+	(category) => loadTemplateForCategory(category),
 );
 
 function validate() {
@@ -196,11 +197,11 @@ async function save() {
 			form.endDate,
 			b.start,
 			b.end,
-			"parent project"
+			"parent project",
 		);
 		if (boundsErr) {
 			setErrors(
-				boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr }
+				boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr },
 			);
 			return;
 		}
@@ -225,6 +226,7 @@ async function save() {
 			expected_end_date: form.endDate,
 			customer: form.client,
 			project_category: form.type,
+			project_type: form.projectType || null,
 			estimated_costing: Number(form.budget),
 			project_manager: form.pm || null,
 			notes: form.description,
@@ -245,7 +247,7 @@ function cancel() {
 }
 
 const subtitle = computed(() =>
-	parentProject.value ? `Subproject under ${parentProject.value.name}` : "Top-level project"
+	parentProject.value ? `Subproject under ${parentProject.value.name}` : "Top-level project",
 );
 
 const breadcrumbs = computed(() => {
@@ -338,6 +340,18 @@ const breadcrumbs = computed(() => {
 								+ New
 							</button>
 						</div>
+					</DeskField>
+					<DeskField label="Project type" hint="Internal or External (ERPNext).">
+						<DeskLinkPicker
+							v-model="form.projectType"
+							data-test="pick-project-type"
+							doctype="Project Type"
+							placeholder="Select project type"
+							label-field="name"
+							value-field="name"
+							:search-fields="['name']"
+							:page-length="20"
+						/>
 					</DeskField>
 					<DeskField label="Project category" :error="errors.type">
 						<DeskLinkPicker

--- a/frontend/src/views/NewTaskView.vue
+++ b/frontend/src/views/NewTaskView.vue
@@ -61,7 +61,7 @@ watch(
 	(newVal, oldVal) => {
 		if (lockedWP.value) return;
 		if (newVal !== oldVal) form.workPackageId = "";
-	}
+	},
 );
 
 function validate() {
@@ -82,11 +82,11 @@ async function save() {
 		form.endDate,
 		b.start,
 		b.end,
-		"project"
+		"project",
 	);
 	if (boundsErr) {
 		setErrors(
-			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr }
+			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr },
 		);
 		return;
 	}
@@ -100,7 +100,7 @@ async function save() {
 			description: form.description,
 			task_status: form.status,
 			priority: form.priority,
-			exp_start_date: form.startDate,
+			exp_start_date: form.taskType === "Milestone" ? form.endDate : form.startDate,
 			exp_end_date: form.endDate,
 			expected_time: Number(form.estimatedHours) || 0,
 			owner: form.assignee, // Map to owner for the adapter/Frappe consistency
@@ -228,8 +228,8 @@ const breadcrumbs = [
 								lockedWP
 									? []
 									: form.projectId
-									? [['project', '=', form.projectId]]
-									: []
+										? [['project', '=', form.projectId]]
+										: []
 							"
 							:page-length="20"
 							placeholder="— None · Direct project task —"
@@ -241,7 +241,13 @@ const breadcrumbs = [
 				</DeskSection>
 
 				<DeskSection title="Schedule" :cols="3">
-					<DeskField label="Start date" :error="errors.startDate">
+					<!-- A Milestone is a point in time: only a Due date, no start (the due
+					     date is the end date behind the scenes, used for delay). -->
+					<DeskField
+						v-if="form.taskType !== 'Milestone'"
+						label="Start date"
+						:error="errors.startDate"
+					>
 						<DeskInput v-model="form.startDate" type="date" />
 					</DeskField>
 					<DeskField label="Due date" :error="errors.endDate">

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -96,6 +96,7 @@ function loadProjectResource() {
 			"project_name",
 			"customer",
 			"project_category",
+			"project_type",
 			"status",
 			"project_status",
 			"priority",
@@ -123,6 +124,7 @@ function loadProjectResource() {
 				status: row?.project_status || row?.status || "New",
 				priority: row?.priority || "Medium",
 				type: row?.project_category || "",
+				projectType: row?.project_type || "",
 				company: row?.company || "",
 				startDate: row?.expected_start_date || null,
 				endDate: row?.expected_end_date || null,
@@ -178,7 +180,7 @@ watch(
 				rows.map((r) => ({ name: r?.name, fullName: r?.full_name || r?.name })),
 		});
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 const pmName = computed(() => {
 	const rows = pmUserResource.value?.data;
@@ -187,7 +189,7 @@ const pmName = computed(() => {
 });
 const resolvedProjectId = computed(() => project.value?.id || props.id);
 const parent = computed(() =>
-	project.value?.parentId ? store.projectById(project.value.parentId) : null
+	project.value?.parentId ? store.projectById(project.value.parentId) : null,
 );
 const subprojectsResource = ref(null);
 const subprojectFilterKey = computed(() => resolvedProjectId.value);
@@ -239,7 +241,7 @@ watch(
 	() => {
 		loadSubprojectsResource();
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 
 const subs = computed(() => {
@@ -253,7 +255,7 @@ const subprojectIdsKey = computed(() =>
 	subs.value
 		.map((p) => p.id)
 		.filter(Boolean)
-		.join("|")
+		.join("|"),
 );
 
 const workPackageProjectIds = computed(() => {
@@ -305,6 +307,9 @@ function loadWorkPackagesResource() {
 			}));
 		},
 	});
+	// A cached list resource returns stale data when we return to this view after
+	// creating a Work Package elsewhere — force a fresh fetch so new WPs appear.
+	workPackagesResource.value?.reload?.();
 }
 
 watch(
@@ -312,7 +317,7 @@ watch(
 	() => {
 		loadWorkPackagesResource();
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 
 watch(subprojectIdsKey, (next, prev) => {
@@ -395,7 +400,7 @@ watch(
 	() => {
 		loadTasksResource();
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 
 watch(subprojectIdsKey, (next, prev) => {
@@ -451,12 +456,12 @@ const boqs = computed(() =>
 	store
 		.boqsByProject(resolvedProjectId.value)
 		.slice()
-		.sort((a, b) => (b.preparedDate || "").localeCompare(a.preparedDate || ""))
+		.sort((a, b) => (b.preparedDate || "").localeCompare(a.preparedDate || "")),
 );
 const activeBoq = computed(
 	() =>
 		store.activeBoqForProject(resolvedProjectId.value) ||
-		boqs.value.find((b) => b.status === "Approved")
+		boqs.value.find((b) => b.status === "Approved"),
 );
 
 // Cost rollups for the summary strip. Planned honours the active BOQ's
@@ -473,7 +478,7 @@ const actualCost = computed(() => {
 });
 const costDeviation = computed(() => actualCost.value - plannedCost.value);
 const costDeviationPct = computed(() =>
-	plannedCost.value ? (costDeviation.value / plannedCost.value) * 100 : 0
+	plannedCost.value ? (costDeviation.value / plannedCost.value) * 100 : 0,
 );
 function deviationColor(pct) {
 	if (Math.abs(pct) < 0.5) return "text-ink-500";
@@ -536,7 +541,7 @@ watch(
 	() => {
 		tab.value = "overview";
 		editing.value = false;
-	}
+	},
 );
 
 // Project team — read from the project's custom_team_members child table
@@ -569,7 +574,7 @@ function colorOf(id) {
 // The Project Team child row only carries user + full_name, so the human-readable
 // role lives on the User's `persona` custom field — same as the prototype shows.
 const teamUserIds = computed(() =>
-	(project.value?.teamMembers || []).map((m) => m.user).filter(Boolean)
+	(project.value?.teamMembers || []).map((m) => m.user).filter(Boolean),
 );
 const teamUsersResource = ref(null);
 watch(
@@ -587,7 +592,7 @@ watch(
 			transform: (rows) => rows.map((r) => ({ name: r?.name, persona: r?.persona || "" })),
 		});
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 const teamPersonaMap = computed(() => {
 	const raw = teamUsersResource.value?.data;
@@ -603,7 +608,7 @@ const projectTeam = computed(() =>
 		role: teamPersonaMap.value[m.user] || "", // the user's persona, e.g. "Project Manager"
 		initials: initialsOf(m.fullName || m.user),
 		color: colorOf(m.user),
-	}))
+	})),
 );
 
 // Users already on the team (+ the PM) — excluded from the add picker.
@@ -685,12 +690,12 @@ async function saveEdit() {
 			editForm.value.endDate,
 			b.start,
 			b.end,
-			"parent project"
+			"parent project",
 		);
 	}
 	if (boundsErr) {
 		setEditErrors(
-			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr }
+			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr },
 		);
 		showToast(boundsErr, "error");
 		return;
@@ -709,6 +714,7 @@ async function saveEdit() {
 			expected_end_date: editForm.value.endDate,
 			customer: editForm.value.client,
 			project_category: editForm.value.type,
+			project_type: editForm.value.projectType || null,
 			location: editForm.value.location || null,
 			// company is locked/inferred server-side (§14) — not editable from the form.
 			estimated_costing: Number(editForm.value.budget),
@@ -778,7 +784,7 @@ async function loadTemplateSummary(type) {
 			{
 				credentials: "include",
 				headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
-			}
+			},
 		);
 		const data = await res.json();
 		const s = data?.message || null;
@@ -810,7 +816,7 @@ async function seedFromTemplate() {
 					"X-Frappe-CSRF-Token": window.csrf_token || "",
 				},
 				body: body.toString(),
-			}
+			},
 		);
 		const data = await res.json().catch(() => ({}));
 		if (!res.ok) throw new Error(data?.exception || data?.exc_type || `HTTP ${res.status}`);
@@ -913,7 +919,7 @@ const breadcrumbs = computed(() => {
 });
 
 const titleStatuses = computed(() =>
-	project.value ? [project.value.status, project.value.priority] : []
+	project.value ? [project.value.status, project.value.priority] : [],
 );
 
 // Schedule-based variance + progress-bar color, same as the list view.
@@ -1306,6 +1312,7 @@ usePageTitle(() => project.value?.name);
 						'description',
 						'planned_start',
 						'planned_end',
+						'task_count',
 						'planned_task_count',
 					]"
 					:columns="[
@@ -1363,9 +1370,11 @@ usePageTitle(() => project.value?.name);
 						}}</span>
 					</template>
 					<template #cell-planned_task_count="{ row }">
-						<span class="text-xs text-ink-700 tabular-nums">{{
-							row.planned_task_count || 0
-						}}</span>
+						<span
+							class="text-xs text-ink-700 tabular-nums"
+							:title="'Actual tasks in stage / planned task count'"
+							>{{ row.task_count || 0 }} / {{ row.planned_task_count || 0 }}</span
+						>
 					</template>
 					<template #cell-_status="{ row }">
 						<span

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -236,14 +236,14 @@ async function saveDep() {
 				props.id,
 				depForm.otherTaskId,
 				depForm.dependency_type,
-				Number(depForm.lag) || 0
+				Number(depForm.lag) || 0,
 			);
 		} else {
 			await addTaskPredecessor(
 				depForm.otherTaskId,
 				props.id,
 				depForm.dependency_type,
-				Number(depForm.lag) || 0
+				Number(depForm.lag) || 0,
 			);
 		}
 		await loadDeps();
@@ -271,8 +271,8 @@ const depPickerFilters = computed(() =>
 		? [
 				["project", "=", task.value.projectId],
 				["name", "!=", props.id],
-		  ]
-		: [["name", "!=", props.id]]
+			]
+		: [["name", "!=", props.id]],
 );
 
 const projectResource = ref(null);
@@ -598,7 +598,7 @@ watch(
 	() => {
 		if (task.value && !editing.value) form.value = buildEditForm(task.value);
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 
 function startEdit() {
@@ -617,11 +617,11 @@ async function saveEdit() {
 			form.value.endDate,
 			b.start,
 			b.end,
-			"project"
+			"project",
 		);
 	if (boundsErr) {
 		setEditErrors(
-			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr }
+			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr },
 		);
 		showToast(boundsErr, "error");
 		return;
@@ -633,7 +633,9 @@ async function saveEdit() {
 			task_status: form.value.status,
 			priority: form.value.priority,
 			type: form.value.task_type,
-			exp_start_date: form.value.startDate,
+			// Milestone = a single date: start collapses onto the due (end) date.
+			exp_start_date:
+				form.value.task_type === "Milestone" ? form.value.endDate : form.value.startDate,
 			exp_end_date: form.value.endDate,
 			description: form.value.description,
 		});
@@ -1164,7 +1166,11 @@ usePageTitle(() => task.value?.name);
 							<DeskField label="Description">
 								<DeskTextarea v-model="form.description" :rows="4" />
 							</DeskField>
-							<DeskField label="Start" :error="editErrors.startDate">
+							<DeskField
+								v-if="form.task_type !== 'Milestone'"
+								label="Start"
+								:error="editErrors.startDate"
+							>
 								<DeskInput
 									v-model="form.startDate"
 									type="date"
@@ -1551,8 +1557,8 @@ usePageTitle(() => task.value?.name);
 								depForm.mode === "edit"
 									? "Edit dependency"
 									: depForm.mode === "add-pred"
-									? "Add predecessor"
-									: "Add successor"
+										? "Add predecessor"
+										: "Add successor"
 							}}
 						</h2>
 						<button

--- a/frontend/src/views/project-detail/ProjectEditModal.vue
+++ b/frontend/src/views/project-detail/ProjectEditModal.vue
@@ -94,6 +94,17 @@ function onCustomerCreated(name) {
 								</button>
 							</div>
 						</DeskField>
+						<DeskField label="Project type" hint="Internal or External (ERPNext).">
+							<DeskLinkPicker
+								v-model="editForm.projectType"
+								doctype="Project Type"
+								placeholder="Select project type"
+								label-field="name"
+								value-field="name"
+								:search-fields="['name']"
+								:page-length="20"
+							/>
+						</DeskField>
 						<DeskField label="Category" :error="errors.type">
 							<DeskLinkPicker
 								v-model="editForm.type"
@@ -123,7 +134,7 @@ function onCustomerCreated(name) {
 								subsCount > 0
 									? `Locked on - this project has ${subsCount} subproject${
 											subsCount === 1 ? '' : 's'
-									  }. Delete or move them out before turning this off.`
+										}. Delete or move them out before turning this off.`
 									: 'Turn on to break this project into subprojects (e.g. Block A / Block B / Tower 1).'
 							"
 						>

--- a/frontend/src/views/project-detail/tabs/OverviewTab.vue
+++ b/frontend/src/views/project-detail/tabs/OverviewTab.vue
@@ -355,8 +355,12 @@ function deviationColor(pct) {
 							<dd><StatusBadge :status="project.priority" /></dd>
 						</div>
 						<div class="flex items-center justify-between px-4 py-2.5 text-xs">
-							<dt class="text-ink-500 font-medium">Type</dt>
+							<dt class="text-ink-500 font-medium">Category</dt>
 							<dd class="text-ink-800">{{ project.type || "—" }}</dd>
+						</div>
+						<div class="flex items-center justify-between px-4 py-2.5 text-xs">
+							<dt class="text-ink-500 font-medium">Project Type</dt>
+							<dd class="text-ink-800">{{ project.projectType || "—" }}</dd>
 						</div>
 						<div
 							v-if="store.isMultiCompany && project.company"

--- a/frontend/src/views/settings/CoreSettingsView.vue
+++ b/frontend/src/views/settings/CoreSettingsView.vue
@@ -26,15 +26,30 @@ const form = ref({});
 const saving = ref(false);
 
 // Project naming is server-persisted (BuildSuite Core Settings Single), unlike the
-// other fields on this screen. Loaded from / saved to the backend directly.
-const projectNaming = ref("Project ID");
-const projectNamingOptions = ref(["Project ID"]);
+// other fields on this screen. Stored resolved value: "Project ID" or a naming
+// series string. In the UI it's a mode select ("Project ID" | "Name Series") plus a
+// series picker shown only in Name Series mode.
+const PROJECT_ID_MODE = "Project ID";
+const NAME_SERIES_MODE = "Name Series";
+const projectNaming = ref(PROJECT_ID_MODE);
+const projectNamingOptions = ref([PROJECT_ID_MODE]);
+
+// The naming series available on the Project doctype (everything but "Project ID").
+const seriesOptions = computed(() =>
+	projectNamingOptions.value.filter((o) => o !== PROJECT_ID_MODE),
+);
+// Human-readable summary of the current setting for the read-only view.
+const projectNamingLabel = computed(() =>
+	projectNaming.value === PROJECT_ID_MODE
+		? "Project ID"
+		: `Name Series — ${projectNaming.value}`,
+);
 
 onMounted(async () => {
 	try {
 		const res = await getCoreSettings();
-		projectNaming.value = res.project_naming || "Project ID";
-		projectNamingOptions.value = res.project_naming_options || ["Project ID"];
+		projectNaming.value = res.project_naming || PROJECT_ID_MODE;
+		projectNamingOptions.value = res.project_naming_options || [PROJECT_ID_MODE];
 	} catch {
 		/* leave defaults; non-admins can't read it */
 	}
@@ -49,9 +64,11 @@ watch(
 );
 
 function startEdit() {
+	const isSeries = projectNaming.value !== PROJECT_ID_MODE;
 	form.value = {
 		...JSON.parse(JSON.stringify(store.coreSettings)),
-		project_naming: projectNaming.value,
+		naming_mode: isSeries ? NAME_SERIES_MODE : PROJECT_ID_MODE,
+		naming_series: isSeries ? projectNaming.value : seriesOptions.value[0] || "",
 	};
 	editing.value = true;
 }
@@ -64,9 +81,13 @@ async function saveEdit() {
 	saving.value = true;
 	try {
 		store.updateCoreSettings({ ...form.value });
-		if (form.value.project_naming && form.value.project_naming !== projectNaming.value) {
-			await setProjectNaming(form.value.project_naming);
-			projectNaming.value = form.value.project_naming;
+		const resolved =
+			form.value.naming_mode === NAME_SERIES_MODE
+				? form.value.naming_series || seriesOptions.value[0]
+				: PROJECT_ID_MODE;
+		if (resolved && resolved !== projectNaming.value) {
+			await setProjectNaming(resolved);
+			projectNaming.value = resolved;
 		}
 		editing.value = false;
 	} catch (err) {
@@ -169,13 +190,23 @@ const PROJECT_TYPES = ["Commercial", "Residential", "Infrastructure", "Industria
 					</DeskField>
 					<DeskField
 						label="Project naming"
-						hint="How a new project's record ID is generated. 'Project ID' uses the entered Project ID as the record name; otherwise the selected ERPNext naming series is used."
+						hint="How a new project's record ID is generated. 'Project ID' uses the entered Project ID as the record name; 'Name Series' uses the selected ERPNext naming series."
 					>
 						<div v-if="!editing" class="text-sm text-ink-900 py-1">
-							{{ projectNaming }}
+							{{ projectNamingLabel }}
 						</div>
-						<DeskSelect v-else v-model="form.project_naming">
-							<option v-for="opt in projectNamingOptions" :key="opt" :value="opt">
+						<DeskSelect v-else v-model="form.naming_mode">
+							<option value="Project ID">Project ID</option>
+							<option value="Name Series">Name Series</option>
+						</DeskSelect>
+					</DeskField>
+					<DeskField
+						v-if="editing && form.naming_mode === 'Name Series'"
+						label="Name series"
+						hint="The ERPNext naming series used to generate the project's record ID."
+					>
+						<DeskSelect v-model="form.naming_series">
+							<option v-for="opt in seriesOptions" :key="opt" :value="opt">
 								{{ opt }}
 							</option>
 						</DeskSelect>


### PR DESCRIPTION
A batch of project/task form fixes:

1. **Project naming** — Core Settings now has a mode select (Project ID | Name Series); Name Series reveals a series picker. The chosen series drives project naming.
2. **Milestone tasks** — create/edit forms show a single **Due date** (no Start) when the task type is Milestone, across every entry point (New Task, the Schedule/Project/Work-Package modals, and Task detail edit). The due date is the end date behind the scenes.
3. **Import toggles** — the New Project "import stages / work packages / tasks" toggles now default consistently (all on for top-level, all off for subprojects).
4. **Project Type** — a link picker fed from the Project Type doctype (Internal/External) on the New Project form, Project detail (read-only) and Edit; the detail view's mislabeled "Type" is renamed **Category**, with a separate **Project Type** row.
5. **Task end date** — a Task never auto-fills its end date from `expected_time` (template-seeded tasks carried it, so editing one fabricated a random end). Task controller override + test.
6. **Work Packages list** — the project's WP list refetches so a newly created WP appears (it was serving a stale cache; the filter/data were already correct).
7. **Allow subproject** — defaults to **off** on new-project create (opt-in).
8. **Stage list** — the project stage list's Tasks column shows **actual / planned** counts (row-click to open was already wired).

## Verification
- 123 backend tests pass, no data leak. Frontend builds clean. Task-override verified: a task with expected_time + start but no end keeps its end empty.