### PR TITLE
fix: estimation list sorting, Assembly Category link, Rate Master link, BOQ columns

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -132,6 +132,34 @@ def get_wo_transitions(name: str):
 
 
 @frappe.whitelist()
+def committed_by_cost_code(project: str):
+	"""Sum of OPEN (Awarded / In Progress) Subcontractor Work Order line amounts for a
+	project, grouped by cost-code group. Feeds the BOQ 'Committed' column — how much of
+	each BOQ group's scope is already committed to subcontractors."""
+	if not project:
+		return {}
+	wos = frappe.get_all(
+		WORK_ORDER,
+		filters={"project": project, "status": ["in", ["Awarded", "In Progress"]]},
+		pluck="name",
+	)
+	if not wos:
+		return {}
+	rows = frappe.get_all(
+		"Subcontractor Work Order Line",
+		filters={"parent": ["in", wos]},
+		fields=["cost_code_group", "amount"],
+	)
+	out = {}
+	for r in rows:
+		code = r.cost_code_group or ""
+		if not code:
+			continue
+		out[code] = out.get(code, 0) + (r.amount or 0)
+	return out
+
+
+@frappe.whitelist()
 def get_project_cost_codes(project: str):
 	"""BOQ groups + items for a project, as pickable cost codes for SOV lines."""
 	if not project:

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -24,6 +24,7 @@ export const applyWoAction = (workOrder, action) =>
 	call("apply_wo_action", { work_order: workOrder, action });
 export const getWoTransitions = (name) => call("get_wo_transitions", { name });
 export const getProjectCostCodes = (project) => call("get_project_cost_codes", { project });
+export const getCommittedByCostCode = (project) => call("committed_by_cost_code", { project });
 
 // Measurement Book — site measurements against a Work Order's SOV lines.
 export const getWorkOrderLines = (workOrder) =>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -29,6 +29,7 @@ const PAGE_TITLES = {
 	boq: "Bill of Quantities",
 	"boq-detail": "BOQ",
 	"rate-master": "Rate Master",
+	"rate-master-detail": "Rate Master",
 	assembly: "Assemblies",
 	"assembly-new": "New Assembly",
 	"assembly-detail": "Assembly",
@@ -194,6 +195,12 @@ const routes = [
 				path: "rate-master",
 				name: "rate-master",
 				component: () => import("@/views/RateMasterView.vue"),
+			},
+			{
+				path: "rate-master/:id",
+				name: "rate-master-detail",
+				component: () => import("@/views/RateMasterView.vue"),
+				props: true,
 			},
 			{
 				path: "assembly",

--- a/frontend/src/views/AssembliesView.vue
+++ b/frontend/src/views/AssembliesView.vue
@@ -1,111 +1,155 @@
 <script setup>
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useDocTypeList } from "@/composables/useDocTypeList";
+import { fmtINR } from "@/utils/format";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
 
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { useDocTypeList } from '@/composables/useDocTypeList'
-import { fmtINR } from '@/utils/format'
-import DeskPage from '@/components/desk/DeskPage.vue'
-import DeskList from '@/components/desk/DeskList.vue'
-import DeskLink from '@/components/desk/DeskLink.vue'
-import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
-import DeskFilterChip from '@/components/desk/DeskFilterChip.vue'
-
-const router = useRouter()
+const router = useRouter();
 
 function onRowClick(row) {
-  router.push(`/assembly/${row.id}`)
+	router.push(`/assembly/${row.id}`);
 }
 
 const breadcrumbs = [
-  { label: 'BuildSuite Core', to: '/' },
-  { label: 'Estimation', to: '/estimation' },
-  { label: 'Assembly' },
-]
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Estimation", to: "/estimation" },
+	{ label: "Assembly" },
+];
 
-const assembliesRes = useDocTypeList('Assembly', {
-  fields: ['name', 'assembly_code', 'assembly_name', 'category', 'uom', 'rate_per_unit', 'component_count', 'notes'],
-  orderBy: 'assembly_code asc',
-  pageLength: 0,
-  cache: 'buildsuite-assembly-list',
-  transform: (data) =>
-    data.map((a) => ({
-      id: a.name,
-      code: a.assembly_code,
-      name: a.assembly_name,
-      category: a.category,
-      unit: a.uom,
-      ratePerUnit: a.rate_per_unit,
-      componentCount: a.component_count,
-      notes: a.notes
-    })),
-})
+const assembliesRes = useDocTypeList("Assembly", {
+	fields: [
+		"name",
+		"assembly_code",
+		"assembly_name",
+		"category",
+		"uom",
+		"rate_per_unit",
+		"component_count",
+		"notes",
+	],
+	orderBy: "creation desc",
+	pageLength: 0,
+	cache: "buildsuite-assembly-list",
+	transform: (data) =>
+		data.map((a) => ({
+			id: a.name,
+			code: a.assembly_code,
+			name: a.assembly_name,
+			category: a.category,
+			unit: a.uom,
+			ratePerUnit: a.rate_per_unit,
+			componentCount: a.component_count,
+			notes: a.notes,
+		})),
+});
 
-const search = ref('')
-const categoryFilter = ref('')
+const search = ref("");
+const categoryFilter = ref("");
 const rows = computed(() => {
-  let data = assembliesRes.data || []
-  if (categoryFilter.value) data = data.filter((a) => a.category === categoryFilter.value)
-  const q = search.value.trim().toLowerCase()
-  if (q) {
-    data = data.filter(
-      (a) => (a.code || '').toLowerCase().includes(q) || (a.name || '').toLowerCase().includes(q),
-    )
-  }
-  return data
-})
+	let data = assembliesRes.data || [];
+	if (categoryFilter.value) data = data.filter((a) => a.category === categoryFilter.value);
+	const q = search.value.trim().toLowerCase();
+	if (q) {
+		data = data.filter(
+			(a) =>
+				(a.code || "").toLowerCase().includes(q) ||
+				(a.name || "").toLowerCase().includes(q),
+		);
+	}
+	return data;
+});
 
 const columns = [
-  { key: 'code', label: 'Code' },
-  { key: 'name', label: 'Name' },
-  { key: 'category', label: 'Category' },
-  { key: 'unit', label: 'Unit' },
-  { key: 'componentCount', label: 'Components', align: 'right' },
-  { key: 'ratePerUnit', label: 'Rate / unit', align: 'right' },
-]
+	{ key: "code", label: "Code" },
+	{ key: "name", label: "Name" },
+	{ key: "category", label: "Category" },
+	{ key: "unit", label: "Unit" },
+	{ key: "componentCount", label: "Components", align: "right" },
+	{ key: "ratePerUnit", label: "Rate / unit", align: "right" },
+];
 </script>
 
 <template>
-  <DeskPage title="Assembly" :breadcrumbs="breadcrumbs">
-    <template #actions>
-      <DeskLink to="/rate-master" class="text-xs">View Rate Master →</DeskLink>
-      <RouterLink to="/assembly/new" class="desk-save-btn">+ New</RouterLink>
-    </template>
+	<DeskPage title="Assembly" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<DeskLink to="/rate-master" class="text-xs">View Rate Master →</DeskLink>
+			<RouterLink to="/assembly/new" class="desk-save-btn">+ New</RouterLink>
+		</template>
 
-    <DeskList v-model="search" :rows="rows" :columns="columns" row-key="id"
-      search-placeholder="Search by code or name…" @row-click="onRowClick">
-      <template #filter-chips>
-        <DeskLinkPicker v-if="!categoryFilter" v-model="categoryFilter" doctype="Assembly Category"
-          label-field="name" value-field="name" placeholder="Category: Any" class="!w-40" />
-        <DeskFilterChip v-else label="Category" :value="categoryFilter" @remove="categoryFilter = ''" />
-      </template>
+		<DeskList
+			v-model="search"
+			:rows="rows"
+			:columns="columns"
+			row-key="id"
+			search-placeholder="Search by code or name…"
+			@row-click="onRowClick"
+		>
+			<template #filter-chips>
+				<DeskLinkPicker
+					v-if="!categoryFilter"
+					v-model="categoryFilter"
+					doctype="Assembly Category"
+					label-field="name"
+					value-field="name"
+					placeholder="Category: Any"
+					class="!w-40"
+				/>
+				<DeskFilterChip
+					v-else
+					label="Category"
+					:value="categoryFilter"
+					@remove="categoryFilter = ''"
+				/>
+			</template>
 
