### PR TITLE
fix: project naming as a Select mode + separate name-series field

### DIFF
--- a/buildsuite_core/api/core_settings.py
+++ b/buildsuite_core/api/core_settings.py
@@ -7,10 +7,14 @@ Vue Settings screen can persist org-wide settings server-side. Admin only."""
 import frappe
 from frappe import _
 
-from buildsuite_core.overrides.project import PROJECT_ID_MODE
+from buildsuite_core.overrides.project import (
+	NAME_SERIES_MODE,
+	PROJECT_ID_MODE,
+)
 
 ADMIN_ROLES = {"System Manager", "BuildSuite Administrator"}
 SETTINGS = "BuildSuite Core Settings"
+NAMING_MODES = [PROJECT_ID_MODE, NAME_SERIES_MODE]
 
 
 def _require_admin():
@@ -18,34 +22,44 @@ def _require_admin():
 		frappe.throw(_("Only an administrator can manage settings."), frappe.PermissionError)
 
 
-def _project_naming_options():
-	"""'Project ID' plus every naming series configured on the Project doctype."""
-	options = [PROJECT_ID_MODE]
+def _project_series_options():
+	"""Every naming series configured on the Project doctype."""
 	field = frappe.get_meta("Project").get_field("naming_series")
 	if field and field.options:
-		options += [row.strip() for row in field.options.split("\n") if row.strip()]
-	return options
+		return [row.strip() for row in field.options.split("\n") if row.strip()]
+	return []
 
 
 @frappe.whitelist()
 def get_core_settings():
 	"""Current settings + the choices the UI needs to render them."""
 	_require_admin()
-	naming = frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE
 	return {
-		"project_naming": naming,
-		"project_naming_options": _project_naming_options(),
+		"project_naming": frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE,
+		"project_naming_series": frappe.db.get_single_value(SETTINGS, "project_naming_series") or "",
+		"project_naming_modes": NAMING_MODES,
+		"project_series_options": _project_series_options(),
 	}
 
 
 @frappe.whitelist()
-def set_project_naming(project_naming: str):
-	"""Set how new projects are named. Must be 'Project ID' or a known Project series."""
+def set_project_naming(project_naming: str, project_naming_series: str = None):
+	"""Set how new projects are named: the mode ('Project ID' | 'Name Series') and,
+	for Name Series, the specific Project naming series."""
 	_require_admin()
-	if project_naming not in _project_naming_options():
-		frappe.throw(_("Unknown project naming option {0}.").format(project_naming))
+	if project_naming not in NAMING_MODES:
+		frappe.throw(_("Project naming must be one of {0}.").format(", ".join(NAMING_MODES)))
+
+	series = (project_naming_series or "").strip()
+	if project_naming == NAME_SERIES_MODE:
+		if series not in _project_series_options():
+			frappe.throw(_("Unknown project naming series {0}.").format(series or "(blank)"))
+	else:
+		series = ""  # Project ID mode ignores the series
+
 	doc = frappe.get_single(SETTINGS)
 	doc.project_naming = project_naming
+	doc.project_naming_series = series
 	doc.flags.ignore_permissions = True
 	doc.save()
-	return {"project_naming": project_naming}
+	return {"project_naming": project_naming, "project_naming_series": series}

--- a/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
+++ b/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
@@ -5,7 +5,8 @@
  "engine": "InnoDB",
  "field_order": [
   "project_section",
-  "project_naming"
+  "project_naming",
+  "project_naming_series"
  ],
  "fields": [
   {
@@ -15,10 +16,18 @@
   },
   {
    "default": "Project ID",
-   "description": "How a Project's record ID (Frappe name) is generated. \"Project ID\" uses the entered Project ID; any other value is an ERPNext naming series (e.g. PROJ-.####).",
+   "description": "How a Project's record ID (Frappe name) is generated. \"Project ID\" uses the entered Project ID; \"Name Series\" uses the naming series selected below.",
    "fieldname": "project_naming",
+   "fieldtype": "Select",
+   "label": "Project Naming",
+   "options": "Project ID\nName Series"
+  },
+  {
+   "depends_on": "eval:doc.project_naming=='Name Series'",
+   "description": "The ERPNext naming series used to generate the project's record ID when Project Naming is \"Name Series\" (e.g. PROJ-.####).",
+   "fieldname": "project_naming_series",
    "fieldtype": "Data",
-   "label": "Project Naming"
+   "label": "Project Naming Series"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/buildsuite_core/overrides/project.py
+++ b/buildsuite_core/overrides/project.py
@@ -4,13 +4,14 @@
 """Project naming override.
 
 The Frappe record `name` for a Project is controlled by the BuildSuite Core
