### PR TITLE
fix: choose the name series on the New Project form, not in settings

### DIFF
--- a/buildsuite_core/api/core_settings.py
+++ b/buildsuite_core/api/core_settings.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 """Whitelisted read/write for BuildSuite Core Settings (a Single doctype), so the
-Vue Settings screen can persist org-wide settings server-side. Admin only."""
+Vue Settings screen can persist org-wide settings server-side."""
 
 import frappe
 from frappe import _
@@ -10,6 +10,8 @@ from frappe import _
 from buildsuite_core.overrides.project import (
 	NAME_SERIES_MODE,
 	PROJECT_ID_MODE,
+	default_project_series,
+	project_naming_mode,
 )
 
 ADMIN_ROLES = {"System Manager", "BuildSuite Administrator"}
@@ -32,34 +34,34 @@ def _project_series_options():
 
 @frappe.whitelist()
 def get_core_settings():
-	"""Current settings + the choices the UI needs to render them."""
+	"""The org-wide settings for the admin Settings screen."""
 	_require_admin()
 	return {
-		"project_naming": frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE,
-		"project_naming_series": frappe.db.get_single_value(SETTINGS, "project_naming_series") or "",
+		"project_naming": project_naming_mode(),
 		"project_naming_modes": NAMING_MODES,
-		"project_series_options": _project_series_options(),
 	}
 
 
 @frappe.whitelist()
-def set_project_naming(project_naming: str, project_naming_series: str = None):
-	"""Set how new projects are named: the mode ('Project ID' | 'Name Series') and,
-	for Name Series, the specific Project naming series."""
+def set_project_naming(project_naming: str):
+	"""Set the project naming MODE ('Project ID' | 'Name Series'). The specific series
+	is chosen per-project on the New Project form, not here."""
 	_require_admin()
 	if project_naming not in NAMING_MODES:
 		frappe.throw(_("Project naming must be one of {0}.").format(", ".join(NAMING_MODES)))
-
-	series = (project_naming_series or "").strip()
-	if project_naming == NAME_SERIES_MODE:
-		if series not in _project_series_options():
-			frappe.throw(_("Unknown project naming series {0}.").format(series or "(blank)"))
-	else:
-		series = ""  # Project ID mode ignores the series
-
 	doc = frappe.get_single(SETTINGS)
 	doc.project_naming = project_naming
-	doc.project_naming_series = series
 	doc.flags.ignore_permissions = True
 	doc.save()
-	return {"project_naming": project_naming, "project_naming_series": series}
+	return {"project_naming": project_naming}
+
+
+@frappe.whitelist()
+def get_project_naming():
+	"""The naming mode + the series options the New Project form needs. Available to
+	any signed-in user (anyone who can create a project), unlike the admin settings."""
+	return {
+		"project_naming": project_naming_mode(),
+		"series_options": _project_series_options(),
+		"default_series": default_project_series(),
+	}

--- a/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
+++ b/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
@@ -5,8 +5,7 @@
  "engine": "InnoDB",
  "field_order": [
   "project_section",
-  "project_naming",
-  "project_naming_series"
+  "project_naming"
  ],
  "fields": [
   {
@@ -16,18 +15,11 @@
   },
   {
    "default": "Project ID",
-   "description": "How a Project's record ID (Frappe name) is generated. \"Project ID\" uses the entered Project ID; \"Name Series\" uses the naming series selected below.",
+   "description": "How a Project's record ID (Frappe name) is generated. \"Project ID\" uses the entered Project ID; \"Name Series\" uses a naming series chosen on the New Project form.",
    "fieldname": "project_naming",
    "fieldtype": "Select",
    "label": "Project Naming",
    "options": "Project ID\nName Series"
-  },
-  {
-   "depends_on": "eval:doc.project_naming=='Name Series'",
-   "description": "The ERPNext naming series used to generate the project's record ID when Project Naming is \"Name Series\" (e.g. PROJ-.####).",
-   "fieldname": "project_naming_series",
-   "fieldtype": "Data",
-   "label": "Project Naming Series"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/buildsuite_core/overrides/project.py
+++ b/buildsuite_core/overrides/project.py
@@ -4,14 +4,14 @@
 """Project naming override.
 
 The Frappe record `name` for a Project is controlled by the BuildSuite Core