-      <template #cell-code="{ row }">
-        <DeskLink :to="`/assembly/${row.id}`" class="font-mono text-xs" @click.stop>{{ row.code }}</DeskLink>
-      </template>
-      <template #cell-name="{ row }">
-        <span class="text-ink-900 font-medium">{{ row.name }}</span>
-        <div v-if="row.notes" class="text-[11px] text-ink-500 truncate">{{ row.notes }}</div>
-      </template>
-      <template #cell-category="{ row }">
-        <span v-if="row.category" class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-700 font-medium"
-          style="border-radius: 9999px;">{{ row.category }}</span>
-        <span v-else class="text-ink-300">—</span>
-      </template>
-      <template #cell-unit="{ row }">
-        <span class="text-ink-600 text-xs">{{ row.unit }}</span>
-      </template>
-      <template #cell-componentCount="{ row }">
-        <span class="text-xs text-ink-700 tabular-nums">{{ row.componentCount || 0 }}</span>
-      </template>
-      <template #cell-ratePerUnit="{ row }">
-        <span class="text-sm font-medium text-ink-900 tabular-nums">{{ fmtINR(row.ratePerUnit) }}</span>
-      </template>
+			<template #cell-code="{ row }">
+				<DeskLink :to="`/assembly/${row.id}`" class="font-mono text-xs" @click.stop>{{
+					row.code
+				}}</DeskLink>
+			</template>
+			<template #cell-name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.name }}</span>
+				<div v-if="row.notes" class="text-[11px] text-ink-500 truncate">
+					{{ row.notes }}
+				</div>
+			</template>
+			<template #cell-category="{ row }">
+				<span
+					v-if="row.category"
+					class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-700 font-medium"
+					style="border-radius: 9999px"
+					>{{ row.category }}</span
+				>
+				<span v-else class="text-ink-300">—</span>
+			</template>
+			<template #cell-unit="{ row }">
+				<span class="text-ink-600 text-xs">{{ row.unit }}</span>
+			</template>
+			<template #cell-componentCount="{ row }">
+				<span class="text-xs text-ink-700 tabular-nums">{{
+					row.componentCount || 0
+				}}</span>
+			</template>
+			<template #cell-ratePerUnit="{ row }">
+				<span class="text-sm font-medium text-ink-900 tabular-nums">{{
+					fmtINR(row.ratePerUnit)
+				}}</span>
+			</template>
 
-      <template #empty>
-        <div class="text-sm text-ink-500">
-          {{ assembliesRes.loading ? 'Loading assemblies…' : 'No assemblies match your filters.' }}
-        </div>
-      </template>
-    </DeskList>
-  </DeskPage>
+			<template #empty>
+				<div class="text-sm text-ink-500">
+					{{
+						assembliesRes.loading
+							? "Loading assemblies…"
+							: "No assemblies match your filters."
+					}}
+				</div>
+			</template>
+		</DeskList>
+	</DeskPage>
 </template>

--- a/frontend/src/views/AssemblyDetailView.vue
+++ b/frontend/src/views/AssemblyDetailView.vue
@@ -1,366 +1,545 @@
 <script setup>
 // Assembly detail — view / edit (modal) / delete + components child-table grid.
 
-import { computed, reactive, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import { useDataStore } from '@/stores'
-import { useConfirm } from '@/composables/useConfirm'
-import { useFormErrors } from '@/composables/useFormErrors'
-import { useDocTypeList } from '@/composables/useDocTypeList'
-import { showToast } from '@/utils/appToast'
-import { createDataAdapter } from '@/data/adapters'
-import { fmtINR } from '@/utils/format'
-import DeskPage from '@/components/desk/DeskPage.vue'
-import DeskSection from '@/components/desk/DeskSection.vue'
-import DeskField from '@/components/desk/DeskField.vue'
-import DeskInput from '@/components/desk/DeskInput.vue'
-import DeskTextarea from '@/components/desk/DeskTextarea.vue'
-import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
-import DeskSearchableSelect from '@/components/desk/DeskSearchableSelect.vue'
-import DeskLink from '@/components/desk/DeskLink.vue'
+import { computed, reactive, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useDataStore } from "@/stores";
+import { useConfirm } from "@/composables/useConfirm";
+import { useFormErrors } from "@/composables/useFormErrors";
+import { useDocTypeList } from "@/composables/useDocTypeList";
+import { showToast } from "@/utils/appToast";
+import { createDataAdapter } from "@/data/adapters";
+import { fmtINR } from "@/utils/format";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskTextarea from "@/components/desk/DeskTextarea.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
 
-const props = defineProps({ id: String })
-const router = useRouter()
-const confirmDialog = useConfirm()
+const props = defineProps({ id: String });
+const router = useRouter();
+const confirmDialog = useConfirm();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
-  assembly_name: 'assemblyName',
-  uom: 'uom',
-})
-const adapter = createDataAdapter(useDataStore())
+	assembly_name: "assemblyName",
+	uom: "uom",
+});
+const adapter = createDataAdapter(useDataStore());
 
-const resource = adapter.read('Assembly', props.id, { fields: ['*'] })
-const doc = computed(() => resource?.doc || null)
+const resource = adapter.read("Assembly", props.id, { fields: ["*"] });
+const doc = computed(() => resource?.doc || null);
 
 const breadcrumbs = computed(() => [
-  { label: 'BuildSuite Core', to: '/' },
-  { label: 'Estimation', to: '/estimation' },
-  { label: 'Assembly', to: '/assembly' },
-  { label: doc.value?.assembly_name || props.id },
-])
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Estimation", to: "/estimation" },
+	{ label: "Assembly", to: "/assembly" },
+	{ label: doc.value?.assembly_name || props.id },
+]);
 
 const cards = computed(() => {
-  const d = doc.value
-  if (!d) return []
-  return [
-    { label: 'Code', value: d.assembly_code, cls: 'font-mono' },
-    { label: 'Category', value: d.category || '—' },
-    { label: 'Unit', value: d.uom },
-    { label: 'Rate / unit (live)', value: fmtINR(d.rate_per_unit), cls: 'font-medium tabular-nums' },
-  ]
-})
+	const d = doc.value;
+	if (!d) return [];
+	return [
+		{ label: "Code", value: d.assembly_code, cls: "font-mono" },
+		{ label: "Category", value: d.category || "—" },
+		{ label: "Unit", value: d.uom },
+		{
+			label: "Rate / unit (live)",
+			value: fmtINR(d.rate_per_unit),
+			cls: "font-medium tabular-nums",
+		},
+	];
+});
 
-const editing = ref(false)
-const saving = ref(false)
-const form = ref({})
+const editing = ref(false);
+const saving = ref(false);
+const form = ref({});
 
 function snapshot() {
-  const d = doc.value
-  if (!d) return {}
-  return {
-    assemblyName: d.assembly_name || '',
-    category: d.category || '',
-    uom: d.uom || '',
-    notes: d.notes || '',
-  }
+	const d = doc.value;
+	if (!d) return {};
+	return {
+		assemblyName: d.assembly_name || "",
+		category: d.category || "",
+		uom: d.uom || "",
+		notes: d.notes || "",
+	};
 }
