### PR TITLE
feat: schedule undo + revisions (schedule snapshots)

### DIFF
--- a/buildsuite_core/api/schedule_engine.py
+++ b/buildsuite_core/api/schedule_engine.py
@@ -382,6 +382,14 @@ def reschedule_downstream(task, new_start=None, new_end=None, dry_run=1):
 	if dry_run:
 		return {"moves": moves}
 
+	# A downstream cascade is a *group* action — capture an undo snapshot of the
+	# project schedule before mutating, so the whole shift can be reverted in one
+	# step. Skipped when nothing downstream moves (that's a single-task change).
+	if moves:
+		from buildsuite_core.api.schedule_snapshot import capture_snapshot
+
+		capture_snapshot(root.project, "Undo", trigger="reschedule_downstream", root_task=task)
+
 	frappe.flags.in_schedule_cascade = True
 	try:
 		if root_override:

--- a/buildsuite_core/api/schedule_snapshot.py
+++ b/buildsuite_core/api/schedule_snapshot.py
@@ -1,0 +1,203 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Schedule snapshots — the shared state layer behind schedule **undo** and
+**revisions**.
+
+A snapshot is a serialized copy of a project's task dates (`exp_start_date` /
+`exp_end_date`). Two kinds:
+
+- **Undo** — captured automatically right before a *group* action (a downstream
+  cascade) mutates several tasks. `undo_last` pops the newest Undo snapshot and
+  restores it, so repeated undo walks the stack back. The stack is bounded per
+  project (`UNDO_LIMIT`); older Undo snapshots auto-prune.
+- **Revision** — a named, user-saved restore point. `save_revision` captures one;
+  `restore_snapshot` restores it (capturing an Undo first, so a restore is itself
+  undoable).
+
+Restore writes each task's dates back via `doc.save()` (so per-Task write perms
+and the progress/stage hooks still run), suppressing per-save conflict re-flagging
+via the `in_schedule_cascade` flag and recomputing conflicts once at the end —
+the same machinery `reschedule_downstream` uses.
+"""
+
+import json
+
+import frappe
+from frappe import _
+from frappe.utils import getdate
+
+SNAPSHOT = "Schedule Snapshot"
+UNDO_LIMIT = 10
+
+
+# --- capture --------------------------------------------------------------
+
+
+def _serialize_schedule(project):
+	"""Every task in the project with its scheduling dates (ISO strings)."""
+	tasks = frappe.get_all(
+		"Task",
+		filters={"project": project},
+		fields=["name", "exp_start_date", "exp_end_date"],
+	)
+	return [
+		{
+			"task": t.name,
+			"exp_start_date": str(t.exp_start_date) if t.exp_start_date else None,
+			"exp_end_date": str(t.exp_end_date) if t.exp_end_date else None,
+		}
+		for t in tasks
+	]
+
+
+def _default_label(kind, trigger, root_task):
+	if kind == "Undo" and root_task:
+		return f"Before cascade from {root_task}"
+	if kind == "Undo":
+		return "Before schedule change"
+	return "Revision"
+
+
+def capture_snapshot(project, kind, label=None, trigger=None, root_task=None):
+	"""Serialize the project schedule into a Schedule Snapshot. Internal — callers
+	are already permitted to change the schedule (or are the cascade itself), so the
+	insert runs with ignore_permissions. Undo snapshots prune to the last UNDO_LIMIT."""
+	rows = _serialize_schedule(project)
+	doc = frappe.get_doc(
+		{
+			"doctype": SNAPSHOT,
+			"project": project,
+			"kind": kind,
+			"label": label or _default_label(kind, trigger, root_task),
+			"trigger": trigger,
+			"root_task": root_task,
+			"task_count": len(rows),
+			"snapshot_data": json.dumps(rows),
+		}
+	).insert(ignore_permissions=True)
+	if kind == "Undo":
+		_prune_undo_stack(project)
+	return doc.name
+
+
+def _prune_undo_stack(project):
+	names = frappe.get_all(
+		SNAPSHOT,
+		filters={"project": project, "kind": "Undo"},
+		order_by="creation desc",
+		pluck="name",
+	)
+	for name in names[UNDO_LIMIT:]:
+		frappe.delete_doc(SNAPSHOT, name, force=True, ignore_permissions=True)
+
+
+# --- restore --------------------------------------------------------------
+
+
+def _apply_snapshot(rows):
+	"""Write the saved dates back to each task. Returns the list of changed task
+	names. Runs under in_schedule_cascade so per-save conflict re-flagging is
+	suppressed; the caller recomputes conflicts once afterwards. Each doc.save()
+	enforces per-Task write permission."""
+	changed = []
+	frappe.flags.in_schedule_cascade = True
+	try:
+		for r in rows:
+			name = r.get("task")
+			if not name or not frappe.db.exists("Task", name):
+				continue
+			new_start = getdate(r["exp_start_date"]) if r.get("exp_start_date") else None
+			new_end = getdate(r["exp_end_date"]) if r.get("exp_end_date") else None
+			t = frappe.get_doc("Task", name)
+			if t.exp_start_date == new_start and t.exp_end_date == new_end:
+				continue
+			t.exp_start_date = new_start
+			t.exp_end_date = new_end
+			t.save()
+			changed.append(name)
+	finally:
+		frappe.flags.in_schedule_cascade = False
+
+	# Re-flag conflicts across the tasks we touched (idempotent per subgraph).
+	from buildsuite_core.api.schedule_engine import recompute_schedule_conflicts
+
+	for name in changed:
+		recompute_schedule_conflicts(name)
+	return changed
+
+
+@frappe.whitelist()
+def restore_snapshot(name, capture_undo=1):
+	"""Restore a snapshot's dates. Captures an Undo of the current state first (so
+	the restore is itself undoable) unless capture_undo=0."""
+	doc = frappe.get_doc(SNAPSHOT, name)
+	if not frappe.has_permission("Project", "read", doc.project):
+		frappe.throw(_("You are not permitted to restore this schedule."), frappe.PermissionError)
+	rows = json.loads(doc.snapshot_data or "[]")
+	if int(capture_undo):
+		capture_snapshot(
+			doc.project, "Undo", label=f"Before restoring {doc.label or name}", trigger="restore_snapshot"
+		)
+	changed = _apply_snapshot(rows)
+	return {"restored": name, "changed": len(changed)}
+
+
+@frappe.whitelist()
+def undo_last(project):
+	"""Pop the newest Undo snapshot for the project, restore it, and delete it — so
+	repeated calls walk the stack back. No-op (undone=False) when the stack is empty."""
+	latest = frappe.get_all(
+		SNAPSHOT,
+		filters={"project": project, "kind": "Undo"},
+		order_by="creation desc",
+		limit=1,
+		pluck="name",
+	)
+	if not latest:
+		return {"undone": False, "remaining": 0}
+	snap = frappe.get_doc(SNAPSHOT, latest[0])
+	if not frappe.has_permission("Project", "read", snap.project):
+		frappe.throw(_("You are not permitted to undo on this schedule."), frappe.PermissionError)
+	rows = json.loads(snap.snapshot_data or "[]")
+	changed = _apply_snapshot(rows)
+	frappe.delete_doc(SNAPSHOT, snap.name, force=True, ignore_permissions=True)
+	remaining = frappe.db.count(SNAPSHOT, {"project": project, "kind": "Undo"})
+	return {"undone": True, "changed": len(changed), "label": snap.label, "remaining": remaining}
+
+
+# --- revisions ------------------------------------------------------------
+
+
+@frappe.whitelist()
+def save_revision(project, label):
+	"""Save a named Revision snapshot of the project's current schedule."""
+	if not frappe.has_permission("Project", "read", project):
+		frappe.throw(_("You are not permitted to snapshot this schedule."), frappe.PermissionError)
+	if not (label or "").strip():
+		frappe.throw(_("A revision label is required."))
+	name = capture_snapshot(project, "Revision", label=label.strip(), trigger="save_revision")
+	return {"name": name}
+
+
+@frappe.whitelist()
+def list_snapshots(project, kind=None):
+	"""Snapshots for a project (newest first). Pass kind to filter to Undo/Revision."""
+	if not frappe.has_permission("Project", "read", project):
+		frappe.throw(_("You are not permitted to view this schedule."), frappe.PermissionError)
+	filters = {"project": project}
+	if kind:
+		filters["kind"] = kind
+	return frappe.get_all(
+		SNAPSHOT,
+		filters=filters,
+		fields=["name", "kind", "label", "trigger", "root_task", "task_count", "creation", "owner"],
+		order_by="creation desc",
+	)
+
+
+@frappe.whitelist()
+def delete_snapshot(name):
+	"""Delete a snapshot (enforces the Schedule Snapshot delete permission)."""
+	frappe.delete_doc(SNAPSHOT, name)
+	return True

