### PR TITLE
feat: SCO activity audit trail

### DIFF
--- a/buildsuite_core/api/sco.py
+++ b/buildsuite_core/api/sco.py
@@ -7,7 +7,7 @@ plain CRUD go through the standard data adapter; only these transitions need the
 
 import frappe
 from frappe import _
-from frappe.utils import today
+from frappe.utils import now_datetime, today
 
 from buildsuite_core.permissions.setup import BOQ_APPROVE_ROLES
 
@@ -17,6 +17,19 @@ SCO = "Scope Change Order"
 def _require_approver():
 	if not set(frappe.get_roles()) & set(BOQ_APPROVE_ROLES):
 		frappe.throw(_("You are not permitted to approve or reject a scope change order."), frappe.PermissionError)
+
+
+def _add_activity(doc, action, comment=None):
+	"""Append an audit-trail row (who did what, when) to the change order."""
+	doc.append(
+		"scope_change_order_activity",
+		{
+			"action": action,
+			"user": frappe.session.user,
+			"activity_on": now_datetime(),
+			"comment": comment,
+		},
+	)
 
 
 @frappe.whitelist()
@@ -31,6 +44,7 @@ def approve_sco(name: str):
 	doc.approved_by = frappe.session.user
 	doc.approved_date = today()
 	doc.rejection_reason = None
+	_add_activity(doc, "Approved")
 	doc.save()
 	return doc.status
 
@@ -45,6 +59,7 @@ def reject_sco(name: str, reason: str = None):
 		frappe.throw(_("Only a Pending Approval change order can be rejected."))
 	doc.status = "Rejected"
 	doc.rejection_reason = reason
+	_add_activity(doc, "Rejected", reason)
 	doc.save()
 	return doc.status
 
@@ -60,6 +75,7 @@ def revise_sco(name: str):
 	doc.approved_by = None
 	doc.approved_date = None
 	doc.rejection_reason = None
+	_add_activity(doc, "Revised")
 	doc.save()
 	return doc.status
 

--- a/buildsuite_core/buildsuite_core/doctype/scope_change_order/scope_change_order.json
+++ b/buildsuite_core/buildsuite_core/doctype/scope_change_order/scope_change_order.json
@@ -24,7 +24,9 @@
   "approved_date",
   "rejection_reason",
   "boq_section",
-  "boq_revision"
+  "boq_revision",
+  "activity_section",
+  "scope_change_order_activity"
  ],
  "fields": [
   {
@@ -158,6 +160,20 @@
    "fieldtype": "Link",
    "label": "BOQ Revision",
    "options": "BOQ",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "activity_section",
+   "fieldtype": "Section Break",
+   "label": "Activity"
+  },
+  {
+   "description": "Audit trail of approval-workflow actions on this change order.",
+   "fieldname": "scope_change_order_activity",
+   "fieldtype": "Table",
+   "label": "Activity",
+   "options": "Scope Change Order Activity",
    "read_only": 1
   }
  ],