-watch(doc, (v) => { if (v && !editing.value) form.value = snapshot() }, { immediate: true })
+watch(
+	doc,
+	(v) => {
+		if (v && !editing.value) form.value = snapshot();
+	},
+	{ immediate: true },
+);
 
 function startEdit() {
-  form.value = snapshot()
-  setErrors({})
-  editing.value = true
+	form.value = snapshot();
+	setErrors({});
+	editing.value = true;
 }
 function cancelEdit() {
-  editing.value = false
+	editing.value = false;
 }
 function validate() {
-  const e = {}
-  if (!form.value.assemblyName?.trim()) e.assemblyName = 'Name is required'
-  if (!form.value.uom) e.uom = 'Unit is required'
-  setErrors(e)
-  return Object.keys(e).length === 0
+	const e = {};
+	if (!form.value.assemblyName?.trim()) e.assemblyName = "Name is required";
+	if (!form.value.uom) e.uom = "Unit is required";
+	setErrors(e);
+	return Object.keys(e).length === 0;
 }
 async function saveEdit() {
-  if (!validate()) return
-  saving.value = true
-  try {
-    await adapter.update('Assembly', props.id, {
-      assembly_name: form.value.assemblyName.trim(),
-      category: form.value.category,
-      uom: form.value.uom,
-      notes: form.value.notes,
-    })
-    resource?.reload?.()
-    editing.value = false
-  } catch (err) {
-    showToast(applyServerErrors(err) ?? 'Failed to update assembly', 'error')
-  } finally {
-    saving.value = false
-  }
+	if (!validate()) return;
+	saving.value = true;
+	try {
+		await adapter.update("Assembly", props.id, {
+			assembly_name: form.value.assemblyName.trim(),
+			category: form.value.category,
+			uom: form.value.uom,
+			notes: form.value.notes,
+		});
+		resource?.reload?.();
+		editing.value = false;
+	} catch (err) {
+		showToast(applyServerErrors(err) ?? "Failed to update assembly", "error");
+	} finally {
+		saving.value = false;
+	}
 }
 
 async function onDelete() {
-  const ok = await confirmDialog({
-    title: 'Delete assembly',
-    message: `Delete "${doc.value?.assembly_name}" (${doc.value?.assembly_code})? This cannot be undone.`,
-    confirmLabel: 'Delete',
-    destructive: true,
-  })
-  if (!ok) return
-  try {
-    await adapter.remove('Assembly', props.id)
-    router.push('/assembly')
-  } catch (err) {
-    showToast(applyServerErrors(err) ?? 'Failed to delete assembly', 'error')
-  }
+	const ok = await confirmDialog({
+		title: "Delete assembly",
+		message: `Delete "${doc.value?.assembly_name}" (${doc.value?.assembly_code})? This cannot be undone.`,
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await adapter.remove("Assembly", props.id);
+		router.push("/assembly");
+	} catch (err) {
+		showToast(applyServerErrors(err) ?? "Failed to delete assembly", "error");
+	}
 }
 
 // Components child table. We send only resource + coefficient; the server
 // computes rate / amount / rate_per_unit / component_count on save.
-const components = computed(() => doc.value?.components || [])
-const savingComponents = ref(false)
-const addingRow = ref(false)
-const newRow = reactive({ resource: '', coefficient: 1, remarks: '' })
+const components = computed(() => doc.value?.components || []);
+const savingComponents = ref(false);
+const addingRow = ref(false);
+const newRow = reactive({ resource: "", coefficient: 1, remarks: "" });
 
 // Rate-master options for the picker — grouped by category, rate as a hint.
-const rateMastersRes = useDocTypeList('Construction Rate Master', {
-  fields: ['name', 'rate_name', 'category', 'current_rate', 'uom'],
-  filters: [['disabled', '=', 0]],
-  orderBy: 'category asc',
-  pageLength: 0,
-  cache: 'buildsuite-rate-master-options',
-})
+const rateMastersRes = useDocTypeList("Construction Rate Master", {
+	fields: ["name", "rate_name", "category", "current_rate", "uom"],
+	filters: [["disabled", "=", 0]],
+	orderBy: "category asc",
+	pageLength: 0,
+	cache: "buildsuite-rate-master-options",
+});
 const rateMasterOptions = computed(() =>
-  (rateMastersRes.data || []).map((r) => ({
-    value: r.name,
-    label: `${r.name} · ${r.rate_name}`,
-    group: r.category,
-    hint: `${fmtINR(r.current_rate)} per ${r.uom}`,
-  })),
-)
+	(rateMastersRes.data || []).map((r) => ({
+		value: r.name,
+		label: `${r.name} · ${r.rate_name}`,
+		group: r.category,
+		hint: `${fmtINR(r.current_rate)} per ${r.uom}`,
+	})),
+);
 
 // Add-row preview — unit/rate from the picked resource (server recomputes on save).
-const newRowResource = computed(() =>
-  (rateMastersRes.data || []).find((r) => r.name === newRow.resource) || null,
-)
-const newRowAmount = computed(() => (Number(newRow.coefficient) || 0) * (newRowResource.value?.current_rate || 0))
+const newRowResource = computed(
+	() => (rateMastersRes.data || []).find((r) => r.name === newRow.resource) || null,
+);
+const newRowAmount = computed(
+	() => (Number(newRow.coefficient) || 0) * (newRowResource.value?.current_rate || 0),
+);
 
 // Keep each child `name` so Frappe updates rows in place, not delete + recreate.
 function currentRows() {
-  return components.value.map((r) => ({
-    name: r.name,
-    resource: r.resource,
-    coefficient: r.coefficient,
-    remarks: r.remarks || '',
-  }))
+	return components.value.map((r) => ({
+		name: r.name,
+		resource: r.resource,
+		coefficient: r.coefficient,
+		remarks: r.remarks || "",
+	}));
 }
 
 async function persistComponents(rows) {
-  savingComponents.value = true
-  try {
-    await adapter.update('Assembly', props.id, { components: rows })
-    await resource?.reload?.()
-  } catch (err) {
-    showToast(applyServerErrors(err) ?? 'Failed to update components', 'error')
-  } finally {
-    savingComponents.value = false
-  }
+	savingComponents.value = true;
+	try {
+		await adapter.update("Assembly", props.id, { components: rows });
+		await resource?.reload?.();
+	} catch (err) {
+		showToast(applyServerErrors(err) ?? "Failed to update components", "error");
+	} finally {
+		savingComponents.value = false;
+	}
 }
 
 function startAddRow() {
-  Object.assign(newRow, { resource: '', coefficient: 1, remarks: '' })
-  addingRow.value = true
+	Object.assign(newRow, { resource: "", coefficient: 1, remarks: "" });
+	addingRow.value = true;
 }
-function cancelAddRow() { addingRow.value = false }
+function cancelAddRow() {
+	addingRow.value = false;
+}
 async function saveAddRow() {
-  if (!newRow.resource || (Number(newRow.coefficient) || 0) < 0) return
-  await persistComponents([
-    ...currentRows(),
-    { resource: newRow.resource, coefficient: Number(newRow.coefficient) || 0, remarks: newRow.remarks },
-  ])
-  cancelAddRow()
+	if (!newRow.resource || (Number(newRow.coefficient) || 0) < 0) return;
+	await persistComponents([
+		...currentRows(),
+		{
+			resource: newRow.resource,
+			coefficient: Number(newRow.coefficient) || 0,
+			remarks: newRow.remarks,
+		},
+	]);
+	cancelAddRow();
 }
 
 function changeCoefficient(index, value) {
-  const rows = currentRows()
-  if (!rows[index]) return
-  rows[index].coefficient = Number(value) || 0
-  persistComponents(rows)
+	const rows = currentRows();
+	if (!rows[index]) return;
+	rows[index].coefficient = Number(value) || 0;
+	persistComponents(rows);
 }
 
 async function removeComponent(index) {
-  const ok = await confirmDialog({
-    title: 'Remove component',
-    message: 'Remove this component from the assembly?',
-    confirmLabel: 'Remove',
-    destructive: true,
-  })
-  if (!ok) return
-  const rows = currentRows().filter((_, i) => i !== index)
-  persistComponents(rows)
+	const ok = await confirmDialog({
+		title: "Remove component",
+		message: "Remove this component from the assembly?",
+		confirmLabel: "Remove",
+		destructive: true,
+	});
+	if (!ok) return;
+	const rows = currentRows().filter((_, i) => i !== index);
+	persistComponents(rows);
 }
 </script>
 
 <template>