-Settings "Project Naming" select:
+Settings "Project Naming" select (the mode):
 
   - "Project ID"  -> the name IS the entered Project ID (custom_project_id). The
                      field is already required + unique, so the id doubles as the
                      record key.
-  - "Name Series" -> the name is generated from the naming series chosen in the
-                     "Project Naming Series" setting (e.g. PROJ-.####), as ERPNext
-                     would by default.
+  - "Name Series" -> the name is generated from the naming series chosen on the New
+                     Project form (the project's own `naming_series` field), falling
+                     back to the Project doctype's default series.
 
 ERPNext's Project has no autoname() of its own (it relies on the naming_series
 autoname rule), so defining one here takes precedence via override_doctype_class.
@@ -28,11 +28,18 @@ NAME_SERIES_MODE = "Name Series"
 SETTINGS = "BuildSuite Core Settings"
 
 
-def project_naming_config():
-	"""(mode, series) from the settings. Defaults to Project ID mode."""
-	mode = frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE
-	series = frappe.db.get_single_value(SETTINGS, "project_naming_series")
-	return mode, series
+def project_naming_mode():
+	return frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE
+
+
+def default_project_series():
+	"""The Project doctype's default naming series (its field default, else the first
+	configured option)."""
+	field = frappe.get_meta("Project").get_field("naming_series")
+	if not field or not field.options:
+		return None
+	options = [row.strip() for row in field.options.split("\n") if row.strip()]
+	return field.default or (options[0] if options else None)
 
 
 def _name_by_project_id(doc):
@@ -44,12 +51,14 @@ def _name_by_project_id(doc):
 
 class BuildSuiteProject(_ERPNextProject):
 	def autoname(self):
-		mode, series = project_naming_config()
-		if mode == NAME_SERIES_MODE and series:
-			self.naming_series = series
-			set_name_by_naming_series(self)
-			return
-		# Project ID mode (also the fallback when Name Series has no series set).
+		if project_naming_mode() == NAME_SERIES_MODE:
+			# Use the series chosen on the New Project form; fall back to the default.
+			if not self.naming_series:
+				self.naming_series = default_project_series()
+			if self.naming_series:
+				set_name_by_naming_series(self)
+				return
+		# Project ID mode (also the fallback when no series is available).
 		_name_by_project_id(self)
 
 
@@ -58,11 +67,8 @@ def reject_duplicate_project_id(doc, method=None):
 	collides on the primary key and would surface as a raw DB error. Reject it up
 	front with a clean message (Frappe's own unique-field check can't catch it here,
 	since it excludes the row whose name equals the id)."""
-	if not doc.is_new():
+	if not doc.is_new() or project_naming_mode() == NAME_SERIES_MODE:
 		return
-	mode, series = project_naming_config()
-	if mode == NAME_SERIES_MODE and series:
-		return  # named by series — id uniqueness is enforced by the field's own unique check
 	project_id = (doc.get("custom_project_id") or "").strip()
 	if project_id and frappe.db.exists("Project", project_id):
 		frappe.throw(_("A project with ID {0} already exists.").format(project_id))

--- a/buildsuite_core/patches/split_project_naming_mode_and_series.py
+++ b/buildsuite_core/patches/split_project_naming_mode_and_series.py
@@ -2,9 +2,9 @@
 # For license information, please see license.txt
 
 """Project Naming was originally a single Data field holding either "Project ID" or
-a naming-series string. It's now a Select mode ("Project ID" | "Name Series") plus a
-separate "Project Naming Series" field. Migrate any stored series string into the new
-shape so existing sites keep naming projects the same way."""
+a naming-series string. It's now a Select MODE only ("Project ID" | "Name Series") —
+the specific series is chosen per-project on the New Project form. Map any legacy
+series string to "Name Series" so existing sites keep generating series-based names."""
 
 import frappe
 
@@ -18,10 +18,6 @@ def execute():
 	if not current or current in (PROJECT_ID_MODE, NAME_SERIES_MODE):
 		return  # already in the new shape (or unset → default Project ID)
 
-	# A legacy series string (e.g. "PROJ-.####") → Name Series mode + that series.
-	doc = frappe.get_single(SETTINGS)
-	doc.project_naming = NAME_SERIES_MODE
-	doc.project_naming_series = current
-	doc.flags.ignore_permissions = True
-	doc.save()
+	# A legacy series string (e.g. "PROJ-.####") just means Name Series mode now.
+	frappe.db.set_single_value(SETTINGS, "project_naming", NAME_SERIES_MODE)
 	frappe.db.commit()

--- a/buildsuite_core/tests/test_project.py
+++ b/buildsuite_core/tests/test_project.py
@@ -75,17 +75,17 @@ class TestProject(BuildSuiteTestCase):
 		).insert(ignore_permissions=True)
 		self.assertEqual(p.name, f"NMID-{self._n}")
 
