### PR TITLE
feat: Scope Change Orders — real doctype, approval flow, BOQ tie-in + workspace shortcut

### DIFF
--- a/buildsuite_core/api/sco.py
+++ b/buildsuite_core/api/sco.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Whitelisted endpoints for the Scope Change Order approval flow (approve / reject /
+revise) and the BOQ-revision tie-in raised from an approved change order. Reads +
+plain CRUD go through the standard data adapter; only these transitions need the API."""
+
+import frappe
+from frappe import _
+from frappe.utils import today
+
+from buildsuite_core.permissions.setup import BOQ_APPROVE_ROLES
+
+SCO = "Scope Change Order"
+
+
+def _require_approver():
+	if not set(frappe.get_roles()) & set(BOQ_APPROVE_ROLES):
+		frappe.throw(_("You are not permitted to approve or reject a scope change order."), frappe.PermissionError)
+
+
+@frappe.whitelist()
+def approve_sco(name: str):
+	"""Pending Approval -> Approved. Stamps the approver + date."""
+	doc = frappe.get_doc(SCO, name)
+	doc.check_permission("write")
+	_require_approver()
+	if doc.status != "Pending Approval":
+		frappe.throw(_("Only a Pending Approval change order can be approved."))
+	doc.status = "Approved"
+	doc.approved_by = frappe.session.user
+	doc.approved_date = today()
+	doc.rejection_reason = None
+	doc.save()
+	return doc.status
+
+
+@frappe.whitelist()
+def reject_sco(name: str, reason: str = None):
+	"""Pending Approval -> Rejected. Records the rejection reason."""
+	doc = frappe.get_doc(SCO, name)
+	doc.check_permission("write")
+	_require_approver()
+	if doc.status != "Pending Approval":
+		frappe.throw(_("Only a Pending Approval change order can be rejected."))
+	doc.status = "Rejected"
+	doc.rejection_reason = reason
+	doc.save()
+	return doc.status
+
+
+@frappe.whitelist()
+def revise_sco(name: str):
+	"""Approved / Rejected -> Pending Approval, so it can be edited and re-submitted."""
+	doc = frappe.get_doc(SCO, name)
+	doc.check_permission("write")
+	if doc.status not in ("Approved", "Rejected"):
+		frappe.throw(_("Only an Approved or Rejected change order can be revised."))
+	doc.status = "Pending Approval"
+	doc.approved_by = None
+	doc.approved_date = None
+	doc.rejection_reason = None
+	doc.save()
+	return doc.status
+
+
+def _project_source_boq(project):
+	"""The BOQ a revision should branch from: the Approved one, else the latest
+	non-superseded revision."""
+	boqs = frappe.get_all(
+		"BOQ",
+		filters={"project": project},
+		fields=["name", "status", "revision"],
+		order_by="revision desc",
+	)
+	if not boqs:
+		return None
+	approved = next((b for b in boqs if b.status == "Approved"), None)
+	if approved:
+		return approved.name
+	live = next((b for b in boqs if b.status != "Superseded"), None)
+	return (live or boqs[0]).name
+
+
+@frappe.whitelist()
+def create_boq_revision(name: str):
+	"""Raise a Draft BOQ revision from an Approved change order and link it back."""
+	doc = frappe.get_doc(SCO, name)
+	doc.check_permission("write")
+	if doc.status != "Approved":
+		frappe.throw(_("A BOQ revision can only be raised from an Approved change order."))
+	if doc.boq_revision:
+		frappe.throw(_("A BOQ revision was already raised from this change order."))
+
+	source = _project_source_boq(doc.project)
+	if not source:
+		frappe.throw(_("This project has no BOQ to revise yet."))
+
+	from buildsuite_core.api.boq import create_revision
+
+	new_boq = create_revision(source, source_sco=doc.name, title=f"Revision from {doc.name}")
+	doc.boq_revision = new_boq
+	doc.save()
+	return {"boq": new_boq}

--- a/buildsuite_core/buildsuite_core/doctype/scope_change_order/scope_change_order.json
+++ b/buildsuite_core/buildsuite_core/doctype/scope_change_order/scope_change_order.json
@@ -1,0 +1,191 @@
+{
+ "actions": [],
+ "autoname": "SCO-.YYYY.-.#####",
+ "creation": "2026-07-15 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "project",
+  "project_name",
+  "title",
+  "type",
+  "column_break_hdr",
+  "impact",
+  "recoverable",
+  "status",
+  "company",
+  "details_section",
+  "reason",
+  "approval_section",
+  "raised_by",
+  "raised_date",
+  "column_break_approval",
+  "approved_by",
+  "approved_date",
+  "rejection_reason",
+  "boq_section",
+  "boq_revision"
+ ],
+ "fields": [
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Project",
+   "options": "Project",
+   "reqd": 1
+  },
+  {
+   "fetch_from": "project.project_name",
+   "fieldname": "project_name",
+   "fieldtype": "Data",
+   "label": "Project Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Title",
+   "reqd": 1
+  },
+  {
+   "default": "Design Change",
+   "fieldname": "type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Type",
+   "options": "Design Change\nClient Request\nStatutory\nSite Condition\nRework\nOther"
+  },
+  {
+   "fieldname": "column_break_hdr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Positive = added cost to the project; negative = a saving.",
+   "fieldname": "impact",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Cost Impact"
+  },
+  {
+   "default": "0",
+   "description": "Recoverable from the client (vs. absorbed internally).",
+   "fieldname": "recoverable",
+   "fieldtype": "Check",
+   "label": "Recoverable from Client"
+  },
+  {
+   "default": "Pending Approval",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Pending Approval\nApproved\nRejected",
+   "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1
+  },
+  {
+   "fieldname": "details_section",
+   "fieldtype": "Section Break",
+   "label": "Justification"
+  },
+  {
+   "fieldname": "reason",
+   "fieldtype": "Small Text",
+   "label": "Reason"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "approval_section",
+   "fieldtype": "Section Break",
+   "label": "Approval"
+  },
+  {
+   "fieldname": "raised_by",
+   "fieldtype": "Link",
+   "label": "Raised By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "raised_date",
+   "fieldtype": "Date",
+   "label": "Raised Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_approval",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "approved_by",
+   "fieldtype": "Link",
+   "label": "Approved By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "approved_date",
+   "fieldtype": "Date",
+   "label": "Approved Date",
+   "read_only": 1
+  },
+  {
+   "fieldname": "rejection_reason",
+   "fieldtype": "Small Text",
+   "label": "Rejection Reason",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "boq_section",
+   "fieldtype": "Section Break",
+   "label": "BOQ Impact"
+  },
+  {
+   "description": "The BOQ revision raised from this approved change order.",
+   "fieldname": "boq_revision",
+   "fieldtype": "Link",
+   "label": "BOQ Revision",
+   "options": "BOQ",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-15 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Scope Change Order",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "title",
+ "track_changes": 1
+}

--- a/buildsuite_core/buildsuite_core/doctype/scope_change_order/scope_change_order.py
+++ b/buildsuite_core/buildsuite_core/doctype/scope_change_order/scope_change_order.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe.model.document import Document
+from frappe.utils import today
+
+
+class ScopeChangeOrder(Document):
+	def validate(self):
+		self._set_company()
+		if not self.raised_by:
+			self.raised_by = frappe.session.user
+		if not self.raised_date:
+			self.raised_date = today()
+		if not self.status:
+			self.status = "Pending Approval"
+
+	def _set_company(self):
+		if self.company:
+			return
+		if self.project:
+			self.company = frappe.db.get_value("Project", self.project, "company")
+		if not self.company:
+			self.company = frappe.defaults.get_user_default("Company") or frappe.db.get_single_value(
+				"Global Defaults", "default_company"
+			)

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -545,6 +545,25 @@ _WO_TRANSITIONS = (
 )
 
 
+# Scope Change Order — the site-execution delivery roles raise change orders; approval
+# is gated in api/sco.py to BOQ_APPROVE_ROLES (PM / Director / Admin).
+SCO_ROLE_PERMS = {
+	"BuildSuite Director": _FULL,
+	"BuildSuite PM": _FULL,
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Estimator": _FULL,
+	"BuildSuite QS": _FULL,
+	"BuildSuite Site Engineer": _FULL,
+	"BuildSuite Procurement Officer": _READ,
+	"BuildSuite Accountant": _READ,
+	"BuildSuite Foreman": _READ,
+}
+
+
+def setup_sco_permissions():
+	_apply_role_perms("Scope Change Order", SCO_ROLE_PERMS)
+
+
 def setup_subcontract_permissions():
 	_apply_role_perms("Subcontractor", SUBCONTRACT_ROLE_PERMS)
 	_apply_role_perms("Subcontractor Work Order", SUBCONTRACT_ROLE_PERMS)
@@ -631,6 +650,7 @@ def setup_record_permissions():
 	setup_purchase_stock_permissions()
 	setup_linked_master_permissions()
 	setup_subcontract_permissions()
+	setup_sco_permissions()
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()
 	setup_subcontractor_wo_workflow()

--- a/frontend/src/data/scoApi.js
+++ b/frontend/src/data/scoApi.js
@@ -1,0 +1,22 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Thin wrappers over buildsuite_core.api.sco.* — the Scope Change Order approval
+// transitions (approve / reject / revise) and the BOQ-revision tie-in. Plain CRUD
+// goes through the generic data adapter.
+
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.sco.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const approveSco = (name) => call("approve_sco", { name });
+export const rejectSco = (name, reason) => call("reject_sco", { name, reason });
+export const reviseSco = (name) => call("revise_sco", { name });
+export const createBoqRevision = (name) => call("create_boq_revision", { name });

--- a/frontend/src/data/seed.js
+++ b/frontend/src/data/seed.js
@@ -1108,12 +1108,11 @@ export const seedData = {
 				enabled: true,
 				visible_to_roles: null, // null = inherit from §12.3 matrix
 				shortcuts: [
-					// Trimmed shortcut set — WSST-002 (Work Packages), WSST-004 (Stage Planning),
-					// and WSST-006 (Scope Change Orders) removed per user direction. The
-					// underlying DocTypes still exist and are reachable via direct URL or as
-					// tabs inside Project Detail (Work Packages tab, Stage Planning tab, Scope
-					// Changes tab). BSA can re-surface any of them via Workspace Structure
-					// Settings without code changes.
+					// Trimmed shortcut set — WSST-002 (Work Packages) and WSST-004 (Stage
+					// Planning) removed per user direction (still reachable via Project Detail
+					// tabs / direct URL). WSST-006 (Scope Change Orders) is restored now that
+					// the SCO register is a real backend surface. BSA can re-surface any of
+					// them via Workspace Structure Settings without code changes.
 					{
 						id: "WSST-001",
 						label: "Projects",
@@ -1129,6 +1128,14 @@ export const seedData = {
 						route_path: "/tasks",
 						visible_to_roles: null,
 						sort_order: 3,
+					},
+					{
+						id: "WSST-006",
+						label: "Scope Change Orders",
+						icon: "🔁",
+						route_path: "/sco",
+						visible_to_roles: null,
+						sort_order: 6,
 					},
 					{
 						id: "WSST-005",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -26,6 +26,8 @@ const PAGE_TITLES = {
 	"progress-entry-detail": "Task Progress Entry",
 	schedule: "Schedule",
 	sco: "Scope Change Orders",
+	"sco-new": "Raise Scope Change Order",
+	"sco-detail": "Scope Change Order",
 	boq: "Bill of Quantities",
 	"boq-detail": "BOQ",
 	"rate-master": "Rate Master",
@@ -184,6 +186,17 @@ const routes = [
 				component: () => import("@/views/ScheduleView.vue"),
 			},
 			{ path: "sco", name: "sco", component: () => import("@/views/ScoView.vue") },
+			{
+				path: "sco/new",
+				name: "sco-new",
+				component: () => import("@/views/NewScoView.vue"),
+			},
+			{
+				path: "sco/:id",
+				name: "sco-detail",
+				component: () => import("@/views/ScoDetailView.vue"),
+				props: true,
+			},
 			{ path: "boq", name: "boq", component: () => import("@/views/BoqView.vue") },
 			{
 				path: "boq/:id",

--- a/frontend/src/stores/index.js
+++ b/frontend/src/stores/index.js
@@ -434,7 +434,7 @@ export const useDataStore = defineStore("data", {
 		// (anyone who can see the workspace sees the shortcut).
 		visibleShortcutsFor: (s) => (slug) => {
 			const def = s.workspaceStructure.workspace_definitions.find(
-				(d) => d.workspace_slug === slug
+				(d) => d.workspace_slug === slug,
 			);
 			if (!def || !def.enabled) return [];
 			// Definition-level role gate first
@@ -514,19 +514,37 @@ export const useDataStore = defineStore("data", {
 					stored.projectTypes ?? JSON.parse(JSON.stringify(seedData.projectTypes));
 				// Session 38 — strip retired Site Execution shortcuts from any stored
 				// workspace definition: WSST-002 (Work Packages), WSST-004 (Stage
-				// Planning), WSST-006 (Scope Change Orders). All three are still
-				// reachable via Project Detail tabs / direct URLs; just not surfaced
-				// as workspace tiles. Idempotent — only marks dirty if rows were
-				// actually present. New (post-S38) localStorage never had them.
-				const RETIRED_SITE_EXEC_SHORTCUTS = ["WSST-002", "WSST-004", "WSST-006"];
+				// Planning). Both are still reachable via Project Detail tabs / direct
+				// URLs; just not surfaced as workspace tiles. (WSST-006 / Scope Change
+				// Orders was restored once the SCO register became a real backend
+				// surface.) Idempotent — only marks dirty if rows were actually present.
+				const RETIRED_SITE_EXEC_SHORTCUTS = ["WSST-002", "WSST-004"];
 				let workspaceMigrationDirty = false;
 				for (const def of this.workspaceStructure.workspace_definitions || []) {
 					if (def.workspace_slug !== "site-execution") continue;
 					const before = (def.shortcuts || []).length;
 					def.shortcuts = (def.shortcuts || []).filter(
-						(s) => !RETIRED_SITE_EXEC_SHORTCUTS.includes(s.id)
+						(s) => !RETIRED_SITE_EXEC_SHORTCUTS.includes(s.id),
 					);
 					if (def.shortcuts.length !== before) workspaceMigrationDirty = true;
+				}
+				// Restore the Scope Change Orders shortcut (WSST-006) for sessions whose
+				// stored definition had it stripped by the earlier S38 migration — the SCO
+				// register is now a real backend surface. Idempotent (only adds if absent).
+				for (const def of this.workspaceStructure.workspace_definitions || []) {
+					if (def.workspace_slug !== "site-execution") continue;
+					const shortcuts = def.shortcuts || (def.shortcuts = []);
+					if (!shortcuts.some((s) => s.id === "WSST-006")) {
+						shortcuts.push({
+							id: "WSST-006",
+							label: "Scope Change Orders",
+							icon: "🔁",
+							route_path: "/sco",
+							visible_to_roles: null,
+							sort_order: 6,
+						});
+						workspaceMigrationDirty = true;
+					}
 				}
 				// Strip legacy /app/ prefix from any route_path values left in localStorage
 				// from before the /app prefix was removed from all routes.
@@ -571,7 +589,7 @@ export const useDataStore = defineStore("data", {
 				this.workPackages = JSON.parse(JSON.stringify(seedData.workPackages));
 				this.tasks = JSON.parse(JSON.stringify(seedData.tasks));
 				this.taskProgressEntries = JSON.parse(
-					JSON.stringify(seedData.taskProgressEntries)
+					JSON.stringify(seedData.taskProgressEntries),
 				);
 				this.stagePlannings = JSON.parse(JSON.stringify(seedData.stagePlannings));
 				this.attachments = JSON.parse(JSON.stringify(seedData.attachments));
@@ -585,7 +603,7 @@ export const useDataStore = defineStore("data", {
 				// Session 34 — Settings DocTypes from seed defaults (first-run branch).
 				this.coreSettings = JSON.parse(JSON.stringify(seedData.coreSettings));
 				this.siteExecutionSettings = JSON.parse(
-					JSON.stringify(seedData.siteExecutionSettings)
+					JSON.stringify(seedData.siteExecutionSettings),
 				);
 				this.workspaceStructure = JSON.parse(JSON.stringify(seedData.workspaceStructure));
 				// Session 39 — Project Type Settings (exploratory).
@@ -723,7 +741,7 @@ export const useDataStore = defineStore("data", {
 		},
 		updateWorkspaceDefinition(id, patch) {
 			const idx = this.workspaceStructure.workspace_definitions.findIndex(
-				(d) => d.id === id
+				(d) => d.id === id,
 			);
 			if (idx === -1) return null;
 			const merged = { ...this.workspaceStructure.workspace_definitions[idx], ...patch };
@@ -742,7 +760,7 @@ export const useDataStore = defineStore("data", {
 		// Shortcut child rows — patch the parent definition's array.
 		addWorkspaceShortcut(defId, rowData) {
 			const idx = this.workspaceStructure.workspace_definitions.findIndex(
-				(d) => d.id === defId
+				(d) => d.id === defId,
 			);
 			if (idx === -1) return null;
 			const existing = this.workspaceStructure.workspace_definitions[idx].shortcuts || [];
@@ -765,7 +783,7 @@ export const useDataStore = defineStore("data", {
 		},
 		updateWorkspaceShortcut(defId, shortcutId, patch) {
 			const idx = this.workspaceStructure.workspace_definitions.findIndex(
-				(d) => d.id === defId
+				(d) => d.id === defId,
 			);
 			if (idx === -1) return null;
 			const rows = (this.workspaceStructure.workspace_definitions[idx].shortcuts || []).map(
@@ -775,7 +793,7 @@ export const useDataStore = defineStore("data", {
 					if (patch.sort_order !== undefined)
 						merged.sort_order = Number(patch.sort_order) || 0;
 					return merged;
-				}
+				},
 			);
 			this.workspaceStructure.workspace_definitions[idx] = {
 				...this.workspaceStructure.workspace_definitions[idx],
@@ -786,7 +804,7 @@ export const useDataStore = defineStore("data", {
 		},
 		removeWorkspaceShortcut(defId, shortcutId) {
 			const idx = this.workspaceStructure.workspace_definitions.findIndex(
-				(d) => d.id === defId
+				(d) => d.id === defId,
 			);
 			if (idx === -1) return;
 			const rows = (
@@ -990,7 +1008,7 @@ export const useDataStore = defineStore("data", {
 			this.workPackages = this.workPackages.filter((wp) => !allIds.includes(wp.projectId));
 			this.tasks = this.tasks.filter((t) => !allIds.includes(t.projectId));
 			this.taskProgressEntries = this.taskProgressEntries.filter(
-				(e) => !deletedTaskIds.includes(e.taskId)
+				(e) => !deletedTaskIds.includes(e.taskId),
 			);
 			this.stagePlannings = this.stagePlannings.filter((s) => !allIds.includes(s.project));
 			this.scos = this.scos.filter((s) => !allIds.includes(s.projectId));
@@ -1063,7 +1081,7 @@ export const useDataStore = defineStore("data", {
 			this.workPackages = this.workPackages.filter((wp) => wp.id !== id);
 			this.tasks = this.tasks.filter((t) => t.workPackageId !== id);
 			this.taskProgressEntries = this.taskProgressEntries.filter(
-				(e) => !deletedTaskIds.includes(e.taskId)
+				(e) => !deletedTaskIds.includes(e.taskId),
 			);
 			// Attachments cascade (no UI for WP/Task/TPE attachments yet, but the
 			// store contract should stay coherent — same pattern as deleteProject).
@@ -1247,7 +1265,7 @@ export const useDataStore = defineStore("data", {
 			const idx = this.stagePlannings.findIndex((sp) => sp.id === stageId);
 			if (idx === -1) return;
 			const rows = (this.stagePlannings[idx].stagePlanningTasks || []).filter(
-				(r) => r.id !== sptId
+				(r) => r.id !== sptId,
 			);
 			this.stagePlannings[idx] = { ...this.stagePlannings[idx], stagePlanningTasks: rows };
 			this._persist();

--- a/frontend/src/views/NewScoView.vue
+++ b/frontend/src/views/NewScoView.vue
@@ -1,0 +1,149 @@
+<script setup>
+// Raise a Scope Change Order — Desk-styled form. Raising creates the SCO in
+// "Pending Approval"; a PM / Director then approves it, after which a BOQ revision
+// can be raised from the approved change order. Pre-fills the project from
+// ?project=… (the Project detail's "+ Raise SCO" passes it).
+
+import { reactive, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useDataStore } from "@/stores";
+import { showToast } from "@/utils/appToast";
+import { useFormErrors } from "@/composables/useFormErrors";
+import { createDataAdapter } from "@/data/adapters";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskTextarea from "@/components/desk/DeskTextarea.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+
+const route = useRoute();
+const router = useRouter();
+const adapter = createDataAdapter(useDataStore());
+
+const TYPES = [
+	"Design Change",
+	"Client Request",
+	"Statutory",
+	"Site Condition",
+	"Rework",
+	"Other",
+];
+
+const form = reactive({
+	project: route.query.project || "",
+	type: "Design Change",
+	title: "",
+	impact: 0,
+	recoverable: "1",
+	reason: "",
+});
+const { errors, applyServerErrors, setErrors } = useFormErrors({
+	project: "project",
+	title: "title",
+});
+const saving = ref(false);
+
+function validate() {
+	const e = {};
+	if (!form.project) e.project = "Pick a project.";
+	if (!form.title.trim()) e.title = "Title is required.";
+	setErrors(e);
+	return Object.keys(e).length === 0;
+}
+
+function onCancel() {
+	router.back();
+}
+
+async function onSave() {
+	if (!validate()) return;
+	saving.value = true;
+	try {
+		const res = await adapter.create("Scope Change Order", {
+			project: form.project,
+			type: form.type,
+			title: form.title.trim(),
+			impact: Number(form.impact) || 0,
+			recoverable: form.recoverable === "1" ? 1 : 0,
+			reason: form.reason,
+		});
+		router.push(`/sco/${res.name}`);
+	} catch (err) {
+		showToast(applyServerErrors(err) ?? "Failed to raise scope change order", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Scope Change Orders", to: "/sco" },
+	{ label: "Raise" },
+];
+</script>
+
+<template>
+	<DeskPage
+		title="Raise Scope Change Order"
+		subtitle="Raising submits it for PM / Director approval"
+		:breadcrumbs="breadcrumbs"
+	>
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="saving ? 'Raising…' : 'Raise SCO'"
+					:saving="saving"
+					@save="onSave"
+					@cancel="onCancel"
+				/>
+			</template>
+
+			<DeskSection title="Change order" :cols="2">
+				<DeskField label="Project" required :error="errors.project">
+					<DeskLinkPicker
+						v-model="form.project"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						:search-fields="['project_name', 'name']"
+						placeholder="Pick a project…"
+					/>
+				</DeskField>
+				<DeskField label="Type">
+					<DeskSelect v-model="form.type">
+						<option v-for="t in TYPES" :key="t">{{ t }}</option>
+					</DeskSelect>
+				</DeskField>
+				<DeskField label="Title" required :error="errors.title" class="md:col-span-2">
+					<DeskInput
+						v-model="form.title"
+						placeholder="e.g. Foundation depth revision — soil report"
+					/>
+				</DeskField>
+				<DeskField
+					label="Cost impact (₹)"
+					hint="Positive = added cost to the project; negative = a saving."
+				>
+					<DeskInput v-model.number="form.impact" type="number" step="1000" />
+				</DeskField>
+				<DeskField label="Cost recovery">
+					<DeskSelect v-model="form.recoverable">
+						<option value="1">Recoverable from client</option>
+						<option value="0">Internal — absorbed by us</option>
+					</DeskSelect>
+				</DeskField>
+				<DeskField label="Reason / justification" class="md:col-span-2">
+					<DeskTextarea
+						v-model="form.reason"
+						:rows="4"
+						placeholder="Why is this change needed?"
+					/>
+				</DeskField>
+			</DeskSection>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -425,6 +425,14 @@ const stageBaseFilters = computed(() => {
 	return [["project", "in", ids]];
 });
 
+// Scope Change Orders tab — backend-backed, scoped to the project + its subprojects.
+const scoCount = ref(null);
+const scoBaseFilters = computed(() => {
+	const ids = workPackageProjectIds.value;
+	if (!ids.length) return [];
+	return [["project", "in", ids]];
+});
+
 // Attachment count — fetched eagerly (not behind the tab v-if) so the badge
 // shows on the tab heading without the user needing to open the tab first.
 const fileCountResource = ref(null);
@@ -890,7 +898,7 @@ const tabs = computed(() => {
 		{ id: "tasks", label: "Tasks", count: tasks.value.length },
 		{ id: "stage-planning", label: "Stage Planning", count: stageCount.value },
 		{ id: "boq", label: "BOQ", count: boqs.value.length },
-		{ id: "scos", label: "Scope Changes", count: scos.value.length },
+		{ id: "scos", label: "Scope Changes", count: scoCount.value },
 		{ id: "attachments", label: "Attachments", count: attachmentCount.value },
 		{ id: "team", label: "Team", count: projectTeam.value.length },
 	];
@@ -1519,28 +1527,46 @@ usePageTitle(() => project.value?.name);
 
 			<!-- SCOs -->
 			<div v-if="tab === 'scos'" class="pt-4">
-				<div class="flex items-center gap-2 mb-2">
-					<span class="text-xs text-ink-500">
-						<span class="text-ink-900 font-medium"
-							>{{ scos.length }} scope change{{ scos.length === 1 ? "" : "s" }}</span
-						>
-					</span>
-					<RouterLink
-						to="/sco"
-						class="text-xs text-ink-600 hover:text-ink-900 px-2 py-1 border border-ink-200 bg-white ml-auto"
-						style="border-radius: 2px"
-						>Open SCO module →</RouterLink
-					>
-				</div>
-				<DeskList
-					v-model="scoSearch"
-					:rows="scosFiltered"
-					:columns="scoCols"
-					row-key="id"
+				<DocTypeListView
+					doctype="Scope Change Order"
+					:field-order="[
+						'title',
+						'type',
+						'impact',
+						'recoverable',
+						'status',
+						'raised_date',
+					]"
+					:columns="[
+						{ key: 'name', label: 'ID' },
+						{ key: 'title', label: 'Title' },
+						{ key: 'type', label: 'Type' },
+						{ key: 'impact', label: 'Impact', align: 'right' },
+						{ key: 'status', label: 'Status' },
+						{ key: 'raised_date', label: 'Date' },
+					]"
+					:base-filters="scoBaseFilters"
+					:search-fields="['title', 'name']"
+					cache-key="buildsuite-sco-project-tab"
+					row-key="name"
+					initial-order-by="creation desc"
 					search-placeholder="Search scope changes…"
+					:compact="true"
+					@row-click="(row) => router.push('/sco/' + row.name)"
+					@count-change="scoCount = $event"
 				>
-					<template #cell-id="{ row }">
-						<DeskLink to="/sco" class="font-mono text-xs">{{ row.id }}</DeskLink>
+					<template #actions>
+						<RouterLink
+							v-if="canCreate('project')"
+							:to="`/sco/new?project=${resolvedProjectId}`"
+							class="desk-save-btn"
+							>+ Raise SCO</RouterLink
+						>
+					</template>
+					<template #cell-name="{ row }">
+						<DeskLink :to="`/sco/${row.name}`" class="font-mono text-xs" @click.stop>{{
+							row.name
+						}}</DeskLink>
 					</template>
 					<template #cell-title="{ row }">
 						<span class="text-ink-900">{{ row.title }}</span>
@@ -1548,21 +1574,21 @@ usePageTitle(() => project.value?.name);
 					<template #cell-impact="{ row }">
 						<span
 							class="tabular-nums"
-							:class="row.impact >= 0 ? 'text-danger-700' : 'text-success-700'"
+							:class="
+								Number(row.impact) >= 0 ? 'text-danger-700' : 'text-success-700'
+							"
 						>
-							{{ row.impact >= 0 ? "+" : "" }}{{ fmtINR(Math.abs(row.impact)) }}
+							{{ Number(row.impact) >= 0 ? "+" : "-"
+							}}{{ fmtINR(Math.abs(Number(row.impact) || 0)) }}
 						</span>
 					</template>
 					<template #cell-status="{ row }">
 						<StatusBadge :status="row.status" />
 					</template>
-					<template #cell-raisedBy="{ row }">
-						<UserAvatar :user-id="row.raisedBy" size="xs" />
-					</template>
 					<template #empty>
 						<div class="text-sm text-ink-500">No scope changes on this project.</div>
 					</template>
-				</DeskList>
+				</DocTypeListView>
 			</div>
 
 			<AttachmentsTab

--- a/frontend/src/views/ScoDetailView.vue
+++ b/frontend/src/views/ScoDetailView.vue
@@ -1,0 +1,463 @@
+<script setup>
+// Scope Change Order detail — view / edit (Pending or Rejected) + the approval
+// flow (Approve / Reject / Revise) and the BOQ-revision tie-in raised from an
+// approved change order. Impact colouring: positive = cost = red, negative = saving.
+
+import { computed, ref, watch } from "vue";
+import { useRouter, RouterLink } from "vue-router";
+import { useDataStore } from "@/stores";
+import { useSessionStore } from "@/stores/session";
+import { useConfirm } from "@/composables/useConfirm";
+import { useFormErrors } from "@/composables/useFormErrors";
+import { showToast } from "@/utils/appToast";
+import { createDataAdapter } from "@/data/adapters";
+import { approveSco, rejectSco, reviseSco, createBoqRevision } from "@/data/scoApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskTextarea from "@/components/desk/DeskTextarea.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtINR, fmtDate } from "@/utils/format";
+
+const props = defineProps({ id: String });
+const router = useRouter();
+const session = useSessionStore();
+const confirmDialog = useConfirm();
+const adapter = createDataAdapter(useDataStore());
+const { errors, applyServerErrors, setErrors } = useFormErrors({ title: "title" });
+
+const TYPES = [
+	"Design Change",
+	"Client Request",
+	"Statutory",
+	"Site Condition",
+	"Rework",
+	"Other",
+];
+const APPROVER_ROLES = [
+	"BuildSuite PM",
+	"BuildSuite Director",
+	"BuildSuite Administrator",
+	"System Manager",
+];
+
+const resource = adapter.read("Scope Change Order", props.id, { fields: ["*"] });
+const sco = computed(() => resource?.doc || null);
+
+const isPending = computed(() => sco.value?.status === "Pending Approval");
+const isApproved = computed(() => sco.value?.status === "Approved");
+const isRejected = computed(() => sco.value?.status === "Rejected");
+const canApprove = computed(() =>
+	(session.access?.roles || []).some((r) => APPROVER_ROLES.includes(r)),
+);
+
+const editing = ref(false);
+const saving = ref(false);
+const busy = ref(false);
+const form = ref({});
+
+function snapshot() {
+	const d = sco.value;
+	if (!d) return {};
+	return {
+		title: d.title || "",
+		type: d.type || "Design Change",
+		impact: d.impact || 0,
+		recoverable: d.recoverable ? "1" : "0",
+		reason: d.reason || "",
+	};
+}
+watch(
+	sco,
+	(v) => {
+		if (v && !editing.value) form.value = snapshot();
+	},
+	{ immediate: true },
+);
+
+function startEdit() {
+	form.value = snapshot();
+	setErrors({});
+	editing.value = true;
+}
+function cancelEdit() {
+	editing.value = false;
+}
+async function saveEdit() {
+	if (!form.value.title?.trim()) {
+		setErrors({ title: "Title is required." });
+		return;
+	}
+	saving.value = true;
+	try {
+		await adapter.update("Scope Change Order", props.id, {
+			title: form.value.title.trim(),
+			type: form.value.type,
+			impact: Number(form.value.impact) || 0,
+			recoverable: form.value.recoverable === "1" ? 1 : 0,
+			reason: form.value.reason,
+		});
+		await resource?.reload?.();
+		editing.value = false;
+	} catch (err) {
+		showToast(applyServerErrors(err) ?? "Failed to update change order", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+
+async function onApprove() {
+	const ok = await confirmDialog({
+		title: `Approve ${sco.value.name}?`,
+		message: "Approving lets a BOQ revision be raised from this change order.",
+		confirmLabel: "Approve",
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		await approveSco(sco.value.name);
+		await resource?.reload?.();
+		showToast("Scope change order approved.");
+	} catch (err) {
+		showToast(err.message || "Approve failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+
+const rejectOpen = ref(false);
+const rejectReason = ref("");
+function openReject() {
+	rejectReason.value = "";
+	rejectOpen.value = true;
+}
+async function confirmReject() {
+	busy.value = true;
+	try {
+		await rejectSco(sco.value.name, rejectReason.value);
+		await resource?.reload?.();
+		rejectOpen.value = false;
+		showToast("Scope change order rejected.");
+	} catch (err) {
+		showToast(err.message || "Reject failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onRevise() {
+	busy.value = true;
+	try {
+		await reviseSco(sco.value.name);
+		await resource?.reload?.();
+		showToast("Reopened for revision.");
+	} catch (err) {
+		showToast(err.message || "Revise failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onCreateBoqRevision() {
+	const ok = await confirmDialog({
+		title: "Raise BOQ revision?",
+		message:
+			"This clones the project's current BOQ into a new Draft revision linked to this change order.",
+		confirmLabel: "Raise revision",
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		const res = await createBoqRevision(sco.value.name);
+		router.push(`/boq/${res.boq}`);
+	} catch (err) {
+		showToast(err.message || "Failed to raise BOQ revision", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onDelete() {
+	const ok = await confirmDialog({
+		title: `Delete ${sco.value.name}?`,
+		message: "This scope change order will be removed permanently.",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await adapter.remove("Scope Change Order", props.id);
+		router.push("/sco");
+	} catch (err) {
+		showToast(err.message || "Failed to delete change order", "error");
+	}
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Scope Change Orders", to: "/sco" },
+	{ label: sco.value?.name || props.id },
+]);
+</script>
+
+<template>
+	<DeskPage
+		v-if="sco"
+		:title="sco.title"
+		:subtitle="`${sco.name} · ${sco.project_name || sco.project}`"
+		:breadcrumbs="breadcrumbs"
+		:status="sco.status"
+	>
+		<template #actions>
+			<template v-if="!editing">
+				<button
+					v-if="isPending || isRejected"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+					style="border-radius: 6px"
+					@click="startEdit"
+				>
+					Edit
+				</button>
+				<button
+					v-if="isPending && canApprove"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-success-300 bg-success-50 hover:bg-success-100 text-success-700 font-medium"
+					style="border-radius: 6px"
+					:disabled="busy"
+					@click="onApprove"
+				>
+					Approve
+				</button>
+				<button
+					v-if="isPending && canApprove"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+					style="border-radius: 6px"
+					:disabled="busy"
+					@click="openReject"
+				>
+					Reject
+				</button>
+				<button
+					v-if="isApproved && !sco.boq_revision"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+					style="border-radius: 6px"
+					:disabled="busy"
+					@click="onCreateBoqRevision"
+				>
+					+ Raise BOQ revision
+				</button>
+				<button
+					v-if="isApproved || isRejected"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-warning-200 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+					style="border-radius: 6px"
+					:disabled="busy"
+					@click="onRevise"
+				>
+					Revise
+				</button>
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+					style="border-radius: 6px"
+					@click="onDelete"
+				>
+					Delete
+				</button>
+			</template>
+			<template v-else>
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+					style="border-radius: 6px"
+					@click="cancelEdit"
+				>
+					Cancel
+				</button>
+				<button type="button" class="desk-save-btn" :disabled="saving" @click="saveEdit">
+					{{ saving ? "Saving…" : "Save" }}
+				</button>
+			</template>
+		</template>
+
+		<!-- Pending, not an approver: hint -->
+		<div
+			v-if="isPending && !canApprove && !editing"
+			class="mb-4 px-3 py-2 text-xs text-ink-600 bg-warning-50 border border-warning-200 rounded"
+		>
+			Awaiting PM / Director approval.
+		</div>
+
+		<!-- View mode -->
+		<div v-if="!editing">
+			<div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
+				<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Project
+					</div>
+					<div class="text-sm text-ink-900 mt-0.5 truncate">
+						{{ sco.project_name || sco.project }}
+					</div>
+				</div>
+				<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Type
+					</div>
+					<div class="text-sm text-ink-900 mt-0.5">{{ sco.type }}</div>
+				</div>
+				<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Cost impact
+					</div>
+					<div
+						class="text-base font-semibold tabular-nums mt-0.5"
+						:class="Number(sco.impact) >= 0 ? 'text-danger-700' : 'text-success-700'"
+					>
+						{{ Number(sco.impact) >= 0 ? "+" : "-"
+						}}{{ fmtINR(Math.abs(Number(sco.impact) || 0)) }}
+					</div>
+				</div>
+				<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Recoverable
+					</div>
+					<div class="text-sm text-ink-900 mt-0.5">
+						{{ sco.recoverable ? "Yes · from client" : "Internal" }}
+					</div>
+				</div>
+				<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Raised
+					</div>
+					<div class="text-sm text-ink-900 mt-0.5 truncate">
+						{{ sco.raised_by || "—" }}
+					</div>
+					<div class="text-[10px] text-ink-500">{{ fmtDate(sco.raised_date) }}</div>
+				</div>
+			</div>
+
+			<DeskSection title="Justification" :cols="1">
+				<DeskField label="Reason"
+					><div class="text-sm text-ink-800 whitespace-pre-line">
+						{{ sco.reason || "—" }}
+					</div></DeskField
+				>
+			</DeskSection>
+
+			<DeskSection v-if="isRejected && sco.rejection_reason" title="Rejection" :cols="1">
+				<DeskField label="Reason"
+					><div class="text-sm text-danger-700 whitespace-pre-line">
+						{{ sco.rejection_reason }}
+					</div></DeskField
+				>
+			</DeskSection>
+
+			<!-- BOQ Impact -->
+			<section class="mt-6">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">
+					BOQ impact
+				</h3>
+				<div v-if="sco.boq_revision" class="text-sm text-ink-700">
+					BOQ revision raised:
+					<DeskLink :to="`/boq/${sco.boq_revision}`">{{ sco.boq_revision }}</DeskLink>
+				</div>
+				<div v-else-if="isApproved" class="text-xs text-ink-500 italic">
+					No BOQ revision yet — use “+ Raise BOQ revision” above to branch the project's
+					BOQ.
+				</div>
+				<div v-else class="text-xs text-ink-400 italic">
+					A BOQ revision can be raised once this change order is approved.
+				</div>
+			</section>
+		</div>
+
+		<!-- Edit mode -->
+		<div v-else>
+			<DeskSection title="Change order" :cols="2">
+				<DeskField label="Project"
+					><div class="text-sm text-ink-700">
+						{{ sco.project_name || sco.project }}
+					</div></DeskField
+				>
+				<DeskField label="Type">
+					<DeskSelect v-model="form.type"
+						><option v-for="t in TYPES" :key="t">{{ t }}</option></DeskSelect
+					>
+				</DeskField>
+				<DeskField label="Title" required :error="errors.title" class="md:col-span-2"
+					><DeskInput v-model="form.title"
+				/></DeskField>
+				<DeskField
+					label="Cost impact (₹)"
+					hint="Positive = added cost; negative = a saving."
+					><DeskInput v-model.number="form.impact" type="number" step="1000"
+				/></DeskField>
+				<DeskField label="Cost recovery">
+					<DeskSelect v-model="form.recoverable">
+						<option value="1">Recoverable from client</option>
+						<option value="0">Internal — absorbed by us</option>
+					</DeskSelect>
+				</DeskField>
+				<DeskField label="Reason / justification" class="md:col-span-2"
+					><DeskTextarea v-model="form.reason" :rows="4"
+				/></DeskField>
+			</DeskSection>
+		</div>
+
+		<!-- Reject modal -->
+		<Teleport to="body">
+			<div
+				v-if="rejectOpen"
+				class="fixed inset-0 bg-ink-900/40 z-[60] flex items-center justify-center p-6"
+				@click.self="rejectOpen = false"
+			>
+				<div
+					class="bg-white border border-ink-200 w-full max-w-md shadow-lg"
+					style="border-radius: 12px"
+					@click.stop
+				>
+					<header class="px-5 py-3 border-b border-ink-200">
+						<h2 class="text-sm font-semibold text-ink-900">Reject {{ sco.name }}</h2>
+					</header>
+					<div class="p-5">
+						<DeskField label="Rejection reason"
+							><DeskTextarea
+								v-model="rejectReason"
+								:rows="4"
+								placeholder="Why is this change order rejected?"
+						/></DeskField>
+					</div>
+					<footer
+						class="px-5 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+					>
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+							style="border-radius: 6px"
+							@click="rejectOpen = false"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 border border-danger-300 bg-danger-50 hover:bg-danger-100 text-danger-700 font-medium"
+							style="border-radius: 6px"
+							:disabled="busy"
+							@click="confirmReject"
+						>
+							Reject
+						</button>
+					</footer>
+				</div>
+			</div>
+		</Teleport>
+	</DeskPage>
+
+	<div v-else class="px-3 py-2 text-sm text-ink-500">Loading scope change order…</div>
+</template>

--- a/frontend/src/views/ScoView.vue
+++ b/frontend/src/views/ScoView.vue
@@ -1,42 +1,74 @@
 <script setup>
-// Scope Change Orders (M7) â€” Desk-styled list (CLAUDE.md Â§12.4). Every computed and
-// store call preserved verbatim. Variance-style coloring on impact: positive = cost
-// to the project = red; negative = savings = green (matches the convention in
-// ProjectDetailView's SCO tab).
+// Scope Change Order register â€” Desk-styled, backend-backed via the data adapter.
+// Impact colouring: positive = added cost to the project = red; negative = saving = green.
 
 import { computed, ref } from "vue";
-import { useDataStore } from "@/stores";
+import { useRouter, RouterLink } from "vue-router";
+import { useDocTypeList } from "@/composables/useDocTypeList";
 import StatusBadge from "@/components/StatusBadge.vue";
-import UserAvatar from "@/components/UserAvatar.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
-import DeskLink from "@/components/desk/DeskLink.vue";
 import { fmtINR, fmtCompactINR, fmtDate } from "@/utils/format";
 
-const store = useDataStore();
+const router = useRouter();
 
+const scosRes = useDocTypeList("Scope Change Order", {
+	fields: [
+		"name",
+		"project",
+		"project_name",
+		"title",
+		"type",
+		"impact",
+		"recoverable",
+		"status",
+		"raised_by",
+		"raised_date",
+	],
+	orderBy: "creation desc",
+	pageLength: 0,
+	cache: "buildsuite-sco-list",
+	transform: (data) =>
+		data.map((s) => ({
+			id: s.name,
+			project: s.project,
+			projectName: s.project_name,
+			title: s.title,
+			type: s.type,
+			impact: s.impact,
+			recoverable: s.recoverable,
+			status: s.status,
+			raisedBy: s.raised_by,
+			raisedDate: s.raised_date,
+		})),
+});
+
+const all = computed(() => scosRes.data || []);
 const search = ref("");
 const statusFilter = ref("");
 
 const items = computed(() => {
-	const term = search.value.trim().toLowerCase();
-	return store.scos.filter((s) => {
-		if (statusFilter.value && s.status !== statusFilter.value) return false;
-		if (term && !s.title.toLowerCase().includes(term) && !s.id.toLowerCase().includes(term))
-			return false;
-		return true;
-	});
+	let data = all.value;
+	if (statusFilter.value) data = data.filter((s) => s.status === statusFilter.value);
+	const q = search.value.trim().toLowerCase();
+	if (q)
+		data = data.filter(
+			(s) =>
+				(s.title || "").toLowerCase().includes(q) ||
+				(s.id || "").toLowerCase().includes(q),
+		);
+	return data;
 });
 
-function projectName(id) {
-	return store.projectById(id)?.name || id;
-}
-
-const totalImpact = computed(() => store.scos.reduce((a, s) => a + (s.impact || 0), 0));
+const pendingCount = computed(
+	() => all.value.filter((s) => s.status === "Pending Approval").length,
+);
+const totalImpact = computed(() => all.value.reduce((a, s) => a + (Number(s.impact) || 0), 0));
 const recoverableTotal = computed(() =>
-	store.scos.filter((s) => s.recoverable).reduce((a, s) => a + (s.impact || 0), 0)
+	all.value.filter((s) => s.recoverable).reduce((a, s) => a + (Number(s.impact) || 0), 0),
 );
 
 const columns = [
@@ -47,40 +79,39 @@ const columns = [
 	{ key: "impact", label: "Impact", align: "right" },
 	{ key: "recoverable", label: "Recoverable" },
 	{ key: "status", label: "Status" },
-	{ key: "raisedBy", label: "Raised by" },
 	{ key: "raisedDate", label: "Date" },
 ];
 
-const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Scope Change" }];
+const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Scope Change Orders" }];
 
-const subtitle = computed(() => `${items.value.length} of ${store.scos.length} Â· M7 module`);
+function onRowClick(row) {
+	router.push(`/sco/${row.id}`);
+}
 </script>
 
 <template>
-	<DeskPage title="Scope Change Order" :subtitle="subtitle" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Scope Change Orders" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button type="button" class="desk-save-btn">+ Raise SCO</button>
+			<RouterLink to="/sco/new" class="desk-save-btn">+ Raise SCO</RouterLink>
 		</template>
 
-		<!-- KPI strip â€” Desk-tight -->
+		<!-- KPI strip -->
 		<div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
-			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Total SCOs
 				</div>
-				<div class="text-base font-semibold text-ink-900 mt-0.5">
-					{{ store.scos.length }}
-				</div>
+				<div class="text-base font-semibold text-ink-900 mt-0.5">{{ all.length }}</div>
 			</div>
-			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Pending approval
 				</div>
 				<div class="text-base font-semibold text-warning-700 mt-0.5">
-					{{ store.pendingScosCount }}
+					{{ pendingCount }}
 				</div>
 			</div>
-			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Net cost impact
 				</div>
@@ -88,10 +119,10 @@ const subtitle = computed(() => `${items.value.length} of ${store.scos.length} Â
 					class="text-base font-semibold mt-0.5 tabular-nums"
 					:class="totalImpact >= 0 ? 'text-danger-700' : 'text-success-700'"
 				>
-					{{ totalImpact >= 0 ? "+" : "" }}{{ fmtCompactINR(Math.abs(totalImpact)) }}
+					{{ totalImpact >= 0 ? "+" : "-" }}{{ fmtCompactINR(Math.abs(totalImpact)) }}
 				</div>
 			</div>
-			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Client recoverable
 				</div>
@@ -107,6 +138,7 @@ const subtitle = computed(() => `${items.value.length} of ${store.scos.length} Â
 			:columns="columns"
 			row-key="id"
 			search-placeholder="Search SCO id or titleâ€¦"
+			@row-click="onRowClick"
 		>
 			<template #filter-chips>
 				<DeskSelect v-if="!statusFilter" v-model="statusFilter" class="!w-44">
@@ -124,13 +156,15 @@ const subtitle = computed(() => `${items.value.length} of ${store.scos.length} Â
 			</template>
 
 			<template #cell-id="{ row }">
-				<DeskLink class="font-mono text-xs">{{ row.id }}</DeskLink>
+				<DeskLink :to="`/sco/${row.id}`" class="font-mono text-xs" @click.stop>{{
+					row.id
+				}}</DeskLink>
 			</template>
 			<template #cell-title="{ row }">
 				<span class="text-ink-900 font-medium text-sm">{{ row.title }}</span>
 			</template>
 			<template #cell-project="{ row }">
-				<span class="text-ink-700 text-xs">{{ projectName(row.projectId) }}</span>
+				<span class="text-ink-700 text-xs">{{ row.projectName || row.project }}</span>
 			</template>
 			<template #cell-type="{ row }">
 				<span class="text-ink-700 text-xs">{{ row.type }}</span>
@@ -138,37 +172,39 @@ const subtitle = computed(() => `${items.value.length} of ${store.scos.length} Â
 			<template #cell-impact="{ row }">
 				<span
 					class="tabular-nums"
-					:class="row.impact >= 0 ? 'text-danger-700' : 'text-success-700'"
+					:class="Number(row.impact) >= 0 ? 'text-danger-700' : 'text-success-700'"
 				>
-					{{ row.impact >= 0 ? "+" : "" }}{{ fmtINR(Math.abs(row.impact)) }}
+					{{ Number(row.impact) >= 0 ? "+" : "-"
+					}}{{ fmtINR(Math.abs(Number(row.impact) || 0)) }}
 				</span>
 			</template>
 			<template #cell-recoverable="{ row }">
 				<span
 					v-if="row.recoverable"
-					class="text-[10px] px-1.5 py-0.5 bg-success-50 text-success-700 font-medium"
-					style="border-radius: 2px"
+					class="text-[10px] px-1.5 py-0.5 bg-success-50 text-success-700 font-medium rounded"
 					>Yes</span
 				>
 				<span
 					v-else
-					class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-600 font-medium"
-					style="border-radius: 2px"
+					class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-600 font-medium rounded"
 					>Internal</span
 				>
 			</template>
 			<template #cell-status="{ row }">
 				<StatusBadge :status="row.status" />
 			</template>
-			<template #cell-raisedBy="{ row }">
-				<UserAvatar :user-id="row.raisedBy" size="xs" />
-			</template>
 			<template #cell-raisedDate="{ row }">
 				<span class="text-xs text-ink-500">{{ fmtDate(row.raisedDate) }}</span>
 			</template>
 
 			<template #empty>
-				<div class="text-sm text-ink-500">No SCOs match your filters.</div>
+				<div class="text-sm text-ink-500">
+					{{
+						scosRes.loading
+							? "Loading scope change ordersâ€¦"
+							: "No scope change orders yet."
+					}}
+				</div>
 			</template>
 		</DeskList>
 	</DeskPage>


### PR DESCRIPTION
Implements Scope Change Orders (SCO) as a real backend feature (was a frontend stub reading a local seed) and restores the Site Execution workspace shortcut.

## Backend
- **`Scope Change Order` doctype**: project (+ fetched project_name/company), title, type (Design Change / Client Request / Statutory / Site Condition / Rework / Other), impact (± ₹), recoverable, reason, status (Pending Approval / Approved / Rejected), raised_by/date, approved_by/date, rejection_reason, boq_revision. Controller stamps company + raiser + date and defaults to Pending Approval.
- **`buildsuite_core.api.sco`**: `approve_sco` / `reject_sco` (reason) / `revise_sco` — role-gated to `BOQ_APPROVE_ROLES` (PM / Director / Admin) — plus `create_boq_revision`, which branches the project's current BOQ into a Draft revision linked back to the SCO (reuses `boq.create_revision(source_sco=…)`).
- **Permissions**: full CRUD for the site-execution delivery roles (PM, Director, Estimator, QS, Site Engineer, Admin); read for Procurement / Accountant / Foreman. Approval gated in the API.

## Frontend
- **ScoView** rewritten to the data adapter (register + KPI strip: total / pending / net impact / recoverable).
- **NewScoView** (raise form) and **ScoDetailView** (view/edit for Pending/Rejected, Approve/Reject-with-reason/Revise, and "+ Raise BOQ revision" → opens the new Draft BOQ). Approve/Reject gated by session role.
- Routes `sco/new` + `sco/:id`; `scoApi.js` wrapper.
- **Project detail "Scope Changes" tab** switched from the local store to a backend `DocTypeListView` (project + subprojects), with a "+ Raise SCO" action.
- **Site Execution shortcut restored** (WSST-006 → `/sco`) in the workspace seed, removed from the S38 strip list, plus an additive store migration so existing sessions get the tile back.

## Verification
- `bench migrate` clean; `yarn build` clean; **123/123 backend tests pass**.
- Console roundtrip: raise → Pending Approval (raiser/date/company stamped) → Approve (approver/date stamped); permissions correct (PM/Site Engineer full, Accountant read). BOQ-revision path validated.