### PR TITLE
fix: persona role retention, hide admin from UI, BOQ assembly rate + UOM

### DIFF
--- a/buildsuite_core/api/users.py
+++ b/buildsuite_core/api/users.py
@@ -52,6 +52,28 @@ def list_buildsuite_users():
 
 
 @frappe.whitelist()
+def get_hidden_user_names():
+	"""User accounts BuildSuite Core's own UI must never surface — its user lists,
+	team pickers, assignee dropdowns and mention/autocomplete. That's the built-in
+	system accounts (Administrator, Guest) plus platform admins: System Manager
+	holders that aren't BuildSuite users (they carry no persona). A real BuildSuite
+	user who also happens to hold System Manager stays visible. Frappe Desk is
+	unaffected — this only feeds the SPA's pickers."""
+	hidden = set(SYSTEM_ACCOUNTS)
+	sysman = frappe.get_all(
+		"Has Role", filters={"role": "System Manager", "parenttype": "User"}, pluck="parent"
+	)
+	if sysman:
+		with_persona = set(
+			frappe.get_all(
+				"User", filters={"name": ["in", sysman], "persona": ["is", "set"]}, pluck="name"
+			)
+		)
+		hidden |= set(sysman) - with_persona
+	return sorted(hidden)
+
+
+@frappe.whitelist()
 def create_buildsuite_user(full_name: str, email: str, persona: str, enabled: int = 1, send_welcome: int = 1):
 	_require_admin()
 	full_name = (full_name or "").strip()

--- a/buildsuite_core/buildsuite_core/doctype/boq_item/boq_item.py
+++ b/buildsuite_core/buildsuite_core/doctype/boq_item/boq_item.py
@@ -11,6 +11,38 @@ from buildsuite_core.buildsuite_core.doctype.boq.boq_rollup import recompute_boq
 _QUANTITY_SOURCES = ("Manual", "Assembly", "Template", "Takeoff")
 
 
+def roll_up_item_rate(item_name):
+	"""Recompute an assembly item's rate as the sum of its sub-items' per-unit
+	amounts, refresh its planned/actual amounts, and roll the BOQ totals.
+
+	Called from the BOQ Sub Item controller whenever a component is added, edited
+	or removed, so the parent item's rate always reflects its current components.
+	No-op during batch operations (explode / recalc set `boq_skip_rollup` and
+	recompute once at the end) or if the item is gone (mid-delete of the parent)."""
+	if frappe.flags.get("boq_skip_rollup"):
+		return
+	item = frappe.db.get_value(
+		"BOQ Item", item_name, ["planned_qty", "actual_qty", "boq"], as_dict=True
+	)
+	if not item:
+		return
+	rate = sum(
+		flt(a)
+		for a in frappe.get_all("BOQ Sub Item", filters={"boq_item": item_name}, pluck="amount")
+	)
+	frappe.db.set_value(
+		"BOQ Item",
+		item_name,
+		{
+			"rate": rate,
+			"planned_amount": flt(item.planned_qty) * rate,
+			"actual_amount": flt(item.actual_qty) * rate,
+		},
+		update_modified=True,
+	)
+	recompute_boq(item.boq)
+
+
 class BOQItem(Document):
 	def validate(self):
 		self.planned_amount = flt(self.planned_qty) * flt(self.rate)
@@ -57,6 +89,12 @@ class BOQItem(Document):
 		recompute_boq(self.boq)
 
 	def on_trash(self):
-		for sub in frappe.get_all("BOQ Sub Item", filters={"boq_item": self.name}, pluck="name"):
-			frappe.delete_doc("BOQ Sub Item", sub, force=True, ignore_permissions=True)
+		# Flag so the sub-items' delete rollup doesn't re-save this item mid-delete —
+		# we recompute the BOQ once below instead.
+		frappe.flags.boq_item_deleting = self.name
+		try:
+			for sub in frappe.get_all("BOQ Sub Item", filters={"boq_item": self.name}, pluck="name"):
+				frappe.delete_doc("BOQ Sub Item", sub, force=True, ignore_permissions=True)
+		finally:
+			frappe.flags.boq_item_deleting = None
 		recompute_boq(self.boq)

