### PR TITLE
fix: install.py IndentationError that broke migrate/install

### DIFF
--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -52,7 +52,6 @@ def seed_master_data():
 
 	seed_categories()
 	create_item_group()
-	
 
 	# Project Type stays native ERPNext (Internal / External) — construction
 	# categories now live in Project Category above. ERPNext ships "External"; we
@@ -76,19 +75,21 @@ def seed_master_data():
 	)
 
 	seed_project_templates()
-  
-  from buildsuite_core.buildsuite_core.doctype.subcontractor.seed_subcontract import (
+
+	# Subcontract module masters — Construction Trades + Work Order Delivery Types.
+	from buildsuite_core.buildsuite_core.doctype.subcontractor.seed_subcontract import (
 		seed_subcontract_masters,
 	)
 
 	seed_subcontract_masters()
 
+
 def create_item_group():
-    if frappe.db.get_value("Item Group","Raw Material"):
-        frappe.rename_doc("Item Group", "Raw Material", "Materials", force=1, merge=0)
-    if frappe.db.get_value("Item Group","Asset"):
-        frappe.rename_doc("Item Group", "Asset", "Assets", force=1, merge=0)
-    frappe.db.commit()
+	if frappe.db.get_value("Item Group", "Raw Material"):
+		frappe.rename_doc("Item Group", "Raw Material", "Materials", force=1, merge=0)
+	if frappe.db.get_value("Item Group", "Asset"):
+		frappe.rename_doc("Item Group", "Asset", "Assets", force=1, merge=0)
+	frappe.db.commit()
 
 def before_migrate():
 	delete_custom_fields(CUSTOM_FIELD)


### PR DESCRIPTION
`install.py` (from #63) had the `seed_subcontract` import inside `seed_master_data()` indented with **spaces** while the rest of the function uses **tabs**, causing:

```
IndentationError: unindent does not match any outer indentation level (install.py, line 80)
```

Since the module can't be imported, `after_install` / `after_migrate` crash — `bench migrate` and fresh installs are broken on develop.

- Re-indented the `seed_subcontract_masters` import block to tabs.
- Normalised `create_item_group()` to tabs (was 4-space) so the whole file is consistent, and removed a stray blank-line tab.

`python -m py_compile buildsuite_core/install.py` now passes.