### PR TITLE
fix: task Gantt link, stage task count, stage progress edit, BOQ sub-item UOM

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/boq_sub_item/boq_sub_item.json
+++ b/buildsuite_core/buildsuite_core/doctype/boq_sub_item/boq_sub_item.json
@@ -13,6 +13,7 @@
   "description",
   "column_break_qty",
   "qty_per_unit",
+  "uom",
   "coefficient",
   "rate",
   "amount",
@@ -67,6 +68,15 @@
    "fieldname": "qty_per_unit",
    "fieldtype": "Float",
    "label": "Qty Per Unit"
+  },
+  {
+   "description": "The component's own native unit, snapshotted from its Rate Master (e.g. bag, litre, day).",
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM",
+   "read_only": 1
   },
   {
    "fieldname": "coefficient",

--- a/buildsuite_core/buildsuite_core/doctype/boq_sub_item/boq_sub_item.py
+++ b/buildsuite_core/buildsuite_core/doctype/boq_sub_item/boq_sub_item.py
@@ -10,9 +10,16 @@ from buildsuite_core.buildsuite_core.doctype.boq_item.boq_item import roll_up_it
 
 class BOQSubItem(Document):
 	def validate(self):
-		# Snapshot the rate from the Rate Master when linked (not a live link).
+		# Snapshot the rate + native unit from the Rate Master when linked (not a live
+		# link). Each component keeps its OWN unit (bag / litre / day…), distinct from
+		# the parent BOQ item's UOM that its coefficient converts to.
 		if self.rate_master:
-			self.rate = frappe.db.get_value("Construction Rate Master", self.rate_master, "current_rate") or 0
+			rm = frappe.db.get_value(
+				"Construction Rate Master", self.rate_master, ["current_rate", "uom"], as_dict=True
+			)
+			if rm:
+				self.rate = rm.current_rate or 0
+				self.uom = rm.uom
 		self.coefficient = flt(self.qty_per_unit)
 		self.amount = flt(self.qty_per_unit) * flt(self.rate)
 

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -15,3 +15,4 @@ buildsuite_core.patches.repair_default_personas
 buildsuite_core.patches.enforce_persona_backend_only
 buildsuite_core.patches.seed_estimation_catalog
 buildsuite_core.patches.split_project_naming_mode_and_series
+buildsuite_core.patches.backfill_boq_sub_item_uom

--- a/buildsuite_core/patches/backfill_boq_sub_item_uom.py
+++ b/buildsuite_core/patches/backfill_boq_sub_item_uom.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Snapshot each BOQ Sub Item's native UOM from its Rate Master.
+
+The `uom` field was added after these rows were created, so existing sub-items have
+an empty unit and the BOQ tree falls back to the parent item's UOM. Backfill from the
+linked Construction Rate Master so every component shows its own unit. Idempotent."""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("BOQ Sub Item", "uom"):
+		return
+	rows = frappe.get_all(
+		"BOQ Sub Item",
+		filters={"rate_master": ["is", "set"], "uom": ["in", ["", None]]},
+		fields=["name", "rate_master"],
+	)
+	for r in rows:
+		uom = frappe.db.get_value("Construction Rate Master", r.rate_master, "uom")
+		if uom:
+			frappe.db.set_value("BOQ Sub Item", r.name, "uom", uom, update_modified=False)

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -190,6 +190,7 @@ const allSubs = computed(() =>
 		rateMasterId: s.rate_master,
 		description: s.description,
 		qtyPerUnit: s.qty_per_unit,
+		uom: s.uom,
 		rate: s.rate,
 		amount: s.amount,
 	})),
@@ -1402,7 +1403,7 @@ const breadcrumbs = computed(() => {
 										>
 									</div>
 									<div class="px-3 py-1 text-xs text-ink-500">
-										{{ item.unit }}
+										{{ si.uom || item.unit }}
 									</div>
 									<div
 										class="px-3 py-1 text-right tabular-nums text-xs text-ink-500"

--- a/frontend/src/views/StagePlanningDetailView.vue
+++ b/frontend/src/views/StagePlanningDetailView.vue
@@ -708,11 +708,32 @@ async function persistChildRows(rows) {
 			planned_task_count: childRows.length,
 		});
 		await stageResource.value?.reload?.();
+		pendingQty.value = {}; // authoritative data reloaded — drop optimistic overrides
 	} catch (err) {
 		showToast(applyServerErrors(err) ?? "Failed to update stage tasks", "error");
 		throw err;
 	} finally {
 		saving.value = false;
+	}
+}
+
+// Inline planned-progress edits are optimistic + debounced: the typed value is held
+// locally (pendingQty) so the input stays controlled, and the save runs quietly
+// (no `saving` toggle, no reload) so it never disables or re-renders the focused
+// input mid-keystroke.
+const pendingQty = ref({});
+let qtyTimer = null;
+
+async function persistQtyRows(rows) {
+	if (!stage.value) return;
+	const childRows = mapChildRowsToBackend(rows);
+	try {
+		await adapter.update("Stage Planning", stage.value.id, {
+			stage_planning_tasks: childRows,
+			planned_task_count: childRows.length,
+		});
+	} catch (err) {
+		showToast(applyServerErrors(err) ?? "Failed to save planned progress", "error");
 	}
 }
 
@@ -725,17 +746,20 @@ async function onPickerSave(payload) {
 	}
 }
 
-async function onPlannedQtyChange(row, value) {
+function onPlannedQtyChange(row, value) {
 	if (!stage.value || !row) return;
 	const qty = Math.max(0, Math.min(100, Number(value) || 0));
-	const nextRows = (stage.value.stagePlanningTasks || []).map((r) =>
-		r.id === row.id ? { ...r, plannedQty: qty, qtyUnit: "%" } : r,
-	);
-	try {
-		await persistChildRows(nextRows);
-	} catch {
-		// toast already shown
-	}
+	// Optimistic: hold the typed value locally so the controlled input keeps it.
+	pendingQty.value = { ...pendingQty.value, [row.id]: qty };
+	// Debounced quiet save — only fires once the user pauses typing.
+	clearTimeout(qtyTimer);
+	qtyTimer = setTimeout(() => {
+		const nextRows = (stage.value?.stagePlanningTasks || []).map((r) => {
+			const q = pendingQty.value[r.id];
+			return q !== undefined ? { ...r, plannedQty: q, qtyUnit: "%" } : r;
+		});
+		persistQtyRows(nextRows);
+	}, 500);
 }
 
 function openPicker() {
@@ -1184,13 +1208,13 @@ usePageTitle(() => stage.value?.stageName);
 						<div class="px-2 py-1">
 							<div class="flex items-center gap-1 justify-end">
 								<DeskInput
-									:model-value="row.plannedQty ?? 100"
+									:model-value="pendingQty[row.id] ?? row.plannedQty ?? 100"
 									type="number"
 									min="0"
 									max="100"
 									step="1"
 									class="!text-xs !text-right !py-1"
-									:disabled="saving || tasksLocked"
+									:disabled="tasksLocked"
 									@update:model-value="onPlannedQtyChange(row, $event)"
 								/>
 								<span class="text-[11px] text-ink-500">%</span>

--- a/frontend/src/views/StagePlanningsView.vue
+++ b/frontend/src/views/StagePlanningsView.vue
@@ -69,10 +69,11 @@ function statusClass(s) {
 	return "bg-ink-100 text-ink-600";
 }
 
-// Real nested-task count, server-maintained (task_count) — Frappe's list API can't
-// return the child table, so the count is materialised on the record.
+// "Tasks in the stage / planned task count" (the target number of tasks set when the
+// stage was created). Both are server-maintained on the record — Frappe's list API
+// can't return the child table.
 function taskCountDisplay(row) {
-	return String(Number(row.task_count) || 0);
+	return `${Number(row.task_count) || 0} / ${Number(row.planned_task_count) || 0}`;
 }
 
 const filterValues = computed(() => ({
@@ -124,6 +125,7 @@ function onRowClick(row) {
 				'planned_start',
 				'planned_end',
 				'task_count',
+				'planned_task_count',
 				'mean_progress',
 				'workflow_state',
 			]"

--- a/frontend/src/views/TaskDetailView.vue
+++ b/frontend/src/views/TaskDetailView.vue
@@ -929,7 +929,11 @@ usePageTitle(() => task.value?.name);
 							Dependencies
 						</div>
 						<RouterLink
-							to="/schedule"
+							:to="
+								task?.projectId
+									? `/schedule?project=${task.projectId}`
+									: '/schedule'
+							"
 							class="text-[10px] text-brand-700 hover:underline"
 							>Open Gantt →</RouterLink
 						>


### PR DESCRIPTION
Four fixes (a fifth reported issue was already implemented).

1. **Task → Open Gantt** now opens the Schedule for the task's own project (`/schedule?project=<id>`) instead of the empty schedule.
2. **Stage task count** now shows **tasks-in-stage / planned count** (`task_count / planned_task_count`) in the Stage Planning list — matching the project-detail tab and the prototype. (Note: the metric is *actual tasks in the stage vs. the planned count set at creation*, per the prototype — not a per-task "achieved-target" computation.)
3. **Editing a stage's planned progress** no longer loses focus after each digit. The inline edit is now optimistic (typed value held locally) with a debounced *quiet* save — no `saving` toggle disabling the input and no `reload()` re-rendering it mid-keystroke.
4. **BOQ sub-item UOM** now shows each component's **own** native unit (bag / litre / day…) instead of the parent assembly's unit. Added a `uom` field to **BOQ Sub Item**, snapshotted from the linked Construction Rate Master in the controller (alongside `rate`), fetched into the tree, and rendered per row (`si.uom || item.unit` fallback). A backfill patch populates existing sub-items.

**Not changed — Issue: Schedule summary rollup.** Already implemented: the Schedule's group-by toggle (`By Stage` / `By WP`) renders summary rows with duration-weighted rolled-up progress (`weightedProgress` → `· N%` + fill bar). The default view is `none` (flat, no summary rows) — switching to a grouping shows the rollup.

## Verification
- `bench migrate` clean (uom column created; backfill populated all existing sub-items from their rate masters — 0 left empty); `yarn build` clean; **123/123 backend tests pass**.