-  <DeskPage v-if="doc" :title="doc.assembly_name" :subtitle="`${doc.assembly_code} · per ${doc.uom}`"
-    :breadcrumbs="breadcrumbs" :status="doc.category">
-    <template #actions>
-      <button type="button" class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
-        style="border-radius: 6px;" @click="startEdit">Edit</button>
-      <button type="button"
-        class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
-        style="border-radius: 6px;" @click="onDelete">Delete</button>
-    </template>
+	<DeskPage
+		v-if="doc"
+		:title="doc.assembly_name"
+		:subtitle="`${doc.assembly_code} · per ${doc.uom}`"
+		:breadcrumbs="breadcrumbs"
+		:status="doc.category"
+	>
+		<template #actions>
+			<button
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="startEdit"
+			>
+				Edit
+			</button>
+			<button
+				type="button"
+				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+				style="border-radius: 6px"
+				@click="onDelete"
+			>
+				Delete
+			</button>
+		</template>
 
-    <!-- Headline strip — code / category / unit / rate -->
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
-      <div v-for="c in cards" :key="c.label" class="bg-white border border-ink-200 px-3 py-2"
-        style="border-radius: 6px;">
-        <div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">{{ c.label }}</div>
-        <div class="text-sm text-ink-900 mt-0.5" :class="c.cls">{{ c.value }}</div>
-      </div>
-    </div>
+		<!-- Headline strip — code / category / unit / rate -->
+		<div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
+			<div
+				v-for="c in cards"
+				:key="c.label"
+				class="bg-white border border-ink-200 px-3 py-2"
+				style="border-radius: 6px"
+			>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					{{ c.label }}
+				</div>
+				<div class="text-sm text-ink-900 mt-0.5" :class="c.cls">{{ c.value }}</div>
+			</div>
+		</div>
 
-    <!-- Notes -->
-    <div v-if="doc.notes" class="mb-4 px-3 py-2 bg-white border border-ink-200" style="border-radius: 6px;">
-      <div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Notes</div>
-      <div class="text-sm text-ink-800 leading-snug whitespace-pre-line">{{ doc.notes }}</div>
-    </div>
+		<!-- Notes -->
+		<div
+			v-if="doc.notes"
+			class="mb-4 px-3 py-2 bg-white border border-ink-200"
+			style="border-radius: 6px"
+		>
+			<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">
+				Notes
+			</div>
+			<div class="text-sm text-ink-800 leading-snug whitespace-pre-line">
+				{{ doc.notes }}
+			</div>
+		</div>
 
-    <!-- Components child table -->
-    <section>
-      <div class="flex items-center justify-between mb-2 gap-3">
-        <div class="text-xs text-ink-500">
-          <span class="text-ink-900 font-medium">{{ components.length }} component{{ components.length === 1 ? '' : 's' }}</span>
-          · linked to Rate Master · coefficient × rate
-        </div>
-        <button v-if="!addingRow" type="button" class="desk-save-btn" :disabled="savingComponents" @click="startAddRow">+ Add Component</button>
-      </div>
+		<!-- Components child table -->
+		<section>
+			<div class="flex items-center justify-between mb-2 gap-3">
+				<div class="text-xs text-ink-500">
+					<span class="text-ink-900 font-medium"
+						>{{ components.length }} component{{
+							components.length === 1 ? "" : "s"
+						}}</span
+					>
+					· linked to Rate Master · coefficient × rate
+				</div>
+				<button
+					v-if="!addingRow"
+					type="button"
+					class="desk-save-btn"
+					:disabled="savingComponents"
+					@click="startAddRow"
+				>
+					+ Add Component
+				</button>
+			</div>
 
-      <div class="bg-white border border-ink-200" style="border-radius: 8px;">
-        <!-- Header strip -->
-        <div class="grid bg-ink-50 border-b border-ink-200 text-[10px] uppercase tracking-wider text-ink-500 font-medium"
-          style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px;">
-          <div class="px-3 py-1.5">Resource</div>
-          <div class="px-3 py-1.5 text-right whitespace-nowrap">Coefficient</div>
-          <div class="px-3 py-1.5">Unit</div>
-          <div class="px-3 py-1.5 text-right whitespace-nowrap">Rate</div>
-          <div class="px-3 py-1.5 text-right whitespace-nowrap">Amount</div>
-          <div class="px-3 py-1.5"></div>
-        </div>
+			<div class="bg-white border border-ink-200" style="border-radius: 8px">
+				<!-- Header strip -->
+				<div
+					class="grid bg-ink-50 border-b border-ink-200 text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+					style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px"
+				>
+					<div class="px-3 py-1.5">Resource</div>
+					<div class="px-3 py-1.5 text-right whitespace-nowrap">Coefficient</div>
+					<div class="px-3 py-1.5">Unit</div>
+					<div class="px-3 py-1.5 text-right whitespace-nowrap">Rate</div>
+					<div class="px-3 py-1.5 text-right whitespace-nowrap">Amount</div>
+					<div class="px-3 py-1.5"></div>
+				</div>
 
-        <!-- Existing rows -->
-        <div v-for="(row, i) in components" :key="row.name || i"
-          class="grid border-b border-ink-100 last:border-b-0 items-center text-sm"
-          style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px;">
-          <div class="px-3 py-2">
-            <DeskLink :to="`/rate-master`" class="text-xs">{{ row.resource_name || row.resource }}</DeskLink>
-            <div v-if="row.remarks" class="text-[11px] text-ink-500 mt-0.5">{{ row.remarks }}</div>
-          </div>
-          <div class="px-2 py-1">
-            <DeskInput :model-value="row.coefficient" type="number" :min="0" :step="0.01"
-              :disabled="savingComponents" @change="(e) => changeCoefficient(i, e.target.value)" />
-          </div>
-          <div class="px-3 py-2 text-xs text-ink-700">{{ row.uom || '—' }}</div>
-          <div class="px-3 py-2 text-right text-sm tabular-nums text-ink-700">{{ fmtINR(row.rate) }}</div>
-          <div class="px-3 py-2 text-right text-sm font-medium tabular-nums text-ink-900">{{ fmtINR(row.amount) }}</div>
-          <div class="px-2 py-1 text-right">
-            <button type="button" class="text-ink-400 hover:text-danger-700 text-base leading-none" title="Remove"
-              :disabled="savingComponents" @click="removeComponent(i)">×</button>
-          </div>
-        </div>
+				<!-- Existing rows -->
+				<div
+					v-for="(row, i) in components"
+					:key="row.name || i"
+					class="grid border-b border-ink-100 last:border-b-0 items-center text-sm"
+					style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px"
+				>
+					<div class="px-3 py-2">
+						<DeskLink :to="`/rate-master/${row.resource}`" class="text-xs">{{
+							row.resource_name || row.resource
+						}}</DeskLink>
+						<div v-if="row.remarks" class="text-[11px] text-ink-500 mt-0.5">
+							{{ row.remarks }}
+						</div>
+					</div>
+					<div class="px-2 py-1">
+						<DeskInput
+							:model-value="row.coefficient"
+							type="number"
+							:min="0"
+							:step="0.01"
+							:disabled="savingComponents"
+							@change="(e) => changeCoefficient(i, e.target.value)"
+						/>
+					</div>
+					<div class="px-3 py-2 text-xs text-ink-700">{{ row.uom || "—" }}</div>
+					<div class="px-3 py-2 text-right text-sm tabular-nums text-ink-700">
+						{{ fmtINR(row.rate) }}
+					</div>
+					<div
+						class="px-3 py-2 text-right text-sm font-medium tabular-nums text-ink-900"
+					>
+						{{ fmtINR(row.amount) }}
+					</div>
+					<div class="px-2 py-1 text-right">
+						<button
+							type="button"
+							class="text-ink-400 hover:text-danger-700 text-base leading-none"
+							title="Remove"
+							:disabled="savingComponents"
+							@click="removeComponent(i)"
+						>
+							×
+						</button>
+					</div>
+				</div>
 