--- a/buildsuite_core/buildsuite_core/doctype/scope_change_order_activity/scope_change_order_activity.json
+++ b/buildsuite_core/buildsuite_core/doctype/scope_change_order_activity/scope_change_order_activity.json
@@ -1,0 +1,52 @@
+{
+ "actions": [],
+ "creation": "2026-07-16 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "action",
+  "user",
+  "activity_on",
+  "comment"
+ ],
+ "fields": [
+  {
+   "fieldname": "action",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Action",
+   "options": "Approved\nRejected\nRevised"
+  },
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User"
+  },
+  {
+   "fieldname": "activity_on",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "Activity On"
+  },
+  {
+   "fieldname": "comment",
+   "fieldtype": "Small Text",
+   "label": "Comment"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-07-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Scope Change Order Activity",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/buildsuite_core/buildsuite_core/doctype/scope_change_order_activity/scope_change_order_activity.py
+++ b/buildsuite_core/buildsuite_core/doctype/scope_change_order_activity/scope_change_order_activity.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ScopeChangeOrderActivity(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		action: DF.Literal["Approved", "Rejected", "Revised"]
+		activity_on: DF.Datetime | None
+		comment: DF.SmallText | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		user: DF.Link | None
+	# end: auto-generated types
+
+	pass

--- a/buildsuite_core/tests/test_sco.py
+++ b/buildsuite_core/tests/test_sco.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Scope Change Order approval workflow + its activity audit trail."""
+
+import frappe
+
+from buildsuite_core.api.sco import approve_sco, reject_sco, revise_sco
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestScopeChangeOrder(BuildSuiteTestCase):
+	def _make_sco(self):
+		project = self._make_project(company=self.company)
+		return frappe.get_doc(
+			{
+				"doctype": "Scope Change Order",
+				"project": project.name,
+				"title": f"SCO {self._n}",
+				"type": "Design Change",
+				"status": "Pending Approval",
+			}
+		).insert(ignore_permissions=True)
+
+	def test_activity_log_records_each_transition(self):
+		sco = self._make_sco()
+		reject_sco(sco.name, "needs costing")
+		revise_sco(sco.name)
+		approve_sco(sco.name)
+
+		doc = frappe.get_doc("Scope Change Order", sco.name)
+		rows = doc.scope_change_order_activity
+		self.assertEqual(
+			[(r.action, r.comment) for r in rows],
+			[("Rejected", "needs costing"), ("Revised", None), ("Approved", None)],
+		)
+		# every entry stamps who + when
+		self.assertTrue(all(r.user == "Administrator" for r in rows))
+		self.assertTrue(all(r.activity_on for r in rows))

--- a/frontend/src/views/ScoDetailView.vue
+++ b/frontend/src/views/ScoDetailView.vue
@@ -50,6 +50,12 @@ const sco = computed(() => resource?.doc || null);
 const isPending = computed(() => sco.value?.status === "Pending Approval");
 const isApproved = computed(() => sco.value?.status === "Approved");
 const isRejected = computed(() => sco.value?.status === "Rejected");
+// Audit trail of workflow actions (approve / reject / revise), newest first.
+const activity = computed(() =>
+	[...(sco.value?.scope_change_order_activity || [])].sort((a, b) =>
+		(b.activity_on || "").localeCompare(a.activity_on || ""),
+	),
+);
 const canApprove = computed(() =>
 	(session.access?.roles || []).some((r) => APPROVER_ROLES.includes(r)),
 );
@@ -374,6 +380,27 @@ const breadcrumbs = computed(() => [
 				<div v-else class="text-xs text-ink-400 italic">
 					A BOQ revision can be raised once this change order is approved.
 				</div>
+			</section>
+
+			<!-- Activity -->
+			<section v-if="activity.length" class="mt-6">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">
+					Activity
+				</h3>
+				<ul class="space-y-1.5">
+					<li
+						v-for="(a, i) in activity"
+						:key="i"
+						class="flex items-start gap-1.5 text-xs flex-wrap"
+					>
+						<span class="font-medium text-ink-800">{{ a.action }}</span>
+						<span class="text-ink-500">by {{ a.user }}</span>
+						<span class="text-ink-400">
+							· {{ a.activity_on ? fmtDate(a.activity_on.slice(0, 10)) : "" }}</span
+						>
+						<span v-if="a.comment" class="text-ink-600 italic">— {{ a.comment }}</span>
+					</li>
+				</ul>
 			</section>
 		</div>
 


### PR DESCRIPTION
## What

Ports the one genuinely-missing slice of the parallel SCO effort in #68 onto our existing Scope Change Order: an **activity audit trail** of the approval workflow.

- **New child doctype `Scope Change Order Activity`** (`action` / `user` / `activity_on` / `comment`), attached as a read-only Table on `Scope Change Order` under a collapsible "Activity" section.
- **`_add_activity()` in `api/sco.py`** records a row on each transition — `approve_sco` → *Approved*, `reject_sco` → *Rejected* (carrying the rejection reason as the comment), `revise_sco` → *Revised* — each stamped with the acting user and timestamp.
- **"Activity" section on `ScoDetailView.vue`** rendering the trail newest-first (action · user · date · comment).
- **Test** `test_sco.py` covering the full reject → revise → approve trail.

Everything else in #68 duplicates SCO work already on `develop`; only the activity log was missing. Our version keeps the `create_boq_revision` tie-in that #68 lacks.

## Test

- New `test_sco.py` green; full suite **124 backend tests** pass.
- `bench migrate` syncs the child doctype; end-to-end probe confirmed reject/revise/approve each log a row.
- `yarn build` clean.

Supersedes #68 (which is being closed as a duplicate).