--- a/buildsuite_core/buildsuite_core/doctype/boq_sub_item/boq_sub_item.py
+++ b/buildsuite_core/buildsuite_core/doctype/boq_sub_item/boq_sub_item.py
@@ -5,6 +5,8 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import flt
 
+from buildsuite_core.buildsuite_core.doctype.boq_item.boq_item import roll_up_item_rate
+
 
 class BOQSubItem(Document):
 	def validate(self):
@@ -22,3 +24,21 @@ class BOQSubItem(Document):
 			if parent:
 				self.work_package = self.work_package or parent.work_package
 				self.cost_head = self.cost_head or parent.cost_head
+
+	def _roll_up_parent(self):
+		"""Refresh the parent item's rate from its current sub-items — unless the
+		parent is itself being deleted (its own on_trash recomputes the BOQ)."""
+		if not self.boq_item:
+			return
+		if frappe.flags.get("boq_item_deleting") == self.boq_item:
+			return
+		roll_up_item_rate(self.boq_item)
+
+	def after_insert(self):
+		self._roll_up_parent()
+
+	def on_update(self):
+		self._roll_up_parent()
+
+	def after_delete(self):
+		self._roll_up_parent()

--- a/buildsuite_core/utils/user.py
+++ b/buildsuite_core/utils/user.py
@@ -1,16 +1,21 @@
 """Keep a User's BuildSuite roles in sync with their Persona.
 
-Persona is now a Link to the Persona master, whose `roles` child table lists the
-roles a user with that persona should hold. We run on `validate` (which fires on
-both insert and update) and mutate `doc.roles` in place — that saves atomically
-with the user and avoids the recursive-save trap that `add_roles`/`remove_roles`
-(which save the doc themselves) would cause.
+Persona is a Link to the Persona master, whose `roles` child table lists the roles
+a user with that persona should hold. We run on `validate` (which fires on both
+insert and update) and mutate `doc.roles` in place — that saves atomically with the
+user and avoids the recursive-save trap that `add_roles`/`remove_roles` (which save
+the doc themselves) would cause.
 
-The persona owns the roles it grants: any persona-managed role that no longer
-matches the current persona is stripped, so the persona stays the single source of
-truth. Protected native roles (System Manager, Administrator) are never stripped —
-a persona may GRANT System Manager, but platform admins hold it for other reasons
-and this hook must not revoke it.
+The sync is **additive**: setting a persona GRANTS its roles, but roles that were
+added on top of a persona — whether native or BuildSuite-custom — are always kept.
+A user with combined responsibilities (e.g. a PM who is also a Site Engineer) is a
+legitimate flow, so manual additions must never be silently reverted.
+
+The only roles ever removed are the ones the *previous* persona granted that the
+new persona no longer grants, and only when the persona actually CHANGES — so
+switching persona doesn't leave the old persona's roles piled on, while a plain
+save (persona unchanged) strips nothing. Protected native roles (System Manager,
+Administrator) are never stripped.
 
 Delete needs no handler: Frappe cascades the Has Role child rows when the User is
 deleted.
@@ -20,24 +25,19 @@ import frappe
 
 from buildsuite_core.permissions.setup import WORKFLOW_EDITOR_ROLE
 
-# Native roles a persona may grant but this hook must never revoke.
+# Native roles this hook must never revoke, even on a persona switch.
 PROTECTED_ROLES = {"System Manager", "Administrator", "All", "Guest"}
 
 
 def _persona_roles(persona):
-	"""Roles granted by a persona (its Persona Role child rows)."""
+	"""Roles a persona grants (its Persona Role child rows) plus the workflow-editor
+	marker that every BuildSuite persona carries."""
 	if not persona:
 		return set()
-	return set(frappe.get_all("Persona Role", filters={"parent": persona}, pluck="role"))
-
-
-def _managed_roles():
-	"""Every role any persona grants (plus the workflow-editor marker), minus the
-	protected native roles. These are the roles the persona field owns and may
-	strip when they no longer match."""
-	roles = set(frappe.get_all("Persona Role", pluck="role"))
-	roles.add(WORKFLOW_EDITOR_ROLE)
-	return roles - PROTECTED_ROLES
+	roles = set(frappe.get_all("Persona Role", filters={"parent": persona}, pluck="role"))
+	if roles:
+		roles.add(WORKFLOW_EDITOR_ROLE)
+	return roles
 
 
 def sync_persona_roles(doc, method=None):
@@ -54,27 +54,26 @@ def sync_persona_roles(doc, method=None):
 	if doc.persona and not frappe.db.exists("Persona", doc.persona):
 		return
 
-	desired = _persona_roles(doc.persona)
+	grant = _persona_roles(doc.persona)
 
-	# Roles to keep/grant for the current persona (grants may include a protected
-	# role like System Manager; stripping below never touches protected roles).
-	keep = set()
-	if desired:
-		keep |= desired
-		keep.add(WORKFLOW_EDITOR_ROLE)
-
-	managed = _managed_roles()
+	# On a persona SWITCH, strip only the roles the previous persona granted that the
+	# new persona no longer grants — never protected roles, never manual additions.
+	before = doc.get_doc_before_save()
+	old_persona = before.persona if before else None
+	strip = set()
+	if old_persona and old_persona != doc.persona:
+		strip = (_persona_roles(old_persona) - grant) - PROTECTED_ROLES
 
 	kept, present = [], set()
 	for row in doc.roles:
-		if row.role in managed and row.role not in keep:
-			continue  # stale persona-managed role — drop it
+		if row.role in strip:
+			continue  # role from the previous persona, not re-granted — drop it
 		kept.append(row)
 		present.add(row.role)
 	doc.roles = kept
 
-	# Grant anything missing (guard on existence so a not-yet-seeded role can't
-	# block the user save).
-	for role in keep - present:
+	# Grant anything the current persona adds that isn't present yet (guard on
+	# existence so a not-yet-seeded role can't block the user save).
+	for role in grant - present:
 		if frappe.db.exists("Role", role):
 			doc.append("roles", {"role": role})

--- a/frontend/src/components/desk/DeskLinkPicker.vue
+++ b/frontend/src/components/desk/DeskLinkPicker.vue
@@ -3,6 +3,11 @@ import { computed, ref, watch } from "vue";
 import { watchDebounced } from "@vueuse/core";
 import Autocomplete from "../../../node_modules/frappe-ui/src/components/Autocomplete/Autocomplete.vue";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useHiddenUsers } from "@/composables/useHiddenUsers";
+
+// Users that BuildSuite Core's own UI must never surface (Administrator, Guest,
+// platform System-Manager admins). Applied to every User picker centrally.
+const { hiddenUsers } = useHiddenUsers();
 
 const props = defineProps({
 	doctype: { type: String, required: true },
@@ -54,11 +59,20 @@ const resolvedFields = computed(() => {
 			props.labelField,
 			...resolvedSearchFields.value,
 			...filterFieldNames.value,
-		])
+		]),
 	);
 });
 
-const serverFilters = computed(() => props.filters);
+const serverFilters = computed(() => {
+	// For the User doctype, exclude the accounts BuildSuite Core hides from its own
+	// pickers (Administrator, Guest, platform admins). Only the array filter form is
+	// rewritten (all User pickers use it); everywhere else, pass through untouched.
+	const usesArrayFilters = Array.isArray(props.filters) || !props.filters;
+	if (props.doctype === "User" && hiddenUsers.value.length && usesArrayFilters) {
+		return [...(props.filters || []), ["name", "not in", hiddenUsers.value]];
+	}
+	return props.filters;
+});
 
 function matchesFilterValue(actual, operator, expected) {
 	if (operator === "=") {
@@ -162,7 +176,13 @@ const selectedOption = computed(() => {
 });
 
 const options = computed(() => {
-	const rows = applyClientFilters(optionsResource.data || [], serverFilters.value);
+	let rows = applyClientFilters(optionsResource.data || [], serverFilters.value);
+	// Belt-and-braces: never render a hidden user even if the server page included
+	// one ("not in" is applied server-side, but this guarantees it in the UI).
+	if (props.doctype === "User" && hiddenUsers.value.length) {
+		const hidden = new Set(hiddenUsers.value);
+		rows = rows.filter((row) => !hidden.has(row?.name));
+	}
 	return rows.map(buildOption);
 });
 
@@ -181,7 +201,7 @@ watchDebounced(
 		});
 		optionsResource.list.fetch();
 	},
-	{ debounce: 250, immediate: true }
+	{ debounce: 250, immediate: true },
 );
 
 watch(
@@ -198,7 +218,7 @@ watch(
 		});
 		optionsResource.list.fetch();
 		fetchSelectedRecord();
-	}
+	},
 );
 
 watch(
@@ -214,7 +234,7 @@ watch(
 		});
 		optionsResource.list.fetch();
 	},
-	{ deep: true }
+	{ deep: true },
 );
 
 watch(
@@ -222,7 +242,7 @@ watch(
 	() => {
 		fetchSelectedRecord();
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 
 function fetchSelectedRecord() {
@@ -321,7 +341,9 @@ function onQueryUpdate(value) {
 	z-index: 80 !important;
 	border: 1px solid theme("colors.ink.200") !important;
 	border-radius: 6px !important;
-	box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06) !important;
+	box-shadow:
+		0 4px 6px -1px rgba(0, 0, 0, 0.1),
+		0 2px 4px -1px rgba(0, 0, 0, 0.06) !important;
 }
 
 /* Force compact typography inside teleported popover */

--- a/frontend/src/composables/useHiddenUsers.js
+++ b/frontend/src/composables/useHiddenUsers.js
@@ -1,0 +1,29 @@
+// User accounts BuildSuite Core's own UI must never surface — its user lists, team
+// pickers, assignee dropdowns and mention/autocomplete. That's the built-in system
+// accounts (Administrator, Guest) plus platform admins (System Manager holders that
+// aren't BuildSuite users). Fetched once from the backend and cached module-wide,
+// then fed into the User link pickers + the user directory. Frappe Desk is
+// unaffected — this only shapes the SPA's own UI.
+
+import { ref } from "vue";
+import { frappeRequest } from "frappe-ui-frappe-request";
+
+const hiddenUsers = ref(["Administrator", "Guest"]);
+let _started = false;
+
+function ensureLoaded() {
+	if (_started) return;
+	_started = true;
+	frappeRequest({ url: "buildsuite_core.api.users.get_hidden_user_names" })
+		.then((names) => {
+			if (Array.isArray(names) && names.length) hiddenUsers.value = names;
+		})
+		.catch(() => {
+			// Keep the built-in accounts hidden even if the endpoint is unreachable.
+		});
+}
+
+export function useHiddenUsers() {
+	ensureLoaded();
+	return { hiddenUsers };
+}

--- a/frontend/src/composables/useUserNames.js
+++ b/frontend/src/composables/useUserNames.js
@@ -9,6 +9,7 @@
 import { computed } from "vue";
 import { useDataStore } from "@/stores";
 import { createDataAdapter } from "@/data/adapters";
+import { useHiddenUsers } from "@/composables/useHiddenUsers";
 
 let _resource = null;
 
@@ -30,9 +31,13 @@ export function useUserNames() {
 		});
 	}
 
+	const { hiddenUsers } = useHiddenUsers();
+
 	const directory = computed(() => {
+		const hidden = new Set(hiddenUsers.value);
 		const map = {};
 		rows(_resource).forEach((u) => {
+			if (hidden.has(u.name)) return; // never surface Administrator / platform admins
 			map[u.name] = { fullName: u.full_name || u.name, image: u.user_image || "" };
 		});
 		return map;

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -122,7 +122,7 @@ watch(
 			projectBoqsRes.reload?.();
 		}
 	},
-	{ immediate: true }
+	{ immediate: true },
 );
 const baseBoq = computed(() => {
 	const bid = boq.value?.baseRevisionId;
@@ -161,7 +161,7 @@ const groups = computed(() =>
 		code: g.code,
 		name: g.group_name,
 		order: g.idx_order,
-	}))
+	})),
 );
 const allItems = computed(() =>
 	rowsOf(itemsRes).map((i) => ({
@@ -180,7 +180,7 @@ const allItems = computed(() =>
 		costHead: i.cost_head,
 		assemblyId: i.assembly,
 		drivingQty: i.driving_qty,
-	}))
+	})),
 );
 const allSubs = computed(() =>
 	rowsOf(subsRes).map((s) => ({
@@ -191,7 +191,7 @@ const allSubs = computed(() =>
 		qtyPerUnit: s.qty_per_unit,
 		rate: s.rate,
 		amount: s.amount,
-	}))
+	})),
 );
 function boqItemsByGroup(groupId) {
 	return allItems.value.filter((i) => i.groupId === groupId);
@@ -286,7 +286,7 @@ async function submit() {
 }
 async function approve() {
 	const others = (projectBoqsRes.data || []).filter(
-		(b) => b.name !== boq.value.id && b.revision !== boq.value.revision
+		(b) => b.name !== boq.value.id && b.revision !== boq.value.revision,
 	);
 	void others;
 	const ok = await confirmDialog({
@@ -323,7 +323,7 @@ async function submitRevision() {
 		const name = await boqApi.createRevision(
 			boq.value.id,
 			revisionModal.value.sourceSco.trim() || null,
-			revisionModal.value.title.trim() || null
+			revisionModal.value.title.trim() || null,
 		);
 		revisionModal.value = null;
 		if (name) router.push(`/boq/${name}`);
@@ -370,7 +370,7 @@ function exportCsv() {
 	lines.push(
 		["BOQ", boq.value.id, "Rev", boq.value.revision, "Status", boq.value.status]
 			.map(csvCell)
-			.join(",")
+			.join(","),
 	);
 	lines.push(
 		[
@@ -387,7 +387,7 @@ function exportCsv() {
 			"Cost Head",
 		]
 			.map(csvCell)
-			.join(",")
+			.join(","),
 	);
 	for (const g of groups.value) {
 		lines.push(["Group", g.code, g.name].map(csvCell).join(","));
@@ -407,13 +407,13 @@ function exportCsv() {
 					it.costHead || "",
 				]
 					.map(csvCell)
-					.join(",")
+					.join(","),
 			);
 			for (const si of boqSubItemsByItem(it.id)) {
 				lines.push(
 					["Sub", "↳", si.description, "", si.qtyPerUnit, si.rate, si.amount]
 						.map(csvCell)
-						.join(",")
+						.join(","),
 				);
 			}
 		}
@@ -462,13 +462,13 @@ async function doClone() {
 				to_project: boq.value.projectId,
 				from_work_package: f.fromWorkPackage,
 				to_work_package: f.toWorkPackage,
-		  }
+			}
 		: {
 				from_project: boq.value.projectId,
 				to_project: f.toProject,
 				to_work_package: f.toWorkPackage || null,
 				title: f.title || null,
-		  };
+			};
 	try {
 		const res = await boqApi.cloneBoq(payload);
 		cloneModal.value = false;
@@ -483,7 +483,7 @@ async function doClone() {
 const canSubmit = computed(() => boq.value?.status === "Draft");
 const canApprove = computed(() => boq.value?.status === "Submitted");
 const isLocked = computed(
-	() => boq.value?.status === "Approved" || boq.value?.status === "Superseded"
+	() => boq.value?.status === "Approved" || boq.value?.status === "Superseded",
 );
 const isEditable = computed(() => boq.value?.status === "Draft");
 
@@ -521,7 +521,7 @@ async function deleteGroupConfirm(g) {
 	const msg = items.length
 		? `Delete group "${g.code} — ${g.name}" with ${items.length} item${
 				items.length === 1 ? "" : "s"
-		  } and their sub-items?`
+			} and their sub-items?`
 		: `Delete group "${g.code} — ${g.name}"?`;
 	if (
 		!(await confirmDialog({
@@ -557,7 +557,7 @@ const itemForm = ref({
 // so you can only link records that belong to this BOQ's project.
 const boqProjectId = computed(() => boq.value?.projectId || "");
 const itemPlannedAmountPreview = computed(
-	() => (Number(itemForm.value.plannedQty) || 0) * (Number(itemForm.value.rate) || 0)
+	() => (Number(itemForm.value.plannedQty) || 0) * (Number(itemForm.value.rate) || 0),
 );
 // Assemblies for the "Source" picker — pick one to auto-fill unit / rate /
 // description (the save handler then auto-explodes the line into sub-items).
@@ -569,7 +569,11 @@ const assembliesRes = useDocTypeList("Assembly", {
 const assembliesMap = computed(() => {
 	const m = {};
 	for (const a of assembliesRes.data || [])
-		m[a.name] = { name: a.assembly_name || a.name, uom: a.uom || "", rate: a.rate_per_unit || 0 };
+		m[a.name] = {
+			name: a.assembly_name || a.name,
+			uom: a.uom || "",
+			rate: a.rate_per_unit || 0,
+		};
 	return m;
 });
 function onAssemblyPicked(id) {
@@ -646,7 +650,7 @@ async function saveItem() {
 				} catch (e) {
 					showToast(
 						parseFrappeError(e).summary ?? "Item saved, but explode failed",
-						"error"
+						"error",
 					);
 				}
 			}
@@ -665,7 +669,7 @@ async function deleteItemConfirm(item) {
 	const msg = subs.length
 		? `Delete item "${item.code} — ${item.description}" with ${subs.length} sub-item${
 				subs.length === 1 ? "" : "s"
-		  }?`
+			}?`
 		: `Delete item "${item.code} — ${item.description}"?`;
 	if (
 		!(await confirmDialog({
@@ -700,7 +704,7 @@ const rateMasterOptions = computed(() =>
 		description: r.rate_name,
 		currentRate: r.current_rate,
 		category: r.category,
-	}))
+	})),
 );
 function openAddSubItem(item) {
 	subItemForm.value = { rateMasterId: null, description: "", qtyPerUnit: 0, rate: 0 };
@@ -724,7 +728,7 @@ function onRateMasterPick(rateMasterId) {
 	}
 }
 const subItemAmountPreview = computed(
-	() => (Number(subItemForm.value.qtyPerUnit) || 0) * (Number(subItemForm.value.rate) || 0)
+	() => (Number(subItemForm.value.qtyPerUnit) || 0) * (Number(subItemForm.value.rate) || 0),
 );
 async function saveSubItem() {
 	const f = subItemForm.value;
@@ -775,7 +779,7 @@ async function deleteSubItemConfirm(si) {
 // Primary action dispatcher — Submit when Draft, Approve when Submitted.
 const showPrimary = computed(() => canSubmit.value || canApprove.value);
 const primaryLabel = computed(() =>
-	canSubmit.value ? "Submit for approval" : canApprove.value ? "Approve" : ""
+	canSubmit.value ? "Submit for approval" : canApprove.value ? "Approve" : "",
 );
 function primaryAction() {
 	if (canSubmit.value) submit();
@@ -784,9 +788,7 @@ function primaryAction() {
 
 // The BOQ id + revision live in the subtitle (as in the prototype), so the
 // breadcrumb trail ends at the project — not a raw BOQ-id crumb.
-const subtitle = computed(() =>
-	boq.value ? `${boq.value.id} · R${boq.value.revision}` : ""
-);
+const subtitle = computed(() => (boq.value ? `${boq.value.id} · R${boq.value.revision}` : ""));
 
 const breadcrumbs = computed(() => {
 	const out = [
@@ -1071,7 +1073,7 @@ const breadcrumbs = computed(() => {
 								variancePill(
 									((groupTotals(g.id).actual - groupTotals(g.id).planned) /
 										(groupTotals(g.id).planned || 1)) *
-										100
+										100,
 								)
 							"
 						>
@@ -1082,7 +1084,7 @@ const breadcrumbs = computed(() => {
 												groupTotals(g.id).planned) /
 												groupTotals(g.id).planned) *
 											100
-									  ).toFixed(1)
+										).toFixed(1)
 									: "0.0"
 							}}%
 						</div>
@@ -1224,7 +1226,7 @@ const breadcrumbs = computed(() => {
 										{{ item.plannedAmount > baseAmount(item.code) ? "+" : ""
 										}}{{
 											fmtCompactINR(
-												item.plannedAmount - baseAmount(item.code)
+												item.plannedAmount - baseAmount(item.code),
 											)
 										}}</span
 									>
@@ -1260,13 +1262,13 @@ const breadcrumbs = computed(() => {
 													item.actualAmount > item.plannedAmount
 														? 'bg-danger-500'
 														: item.actualAmount >
-														  item.plannedAmount * 0.9
-														? 'bg-warning-500'
-														: 'bg-success-500'
+															  item.plannedAmount * 0.9
+															? 'bg-warning-500'
+															: 'bg-success-500'
 												"
 												:style="`width: ${Math.min(
 													100,
-													pctOf(item.actualAmount, item.plannedAmount)
+													pctOf(item.actualAmount, item.plannedAmount),
 												).toFixed(1)}%`"
 											></div>
 										</div>
@@ -1278,7 +1280,7 @@ const breadcrumbs = computed(() => {
 										variancePill(
 											((item.actualAmount - item.plannedAmount) /
 												(item.plannedAmount || 1)) *
-												100
+												100,
 										)
 									"
 								>
@@ -1288,7 +1290,7 @@ const breadcrumbs = computed(() => {
 													((item.actualAmount - item.plannedAmount) /
 														item.plannedAmount) *
 													100
-											  ).toFixed(1)
+												).toFixed(1)
 											: "0.0"
 									}}%
 								</div>
@@ -1324,7 +1326,9 @@ const breadcrumbs = computed(() => {
 											>{{ si.rateMasterId }}</DeskLink
 										>
 									</div>
-									<div></div>
+									<div class="px-3 py-1 text-xs text-ink-500">
+										{{ item.unit }}
+									</div>
 									<div
 										class="px-3 py-1 text-right tabular-nums text-xs text-ink-500"
 									>


### PR DESCRIPTION
Four independent fixes.

## 1. Manual roles stripped from a user with a persona
`sync_persona_roles` treated **every** role in **any** persona as "persona-managed" and stripped those not in the current persona — so a manually-added BuildSuite-custom role was dropped on save (native roles survived only because they were in `PROTECTED_ROLES`).
- Now **additive**: setting a persona grants its roles; on a persona *switch* only the *previous* persona's roles that the new one no longer grants are removed. A plain save strips nothing, so manual additions (native or custom) always persist. Verified: a PM-persona user keeps a manually-added Site Engineer role across saves, and switching persona keeps the manual role while swapping the persona's own roles.

## 2. Administrator / System Manager visible in BuildSuite Core UI
- Backend `get_hidden_user_names()` returns the accounts to hide: Administrator, Guest, and platform admins (System Manager holders that carry no persona) — a real BuildSuite user who also holds System Manager stays visible.
- `DeskLinkPicker` excludes them from **every** `doctype="User"` picker centrally (server filter + client guarantee), and the shared user directory (`useUserNames`) drops them too. Frappe Desk is unaffected.

## 3. Assembly rate stale when a BOQ sub-item changes
BOQ Sub Item is a standalone doctype, so adding one never re-ran the parent item's rollup. Added `roll_up_item_rate()` + sub-item `after_insert`/`on_update`/`after_delete` hooks: the parent item's rate now recomputes to the sum of its current sub-items and rolls into the BOQ totals immediately. Verified: editing a component moved an item's rate 1.0 → 1500.0 = Σ sub-item amounts.

## 4. UOM missing on BOQ assembly component rows
Item rows already showed the unit; component (sub-item) rows left the Unit column blank. They now display the UOM (inherited from the parent item), so every row shows a unit.

## Verification
`yarn build` clean · `py_compile` clean · **123/123 backend tests pass** · live console checks for fixes 1–3 and the hidden-users endpoint.