-        <!-- Empty state -->
-        <div v-if="!components.length && !addingRow" class="px-3 py-4 text-xs text-ink-500">
-          No components yet — add one to price this assembly.
-        </div>
+				<!-- Empty state -->
+				<div
+					v-if="!components.length && !addingRow"
+					class="px-3 py-4 text-xs text-ink-500"
+				>
+					No components yet — add one to price this assembly.
+				</div>
 
-        <!-- Add row -->
-        <div v-if="addingRow" class="grid border-t border-ink-200 items-start text-sm bg-brand-50"
-          style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px;">
-          <div class="px-2 py-2">
-            <DeskSearchableSelect v-model="newRow.resource" :options="rateMasterOptions"
-              placeholder="Pick a rate master…" search-placeholder="Search rate master…" />
-            <div class="mt-1">
-              <DeskInput v-model="newRow.remarks" placeholder="Remarks (optional)" />
-            </div>
-          </div>
-          <div class="px-2 py-2">
-            <DeskInput v-model="newRow.coefficient" type="number" :min="0" :step="0.01" />
-          </div>
-          <div class="px-3 py-2 text-xs text-ink-700">{{ newRowResource?.uom || '—' }}</div>
-          <div class="px-3 py-2 text-right text-sm tabular-nums text-ink-700">
-            {{ newRowResource ? fmtINR(newRowResource.current_rate) : '— auto —' }}
-          </div>
-          <div class="px-3 py-2 text-right text-sm font-medium tabular-nums text-ink-900">
-            {{ newRowResource ? fmtINR(newRowAmount) : '— auto —' }}
-          </div>
-          <div class="px-2 py-2 flex items-center gap-1 justify-end">
-            <button type="button" class="desk-save-btn !px-2 !py-1 !text-[11px]" :disabled="savingComponents" @click="saveAddRow">Add</button>
-            <button type="button" class="text-ink-400 hover:text-danger-700 text-base leading-none" @click="cancelAddRow">×</button>
-          </div>
-        </div>
+				<!-- Add row -->
+				<div
+					v-if="addingRow"
+					class="grid border-t border-ink-200 items-start text-sm bg-brand-50"
+					style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px"
+				>
+					<div class="px-2 py-2">
+						<DeskSearchableSelect
+							v-model="newRow.resource"
+							:options="rateMasterOptions"
+							placeholder="Pick a rate master…"
+							search-placeholder="Search rate master…"
+						/>
+						<div class="mt-1">
+							<DeskInput v-model="newRow.remarks" placeholder="Remarks (optional)" />
+						</div>
+					</div>
+					<div class="px-2 py-2">
+						<DeskInput
+							v-model="newRow.coefficient"
+							type="number"
+							:min="0"
+							:step="0.01"
+						/>
+					</div>
+					<div class="px-3 py-2 text-xs text-ink-700">
+						{{ newRowResource?.uom || "—" }}
+					</div>
+					<div class="px-3 py-2 text-right text-sm tabular-nums text-ink-700">
+						{{ newRowResource ? fmtINR(newRowResource.current_rate) : "— auto —" }}
+					</div>
+					<div
+						class="px-3 py-2 text-right text-sm font-medium tabular-nums text-ink-900"
+					>
+						{{ newRowResource ? fmtINR(newRowAmount) : "— auto —" }}
+					</div>
+					<div class="px-2 py-2 flex items-center gap-1 justify-end">
+						<button
+							type="button"
+							class="desk-save-btn !px-2 !py-1 !text-[11px]"
+							:disabled="savingComponents"
+							@click="saveAddRow"
+						>
+							Add
+						</button>
+						<button
+							type="button"
+							class="text-ink-400 hover:text-danger-700 text-base leading-none"
+							@click="cancelAddRow"
+						>
+							×
+						</button>
+					</div>
+				</div>
 
-        <!-- Footer total -->
-        <div class="grid border-t border-ink-200 bg-ink-50 text-sm"
-          style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px;">
-          <div class="px-3 py-2 text-right text-[11px] uppercase tracking-wider text-ink-500 font-medium" style="grid-column: 1 / span 4;">Rate / unit (Assembly)</div>
-          <div class="px-3 py-2 text-right font-semibold text-ink-900 tabular-nums">{{ fmtINR(doc.rate_per_unit) }}</div>
-          <div></div>
-        </div>
-      </div>
-    </section>
+				<!-- Footer total -->
+				<div
+					class="grid border-t border-ink-200 bg-ink-50 text-sm"
+					style="grid-template-columns: minmax(260px, 1fr) 110px 60px 110px 110px 60px"
+				>
+					<div
+						class="px-3 py-2 text-right text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						style="grid-column: 1 / span 4"
+					>
+						Rate / unit (Assembly)
+					</div>
+					<div class="px-3 py-2 text-right font-semibold text-ink-900 tabular-nums">
+						{{ fmtINR(doc.rate_per_unit) }}
+					</div>
+					<div></div>
+				</div>
+			</div>
+		</section>
 
-    <!-- Edit modal -->
-    <Teleport to="body">
-      <div
-        v-if="editing"
-        class="fixed inset-0 bg-ink-900/40 z-[60] flex items-center justify-center p-6"
-        @click.self="cancelEdit"
-      >
-        <div
-          class="bg-white border border-ink-200 w-full max-w-2xl shadow-fp-lg flex flex-col"
-          style="border-radius: 12px; max-height: calc(100vh - 3rem);"
-          @click.stop
-        >
-          <header class="px-5 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0 bg-white" style="border-radius: 12px 12px 0 0;">
-            <div class="min-w-0 flex-1">
-              <h2 class="text-sm font-semibold text-ink-900">Edit assembly</h2>
-              <p class="text-[11px] text-ink-500 mt-0.5 truncate">{{ doc.assembly_name }}</p>
-            </div>
-            <button type="button" class="text-ink-500 hover:text-ink-900 text-lg leading-none" aria-label="Close" @click="cancelEdit">×</button>
-          </header>
+		<!-- Edit modal -->
+		<Teleport to="body">
+			<div
+				v-if="editing"
+				class="fixed inset-0 bg-ink-900/40 z-[60] flex items-center justify-center p-6"
+				@click.self="cancelEdit"
+			>
+				<div
+					class="bg-white border border-ink-200 w-full max-w-2xl shadow-fp-lg flex flex-col"
+					style="border-radius: 12px; max-height: calc(100vh - 3rem)"
+					@click.stop
+				>
+					<header
+						class="px-5 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0 bg-white"
+						style="border-radius: 12px 12px 0 0"
+					>
+						<div class="min-w-0 flex-1">
+							<h2 class="text-sm font-semibold text-ink-900">Edit assembly</h2>
+							<p class="text-[11px] text-ink-500 mt-0.5 truncate">
+								{{ doc.assembly_name }}
+							</p>
+						</div>
+						<button
+							type="button"
+							class="text-ink-500 hover:text-ink-900 text-lg leading-none"
+							aria-label="Close"
+							@click="cancelEdit"
+						>
+							×
+						</button>
+					</header>
 
