### PR TITLE
fix: broken apply_workflow override that crashed every workflow transition

### DIFF
--- a/buildsuite_core/workflow.py
+++ b/buildsuite_core/workflow.py
@@ -1,4 +1,16 @@
+from datetime import datetime
+
 import frappe
+from frappe import _
+from frappe.model.docstatus import DocStatus
+from frappe.model.workflow import (
+	WorkflowTransitionError,
+	get_transitions,
+	get_workflow,
+	has_approval_access,
+)
+from frappe.utils import cint
+
 
 @frappe.whitelist()
 def apply_workflow(doc, action):
@@ -51,7 +63,11 @@ def apply_workflow(doc, action):
 	return doc
 
 
-def create_workflow_log(doc,old_state,new_state,user, workflow):
+def create_workflow_log(doc, old_state, new_state, user, workflow):
+    # The Pending Approval Log doctype is optional — skip logging (rather than
+    # break the workflow transition) when it isn't installed on the site.
+    if not frappe.db.table_exists("Pending Approval Log"):
+        return
     now = datetime.now()
     transitions = get_transitions(doc, workflow)
 
@@ -87,9 +103,6 @@ def create_workflow_log(doc,old_state,new_state,user, workflow):
             frappe.db.commit()
         except Exception as e:
             frappe.log_error(f"Error creating Pending Approval Log: {str(e)}", "Approval Log Error")
-
-
-from frappe.model.workflow import get_workflow
 
 
 def delete_workflow_log(doc, method):


### PR DESCRIPTION
`buildsuite_core/workflow.py` (from #63) globally monkeypatches Frappe's `apply_workflow` (via `apply_patches()` in `__init__.py`), but the override was broken two ways:

1. **Missing imports** — `get_transitions`, `get_workflow`, `has_approval_access`, `WorkflowTransitionError`, `_`, `cint`, `DocStatus`, `datetime` were all used but never imported → `NameError: name 'get_transitions' is not defined` on **every** workflow action (Stage Planning approval, Subcontractor Work Order approval, …).
2. **Logs to a non-existent doctype** — `create_workflow_log` queries `Pending Approval Log`, which doesn't exist in the app, outside its try/except → `Table 'tabPending Approval Log' doesn't exist`.

Effect: all workflow transitions crashed; 10 backend tests failed.

Fix:
- Added the missing imports at the top of the module.
- Guarded `create_workflow_log` to no-op when the `Pending Approval Log` table isn't installed, so transitions never fail on its absence (the logging scaffolding stays for when that doctype lands).

**123/123 backend tests pass**; `py_compile` clean.

> Note for follow-up: this override reimplements core `apply_workflow` and does a mid-transaction `frappe.db.commit()` in the log path — both are fragile. Worth revisiting whether the Pending Approval Log logging should be a `doc_events` hook rather than a global monkeypatch of core workflow.