--- a/buildsuite_core/buildsuite_core/doctype/schedule_snapshot/schedule_snapshot.json
+++ b/buildsuite_core/buildsuite_core/doctype/schedule_snapshot/schedule_snapshot.json
@@ -1,0 +1,105 @@
+{
+ "actions": [],
+ "autoname": "SNAP-.#####",
+ "creation": "2026-07-16 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "project",
+  "kind",
+  "label",
+  "column_break_meta",
+  "trigger",
+  "root_task",
+  "task_count",
+  "section_break_data",
+  "snapshot_data"
+ ],
+ "fields": [
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Project",
+   "options": "Project",
+   "reqd": 1
+  },
+  {
+   "default": "Undo",
+   "fieldname": "kind",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Kind",
+   "options": "Undo\nRevision",
+   "reqd": 1
+  },
+  {
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label"
+  },
+  {
+   "fieldname": "column_break_meta",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "The action that created this snapshot (e.g. reschedule_downstream).",
+   "fieldname": "trigger",
+   "fieldtype": "Data",
+   "label": "Trigger"
+  },
+  {
+   "fieldname": "root_task",
+   "fieldtype": "Link",
+   "label": "Root Task",
+   "options": "Task"
+  },
+  {
+   "fieldname": "task_count",
+   "fieldtype": "Int",
+   "label": "Task Count",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_data",
+   "fieldtype": "Section Break",
+   "label": "Snapshot"
+  },
+  {
+   "description": "JSON list of {task, exp_start_date, exp_end_date} captured at snapshot time.",
+   "fieldname": "snapshot_data",
+   "fieldtype": "Long Text",
+   "label": "Snapshot Data",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "links": [],
+ "modified": "2026-07-16 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Schedule Snapshot",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "creation",
+ "sort_order": "DESC",
+ "title_field": "label",
+ "track_changes": 0
+}

