### PR TITLE
feat: add configurable Rate Master update threshold

### DIFF
--- a/buildsuite_core/api/procurement.py
+++ b/buildsuite_core/api/procurement.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.query_builder.functions import Count, Sum
 from frappe.utils import add_days, date_diff, flt, nowdate
 
-RM_THRESHOLD_PCT = 5  # keep in sync with public/js/purchase_order.js
+from buildsuite_core.api.rate_master import get_rate_update_threshold
 
 
 @frappe.whitelist()
@@ -72,7 +72,7 @@ def _over_rate_line_count(po_names: list[str]) -> int:
 	if not po_names:
 		return 0
 	poi = frappe.qb.DocType("Purchase Order Item")
-	limit = 1 + RM_THRESHOLD_PCT / 100
+	limit = 1 + get_rate_update_threshold() / 100
 	return (
 		frappe.qb.from_(poi)
 		.select(Count(poi.name))

--- a/buildsuite_core/api/rate_master.py
+++ b/buildsuite_core/api/rate_master.py
@@ -6,6 +6,13 @@ from frappe.utils import flt
 
 
 @frappe.whitelist()
+def get_rate_update_threshold():
+	"""PO-submit rate-prompt threshold (%) from Core Settings; 5.0 if unset."""
+	raw = frappe.db.get_single_value("BuildSuite Core Settings", "rate_master_update_threshold")
+	return flt(raw) if raw else 5.0
+
+
+@frappe.whitelist()
 def update_rates_from_po(purchase_order, updates, supplier=None):
 	if isinstance(updates, str):
 		updates = json.loads(updates)

--- a/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
+++ b/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
@@ -1,11 +1,12 @@
 {
  "actions": [],
- "creation": "2026-07-06 00:00:00.000000",
+ "creation": "2026-07-06 00:00:00",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
   "project_section",
-  "project_naming"
+  "project_naming",
+  "rate_master_update_threshold"
  ],
  "fields": [
   {
@@ -20,12 +21,18 @@
    "fieldtype": "Select",
    "label": "Project Naming",
    "options": "Project ID\nName Series"
+  },
+  {
+   "default": "5.0",
+   "fieldname": "rate_master_update_threshold",
+   "fieldtype": "Percent",
+   "label": "Rate Master Update Threshold (%)"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-07-06 00:00:00.000000",
+ "modified": "2026-07-15 20:52:17.220438",
  "modified_by": "Administrator",
  "module": "BuildSuite Core",
  "name": "BuildSuite Core Settings",
@@ -41,6 +48,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.py
+++ b/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.py
@@ -5,4 +5,16 @@ from frappe.model.document import Document
 
 
 class BuildSuiteCoreSettings(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		project_naming: DF.Literal["Project ID", "Name Series"]
+		rate_master_update_threshold: DF.Percent
+	# end: auto-generated types
+
 	pass

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -16,3 +16,4 @@ buildsuite_core.patches.enforce_persona_backend_only
 buildsuite_core.patches.seed_estimation_catalog
 buildsuite_core.patches.split_project_naming_mode_and_series
 buildsuite_core.patches.backfill_boq_sub_item_uom
+buildsuite_core.patches.set_default_rate_master_update_threshold

--- a/buildsuite_core/patches/set_default_rate_master_update_threshold.py
+++ b/buildsuite_core/patches/set_default_rate_master_update_threshold.py
@@ -1,0 +1,4 @@
+import frappe
+
+def execute():
+	frappe.db.set_single_value('BuildSuite Core Settings', 'rate_master_update_threshold', 5)

--- a/buildsuite_core/public/js/purchase_order.js
+++ b/buildsuite_core/public/js/purchase_order.js
@@ -1,5 +1,12 @@
 frappe.ui.form.on('Purchase Order', {
     onload: function (frm) {
+        frappe.call({
+            method: "buildsuite_core.api.rate_master.get_rate_update_threshold",
+            callback(r) {
+                rm_threshold_pct = flt(r.message);
+                render_banner(frm);
+            },
+        });
         ['schedule_date'].forEach(field => {
           frappe.ui.form.on('Purchase Order', {
             [field]: function (frm) {
@@ -122,11 +129,11 @@ frappe.ui.form.on("Purchase Order Item", {
 // Rate Master sync: warn on submit when a PO line's rate is above the linked
 // Construction Rate Master, and offer to update the master.
 // ---------------------------------------------------------------------------
-const RM_THRESHOLD_PCT = 5; // TODO: move to BuildSuite Core Settings.
+let rm_threshold_pct = 5; // set from BuildSuite Core Settings on form load (onload)
 const esc = frappe.utils.escape_html;
 
 function above_threshold_lines(frm) {
-	const limit = 1 + RM_THRESHOLD_PCT / 100;
+	const limit = 1 + rm_threshold_pct / 100;
 	return (frm.doc.items || []).filter(
 		(row) =>
 			row.custom_rate_master &&
@@ -186,7 +193,7 @@ function render_banner(frm) {
 			<b>⚠ On Submit: ${rows.length} Rate Master update(s) will be proposed</b>
 			<ul style="margin:6px 0 0;padding-left:0;list-style:none;">${items}</ul>
 			<div style="margin-top:8px;font-size:11px;color:var(--text-muted);font-style:italic;">
-				Rates above ${RM_THRESHOLD_PCT}% of the Rate Master rate trigger the prompt at submit.
+				Rates above ${rm_threshold_pct}% of the Rate Master rate trigger the prompt at submit.
 				Updating affects future estimates only.
 			</div>
 		</div>


### PR DESCRIPTION
Adds a Rate Master Update Threshold (%) setting (default 5%) so the PO rate-update prompt uses a configurable value instead of a hard-coded 5.