-	def test_project_named_by_series_when_setting_is_a_series(self):
-		frappe.db.set_single_value(
-			"BuildSuite Core Settings",
-			{"project_naming": "Name Series", "project_naming_series": "PROJ-.####"},
-		)
+	def test_project_named_by_series_when_mode_is_name_series(self):
+		# Name Series mode: the record name comes from the series chosen on the form
+		# (the project's naming_series), not the entered Project ID.
+		frappe.db.set_single_value("BuildSuite Core Settings", "project_naming", "Name Series")
 		p = frappe.get_doc(
 			{
 				"doctype": "Project",
 				"project_name": f"NM2 {self._n}",
 				"custom_project_id": f"NMID2-{self._n}",
 				"company": self.company,
+				"naming_series": "PROJ-.####",
 			}
 		).insert(ignore_permissions=True)
 		self.assertTrue(p.name.startswith("PROJ-"))

--- a/frontend/src/data/coreSettingsApi.js
+++ b/frontend/src/data/coreSettingsApi.js
@@ -16,8 +16,7 @@ async function call(method, args) {
 }
 
 export const getCoreSettings = () => call("get_core_settings");
-export const setProjectNaming = (projectNaming, projectNamingSeries) =>
-	call("set_project_naming", {
-		project_naming: projectNaming,
-		project_naming_series: projectNamingSeries || "",
-	});
+export const setProjectNaming = (projectNaming) =>
+	call("set_project_naming", { project_naming: projectNaming });
+// Naming mode + series options for the New Project form (available to any user).
+export const getProjectNaming = () => call("get_project_naming");

--- a/frontend/src/views/NewProjectView.vue
+++ b/frontend/src/views/NewProjectView.vue
@@ -10,6 +10,7 @@ import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { usePermissions } from "@/composables/usePermissions";
 import { createDataAdapter } from "@/data/adapters";