-          <div class="p-5 overflow-y-auto flex-1">
-            <DeskSection title="Assembly details">
-              <DeskField label="Code" hint="The assembly's identifier — not editable.">
-                <span class="text-sm font-mono text-ink-700">{{ doc.assembly_code }}</span>
-              </DeskField>
-              <DeskField label="Name" required :error="errors.assemblyName">
-                <DeskInput v-model="form.assemblyName" />
-              </DeskField>
-              <DeskField label="Unit (per)" required hint="The per-unit basis — component coefficients mean &quot;how much per one of this unit&quot;." :error="errors.uom">
-                <DeskLinkPicker v-model="form.uom" doctype="UOM" label-field="name" value-field="name"
-                  placeholder="— Select unit —" />
-              </DeskField>
-              <DeskField label="Category">
-                <DeskLinkPicker v-model="form.category" doctype="Assembly Category" label-field="name"
-                  value-field="name" placeholder="— Select category —" />
-              </DeskField>
-              <DeskField label="Notes">
-                <DeskTextarea v-model="form.notes" :rows="3" />
-              </DeskField>
-            </DeskSection>
-          </div>
+					<div class="p-5 overflow-y-auto flex-1">
+						<DeskSection title="Assembly details">
+							<DeskField
+								label="Code"
+								hint="The assembly's identifier — not editable."
+							>
+								<span class="text-sm font-mono text-ink-700">{{
+									doc.assembly_code
+								}}</span>
+							</DeskField>
+							<DeskField label="Name" required :error="errors.assemblyName">
+								<DeskInput v-model="form.assemblyName" />
+							</DeskField>
+							<DeskField
+								label="Unit (per)"
+								required
+								hint='The per-unit basis — component coefficients mean "how much per one of this unit".'
+								:error="errors.uom"
+							>
+								<DeskLinkPicker
+									v-model="form.uom"
+									doctype="UOM"
+									label-field="name"
+									value-field="name"
+									placeholder="— Select unit —"
+								/>
+							</DeskField>
+							<DeskField label="Category">
+								<DeskLinkPicker
+									v-model="form.category"
+									doctype="Assembly Category"
+									label-field="name"
+									value-field="name"
+									placeholder="— Select category —"
+								/>
+							</DeskField>
+							<DeskField label="Notes">
+								<DeskTextarea v-model="form.notes" :rows="3" />
+							</DeskField>
+						</DeskSection>
+					</div>
 
-          <footer class="px-5 py-3 border-t border-ink-200 flex items-center justify-end gap-2 flex-shrink-0 bg-white" style="border-radius: 0 0 12px 12px;">
-            <button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700" style="border-radius: 6px;" :disabled="saving" @click="cancelEdit">Cancel</button>
-            <button type="button" class="desk-save-btn" :disabled="saving" @click="saveEdit">{{ saving ? 'Saving…' : 'Save' }}</button>
-          </footer>
-        </div>
-      </div>
-    </Teleport>
-  </DeskPage>
+					<footer
+						class="px-5 py-3 border-t border-ink-200 flex items-center justify-end gap-2 flex-shrink-0 bg-white"
+						style="border-radius: 0 0 12px 12px"
+					>
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+							style="border-radius: 6px"
+							:disabled="saving"
+							@click="cancelEdit"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							class="desk-save-btn"
+							:disabled="saving"
+							@click="saveEdit"
+						>
+							{{ saving ? "Saving…" : "Save" }}
+						</button>
+					</footer>
+				</div>
+			</div>
+		</Teleport>
+	</DeskPage>
 
-  <div v-else class="px-3 py-2 text-sm text-ink-500">Loading assembly…</div>
+	<div v-else class="px-3 py-2 text-sm text-ink-500">Loading assembly…</div>
 </template>

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -15,6 +15,7 @@ import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import { parseFrappeError } from "@/utils/frappeError";
 import * as boqApi from "@/utils/boqApi";
+import { getCommittedByCostCode } from "@/data/subcontractApi";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -204,7 +205,7 @@ const boqItemsByBoq = computed(() => allItems.value);
 // Shared 10-column grid for the tree header + group / item / sub-item rows so every
 // level lines up. Without it the rows have no column template and collapse.
 const treeGridStyle =
