### PR TITLE
fix: Assembly category uses link picker

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/construction_rate_master/construction_rate_master.json
+++ b/buildsuite_core/buildsuite_core/doctype/construction_rate_master/construction_rate_master.json
@@ -44,7 +44,7 @@
    "fieldname": "category",
    "fieldtype": "Select",
    "in_list_view": 1,
-   "label": "Resource Type",
+   "label": "Category",
    "options": "Material\nLabour\nEquipment",
    "reqd": 1
   },
@@ -111,6 +111,7 @@
   {
    "fieldname": "rate_master_category",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Rate Master Category",
    "options": "Rate Master Category"
   }
@@ -118,7 +119,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-06 21:25:33.913303",
+ "modified": "2026-07-11 07:15:06.422414",
  "modified_by": "Administrator",
  "module": "BuildSuite Core",
  "name": "Construction Rate Master",

--- a/frontend/src/views/AssembliesView.vue
+++ b/frontend/src/views/AssembliesView.vue
@@ -3,17 +3,14 @@
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDocTypeList } from '@/composables/useDocTypeList'
-import { useDoctypeMeta } from '@/composables/useDoctypeMeta'
 import { fmtINR } from '@/utils/format'
 import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskList from '@/components/desk/DeskList.vue'
 import DeskLink from '@/components/desk/DeskLink.vue'
-import DeskSelect from '@/components/desk/DeskSelect.vue'
+import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
 import DeskFilterChip from '@/components/desk/DeskFilterChip.vue'
 
 const router = useRouter()
-const { selectOptions } = useDoctypeMeta('Assembly')
-const categoryOptions = computed(() => selectOptions('category'))
 
 function onRowClick(row) {
   router.push(`/assembly/${row.id}`)
@@ -77,10 +74,8 @@ const columns = [
     <DeskList v-model="search" :rows="rows" :columns="columns" row-key="id"
       search-placeholder="Search by code or name…" @row-click="onRowClick">
       <template #filter-chips>
-        <DeskSelect v-if="!categoryFilter" v-model="categoryFilter" class="!w-40">
-          <option value="">Category: Any</option>
-          <option v-for="c in categoryOptions" :key="c">{{ c }}</option>
-        </DeskSelect>
+        <DeskLinkPicker v-if="!categoryFilter" v-model="categoryFilter" doctype="Assembly Category"
+          label-field="name" value-field="name" placeholder="Category: Any" class="!w-40" />
         <DeskFilterChip v-else label="Category" :value="categoryFilter" @remove="categoryFilter = ''" />
       </template>
 

--- a/frontend/src/views/AssemblyDetailView.vue
+++ b/frontend/src/views/AssemblyDetailView.vue
@@ -6,7 +6,6 @@ import { useRouter } from 'vue-router'
 import { useDataStore } from '@/stores'
 import { useConfirm } from '@/composables/useConfirm'
 import { useFormErrors } from '@/composables/useFormErrors'
-import { useDoctypeMeta } from '@/composables/useDoctypeMeta'
 import { useDocTypeList } from '@/composables/useDocTypeList'
 import { showToast } from '@/utils/appToast'
 import { createDataAdapter } from '@/data/adapters'
@@ -15,7 +14,6 @@ import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskSection from '@/components/desk/DeskSection.vue'
 import DeskField from '@/components/desk/DeskField.vue'
 import DeskInput from '@/components/desk/DeskInput.vue'
-import DeskSelect from '@/components/desk/DeskSelect.vue'
 import DeskTextarea from '@/components/desk/DeskTextarea.vue'
 import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
 import DeskSearchableSelect from '@/components/desk/DeskSearchableSelect.vue'
@@ -29,9 +27,6 @@ const { errors, applyServerErrors, setErrors } = useFormErrors({
   uom: 'uom',
 })
 const adapter = createDataAdapter(useDataStore())
-
-const { selectOptions } = useDoctypeMeta('Assembly')
-const categoryOptions = computed(() => selectOptions('category'))
 
 const resource = adapter.read('Assembly', props.id, { fields: ['*'] })
 const doc = computed(() => resource?.doc || null)
@@ -349,10 +344,8 @@ async function removeComponent(index) {
                   placeholder="— Select unit —" />
               </DeskField>
               <DeskField label="Category">
-                <DeskSelect v-model="form.category">
-                  <option value="">— Select —</option>
-                  <option v-for="c in categoryOptions" :key="c">{{ c }}</option>
-                </DeskSelect>
+                <DeskLinkPicker v-model="form.category" doctype="Assembly Category" label-field="name"
+                  value-field="name" placeholder="— Select category —" />
               </DeskField>
               <DeskField label="Notes">
                 <DeskTextarea v-model="form.notes" :rows="3" />

--- a/frontend/src/views/NewAssemblyView.vue
+++ b/frontend/src/views/NewAssemblyView.vue
@@ -1,10 +1,9 @@
 <script setup>
-import { reactive, ref, computed } from 'vue'
+import { reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useDataStore } from '@/stores'
 import { showToast } from '@/utils/appToast'
 import { useFormErrors } from '@/composables/useFormErrors'
-import { useDoctypeMeta } from '@/composables/useDoctypeMeta'
 import { createDataAdapter } from '@/data/adapters'
 import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskForm from '@/components/desk/DeskForm.vue'
@@ -12,16 +11,12 @@ import DeskActionBar from '@/components/desk/DeskActionBar.vue'
 import DeskSection from '@/components/desk/DeskSection.vue'
 import DeskField from '@/components/desk/DeskField.vue'
 import DeskInput from '@/components/desk/DeskInput.vue'
-import DeskSelect from '@/components/desk/DeskSelect.vue'
 import DeskTextarea from '@/components/desk/DeskTextarea.vue'
 import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
 
 const router = useRouter()
 const store = useDataStore()
 const adapter = createDataAdapter(store)
-
-const { selectOptions } = useDoctypeMeta('Assembly')
-const categoryOptions = computed(() => selectOptions('category'))
 
 const form = reactive({ assemblyCode: '', assemblyName: '', uom: '', category: '', notes: '' })
 const { errors, applyServerErrors, setErrors } = useFormErrors({
@@ -92,10 +87,8 @@ const breadcrumbs = [
             placeholder="— Select unit —" />
         </DeskField>
         <DeskField label="Category">
-          <DeskSelect v-model="form.category">
-            <option value="">— Select —</option>
-            <option v-for="c in categoryOptions" :key="c">{{ c }}</option>
-          </DeskSelect>
+          <DeskLinkPicker v-model="form.category" doctype="Assembly Category" label-field="name"
+            value-field="name" placeholder="— Select category —" />
         </DeskField>
         <DeskField label="Notes">
           <DeskTextarea v-model="form.notes" :rows="3" />


### PR DESCRIPTION
Assembly `category` is now a Link (Assembly Category), but the Vue UI still showed it as a plain dropdown, so it broke.

- Assembly category now uses the link picker in the new form,edit modal, and list filter.
- Rate Master: relabel category "Resource Type" -> "Category", hide the old rate_master_category link field.