--- a/buildsuite_core/buildsuite_core/doctype/schedule_snapshot/schedule_snapshot.py
+++ b/buildsuite_core/buildsuite_core/doctype/schedule_snapshot/schedule_snapshot.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class ScheduleSnapshot(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		kind: DF.Literal["Undo", "Revision"]
+		label: DF.Data | None
+		project: DF.Link
+		root_task: DF.Link | None
+		snapshot_data: DF.LongText | None
+		task_count: DF.Int
+		trigger: DF.Data | None
+	# end: auto-generated types
+
+	pass

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -378,6 +378,13 @@ def setup_task_permissions():
 	_apply_role_perms("Task", TASK_ROLE_PERMS)
 
 
+def setup_schedule_snapshot_permissions():
+	# Schedule undo/revision snapshots follow Task-edit rights — whoever can change
+	# the schedule can capture, restore and delete its snapshots. Restore additionally
+	# enforces per-Task write on save.
+	_apply_role_perms("Schedule Snapshot", TASK_ROLE_PERMS)
+
+
 def setup_work_package_permissions():
 	_apply_role_perms("Work Package", WORK_PACKAGE_ROLE_PERMS)
 
@@ -642,6 +649,7 @@ def setup_record_permissions():
 
 	setup_project_permissions()
 	setup_task_permissions()
+	setup_schedule_snapshot_permissions()
 	setup_work_package_permissions()
 	setup_task_progress_entry_permissions()
 	setup_stage_planning_permissions()

--- a/buildsuite_core/tests/test_schedule_snapshot.py
+++ b/buildsuite_core/tests/test_schedule_snapshot.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Schedule snapshots — auto-undo for cascading (group) actions + named revisions."""
+
+from frappe.utils import getdate
+
+from buildsuite_core.api import schedule_snapshot as ss
+from buildsuite_core.api.schedule_engine import reschedule_downstream
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestScheduleSnapshot(BuildSuiteTestCase):
+	def _dated_task(self, project, start, end):
+		t = self._make_task(project)
+		t.exp_start_date = getdate(start)
+		t.exp_end_date = getdate(end)
+		t.save(ignore_permissions=True)
+		return t
+
+	def _chain(self):
+		"""Project with A --FS--> B, so moving A cascades B."""
+		p = self._make_project(company=self.company)
+		a = self._dated_task(p.name, "2026-01-01", "2026-01-10")
+		b = self._dated_task(p.name, "2026-01-11", "2026-01-20")
+		b.append("depends_on", {"task": a.name, "dependency_type": "FS", "lag_days": 0})
+		b.save(ignore_permissions=True)
+		return p, a, b
+
+	def _dates(self, name):
+		import frappe
+
+		return frappe.db.get_value("Task", name, ["exp_start_date", "exp_end_date"])
+
+	def test_cascade_captures_undo_and_undo_restores(self):
+		p, a, b = self._chain()
+		before_a, before_b = self._dates(a.name), self._dates(b.name)
+
+		res = reschedule_downstream(a.name, new_start="2026-01-06", new_end="2026-01-15", dry_run=0)
+		self.assertGreaterEqual(len(res["moves"]), 1)  # B cascades downstream
+
+		self.assertEqual(len(ss.list_snapshots(p.name, kind="Undo")), 1)
+		self.assertNotEqual(self._dates(b.name), before_b)  # B actually moved
+
+		out = ss.undo_last(p.name)
+		self.assertTrue(out["undone"])
+		self.assertEqual(self._dates(a.name), before_a)
+		self.assertEqual(self._dates(b.name), before_b)
+		self.assertEqual(len(ss.list_snapshots(p.name, kind="Undo")), 0)  # popped
+
+	def test_single_task_move_captures_no_undo(self):
+		# A move with nothing downstream is not a group action → no undo snapshot.
+		p = self._make_project(company=self.company)
+		a = self._dated_task(p.name, "2026-01-01", "2026-01-10")
+		reschedule_downstream(a.name, new_start="2026-02-01", new_end="2026-02-10", dry_run=0)
+		self.assertEqual(len(ss.list_snapshots(p.name, kind="Undo")), 0)
+
+	def test_save_and_restore_revision(self):
+		p, a, _b = self._chain()
+		baseline = self._dates(a.name)
+		rev = ss.save_revision(p.name, "Baseline")["name"]
+
+		a.exp_start_date = getdate("2026-03-01")
+		a.exp_end_date = getdate("2026-03-10")
+		a.save(ignore_permissions=True)
+		self.assertNotEqual(self._dates(a.name), baseline)
+
+		ss.restore_snapshot(rev)
+		self.assertEqual(self._dates(a.name), baseline)
+		# restoring a revision captures an Undo first, so it's itself undoable
+		self.assertGreaterEqual(len(ss.list_snapshots(p.name, kind="Undo")), 1)
+
+	def test_undo_stack_prunes_to_limit(self):
+		p, a, _b = self._chain()
+		for i in range(ss.UNDO_LIMIT + 3):
+			reschedule_downstream(
+				a.name,
+				new_start=f"2026-01-{6 + i:02d}",
+				new_end=f"2026-01-{15 + i:02d}",
+				dry_run=0,
+			)
+		self.assertEqual(len(ss.list_snapshots(p.name, kind="Undo")), ss.UNDO_LIMIT)

--- a/docs/boq-implementation.md
+++ b/docs/boq-implementation.md
@@ -1,0 +1,270 @@
+# BOQ (Bill of Quantities) — Developer Documentation
+
+> Ground-truth for the BOQ subsystem: the data model, the amount roll-up chain, the
+> approval workflow, the whitelisted API, permissions, and the frontend. Derived from
+> the code under `buildsuite_core/buildsuite_core/doctype/boq*`, `buildsuite_core/api/boq.py`,
+> `buildsuite_core/permissions/setup.py`, and `frontend/src/views/Boq*.vue`.
+> When this doc and the code disagree, **the code wins** — update this file.
+
+---
+
+## 1. What it is
+
+A **BOQ** is a costed, revisable estimate for a **Project**, structured as a three-level tree:
+
+```
+BOQ                         (the estimate — one per revision, one Approved per project)
+ └─ BOQ Group               (a section: "Civil Works", "MEP", …)
+     └─ BOQ Item            (a line of work: qty × rate = amount; optionally an Assembly)
+         └─ BOQ Sub Item    (rate-analysis component: resource + coefficient + rate)
+```
+
+BOQ Items can be **manual** (rate typed in) or **assembly-driven** (rate derived from
+sub-items exploded out of an `Assembly`). Items optionally tag a **Work Package** and a
+**Task**; task progress drives actuals. A BOQ carries **margin** + **tax** rates and rolls
+everything up to a `total`, with a per-Work-Package breakdown.
+
+---
+
+## 2. Data model
+
+Four doctypes. **None are child tables** — the tree is an adjacency list of standalone
+doctypes wired by parent-pointer `Link` fields. (The *only* child table in the model is
+`wp_summaries` on the BOQ, holding the per-WP roll-up buckets.)
+
+### 2.1 `BOQ` — `autoname: BOQ-.#####`, `title_field: title`
+
+| Field | Type | Notes |
+|---|---|---|
+| `project` | Link → Project | required |
+| `company` | Link → Company | defaulted from the project (`before_insert`/`validate`) |
+| `title` | Data | |
+| `revision` | Int | 1-based; `create_revision` sets `max+1` |
+| `base_revision` | Link → BOQ | the revision this was cloned from |
+| `status` | Select | **Draft / Submitted / Approved / Superseded** |
+| `source_sco` | Link | set when a revision is raised from a Scope Change Order |
+| `prepared_by` / `prepared_date` | Link User / Date | stamped `before_insert` |
+| `approved_by` / `approved_date` | Link User / Date | stamped on approve |
+| `margin_rate` / `tax_rate` | Percent | inputs to the roll-up |
+| `planned_amount` / `actual_amount` / `margin_amount` / `tax_amount` / `total` | Currency | **server-derived** (see §3) |
+| `wp_summaries` | Table → BOQ WP Summary | per-WP buckets: planned / margin / tax / total |
+
+### 2.2 `BOQ Group` — `boq → BOQ`, `code`, `group_name`, `idx_order`
+
+The section header. `code` (e.g. `A`, `B`) is a display/business code, **not** the relational
+key. Ordered by `idx_order`.
+
+### 2.3 `BOQ Item` — the costed line
+
+`boq → BOQ`, `boq_group → BOQ Group`, `code`, `description`, `unit → UOM`,
+`planned_qty`, `rate`, `planned_amount`, `actual_qty`, `actual_amount`,
+`task → Task`, `work_package → Work Package`, `cost_head` (Select),
+`quantity_source` (Manual / Assembly / Template / Takeoff), `assembly → Assembly`, `driving_qty`.
+
+### 2.4 `BOQ Sub Item` — rate-analysis component
+
+`boq → BOQ`, `boq_item → BOQ Item`, `rate_master → Construction Rate Master`,
+`resource_name`, `description`, `qty_per_unit`, `uom → UOM`, `coefficient`, `rate`, `amount`,
+`qty`, `work_package`, `cost_head`, `source_assembly → Assembly`.
+
+### 2.5 How the levels link
+
+Each child stores the **docname** of its parent; every level *also* carries a **direct
+`boq`** link to the root (denormalized) so "all items in this BOQ" / "all sub-items in this
+BOQ" is one flat query without walking the tree:
+
+```
+BOQ ◄── BOQ Group.boq
+BOQ ◄── BOQ Item.boq          BOQ Group ◄── BOQ Item.boq_group
+BOQ ◄── BOQ Sub Item.boq      BOQ Item  ◄── BOQ Sub Item.boq_item
+```
+
+Nothing *outside* the BOQ tree Links to a Group/Item/Sub Item — the only inbound references
+are these internal parent pointers. The denormalized `boq` link must be kept consistent by
+the code that creates rows (clone / explode / import all set it). There are **no DB-level
+foreign keys**; cascade delete is enforced in controllers (§4).
+
+---
+
+## 3. The amount roll-up chain (server-authoritative)
+
+Amounts and the assembly-item rate are **derived on the server**. Forms must never write
+`planned_amount`, `actual_amount`, `total`, or an assembly item's `rate`.
+
+```
+BOQ Sub Item.validate         amount = qty_per_unit × rate          (rate snapshotted from Rate Master)
+        │  after_insert / on_update / after_delete
+        ▼
+roll_up_item_rate(item)       item.rate = Σ sub_item.amount
+        │                     item.planned_amount = planned_qty × rate
+        │                     item.actual_amount  = actual_qty  × rate
+        ▼
+recompute_boq(boq)  ──►  BOQ.validate ──► compute_boq_totals(doc):
+        planned = Σ item.planned_amount
+        margin  = planned × margin_rate%
+        tax     = (planned + margin) × tax_rate%
+        total   = planned + margin + tax
+        actual  = Σ item.actual_amount
+        wp_summaries = buckets by work_package, margin+tax split proportionally to each WP's planned share
+```
+
+Key points:
+
+- **Manual item:** `rate` is typed; `BOQ Item.validate` computes `planned_amount = planned_qty × rate`.
+- **Assembly item:** `rate` is **derived** — `roll_up_item_rate` sums the sub-items' `amount`.
+  Editing/adding/removing a sub-item re-rolls the item, then the BOQ.
+- **Rate Master snapshot:** a sub-item linked to a `Construction Rate Master` snapshots
+  `rate` + `uom` from it at validate-time — it is a *snapshot*, not a live link. Each component
+  keeps its own unit (bag / litre / day…), distinct from the parent item's UOM.
+- **`recompute_boq(name)`** simply re-saves the BOQ so its `validate` re-rolls. Batch
+  operations set **`frappe.flags.boq_skip_rollup = True`** to suppress the per-row re-save and
+  call `recompute_boq` **once** at the end (see explode / recalc / clone).
+
+Relevant code: `doctype/boq/boq_rollup.py` (`compute_boq_totals`, `recompute_boq`),
+`doctype/boq_item/boq_item.py` (`roll_up_item_rate`), `doctype/boq_sub_item/boq_sub_item.py`.
+
+---
+
+## 4. Controllers
+
+| Doctype | Hook | Behavior |
+|---|---|---|
+| **BOQ** | `before_insert` | default company from project; stamp `prepared_by/date`; default `status=Draft`, `revision=1` |
+| | `validate` | default company; `compute_boq_totals(self)` |
+| | `on_trash` | cascade-delete the tree — **Sub Items → Items → Groups** |
+| **BOQ Item** | `validate` | `planned_amount = planned_qty × rate`; `actual_amount = actual_qty × rate`; default `driving_qty = planned_qty`; normalize `quantity_source`; **project-scope check** |
+| | `on_update` | push `work_package` + `cost_head` down to its sub-items (denormalized join keys); `recompute_boq` |
+| | `on_trash` | delete its sub-items under the `boq_item_deleting` flag; `recompute_boq` once |
+| **BOQ Sub Item** | `validate` | snapshot `rate`+`uom` from Rate Master; `coefficient = qty_per_unit`; `amount = qty_per_unit × rate`; inherit parent's WP/cost-head when unset |
+| | `after_insert` / `on_update` / `after_delete` | `roll_up_item_rate(boq_item)` (skipped if the parent item is mid-delete) |
+| **BOQ Group** | `on_trash` | (group-level cleanup) |
+
+**Project-scope validation** (`BOQ Item._validate_project_scope`): an item's `task` and
+`work_package` must belong to the **BOQ's own project** — you can't cost another project's
+work into this BOQ; otherwise it `frappe.throw`s.
+
+---
+
+## 5. Workflow
+
+```
+Draft ──submit_boq──► Submitted ──approve_boq──► Approved
+  ▲                                                 │
+  └──────── create_revision (new Draft) ◄───────────┘   approving a revision
+                                                         SUPERSEDES the prior Approved
+Approved (prior) ──────────────────────────────► Superseded
+```
+
+- **`submit_boq`** — `Draft → Submitted`. Requires write.
+- **`approve_boq`** — `Draft/Submitted → Approved`; **supersedes any other `Approved` BOQ of
+  the same project** (→ `Superseded`), so a project has at most **one Approved BOQ**. Stamps
+  `approved_by/date`. Gated server-side to **`BOQ_APPROVE_ROLES`**.
+- **No un-approve.** To change an Approved BOQ you raise a **revision** (a fresh Draft via
+  `create_revision`); approving it supersedes the old one.
+- **Draft-only edits:** `explode_item` and `import_template` enforce `_require_draft`; the
+  frontend also gates the edit UI on `status === "Draft"`.
+
+---
+
+## 6. Whitelisted API — `buildsuite_core/api/boq.py`
+
+Reads and plain CRUD on the tree go through the generic data adapter
+(`frappe.client.*`). Only the operations below need the API. Frontend wrappers live in
+`frontend/src/utils/boqApi.js`.
+
+| Endpoint | Signature | Purpose |
+|---|---|---|
+| `submit_boq` | `(boq)` | Draft → Submitted |
+| `approve_boq` | `(boq)` | Approve; supersede sibling Approved; role-gated |
+| `explode_item` | `(boq_item)` | Rebuild an item's sub-items from its Assembly (Draft only, idempotent) |
+| `recalculate_actuals` | `(boq)` | For task-linked items: `actual_qty = planned_qty × task.progress%` |
+| `create_revision` | `(boq, source_sco=None, title=None)` | Clone into a new Draft revision (`revision = max+1`, `base_revision = src`) |
+| `clone_boq` | `(from_project, to_project, from_work_package=None, to_work_package=None, title=None)` | project→project copy, or WP→WP retag within a project |
+| `import_template` | `(boq, estimate_template)` | Seed groups+items from an Estimate Template into a Draft BOQ |
+
+### 6.1 Assembly explosion — `explode_item`
+Draft only. Deletes the item's existing sub-items, then inserts one `BOQ Sub Item` per
+assembly component (`qty = coefficient × driving_qty`), stamping the item's WP/cost-head and
+`source_assembly`. Sets `item.quantity_source = "Assembly"`, `item.rate = assembly.rate_per_unit`,
+and `planned_qty = driving_qty = driving`. Wrapped in `boq_skip_rollup`, with a single
+`recompute_boq` at the end. Idempotent (re-exploding replaces the sub-items).
+
+### 6.2 Actuals — `recalculate_actuals`
+For every item with a `task`, sets `actual_qty = planned_qty × task.progress / 100` and
+`actual_amount = actual_qty × rate`. Batch-flagged; one `recompute_boq` at the end. (Task
+progress is itself server-derived — see the main CLAUDE.md progress rules.)
+
+### 6.3 Revisions & clones — `_clone_tree`
+`_clone_tree(src_boq, dst_boq, reset_actuals=True, src_wp=None, wp_override=None, drop_wp=False)`
+copies groups → items → sub-items from one BOQ into another.
+- **`create_revision`** — same project, `revision = max+1`, `base_revision = src`, copies
+  `margin_rate`/`tax_rate`. Used by the **SCO → BOQ revision** tie-in (`source_sco` set;
+  see `api/sco.py::create_boq_revision`).
+- **`clone_boq`** — two modes:
+  - *project → project*: a new Draft BOQ on the target, WP tags dropped (`drop_wp`).
+  - *WP → WP (same project)*: retag the source WP's lines onto the target WP on the project's
+    latest BOQ (`src_wp` + `wp_override`).
+
+### 6.4 Template import — `import_template`
+Seeds groups + items from an `Estimate Template` into a Draft BOQ (reusing existing groups by
+name). Assembly rows auto-explode; Resource rows get a single rate-analysis sub-item.
+
+---
+
+## 7. Permissions
+
+`buildsuite_core/permissions/setup.py` → `setup_boq_permissions()` applies `BOQ_ROLE_PERMS`
+across `BOQ_DOCTYPES = (BOQ, BOQ Group, BOQ Item, BOQ Sub Item)`.
+
+- **Full CRUD** — the estimation roles `_ESTIMATION_ROLES`:
+  **BuildSuite Administrator, Director, PM, Estimator, QS** (`_BOQ_FULL`).
+  *System Manager* is omitted here but keeps native full perms on custom doctypes.
+- **Everyone else: no access** (the Estimation workspace is hidden from them). *M2 tightened
+  this from the earlier "read for Site Engineer / Foreman / Accountant / HR".*
+- **Approve is separately gated** (server-authoritative, in `approve_boq`) to
+  **`BOQ_APPROVE_ROLES` = Director, PM, Administrator, System Manager**.
+- The tree's link pickers resolve `BOQ_LINKED_MASTER_DOCTYPES` (UOM, Construction Rate Master,
+  Assembly, Estimate Template), so BOQ-readable roles get read on those.
+
+The backend is always authoritative; the SPA's `usePermissions()` only hides buttons that
+would fail.
+
+---
+
+## 8. Frontend — `frontend/src/views/`
+
+- **`BoqView.vue`** — the BOQ list (search across id/title; a project picker to create a new BOQ).
+- **`BoqDetailView.vue`** — the three-level tree editor + roll-up summary.
+  - **Loads** the BOQ via `adapter.read("BOQ", id)`, and the tree as **three separate lists**
+    via `adapter.list` filtered by `boq` (`childList("BOQ Group")`, `"BOQ Item"`,
+    `"BOQ Sub Item"`), grouped client-side (`boqItemsByGroup`, `boqSubItemsByItem`).
+  - **CRUD** on groups/items/sub-items via `adapter.create/update/remove`.
+  - **Workflow / explode / revision / clone / import / recalc** via the whitelisted
+    `boqApi.*` wrappers.
+  - **Group/Item codes are optional** — blank auto-generates (`nextGroupCode` → `A, B, C…`;
+    `nextItemCode` → `{group}.NN`), computed client-side so the backend always receives a code.
+  - **Tree search** filters the tree to matching paths (code / description / unit / rate-master),
+    auto-expands them, and highlights matches.
+
+Data seam: `createDataAdapter(store)` → `remoteDataAdapter` (real Frappe via `frappe.client.*`)
+by default; `VITE_DATA_MODE=local` uses the Pinia seed. See `frontend/DEVELOPER_GUIDE.md`.
+
+---
+
+## 9. Invariants & gotchas
+
+- **Amounts + assembly-item rates are server-derived.** Never POST `planned_amount`,
+  `actual_amount`, `total`, or an assembly item's `rate` from a form.
+- **`code` is display, docname is the key.** Renaming a code never breaks the tree.
+- **The `boq` link is denormalized** on every level for flat queries — keep it consistent when
+  writing rows (clone/explode/import already do).
+- **Batch ops set `frappe.flags.boq_skip_rollup`** to avoid O(n) re-saves; they call
+  `recompute_boq` exactly once at the end. If you add a bulk mutation, follow the same pattern.
+- **Cascade delete is in code** (`BOQ.on_trash`, `BOQ Item.on_trash`), not the DB. The
+  `boq_item_deleting` flag stops a sub-item's delete-rollup from re-saving a parent that is
+  itself being deleted.
+- **One Approved BOQ per project** — `approve_boq` supersedes the rest.
+- **Draft-only structural edits** — enforced by `_require_draft` in the API; mirror this in any
+  new mutating endpoint.
+- **Backend touching whitelisted methods / workflow / permissions → `bench migrate`** and a
+  real browser pass before calling it done (see main CLAUDE.md §3).

--- a/frontend/src/utils/scheduleApi.js
+++ b/frontend/src/utils/scheduleApi.js
@@ -31,7 +31,7 @@ async function request(method, { params, body, base = BASE } = {}) {
 				? {
 						"Content-Type": "application/json",
 						"X-Frappe-CSRF-Token": window.csrf_token || "",
-				  }
+					}
 				: {}),
 		},
 		...(body ? { body: JSON.stringify(body) } : {}),
@@ -61,3 +61,31 @@ export const rescheduleDownstream = (task, newStart = null, newEnd = null, dryRu
 		base: ENGINE_BASE,
 		body: { task, new_start: newStart, new_end: newEnd, dry_run: dryRun },
 	});
+
+// --- schedule snapshots: undo + revisions --------------------------------
+const SNAPSHOT_BASE = "/api/method/buildsuite_core.api.schedule_snapshot.";
+
+// Pop + restore the newest auto-captured Undo snapshot (walks the stack back).
+export const undoLast = (project) =>
+	request("undo_last", { base: SNAPSHOT_BASE, body: { project } });
+
+// Snapshots for a project; pass kind ("Undo" | "Revision") to filter.
+export const listSnapshots = (project, kind = null) =>
+	request("list_snapshots", {
+		base: SNAPSHOT_BASE,
+		params: kind ? { project, kind } : { project },
+	});
+
+// Save the current schedule as a named Revision restore point.
+export const saveRevision = (project, label) =>
+	request("save_revision", { base: SNAPSHOT_BASE, body: { project, label } });
+
+// Restore a snapshot by name (captures an Undo first unless captureUndo=0).
+export const restoreSnapshot = (name, captureUndo = 1) =>
+	request("restore_snapshot", {
+		base: SNAPSHOT_BASE,
+		body: { name, capture_undo: captureUndo },
+	});
+
+export const deleteSnapshot = (name) =>
+	request("delete_snapshot", { base: SNAPSHOT_BASE, body: { name } });

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -11,10 +11,17 @@ import {
 	addTaskPredecessor,
 	removeTaskPredecessor,
 	rescheduleDownstream,
+	undoLast,
+	listSnapshots,
+	saveRevision,
+	restoreSnapshot,
+	deleteSnapshot,
 } from "@/utils/scheduleApi";
 import { dateBoundsError } from "@/utils/dateBounds";
 import { parseFrappeError } from "@/utils/frappeError";
 import { computeAllConflicts, hasCycle, computeCascade } from "@/composables/useScheduleEngine";
+import { showToast } from "@/utils/appToast";
+import { useConfirm } from "@/composables/useConfirm";
 
 const store = useDataStore();
 const adapter = createDataAdapter(store);
@@ -36,6 +43,101 @@ const projectMeta = ref(null); // {name, startDate, endDate} — project boundar
 const loading = ref(false);
 const errorMsg = ref("");
 let errorTimer = null;
+
+const confirmDialog = useConfirm();
+
+// === Schedule snapshots: undo (auto) + revisions (named) ==============
+const undoSnaps = ref([]); // auto-captured Undo stack (newest first)
+const revisions = ref([]); // user-saved Revision snapshots
+const revisionsOpen = ref(false);
+const newRevisionLabel = ref("");
+const snapBusy = ref(false);
+const undoCount = computed(() => undoSnaps.value.length);
+
+async function refreshSnapshots() {
+	if (!selectedProject.value) {
+		undoSnaps.value = [];
+		revisions.value = [];
+		return;
+	}
+	try {
+		const all = await listSnapshots(selectedProject.value);
+		undoSnaps.value = all.filter((s) => s.kind === "Undo");
+		revisions.value = all.filter((s) => s.kind === "Revision");
+	} catch {
+		/* non-fatal — leave existing lists */
+	}
+}
+
+async function onUndo() {
+	if (!undoCount.value || snapBusy.value) return;
+	snapBusy.value = true;
+	try {
+		const res = await undoLast(selectedProject.value);
+		if (res?.undone) {
+			await loadSchedule(); // reloads + refreshes snapshots
+			showToast(`Undone: ${res.label || "last cascade"} (${res.changed} tasks)`);
+		}
+	} catch (err) {
+		flashError(parseFrappeError(err).summary || "Undo failed.");
+	} finally {
+		snapBusy.value = false;
+	}
+}
+
+async function onSaveRevision() {
+	const label = newRevisionLabel.value.trim();
+	if (!label) {
+		flashError("Give the revision a name first.");
+		return;
+	}
+	snapBusy.value = true;
+	try {
+		await saveRevision(selectedProject.value, label);
+		newRevisionLabel.value = "";
+		await refreshSnapshots();
+		showToast(`Saved revision "${label}".`);
+	} catch (err) {
+		flashError(parseFrappeError(err).summary || "Could not save revision.");
+	} finally {
+		snapBusy.value = false;
+	}
+}
+
+async function onRestoreRevision(snap) {
+	const ok = await confirmDialog({
+		title: "Restore revision?",
+		message: `Restore the schedule to "${snap.label}"? Current dates are saved to Undo first, so you can revert this.`,
+		confirmLabel: "Restore",
+	});
+	if (!ok) return;
+	snapBusy.value = true;
+	try {
+		await restoreSnapshot(snap.name);
+		await loadSchedule(); // reloads + refreshes snapshots
+		showToast(`Restored "${snap.label}".`);
+	} catch (err) {
+		flashError(parseFrappeError(err).summary || "Restore failed.");
+	} finally {
+		snapBusy.value = false;
+	}
+}
+
+async function onDeleteRevision(snap) {
+	const ok = await confirmDialog({
+		title: "Delete revision?",
+		message: `Delete the saved revision "${snap.label}"? This does not change the schedule.`,
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await deleteSnapshot(snap.name);
+		await refreshSnapshots();
+	} catch (err) {
+		flashError(parseFrappeError(err).summary || "Could not delete revision.");
+	}
+}
 
 const newTaskOpen = ref(false);
 const draggedDep = ref(null);
@@ -66,7 +168,7 @@ const ROW_PAD_Y = (ROW_HEIGHT - BAR_HEIGHT) / 2;
 const SCROLLBAR_CLEARANCE = 16;
 
 const isDarkMode = computed(
-	() => typeof document !== "undefined" && document.documentElement.classList.contains("dark")
+	() => typeof document !== "undefined" && document.documentElement.classList.contains("dark"),
 );
 const diamondBaseFill = computed(() => (isDarkMode.value ? "#F1F5F9" : "#0F172A"));
 const diamondBaseStroke = computed(() => (isDarkMode.value ? "#94A3B8" : "#0F172A"));
@@ -144,6 +246,7 @@ async function loadSchedule() {
 		wpData.value = [];
 		stageData.value = [];
 		projectMeta.value = null;
+		refreshSnapshots();
 		return;
 	}
 	loading.value = true;
@@ -170,6 +273,7 @@ async function loadSchedule() {
 	} finally {
 		loading.value = false;
 		nextTick(jumpToToday);
+		refreshSnapshots();
 	}
 }
 // Keep the selected project in the URL (?project=) so the schedule is bookmarkable
@@ -183,7 +287,7 @@ watch(
 	() => route.query.project,
 	(val) => {
 		if ((val || "") !== (selectedProject.value || "")) selectedProject.value = val || "";
-	}
+	},
 );
 watch(selectedProject, loadSchedule, { immediate: true });
 
@@ -208,14 +312,14 @@ const allSorted = computed(() =>
 			);
 		}
 		return (a.name || "").localeCompare(b.name || "");
-	})
+	}),
 );
 // Search filters the rows (client-side); the axis uses the unfiltered set so it doesn't shift.
 const tasks = computed(() => {
 	const q = search.value.trim().toLowerCase();
 	if (!q) return allSorted.value;
 	return allSorted.value.filter(
-		(t) => t.name.toLowerCase().includes(q) || t.id.toLowerCase().includes(q)
+		(t) => t.name.toLowerCase().includes(q) || t.id.toLowerCase().includes(q),
 	);
 });
 
@@ -259,7 +363,7 @@ const timelineWidth = computed(() => {
 });
 const timelineHeight = computed(() => Math.max(layoutRows.value.length, 1) * ROW_HEIGHT);
 const effectiveBodyHeight = computed(
-	() => Math.max(timelineHeight.value, MIN_BODY_HEIGHT) + SCROLLBAR_CLEARANCE
+	() => Math.max(timelineHeight.value, MIN_BODY_HEIGHT) + SCROLLBAR_CLEARANCE,
 );
 const todayX = computed(() => dateToX(new Date().toISOString().slice(0, 10)));
 
@@ -451,7 +555,7 @@ const groupedRows = computed(() => {
 	return rows;
 });
 const layoutRows = computed(() =>
-	groupedRows.value.map((r, i) => ({ ...r, rowIndex: i, rowY: i * ROW_HEIGHT }))
+	groupedRows.value.map((r, i) => ({ ...r, rowIndex: i, rowY: i * ROW_HEIGHT })),
 );
 
 const summaryBars = computed(() => {
@@ -544,7 +648,7 @@ const barById = computed(() => {
 const dependencies = computed(() => {
 	const visibleIds = new Set(tasks.value.map((t) => t.id));
 	return allDeps.value.filter(
-		(d) => visibleIds.has(d.predecessor) && visibleIds.has(d.successor)
+		(d) => visibleIds.has(d.predecessor) && visibleIds.has(d.successor),
 	);
 });
 function arrowPath(fromX, fromY, toX, toY, type) {
@@ -616,10 +720,10 @@ const subTicks = computed(() => {
 		viewMode.value === "day"
 			? 1
 			: viewMode.value === "week"
-			? 7
-			: viewMode.value === "month"
-			? 30
-			: 90;
+				? 7
+				: viewMode.value === "month"
+					? 30
+					: 90;
 	while (cursor.getTime() < dateRange.value.maxMs) {
 		let label = "";
 		if (viewMode.value === "day") label = String(cursor.getDate());
@@ -728,7 +832,7 @@ function onBarMouseDown(task, e, mode) {
 function onBarMouseMove(e) {
 	if (!draggedBar.value) return;
 	draggedBar.value.deltaDays = Math.round(
-		(e.clientX - draggedBar.value.startClientX) / pxPerDay.value
+		(e.clientX - draggedBar.value.startClientX) / pxPerDay.value,
 	);
 }
 function onBarMouseUp() {
@@ -812,7 +916,7 @@ async function confirmCascade() {
 			ps.rootTaskId,
 			ps.rootAfter.startDate || null,
 			ps.rootAfter.endDate || null,
-			0
+			0,
 		);
 	} catch (err) {
 		flashError(parseFrappeError(err).summary || "Cascade failed.");
@@ -988,7 +1092,7 @@ async function applyPopover() {
 			d.successor,
 			d.predecessor,
 			d.dependency_type,
-			Number(d.lag) || 0
+			Number(d.lag) || 0,
 		);
 	} catch (err) {
 		if (prev && idx >= 0) {
@@ -1118,6 +1222,107 @@ onBeforeUnmount(() => {
 			>
 				Today
 			</button>
+
+			<!-- Undo the last cascading (group) action -->
+			<button
+				v-if="selectedProject"
+				class="text-xs px-2.5 py-1 border border-ink-200 rounded bg-white hover:bg-ink-50 disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-1"
+				:disabled="!undoCount || snapBusy"
+				:title="
+					undoCount
+						? `Undo the last cascade (${undoCount} step${undoCount === 1 ? '' : 's'} available)`
+						: 'Nothing to undo — undo captures cascading (multi-task) changes'
+				"
+				@click="onUndo"
+			>
+				<span>↶ Undo</span>
+				<span
+					v-if="undoCount"
+					class="text-[10px] px-1 rounded bg-ink-100 text-ink-600 tabular-nums"
+					>{{ undoCount }}</span
+				>
+			</button>
+
+			<!-- Revisions: named restore points -->
+			<div v-if="selectedProject" class="relative">
+				<button
+					class="text-xs px-2.5 py-1 border border-ink-200 rounded bg-white hover:bg-ink-50 inline-flex items-center gap-1"
+					:class="revisionsOpen ? 'bg-ink-50' : ''"
+					@click="revisionsOpen = !revisionsOpen"
+				>
+					<span>Revisions</span>
+					<span
+						v-if="revisions.length"
+						class="text-[10px] px-1 rounded bg-ink-100 text-ink-600 tabular-nums"
+						>{{ revisions.length }}</span
+					>
+					<span class="text-ink-400">▾</span>
+				</button>
+				<div
+					v-if="revisionsOpen"
+					class="fixed inset-0 z-[55]"
+					@click="revisionsOpen = false"
+				></div>
+				<div
+					v-if="revisionsOpen"
+					class="absolute right-0 top-full mt-1 z-[56] w-80 bg-white border border-ink-200 rounded-md shadow-fp-lg"
+				>
+					<div class="p-2 border-b border-ink-100 flex items-center gap-1.5">
+						<input
+							v-model="newRevisionLabel"
+							type="text"
+							placeholder="Name this revision…"
+							class="desk-input !py-1 !text-xs flex-1"
+							aria-label="Revision name"
+							@keydown.enter="onSaveRevision"
+						/>
+						<button
+							class="text-xs px-2.5 py-1 rounded bg-ink-900 text-white hover:bg-ink-800 disabled:opacity-50"
+							:disabled="snapBusy || !newRevisionLabel.trim()"
+							@click="onSaveRevision"
+						>
+							Save
+						</button>
+					</div>
+					<div class="max-h-72 overflow-y-auto scrollbar-thin py-1">
+						<div
+							v-if="!revisions.length"
+							class="px-3 py-4 text-center text-[11px] text-ink-400 italic"
+						>
+							No saved revisions yet. Save one to snapshot the current schedule.
+						</div>
+						<div
+							v-for="rev in revisions"
+							:key="rev.name"
+							class="px-3 py-2 hover:bg-ink-50 flex items-center gap-2 group/rev"
+						>
+							<div class="min-w-0 flex-1">
+								<div class="text-xs text-ink-900 truncate font-medium">
+									{{ rev.label }}
+								</div>
+								<div class="text-[10px] text-ink-500 tabular-nums">
+									{{ rev.task_count }} tasks ·
+									{{ rev.creation ? rev.creation.slice(0, 16) : "" }}
+								</div>
+							</div>
+							<button
+								class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 rounded"
+								:disabled="snapBusy"
+								@click="onRestoreRevision(rev)"
+							>
+								Restore
+							</button>
+							<button
+								class="text-[11px] px-1.5 py-0.5 text-ink-400 hover:text-danger-600"
+								title="Delete revision"
+								@click="onDeleteRevision(rev)"
+							>
+								✕
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
 
 			<button v-if="canCreateHere" class="desk-save-btn" @click="newTaskOpen = true">
 				+ New Task
@@ -1434,8 +1639,8 @@ onBeforeUnmount(() => {
 									r.kind === 'group'
 										? 'bg-ink-50/60 border-b border-ink-200'
 										: idx % 2
-										? 'bg-ink-50/20'
-										: '',
+											? 'bg-ink-50/20'
+											: '',
 								]"
 							></div>
 
@@ -1565,8 +1770,8 @@ onBeforeUnmount(() => {
 									>{{
 										canEditTask(b.task)
 											? "Hover and click to place a 1-" +
-											  viewMode +
-											  " block · drag the edges after to extend"
+												viewMode +
+												" block · drag the edges after to extend"
 											: "No timeline set"
 									}}</span
 								>
@@ -1612,15 +1817,15 @@ onBeforeUnmount(() => {
 									b.task.schedule_conflict
 										? b.task.name + ' — ' + b.task.conflict_reason
 										: b.task.name +
-										  ' · ' +
-										  fmtShort(b.task.startDate) +
-										  ' → ' +
-										  fmtShort(b.task.endDate) +
-										  ' · ' +
-										  b.task.progress +
-										  '%' +
-										  (b.isOverdue ? ' · OVERDUE' : '') +
-										  (b.isInspection ? ' · Inspection' : '')
+											' · ' +
+											fmtShort(b.task.startDate) +
+											' → ' +
+											fmtShort(b.task.endDate) +
+											' · ' +
+											b.task.progress +
+											'%' +
+											(b.isOverdue ? ' · OVERDUE' : '') +
+											(b.isInspection ? ' · Inspection' : '')
 								"
 								@mousedown="onBarMouseDown(b.task, $event, 'move')"
 							>
@@ -1692,9 +1897,9 @@ onBeforeUnmount(() => {
 									b.task.schedule_conflict
 										? b.task.name + ' — ' + b.task.conflict_reason
 										: b.task.name +
-										  ' · Milestone · ' +
-										  fmtShort(b.task.endDate) +
-										  (b.isOverdue ? ' · OVERDUE' : '')
+											' · Milestone · ' +
+											fmtShort(b.task.endDate) +
+											(b.isOverdue ? ' · OVERDUE' : '')
 								"
 							>
 								<svg :width="DIAMOND_W" :height="ROW_HEIGHT" class="flex-shrink-0">
@@ -1709,15 +1914,15 @@ onBeforeUnmount(() => {
 											b.task.status === 'Completed'
 												? '#16A34A'
 												: b.task.schedule_conflict
-												? '#DC2626'
-												: diamondBaseFill
+													? '#DC2626'
+													: diamondBaseFill
 										"
 										:stroke="
 											b.task.schedule_conflict
 												? '#7F1D1D'
 												: b.isOverdue
-												? '#D97706'
-												: diamondBaseStroke
+													? '#D97706'
+													: diamondBaseStroke
 										"
 										:stroke-width="
 											b.task.schedule_conflict || b.isOverdue ? '2' : '1'
@@ -1793,7 +1998,7 @@ onBeforeUnmount(() => {
 											Math.max(
 												0,
 												Math.min(timelineWidth, projectBand.endX) -
-													Math.max(0, projectBand.startX)
+													Math.max(0, projectBand.startX),
 											) + 'px',
 										top: '0px',
 										bottom: '0px',
@@ -2128,9 +2333,13 @@ html.dark .schedule-date-input:focus {
    (near-black light / near-white dark). A same-mode halo lifts it off the
    fill in either theme. */
 .gantt-bar-label {
-	text-shadow: 0 0 3px rgba(255, 255, 255, 0.85), 0 1px 1px rgba(255, 255, 255, 0.55);
+	text-shadow:
+		0 0 3px rgba(255, 255, 255, 0.85),
+		0 1px 1px rgba(255, 255, 255, 0.55);
 }
 html.dark .gantt-bar-label {
-	text-shadow: 0 0 3px rgba(0, 0, 0, 0.65), 0 1px 1px rgba(0, 0, 0, 0.45);
+	text-shadow:
+		0 0 3px rgba(0, 0, 0, 0.65),
+		0 1px 1px rgba(0, 0, 0, 0.45);
 }
 </style>


### PR DESCRIPTION
Adds an undo layer for **cascading** scheduler actions, plus named **revisions**, on a shared snapshot substrate.

## Why
Moving a task in the Gantt cascades a duration-preserving shift across its whole downstream subgraph (`reschedule_downstream`). If that was a mistake, you had to re-fix every affected task by hand. This captures the pre-state so the whole group shift reverts in one click — and the same substrate gives named restore points.

## Data model
New **`Schedule Snapshot`** doctype (per project) — a serialized copy of the project's task dates (`exp_start_date`/`exp_end_date`) with a `kind`:
- **Undo** — auto-captured right before a *group* action (a cascade that moves ≥1 downstream task). A single-task move captures nothing. Bounded stack: last 10 per project, older ones auto-prune.
- **Revision** — a named, user-saved restore point.

## Backend — `api/schedule_snapshot.py`
- `undo_last(project)` — pop the newest Undo snapshot, restore it, delete it → repeated calls walk the stack back.
- `save_revision(project, label)` / `list_snapshots(project, kind?)` / `restore_snapshot(name)` / `delete_snapshot(name)`.
- Restore writes dates back via `doc.save()` (per-Task write perms + progress/stage hooks still run), under the existing `in_schedule_cascade` flag, recomputing conflicts once — same machinery as the cascade. A revision restore captures an Undo first, so it's itself undoable.
- Capture hooked into `reschedule_downstream` commit, only when `moves` is non-empty.
- Permissions follow Task-edit rights (`setup_schedule_snapshot_permissions`).

## Frontend — `ScheduleView.vue`
- **↶ Undo** button (with a depth badge; disabled when the stack is empty).
- **Revisions** dropdown: name + save the current schedule, list saved revisions, Restore / delete each.

## Test
- `test_schedule_snapshot.py` (4 tests): cascade captures undo + undo restores exactly; a single-task move captures nothing; save→restore revision round-trip; the undo stack prunes to the limit.
- Full suite **127 backend tests** green; `bench migrate` syncs the doctype + perms; `yarn build` + prettier clean; end-to-end probe on a real project confirmed undo restores the pre-cascade state exactly.