-	"grid-template-columns: 28px 80px 1fr 80px 90px 100px 110px 110px 110px 80px;";
+	"grid-template-columns: 28px 80px minmax(240px, 1fr) 80px 90px 100px 110px 120px 110px 110px 120px 80px 110px; min-width: 1360px;";
 
 const totals = computed(() => {
 	const planned = allItems.value.reduce((a, i) => a + (i.plannedAmount || 0), 0);
@@ -253,6 +254,47 @@ function groupTotals(groupId) {
 	const planned = items.reduce((a, i) => a + (i.plannedAmount || 0), 0);
 	const actual = items.reduce((a, i) => a + (i.actualAmount || 0), 0);
 	return { planned, actual, count: items.length };
+}
+
+// === Committed (open subcontractor work orders) + Work Package labels ===
+// Committed is a group-level column: the sum of open WO line amounts mapped to the
+// group's cost code. WP + Cost Head are per-item (already on the item).
+const committedMap = ref({}); // { cost_code_group: amount }
+watch(
+	() => boq.value?.projectId,
+	async (pid) => {
+		committedMap.value = {};
+		if (!pid) return;
+		try {
+			committedMap.value = (await getCommittedByCostCode(pid)) || {};
+		} catch {
+			committedMap.value = {};
+		}
+	},
+	{ immediate: true },
+);
+function groupCommitted(group) {
+	return committedMap.value[group.code] || 0;
+}
+
+const wpRes = useDocTypeList("Work Package", {
+	fields: ["name", "code", "work_package_name"],
+	orderBy: "code asc",
+	pageLength: 0,
+	cache: "buildsuite-wp-code-map",
+});
+const wpMap = computed(() => {
+	const m = {};
+	(wpRes.data || []).forEach((w) => {
+		m[w.name] = { code: w.code || w.name, name: w.work_package_name || "" };
+	});
+	return m;
+});
+function wpCode(id) {
+	return id ? wpMap.value[id]?.code || id : "";
+}
+function wpName(id) {
+	return id ? wpMap.value[id]?.name || "" : "";
 }
 function baseAmount(code) {
 	if (!baseBoq.value) return null;
@@ -1021,8 +1063,9 @@ const breadcrumbs = computed(() => {
 				</div>
 			</div>
 
-			<!-- The 3-level tree — Desk styling -->
-			<div class="bg-white border border-ink-200 overflow-hidden" style="border-radius: 2px">
+			<!-- The 3-level tree — Desk styling. overflow-x-auto so the row grid keeps
+			     its full min-width on narrow viewports. -->
+			<div class="bg-white border border-ink-200 overflow-x-auto" style="border-radius: 2px">
 				<!-- Header strip -->
 				<div
 					class="grid items-center bg-ink-50 border-b border-ink-200 text-[11px] text-ink-500 uppercase tracking-wider font-semibold"
@@ -1035,9 +1078,12 @@ const breadcrumbs = computed(() => {
 					<div class="px-3 py-2 text-right">Plan Qty</div>
 					<div class="px-3 py-2 text-right">Rate (₹)</div>
 					<div class="px-3 py-2 text-right">Planned</div>
+					<div class="px-3 py-2 text-right">Committed</div>
 					<div class="px-3 py-2 text-right">Actual</div>
 					<div class="px-3 py-2 text-right">Variance</div>
+					<div class="px-3 py-2">WP</div>
 					<div class="px-3 py-2 text-center">Task</div>
+					<div class="px-3 py-2">Cost Head</div>
 				</div>
 
 				<template v-for="g in groups" :key="g.id">
@@ -1064,6 +1110,12 @@ const breadcrumbs = computed(() => {
 						>
 							{{ fmtCompactINR(groupTotals(g.id).planned) }}
 						</div>
+						<div
+							class="px-3 py-2 text-right tabular-nums text-sm text-info-700"
+							:title="`Open subcontractor work orders mapped to cost code ${g.code}`"
+						>
+							{{ fmtCompactINR(groupCommitted(g)) }}
+						</div>
 						<div class="px-3 py-2 text-right tabular-nums text-sm text-ink-700">
 							{{ fmtCompactINR(groupTotals(g.id).actual) }}
 						</div>
@@ -1088,6 +1140,8 @@ const breadcrumbs = computed(() => {
 									: "0.0"
 							}}%
 						</div>
+						<div></div>
+						<div></div>
 						<div></div>
 
 						<!-- Edit / Delete (hover-visible, only when BOQ is Draft) -->
@@ -1247,6 +1301,7 @@ const breadcrumbs = computed(() => {
 								>
 									{{ fmtCompactINR(item.plannedAmount) }}
 								</div>
+								<div></div>
 								<div class="px-3 py-1.5">
 									<div class="flex flex-col items-end">
 										<span class="tabular-nums text-sm text-ink-700">{{
@@ -1294,6 +1349,17 @@ const breadcrumbs = computed(() => {
 											: "0.0"
 									}}%
 								</div>
+								<div class="px-3 py-1.5">
+									<DeskLink
+										v-if="item.workPackageId"
+										:to="`/work-packages/${item.workPackageId}`"
+										@click.stop
+										class="text-[10px] font-mono"
+										:title="wpName(item.workPackageId)"
+										>{{ wpCode(item.workPackageId) }}</DeskLink
+									>
+									<span v-else class="text-[10px] text-ink-300">—</span>
+								</div>
 								<div class="px-3 py-1.5 text-center">
 									<DeskLink
 										v-if="item.taskId"
@@ -1301,6 +1367,15 @@ const breadcrumbs = computed(() => {
 										@click.stop
 										class="text-[10px] font-mono"
 										>{{ item.taskId.slice(-4) }}</DeskLink
+									>
+									<span v-else class="text-[10px] text-ink-300">—</span>
+								</div>
+								<div class="px-3 py-1.5">
+									<span
+										v-if="item.costHead"
+										class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-700"
+										style="border-radius: 9999px"
+										>{{ item.costHead }}</span
 									>
 									<span v-else class="text-[10px] text-ink-300">—</span>
 								</div>
@@ -1320,7 +1395,7 @@ const breadcrumbs = computed(() => {
 										↳ {{ si.description }}
 										<DeskLink
 											v-if="si.rateMasterId"
-											to="/rate-master"
+											:to="`/rate-master/${si.rateMasterId}`"
 											@click.stop
 											class="ml-2 text-[10px] font-mono"
 											>{{ si.rateMasterId }}</DeskLink
@@ -1344,9 +1419,12 @@ const breadcrumbs = computed(() => {
 									>
 										{{ fmtINR(si.amount) }}
 									</div>
+									<div></div>
 									<div class="px-3 py-1 text-right text-[10px] text-ink-400">
 										per {{ item.unit }}
 									</div>
+									<div></div>
+									<div></div>
 									<div></div>
 									<div></div>
 
@@ -1411,6 +1489,9 @@ const breadcrumbs = computed(() => {
 									<div></div>
 									<div></div>
 									<div></div>
+									<div></div>
+									<div></div>
+									<div></div>
 								</div>
 
 								<!-- Inline "+ Add Sub-item" affordance -->
@@ -1434,6 +1515,9 @@ const breadcrumbs = computed(() => {
 									<div></div>
 									<div></div>
 									<div></div>
+									<div></div>
+									<div></div>
+									<div></div>
 								</div>
 							</template>
 						</template>
@@ -1450,6 +1534,9 @@ const breadcrumbs = computed(() => {
 							<div class="px-3 py-1.5 text-xs text-brand-700 font-medium">
 								+ Add item to {{ g.code }} — {{ g.name }}
 							</div>
+							<div></div>
+							<div></div>
+							<div></div>
 							<div></div>
 							<div></div>
 							<div></div>

--- a/frontend/src/views/EstimateTemplatesView.vue
+++ b/frontend/src/views/EstimateTemplatesView.vue
@@ -1,106 +1,146 @@
 <script setup>
-import { computed, ref } from 'vue'
-import { useRouter } from 'vue-router'
-import { useDocTypeList } from '@/composables/useDocTypeList'
-import { fmtINR, fmtDate } from '@/utils/format'
-import DeskPage from '@/components/desk/DeskPage.vue'
-import DeskList from '@/components/desk/DeskList.vue'
-import DeskLink from '@/components/desk/DeskLink.vue'
+import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useDocTypeList } from "@/composables/useDocTypeList";
+import { fmtINR, fmtDate } from "@/utils/format";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
 
-const router = useRouter()
+const router = useRouter();
 
 function onRowClick(row) {
-  router.push(`/estimate-template/${row.id}`)
+	router.push(`/estimate-template/${row.id}`);
 }
 
 const breadcrumbs = [
-  { label: 'BuildSuite Core', to: '/' },
-  { label: 'Estimation', to: '/estimation' },
-  { label: 'Estimate Template' },
-]
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Estimation", to: "/estimation" },
+	{ label: "Estimate Template" },
+];
 
-const templatesRes = useDocTypeList('Estimate Template', {
-  fields: ['name', 'template_code', 'template_name', 'project_category', 'enabled', 'row_count', 'estimated_total', 'modified'],
-  orderBy: 'template_code asc',
-  pageLength: 0,
-  cache: 'buildsuite-estimate-template-list',
-  transform: (data) =>
-    data.map((t) => ({
-      id: t.name,
-      code: t.template_code,
-      name: t.template_name,
-      projectType: t.project_category,
-      rows: t.row_count,
-      estimated: t.estimated_total,
-      updated: t.modified,
-      enabled: t.enabled,
-    })),
-})
+const templatesRes = useDocTypeList("Estimate Template", {
+	fields: [
+		"name",
+		"template_code",
+		"template_name",
+		"project_category",
+		"enabled",
+		"row_count",
+		"estimated_total",
+		"modified",
+	],
+	orderBy: "creation desc",
+	pageLength: 0,
+	cache: "buildsuite-estimate-template-list",
+	transform: (data) =>
+		data.map((t) => ({
+			id: t.name,
+			code: t.template_code,
+			name: t.template_name,
+			projectType: t.project_category,
+			rows: t.row_count,
+			estimated: t.estimated_total,
+			updated: t.modified,
+			enabled: t.enabled,
+		})),
+});
 
-const search = ref('')
+const search = ref("");
 const rows = computed(() => {
-  let data = templatesRes.data || []
-  const q = search.value.trim().toLowerCase()
-  if (q) {
-    data = data.filter(
-      (t) => (t.code || '').toLowerCase().includes(q) || (t.name || '').toLowerCase().includes(q),
-    )
-  }
-  return data
-})
+	let data = templatesRes.data || [];
+	const q = search.value.trim().toLowerCase();
+	if (q) {
+		data = data.filter(
+			(t) =>
+				(t.code || "").toLowerCase().includes(q) ||
+				(t.name || "").toLowerCase().includes(q),
+		);
+	}
+	return data;
+});
 
 const columns = [
-  { key: 'code', label: 'Code' },
-  { key: 'name', label: 'Name' },
-  { key: 'projectType', label: 'Project Category' },
-  { key: 'rows', label: 'Rows', align: 'right' },
-  { key: 'estimated', label: 'Estimated', align: 'right' },
-  { key: 'updated', label: 'Updated' },
-  { key: 'enabled', label: 'Status' },
-]
+	{ key: "code", label: "Code" },
+	{ key: "name", label: "Name" },
+	{ key: "projectType", label: "Project Category" },
+	{ key: "rows", label: "Rows", align: "right" },
+	{ key: "estimated", label: "Estimated", align: "right" },
+	{ key: "updated", label: "Updated" },
+	{ key: "enabled", label: "Status" },
+];
 </script>
 
 <template>
-  <DeskPage title="Estimate Template" :breadcrumbs="breadcrumbs">
-    <template #actions>
-      <DeskLink to="/assembly" class="text-xs">View Assemblies →</DeskLink>
-      <RouterLink to="/estimate-template/new" class="desk-save-btn">+ New</RouterLink>
-    </template>
+	<DeskPage title="Estimate Template" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<DeskLink to="/assembly" class="text-xs">View Assemblies →</DeskLink>
+			<RouterLink to="/estimate-template/new" class="desk-save-btn">+ New</RouterLink>
+		</template>
 
-    <DeskList v-model="search" :rows="rows" :columns="columns" row-key="id"
-      search-placeholder="Search by code or name…" @row-click="onRowClick">
-      <template #cell-code="{ row }">
-        <DeskLink :to="`/estimate-template/${row.id}`" class="font-mono text-xs" @click.stop>{{ row.code }}</DeskLink>
-      </template>
-      <template #cell-name="{ row }">
-        <span class="text-ink-900 font-medium">{{ row.name }}</span>
-      </template>
-      <template #cell-projectType="{ row }">
-        <span v-if="row.projectType" class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-700 font-medium"
-          style="border-radius: 9999px;">{{ row.projectType }}</span>
-        <span v-else class="text-ink-300">Any</span>
-      </template>
-      <template #cell-rows="{ row }">
-        <span class="text-xs text-ink-700 tabular-nums">{{ row.rows || 0 }}</span>
-      </template>
-      <template #cell-estimated="{ row }">
-        <span class="text-sm font-medium text-ink-900 tabular-nums">{{ fmtINR(row.estimated) }}</span>
-      </template>
-      <template #cell-updated="{ row }">
-        <span class="text-xs text-ink-500 whitespace-nowrap">{{ fmtDate(row.updated) }}</span>
-      </template>
-      <template #cell-enabled="{ row }">
-        <span v-if="row.enabled" class="text-[10px] px-2 py-0.5 bg-success-50 text-success-700 font-medium"
-          style="border-radius: 9999px;">Enabled</span>
-        <span v-else class="text-[10px] px-2 py-0.5 bg-ink-100 text-ink-500 font-medium"
-          style="border-radius: 9999px;">Disabled</span>
-      </template>
+		<DeskList
+			v-model="search"
+			:rows="rows"
+			:columns="columns"
+			row-key="id"
+			search-placeholder="Search by code or name…"
+			@row-click="onRowClick"
+		>
+			<template #cell-code="{ row }">
+				<DeskLink
+					:to="`/estimate-template/${row.id}`"
+					class="font-mono text-xs"
+					@click.stop
+					>{{ row.code }}</DeskLink
+				>
+			</template>
+			<template #cell-name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.name }}</span>
+			</template>
+			<template #cell-projectType="{ row }">
+				<span
+					v-if="row.projectType"
+					class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-700 font-medium"
+					style="border-radius: 9999px"
+					>{{ row.projectType }}</span
+				>
+				<span v-else class="text-ink-300">Any</span>
+			</template>
+			<template #cell-rows="{ row }">
+				<span class="text-xs text-ink-700 tabular-nums">{{ row.rows || 0 }}</span>
+			</template>
+			<template #cell-estimated="{ row }">
+				<span class="text-sm font-medium text-ink-900 tabular-nums">{{
+					fmtINR(row.estimated)
+				}}</span>
+			</template>
+			<template #cell-updated="{ row }">
+				<span class="text-xs text-ink-500 whitespace-nowrap">{{
+					fmtDate(row.updated)
+				}}</span>
+			</template>
+			<template #cell-enabled="{ row }">
+				<span
+					v-if="row.enabled"
+					class="text-[10px] px-2 py-0.5 bg-success-50 text-success-700 font-medium"
+					style="border-radius: 9999px"
+					>Enabled</span
+				>
+				<span
+					v-else
+					class="text-[10px] px-2 py-0.5 bg-ink-100 text-ink-500 font-medium"
+					style="border-radius: 9999px"
+					>Disabled</span
+				>
+			</template>
 
-      <template #empty>
-        <div class="text-sm text-ink-500">
-          {{ templatesRes.loading ? 'Loading templates…' : 'No estimate templates yet.' }}
-        </div>
-      </template>
-    </DeskList>
-  </DeskPage>
+			<template #empty>
+				<div class="text-sm text-ink-500">
+					{{
+						templatesRes.loading ? "Loading templates…" : "No estimate templates yet."
+					}}
+				</div>
+			</template>
+		</DeskList>
+	</DeskPage>
 </template>

--- a/frontend/src/views/RateMasterView.vue
+++ b/frontend/src/views/RateMasterView.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { createDataAdapter } from "@/data/adapters";
 import { useDocTypeList } from "@/composables/useDocTypeList";
@@ -18,6 +19,8 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 
+const props = defineProps({ id: { type: String, default: "" } });
+const router = useRouter();
 const store = useDataStore();
 const adapter = createDataAdapter(store);
 const confirmDialog = useConfirm();
@@ -91,7 +94,7 @@ const rows = computed(() => {
 		data = data.filter(
 			(r) =>
 				(r.code || "").toLowerCase().includes(q) ||
-				(r.description || "").toLowerCase().includes(q)
+				(r.description || "").toLowerCase().includes(q),
 		);
 	}
 	return data;
@@ -189,8 +192,10 @@ async function save() {
 }
 
 // Load the full doc (incl. rate_history) for the side sheet — the list payload omits child tables.
-function onRowClick(row) {
-	rateRes.value = adapter.read("Construction Rate Master", row.id, {
+// Open the detail drawer for a rate. Reads the record directly, so a deep link to
+// /rate-master/<code> works even before the list has loaded.
+function openRate(id) {
+	rateRes.value = adapter.read("Construction Rate Master", id, {
 		transform: (docs) =>
 			docs.map((d) => ({
 				id: d.name,
@@ -211,8 +216,27 @@ function onRowClick(row) {
 			})),
 	});
 }
+
+// Clicking a row navigates to the record's URL; the route watcher opens the drawer.
+function onRowClick(row) {
+	if (props.id === row.id) openRate(row.id);
+	else router.push(`/rate-master/${encodeURIComponent(row.id)}`);
+}
+
+// Drive the drawer from the route param so /rate-master/<code> deep-links work and
+// the URL reflects the open record.
+watch(
+	() => props.id,
+	(id) => {
+		if (id) openRate(id);
+		else rateRes.value = null;
+	},
+	{ immediate: true },
+);
+
 function closeDrawer() {
-	rateRes.value = null;
+	if (props.id) router.push("/rate-master");
+	else rateRes.value = null;
 }
 
 function editRate() {


### PR DESCRIPTION
Five fixes across Estimation, Assembly, Rate Master and BOQ.

1. **Estimate Template list** now defaults to `creation desc` (most recent first) instead of `template_code asc`; manual re-sort still works.
2. **Assembly Category not linked** — the Assembly form/edit/filter treated `category` as a Select (fed by doctype meta, which returned nothing for a Link field), so the picker was empty. Now uses a `DeskLinkPicker` over the seeded **Assembly Category** master.
3. **Assembly list** now defaults to `creation desc` (most recent first).
4. **Rate Master code opened the list** — clicking a Rate Master code (e.g. in a BOQ sub-item) went to `/rate-master`. Added a `/rate-master/:id` route that drives the detail drawer, so a code opens the record directly (`/rate-master/CEM-93`); the BOQ sub-item + Assembly component links point at it.
5. **BOQ view missing columns** — added **Committed** (group-level, right of Planned), **WP** (per-item link, right of Variance) and **Cost Head** (rightmost), matching the prototype's column set and order. Committed is a new whitelisted rollup, `committed_by_cost_code(project)`, summing open (Awarded / In Progress) Subcontractor Work Order line amounts by cost-code group. The tree now scrolls horizontally (overflow-x-auto + min-width) like the prototype.

## Verification
`yarn build` clean · `py_compile` clean · **123/123 backend tests pass** · `committed_by_cost_code('PROJ-1638')` returns `{D: 680000, E: 432000}` from the two in-progress WOs.