+import { getProjectNaming } from "@/data/coreSettingsApi";
 import { endBeforeStartError, outOfParentBoundsError } from "@/utils/dateBounds";
 import { fetchProjectBounds } from "@/utils/projectBounds";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -78,6 +79,8 @@ const form = reactive({
 	type: "",
 	// Native ERPNext Project Type (Internal / External) — distinct from Category.
 	projectType: "",
+	// Naming series (only used/sent when the org's naming mode is "Name Series").
+	namingSeries: "",
 	startDate: new Date().toISOString().slice(0, 10),
 	endDate: "",
 	budget: "",
@@ -110,6 +113,25 @@ const saving = ref(false);
 // Subprojects inherit the parent's company, so the field is hidden for them and
 // the value isn't sent. Company is locked after create. Uses a BuildSuite helper
 // rather than get_value on the Global Defaults Single (which 403s for non-admins).
+// Project naming mode (from BuildSuite Core Settings). When it's "Name Series", the
+// New Project form shows a naming-series select (default series pre-selected) and the
+// project's record ID comes from that series instead of the entered Project ID.
+const namingMode = ref("Project ID");
+const seriesOptions = ref([]);
+async function loadProjectNaming() {
+	try {
+		const res = await getProjectNaming();
+		namingMode.value = res.project_naming || "Project ID";
+		seriesOptions.value = res.series_options || [];
+		if (namingMode.value === "Name Series") {
+			form.namingSeries = res.default_series || seriesOptions.value[0] || "";
+		}
+	} catch {
+		/* default to Project ID mode */
+	}
+}
+loadProjectNaming();
+
 async function loadDefaultCompany() {
 	if (route.query.parentId) return; // subproject — inherits parent's company
 	try {
@@ -227,6 +249,8 @@ async function save() {
 			customer: form.client,
 			project_category: form.type,
 			project_type: form.projectType || null,
+			// Only meaningful in Name Series mode; the backend autoname uses it.
+			naming_series: namingMode.value === "Name Series" ? form.namingSeries || null : null,
 			estimated_costing: Number(form.budget),
 			project_manager: form.pm || null,
 			notes: form.description,
@@ -304,6 +328,17 @@ const breadcrumbs = computed(() => {
 							data-test="field-code"
 							placeholder="e.g. BTP-P2"
 						/>
+					</DeskField>
+					<!-- Shown only when the org's project naming mode is "Name Series":
+					     the record ID is generated from the chosen series. -->
+					<DeskField
+						v-if="namingMode === 'Name Series'"
+						label="Name series"
+						hint="The naming series used to generate this project's record ID."
+					>
+						<DeskSelect v-model="form.namingSeries">
+							<option v-for="s in seriesOptions" :key="s" :value="s">{{ s }}</option>
+						</DeskSelect>
 					</DeskField>
 					<!-- Session 40: Client is now a Link field onto the Customer master
              (ERPNext-native Customer DocType). The stored value is the

--- a/frontend/src/views/settings/CoreSettingsView.vue
+++ b/frontend/src/views/settings/CoreSettingsView.vue
@@ -6,7 +6,7 @@
 // represents it as store.coreSettings (flat object). Edits flow through
 // store.updateCoreSettings(patch).
 
-import { ref, computed, watch, onMounted } from "vue";
+import { ref, watch, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import { getCoreSettings, setProjectNaming } from "@/data/coreSettingsApi";
@@ -17,7 +17,6 @@ import DeskActionBar from "@/components/desk/DeskActionBar.vue";
 import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
-import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 
 const router = useRouter();
 const store = useDataStore();
@@ -26,34 +25,18 @@ const editing = ref(false);
 const form = ref({});
 const saving = ref(false);
 
-// Project naming is server-persisted (BuildSuite Core Settings Single), unlike the
-// other fields on this screen. It's a mode ("Project ID" | "Name Series") plus, for
-// Name Series, the specific Project naming series.
+// Project naming MODE is server-persisted (BuildSuite Core Settings Single). It's
+// just the mode here ("Project ID" | "Name Series"); the specific series, when Name
+// Series, is chosen per-project on the New Project form.
 const PROJECT_ID_MODE = "Project ID";
-const NAME_SERIES_MODE = "Name Series";
-const projectNaming = ref(PROJECT_ID_MODE); // the mode
-const projectNamingSeries = ref(""); // the chosen series (Name Series mode)
-const namingModes = ref([PROJECT_ID_MODE, NAME_SERIES_MODE]);
-const seriesOptions = ref([]); // Project naming series available to pick
-
-// { value, label } options for the searchable series picker.
-const seriesPickerOptions = computed(() =>
-	seriesOptions.value.map((s) => ({ value: s, label: s })),
-);
-// Human-readable summary for the read-only view.
-const projectNamingLabel = computed(() =>
-	projectNaming.value === NAME_SERIES_MODE
-		? `Name Series — ${projectNamingSeries.value || "(none selected)"}`
-		: "Project ID",
-);
+const projectNaming = ref(PROJECT_ID_MODE);
+const namingModes = ref([PROJECT_ID_MODE, "Name Series"]);
 
 onMounted(async () => {
 	try {
 		const res = await getCoreSettings();
 		projectNaming.value = res.project_naming || PROJECT_ID_MODE;
-		projectNamingSeries.value = res.project_naming_series || "";
-		namingModes.value = res.project_naming_modes || [PROJECT_ID_MODE, NAME_SERIES_MODE];
-		seriesOptions.value = res.project_series_options || [];
+		namingModes.value = res.project_naming_modes || namingModes.value;
 	} catch {
 		/* leave defaults; non-admins can't read it */
 	}
@@ -71,7 +54,6 @@ function startEdit() {
 	form.value = {
 		...JSON.parse(JSON.stringify(store.coreSettings)),
 		naming_mode: projectNaming.value,
-		naming_series: projectNamingSeries.value || seriesOptions.value[0] || "",
 	};
 	editing.value = true;
 }
@@ -81,19 +63,12 @@ function cancelEdit() {
 }
 async function saveEdit() {
 	if (!store.isAdmin) return;
-	if (form.value.naming_mode === NAME_SERIES_MODE && !form.value.naming_series) {
-		showToast("Pick a naming series.", "error");
-		return;
-	}
 	saving.value = true;
 	try {
 		store.updateCoreSettings({ ...form.value });
-		const mode = form.value.naming_mode;
-		const series = mode === NAME_SERIES_MODE ? form.value.naming_series : "";
-		if (mode !== projectNaming.value || series !== projectNamingSeries.value) {
-			await setProjectNaming(mode, series);
-			projectNaming.value = mode;
-			projectNamingSeries.value = series;
+		if (form.value.naming_mode && form.value.naming_mode !== projectNaming.value) {
+			await setProjectNaming(form.value.naming_mode);
+			projectNaming.value = form.value.naming_mode;
 		}
 		editing.value = false;
 	} catch (err) {
@@ -196,26 +171,14 @@ const PROJECT_TYPES = ["Commercial", "Residential", "Infrastructure", "Industria
 					</DeskField>
 					<DeskField
 						label="Project naming"
-						hint="How a new project's record ID is generated. 'Project ID' uses the entered Project ID as the record name; 'Name Series' uses the selected ERPNext naming series."
+						hint="How a new project's record ID is generated. 'Project ID' uses the entered Project ID as the record name; 'Name Series' lets the creator pick a naming series on the New Project form."
 					>
 						<div v-if="!editing" class="text-sm text-ink-900 py-1">
-							{{ projectNamingLabel }}
+							{{ projectNaming }}
 						</div>
 						<DeskSelect v-else v-model="form.naming_mode">
 							<option v-for="m in namingModes" :key="m" :value="m">{{ m }}</option>
 						</DeskSelect>
-					</DeskField>
-					<DeskField
-						v-if="editing && form.naming_mode === 'Name Series'"
-						label="Name series"
-						hint="The Project naming series used to generate the record ID."
-					>
-						<DeskSearchableSelect
-							v-model="form.naming_series"
-							:options="seriesPickerOptions"
-							placeholder="Select a naming series"
-							search-placeholder="Search series…"
-						/>
 					</DeskField>
 				</DeskSection>
 			</div>


### PR DESCRIPTION
Moves the specific naming series out of BuildSuite Core Settings and into the New Project form, per the intended design.

## Changes
- **BuildSuite Core Settings** now holds only the `project_naming` **mode** Select (Project ID | Name Series). The `project_naming_series` field is removed.
- **New Project form**: when the org's mode is "Name Series", a **Name series select** appears (defaulting to the default Project series, pre-selected). Its value is sent as the project's `naming_series`. In "Project ID" mode the select is hidden and the entered Project ID is the record name (unchanged).
- **Autoname** in Name Series mode uses the project's own `naming_series` (from the form), falling back to the Project doctype's default series.
- A non-admin `get_project_naming` endpoint feeds the form (any project creator, not just admins).
- Migration patch updated to just set the mode.

This sets up the future where the series can vary by company — for now the select lists the default Project naming series and is selected by default when visible.

## Verification
- Name Series (with/without a form series) names by the series; Project ID names by the id; the settings series field is gone; 123 backend tests pass; frontend builds clean.