-Settings "Project Naming" option:
+Settings "Project Naming" select:
 
   - "Project ID"  -> the name IS the entered Project ID (custom_project_id). The
                      field is already required + unique, so the id doubles as the
                      record key.
-  - anything else -> treated as an ERPNext naming series (e.g. PROJ-.####), and
-                     the name is generated from it as ERPNext would by default.
+  - "Name Series" -> the name is generated from the naming series chosen in the
+                     "Project Naming Series" setting (e.g. PROJ-.####), as ERPNext
+                     would by default.
 
 ERPNext's Project has no autoname() of its own (it relies on the naming_series
 autoname rule), so defining one here takes precedence via override_doctype_class.
@@ -23,24 +24,33 @@ from frappe.model.naming import set_name_by_naming_series
 from erpnext.projects.doctype.project.project import Project as _ERPNextProject
 
 PROJECT_ID_MODE = "Project ID"
+NAME_SERIES_MODE = "Name Series"
+SETTINGS = "BuildSuite Core Settings"
 
 
-def project_naming_mode():
-	return frappe.db.get_single_value("BuildSuite Core Settings", "project_naming") or PROJECT_ID_MODE
+def project_naming_config():
+	"""(mode, series) from the settings. Defaults to Project ID mode."""
+	mode = frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE
+	series = frappe.db.get_single_value(SETTINGS, "project_naming_series")
+	return mode, series
+
+
+def _name_by_project_id(doc):
+	project_id = (doc.get("custom_project_id") or "").strip()
+	if not project_id:
+		frappe.throw(_("Project ID is required."))
+	doc.name = project_id
 
 
 class BuildSuiteProject(_ERPNextProject):
 	def autoname(self):
-		mode = project_naming_mode()
-		if mode == PROJECT_ID_MODE:
-			project_id = (self.get("custom_project_id") or "").strip()
-			if not project_id:
-				frappe.throw(_("Project ID is required."))
-			self.name = project_id
+		mode, series = project_naming_config()
+		if mode == NAME_SERIES_MODE and series:
+			self.naming_series = series
+			set_name_by_naming_series(self)
 			return
-		# Otherwise treat the setting as a naming series.
-		self.naming_series = mode
-		set_name_by_naming_series(self)
+		# Project ID mode (also the fallback when Name Series has no series set).
+		_name_by_project_id(self)
 
 
 def reject_duplicate_project_id(doc, method=None):
@@ -48,8 +58,11 @@ def reject_duplicate_project_id(doc, method=None):
 	collides on the primary key and would surface as a raw DB error. Reject it up
 	front with a clean message (Frappe's own unique-field check can't catch it here,
 	since it excludes the row whose name equals the id)."""
-	if not doc.is_new() or project_naming_mode() != PROJECT_ID_MODE:
+	if not doc.is_new():
 		return
+	mode, series = project_naming_config()
+	if mode == NAME_SERIES_MODE and series:
+		return  # named by series — id uniqueness is enforced by the field's own unique check
 	project_id = (doc.get("custom_project_id") or "").strip()
 	if project_id and frappe.db.exists("Project", project_id):
 		frappe.throw(_("A project with ID {0} already exists.").format(project_id))

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -13,3 +13,4 @@ buildsuite_core.patches.migrate_project_type_to_category
 buildsuite_core.patches.remove_legacy_project_template_doctypes
 buildsuite_core.patches.repair_default_personas
 buildsuite_core.patches.enforce_persona_backend_only
+buildsuite_core.patches.split_project_naming_mode_and_series

--- a/buildsuite_core/patches/split_project_naming_mode_and_series.py
+++ b/buildsuite_core/patches/split_project_naming_mode_and_series.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Project Naming was originally a single Data field holding either "Project ID" or
+a naming-series string. It's now a Select mode ("Project ID" | "Name Series") plus a
+separate "Project Naming Series" field. Migrate any stored series string into the new
+shape so existing sites keep naming projects the same way."""
+
+import frappe
+
+PROJECT_ID_MODE = "Project ID"
+NAME_SERIES_MODE = "Name Series"
+SETTINGS = "BuildSuite Core Settings"
+
+
+def execute():
+	current = frappe.db.get_single_value(SETTINGS, "project_naming")
+	if not current or current in (PROJECT_ID_MODE, NAME_SERIES_MODE):
+		return  # already in the new shape (or unset → default Project ID)
+
+	# A legacy series string (e.g. "PROJ-.####") → Name Series mode + that series.
+	doc = frappe.get_single(SETTINGS)
+	doc.project_naming = NAME_SERIES_MODE
+	doc.project_naming_series = current
+	doc.flags.ignore_permissions = True
+	doc.save()
+	frappe.db.commit()

--- a/buildsuite_core/tests/test_project.py
+++ b/buildsuite_core/tests/test_project.py
@@ -76,7 +76,10 @@ class TestProject(BuildSuiteTestCase):
 		self.assertEqual(p.name, f"NMID-{self._n}")
 
 	def test_project_named_by_series_when_setting_is_a_series(self):
-		frappe.db.set_single_value("BuildSuite Core Settings", "project_naming", "PROJ-.####")
+		frappe.db.set_single_value(
+			"BuildSuite Core Settings",
+			{"project_naming": "Name Series", "project_naming_series": "PROJ-.####"},
+		)
 		p = frappe.get_doc(
 			{
 				"doctype": "Project",

--- a/frontend/src/data/coreSettingsApi.js
+++ b/frontend/src/data/coreSettingsApi.js
@@ -16,5 +16,8 @@ async function call(method, args) {
 }
 
 export const getCoreSettings = () => call("get_core_settings");
-export const setProjectNaming = (projectNaming) =>
-	call("set_project_naming", { project_naming: projectNaming });
+export const setProjectNaming = (projectNaming, projectNamingSeries) =>
+	call("set_project_naming", {
+		project_naming: projectNaming,
+		project_naming_series: projectNamingSeries || "",
+	});

--- a/frontend/src/views/settings/CoreSettingsView.vue
+++ b/frontend/src/views/settings/CoreSettingsView.vue
@@ -17,6 +17,7 @@ import DeskActionBar from "@/components/desk/DeskActionBar.vue";
 import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 
 const router = useRouter();
 const store = useDataStore();
@@ -26,30 +27,33 @@ const form = ref({});
 const saving = ref(false);
 
 // Project naming is server-persisted (BuildSuite Core Settings Single), unlike the
-// other fields on this screen. Stored resolved value: "Project ID" or a naming
-// series string. In the UI it's a mode select ("Project ID" | "Name Series") plus a
-// series picker shown only in Name Series mode.
+// other fields on this screen. It's a mode ("Project ID" | "Name Series") plus, for
+// Name Series, the specific Project naming series.
 const PROJECT_ID_MODE = "Project ID";
 const NAME_SERIES_MODE = "Name Series";
-const projectNaming = ref(PROJECT_ID_MODE);
-const projectNamingOptions = ref([PROJECT_ID_MODE]);
+const projectNaming = ref(PROJECT_ID_MODE); // the mode
+const projectNamingSeries = ref(""); // the chosen series (Name Series mode)
+const namingModes = ref([PROJECT_ID_MODE, NAME_SERIES_MODE]);
+const seriesOptions = ref([]); // Project naming series available to pick
 
-// The naming series available on the Project doctype (everything but "Project ID").
-const seriesOptions = computed(() =>
-	projectNamingOptions.value.filter((o) => o !== PROJECT_ID_MODE),
+// { value, label } options for the searchable series picker.
+const seriesPickerOptions = computed(() =>
+	seriesOptions.value.map((s) => ({ value: s, label: s })),
 );
-// Human-readable summary of the current setting for the read-only view.
+// Human-readable summary for the read-only view.
 const projectNamingLabel = computed(() =>
-	projectNaming.value === PROJECT_ID_MODE
-		? "Project ID"
-		: `Name Series — ${projectNaming.value}`,
+	projectNaming.value === NAME_SERIES_MODE
+		? `Name Series — ${projectNamingSeries.value || "(none selected)"}`
+		: "Project ID",
 );
 
 onMounted(async () => {
 	try {
 		const res = await getCoreSettings();
 		projectNaming.value = res.project_naming || PROJECT_ID_MODE;
-		projectNamingOptions.value = res.project_naming_options || [PROJECT_ID_MODE];
+		projectNamingSeries.value = res.project_naming_series || "";
+		namingModes.value = res.project_naming_modes || [PROJECT_ID_MODE, NAME_SERIES_MODE];
+		seriesOptions.value = res.project_series_options || [];
 	} catch {
 		/* leave defaults; non-admins can't read it */
 	}
@@ -64,11 +68,10 @@ watch(
 );
 
 function startEdit() {
-	const isSeries = projectNaming.value !== PROJECT_ID_MODE;
 	form.value = {
 		...JSON.parse(JSON.stringify(store.coreSettings)),
-		naming_mode: isSeries ? NAME_SERIES_MODE : PROJECT_ID_MODE,
-		naming_series: isSeries ? projectNaming.value : seriesOptions.value[0] || "",
+		naming_mode: projectNaming.value,
+		naming_series: projectNamingSeries.value || seriesOptions.value[0] || "",
 	};
 	editing.value = true;
 }
@@ -78,16 +81,19 @@ function cancelEdit() {
 }
 async function saveEdit() {
 	if (!store.isAdmin) return;
+	if (form.value.naming_mode === NAME_SERIES_MODE && !form.value.naming_series) {
+		showToast("Pick a naming series.", "error");
+		return;
+	}
 	saving.value = true;
 	try {
 		store.updateCoreSettings({ ...form.value });
-		const resolved =
-			form.value.naming_mode === NAME_SERIES_MODE
-				? form.value.naming_series || seriesOptions.value[0]
-				: PROJECT_ID_MODE;
-		if (resolved && resolved !== projectNaming.value) {
-			await setProjectNaming(resolved);
-			projectNaming.value = resolved;
+		const mode = form.value.naming_mode;
+		const series = mode === NAME_SERIES_MODE ? form.value.naming_series : "";
+		if (mode !== projectNaming.value || series !== projectNamingSeries.value) {
+			await setProjectNaming(mode, series);
+			projectNaming.value = mode;
+			projectNamingSeries.value = series;
 		}
 		editing.value = false;
 	} catch (err) {
@@ -196,20 +202,20 @@ const PROJECT_TYPES = ["Commercial", "Residential", "Infrastructure", "Industria
 							{{ projectNamingLabel }}
 						</div>
 						<DeskSelect v-else v-model="form.naming_mode">
-							<option value="Project ID">Project ID</option>
-							<option value="Name Series">Name Series</option>
+							<option v-for="m in namingModes" :key="m" :value="m">{{ m }}</option>
 						</DeskSelect>
 					</DeskField>
 					<DeskField
 						v-if="editing && form.naming_mode === 'Name Series'"
 						label="Name series"
-						hint="The ERPNext naming series used to generate the project's record ID."
+						hint="The Project naming series used to generate the record ID."
 					>
-						<DeskSelect v-model="form.naming_series">
-							<option v-for="opt in seriesOptions" :key="opt" :value="opt">
-								{{ opt }}
-							</option>
-						</DeskSelect>
+						<DeskSearchableSelect
+							v-model="form.naming_series"
+							:options="seriesPickerOptions"
+							placeholder="Select a naming series"
+							search-placeholder="Search series…"
+						/>
 					</DeskField>
 				</DeskSection>
 			</div>


### PR DESCRIPTION
Reworks the project-naming setting so the mode is a proper **Select**, not a Data field.

## Changes
- **BuildSuite Core Settings**: `project_naming` is now a **Select** ("Project ID" | "Name Series"), plus a separate **`project_naming_series`** field (shown only in Name Series mode).
- **Autoname** reads both: Name Series + a series → the series generates the name; otherwise the entered Project ID is the name.
- **Migration patch** converts existing sites (a stored series string like `PROJ-.####` → mode "Name Series" + that series).
- **API** returns/accepts mode + series (with the Project series options); validates the mode and series.
- **Frontend** (Core Settings): a mode select, and when "Name Series" is chosen, a searchable series picker (`DeskSearchableSelect`) to select the specific Project naming series. Project ID mode hides the series picker.

## Verification
- Migration converted the existing value correctly; both modes name projects as expected; invalid mode/series rejected.
- 123 backend tests pass; frontend builds clean.

Note: Frappe has no "Naming Series" doctype to link to, so the series picker is a searchable option-fed select (fed from the Project doctype's naming series) rather than a doctype link picker.