### PR TITLE
fix: show project name on the work order detail

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -38,6 +38,7 @@ def _serialize(doc):
 		"subcontractor": doc.subcontractor,
 		"subcontractor_name": doc.subcontractor_name,
 		"project": doc.project,
+		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
 		"date": str(doc.date) if doc.date else None,
 		"delivery_type": doc.delivery_type,
 		"retention_percent": doc.retention_percent,

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -5,7 +5,7 @@
 // current user). Measurement Books + RA bills land in a later pass.
 
 import { computed, ref, watch } from "vue";
-import { useRouter, RouterLink } from "vue-router";
+import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
@@ -115,7 +115,7 @@ const tabs = computed(() => [
 	<DeskPage
 		v-if="wo"
 		:title="wo.subcontractor_name || wo.name"
-		:subtitle="`${wo.name} · ${wo.project}`"
+		:subtitle="`${wo.name} · ${wo.project_name || wo.project}`"
 		:breadcrumbs="breadcrumbs"
 		:status="wo.delivery_type ? [wo.status, wo.delivery_type] : wo.status"
 	>
@@ -174,7 +174,7 @@ const tabs = computed(() => [
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Project
 				</div>
-				<div class="text-sm text-ink-900 mt-0.5 truncate">{{ wo.project }}</div>
+				<div class="text-sm text-ink-900 mt-0.5 truncate">{{ wo.project_name || wo.project }}</div>
 				<div class="text-[10px] text-ink-500">{{ fmtDate(wo.date) }}</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">


### PR DESCRIPTION
The Work Order detail's Project card (and page subtitle) rendered the Frappe id (e.g. `PROJ-1638`) instead of the human `project_name`.

- Backend: `_serialize` on the WO API now includes `project_name` (fetched from Project).
- Frontend: the detail's Project card + subtitle use `project_name`, falling back to the id.

Verified: `yarn build` clean, `py_compile` clean, payload returns `project_name` alongside `project`.