### PR TITLE
feat: Scope Change Order roles & permissions

### DIFF
--- a/buildsuite_core/hooks.py
+++ b/buildsuite_core/hooks.py
@@ -145,6 +145,7 @@ permission_query_conditions = {
 	"Work Package": "buildsuite_core.permissions.work_package.get_work_package_permission_query",
 	"Task Progress Entry": "buildsuite_core.permissions.task_progress_entry.get_task_progress_entry_permission_query",
 	"Stage Planning": "buildsuite_core.permissions.stage_planning.get_stage_planning_permission_query",
+	"Scope Change Order": "buildsuite_core.permissions.sco.get_sco_permission_query",
 }
 
 has_permission = {
@@ -153,6 +154,7 @@ has_permission = {
 	"Work Package": "buildsuite_core.permissions.work_package.has_work_package_permission",
 	"Task Progress Entry": "buildsuite_core.permissions.task_progress_entry.has_task_progress_entry_permission",
 	"Stage Planning": "buildsuite_core.permissions.stage_planning.has_stage_planning_permission",
+	"Scope Change Order": "buildsuite_core.permissions.sco.has_sco_permission",
 }
 
 # Override the Project controller so its record name honours the BuildSuite Core

--- a/buildsuite_core/permissions/sco.py
+++ b/buildsuite_core/permissions/sco.py
@@ -1,0 +1,55 @@
+"""Record-level access for the Scope Change Order doctype.
+
+The SCO role matrix (setup.py SCO_ROLE_PERMS) is flat — full roles (Director, PM,
+QS, Administrator, System Manager) and the read-only roles (Estimator, Procurement
+Officer, Accountant) see every change order. The **Site Engineer** is the one scoped
+role: they can *raise* (create) a change order and read only their OWN, and cannot
+approve (approval is gated to BOQ_APPROVE_ROLES in api/sco.py). Foreman / Store Keeper
+/ HR Manager have no DocPerm at all, so they never reach these hooks.
+"""
+
+import frappe
+
+# Roles restricted to their own change orders.
+OWN_SCOPE_ROLES = {"BuildSuite Site Engineer"}
+
+# Roles that grant the broader "see everything" access; a user holding any of these
+# is NOT own-scoped even if they also hold an own-scope role.
+_BROADER_ROLES = {
+	"BuildSuite Director",
+	"BuildSuite PM",
+	"BuildSuite QS",
+	"BuildSuite Administrator",
+	"System Manager",
+	"BuildSuite Estimator",
+	"BuildSuite Procurement Officer",
+	"BuildSuite Accountant",
+}
+
+
+def _is_own_scoped(user):
+	roles = set(frappe.get_roles(user))
+	return bool(roles & OWN_SCOPE_ROLES) and not (roles & _BROADER_ROLES)
+
+
+def get_sco_permission_query(user):
+	"""List-view scoping: own-scoped users see only change orders they created."""
+	if not user:
+		user = frappe.session.user
+	if _is_own_scoped(user):
+		return f"(`tabScope Change Order`.owner = {frappe.db.escape(user)})"
+	return ""
+
+
+def has_sco_permission(doc, ptype="read", user=None):
+	"""Record-level gate: own-scoped users may create freely but only act on their
+	own change orders. Everyone else is governed purely by DocPerm."""
+	if not user:
+		user = frappe.session.user
+	if not _is_own_scoped(user):
+		return True
+	if ptype == "create":
+		return True
+	if not getattr(doc, "name", None):
+		return True
+	return doc.owner == user

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -552,18 +552,21 @@ _WO_TRANSITIONS = (
 )
 
 
-# Scope Change Order — the site-execution delivery roles raise change orders; approval
-# is gated in api/sco.py to BOQ_APPROVE_ROLES (PM / Director / Admin).
+# Scope Change Order — role matrix (SCO is header-only + status-based, not submittable,
+# so Submit/Cancel don't apply; "full" = CRWD). PM/QS prepare + quantify, Director
+# approves; approval is gated in api/sco.py to BOQ_APPROVE_ROLES (PM / Director / Admin).
+# The Site Engineer can *raise* (create) and read only their OWN change orders
+# (own-scope enforced in permissions/sco.py); Foreman / Store Keeper / HR Manager have
+# no access; Estimator / Procurement Officer / Accountant are read-only.
 SCO_ROLE_PERMS = {
 	"BuildSuite Director": _FULL,
 	"BuildSuite PM": _FULL,
-	"BuildSuite Administrator": _FULL,
-	"BuildSuite Estimator": _FULL,
 	"BuildSuite QS": _FULL,
-	"BuildSuite Site Engineer": _FULL,
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Estimator": _READ,
+	"BuildSuite Site Engineer": _RAISE,  # create-own; cannot approve
 	"BuildSuite Procurement Officer": _READ,
 	"BuildSuite Accountant": _READ,
-	"BuildSuite Foreman": _READ,
 }
 
 

--- a/buildsuite_core/tests/test_sco.py
+++ b/buildsuite_core/tests/test_sco.py
@@ -37,3 +37,110 @@ class TestScopeChangeOrder(BuildSuiteTestCase):
 		# every entry stamps who + when
 		self.assertTrue(all(r.user == "Administrator" for r in rows))
 		self.assertTrue(all(r.activity_on for r in rows))
+
+
+class TestScopeChangeOrderPermissions(BuildSuiteTestCase):
+	"""The 12-persona SCO role matrix (setup.py SCO_ROLE_PERMS + permissions/sco.py)."""
+
+	def _user(self, persona, prefix):
+		email = f"{prefix}-{self._n}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": prefix.upper(),
+				"send_welcome_email": 0,
+				"user_type": "System User",
+				"persona": persona,
+				"company": self.company,
+			}
+		).insert(ignore_permissions=True)
+		return email
+
+	def _sco(self, owner=None):
+		h = frappe.generate_hash(length=6)
+		project = frappe.get_doc(
+			{
+				"doctype": "Project",
+				"project_name": f"SCO Perm {h}",
+				"custom_project_id": f"SCOP-{h}",
+				"project_status": "Ongoing",
+				"company": self.company,
+			}
+		).insert(ignore_permissions=True)
+		doc = frappe.get_doc(
+			{
+				"doctype": "Scope Change Order",
+				"project": project.name,
+				"title": f"SCO {h}",
+				"type": "Design Change",
+				"status": "Pending Approval",
+			}
+		).insert(ignore_permissions=True)
+		if owner:
+			frappe.db.set_value("Scope Change Order", doc.name, "owner", owner)
+		return doc
+
+	def _as(self, user, fn):
+		frappe.set_user(user)
+		try:
+			return fn()
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_estimator_is_read_only(self):
+		est = self._user("Estimator", "est")
+		sco = self._sco()
+
+		def checks():
+			self.assertTrue(frappe.has_permission("Scope Change Order", "read", doc=sco.name))
+			self.assertFalse(frappe.has_permission("Scope Change Order", "create"))
+			self.assertFalse(frappe.has_permission("Scope Change Order", "write", doc=sco.name))
+
+		self._as(est, checks)
+
+	def test_foreman_has_no_access(self):
+		fm = self._user("Foreman / Supervisor", "fm")
+		sco = self._sco()
+		self._as(
+			fm,
+			lambda: self.assertFalse(
+				frappe.has_permission("Scope Change Order", "read", doc=sco.name)
+			),
+		)
+
+	def test_qs_is_full(self):
+		qs = self._user("Quantity Surveyor", "qs")
+		sco = self._sco()
+
+		def checks():
+			self.assertTrue(frappe.has_permission("Scope Change Order", "create"))
+			self.assertTrue(frappe.has_permission("Scope Change Order", "write", doc=sco.name))
+			self.assertTrue(frappe.has_permission("Scope Change Order", "delete", doc=sco.name))
+
+		self._as(qs, checks)
+
+	def test_site_engineer_create_own_scope(self):
+		se = self._user("Site Engineer", "se")
+		others = self._sco()  # owned by Administrator
+		mine = self._sco(owner=se)
+
+		def checks():
+			self.assertTrue(frappe.has_permission("Scope Change Order", "create"))
+			# read only their OWN change orders
+			self.assertTrue(frappe.has_permission("Scope Change Order", "read", doc=mine.name))
+			self.assertFalse(frappe.has_permission("Scope Change Order", "read", doc=others.name))
+			# CR only — no write/delete even on their own
+			self.assertFalse(frappe.has_permission("Scope Change Order", "write", doc=mine.name))
+
+		self._as(se, checks)
+
+	def test_site_engineer_cannot_approve(self):
+		se = self._user("Site Engineer", "se2")
+		sco = self._sco(owner=se)
+
+		def attempt():
+			with self.assertRaises(frappe.PermissionError):
+				approve_sco(sco.name)
+
+		self._as(se, attempt)

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -427,6 +427,8 @@ const _FULL = { c: true, r: true, e: true, d: true };
 const _READ = { c: false, r: true, e: false, d: false };
 const _NONE = { c: false, r: false, e: false, d: false };
 const _OWN = { c: true, r: true, e: "own", d: "own" };
+// Create + read only (no edit/delete) — the SCO "raise-own" grant for Site Engineer.
+const _CREATE_READ = { c: true, r: true, e: false, d: false };
 
 export const PERSONA_CAPS = {
 	director: {
@@ -435,6 +437,7 @@ export const PERSONA_CAPS = {
 		task: _FULL,
 		taskProgressEntry: _FULL,
 		stagePlanning: _FULL,
+		sco: _FULL,
 	},
 	pm: {
 		project: _FULL,
@@ -442,6 +445,7 @@ export const PERSONA_CAPS = {
 		task: _FULL,
 		taskProgressEntry: _FULL,
 		stagePlanning: _FULL,
+		sco: _FULL,
 	},
 	admin: {
 		project: _FULL,
@@ -449,6 +453,7 @@ export const PERSONA_CAPS = {
 		task: _FULL,
 		taskProgressEntry: _FULL,
 		stagePlanning: _FULL,
+		sco: _FULL,
 	},
 	bsa: {
 		project: _FULL,
@@ -456,6 +461,7 @@ export const PERSONA_CAPS = {
 		task: _FULL,
 		taskProgressEntry: _FULL,
 		stagePlanning: _FULL,
+		sco: _FULL,
 	},
 	estimator: {
 		project: _READ,
@@ -463,6 +469,7 @@ export const PERSONA_CAPS = {
 		task: _READ,
 		taskProgressEntry: _READ,
 		stagePlanning: _READ,
+		sco: _READ,
 	},
 	qs: {
 		project: _READ,
@@ -470,6 +477,7 @@ export const PERSONA_CAPS = {
 		task: _READ,
 		taskProgressEntry: _READ,
 		stagePlanning: _READ,
+		sco: _FULL,
 	},
 	accountant: {
 		project: _READ,
@@ -477,6 +485,7 @@ export const PERSONA_CAPS = {
 		task: _READ,
 		taskProgressEntry: _READ,
 		stagePlanning: _READ,
+		sco: _READ,
 	},
 	procurement: {
 		project: _READ,
@@ -484,6 +493,7 @@ export const PERSONA_CAPS = {
 		task: _READ,
 		taskProgressEntry: _NONE,
 		stagePlanning: _NONE,
+		sco: _READ,
 	},
 	"store-keeper": {
 		project: _READ,
@@ -491,6 +501,7 @@ export const PERSONA_CAPS = {
 		task: _READ,
 		taskProgressEntry: _NONE,
 		stagePlanning: _NONE,
+		sco: _NONE,
 	},
 	"site-engineer": {
 		project: _READ,
@@ -498,6 +509,7 @@ export const PERSONA_CAPS = {
 		task: _OWN,
 		taskProgressEntry: _OWN,
 		stagePlanning: _OWN,
+		sco: _CREATE_READ,
 	},
 	foreman: {
 		project: _READ,
@@ -505,6 +517,7 @@ export const PERSONA_CAPS = {
 		task: _OWN,
 		taskProgressEntry: _OWN,
 		stagePlanning: _OWN,
+		sco: _NONE,
 	},
 	"hr-manager": {
 		project: _NONE,
@@ -512,5 +525,6 @@ export const PERSONA_CAPS = {
 		task: _NONE,
 		taskProgressEntry: _READ,
 		stagePlanning: _NONE,
+		sco: _NONE,
 	},
 };

--- a/frontend/src/views/NewScoView.vue
+++ b/frontend/src/views/NewScoView.vue
@@ -9,6 +9,7 @@ import { useRoute, useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
+import { usePermissions } from "@/composables/usePermissions";
 import { createDataAdapter } from "@/data/adapters";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -23,6 +24,7 @@ import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 const route = useRoute();
 const router = useRouter();
 const adapter = createDataAdapter(useDataStore());
+const { canCreate } = usePermissions();
 
 const TYPES = [
 	"Design Change",
@@ -92,7 +94,14 @@ const breadcrumbs = [
 		subtitle="Raising submits it for PM / Director approval"
 		:breadcrumbs="breadcrumbs"
 	>
-		<DeskForm>
+		<div
+			v-if="!canCreate('sco')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to raise a scope change order.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Raising…' : 'Raise SCO'"

--- a/frontend/src/views/ScoDetailView.vue
+++ b/frontend/src/views/ScoDetailView.vue
@@ -8,6 +8,7 @@ import { useRouter, RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useSessionStore } from "@/stores/session";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
@@ -26,6 +27,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const session = useSessionStore();
 const confirmDialog = useConfirm();
+const { canEditRecord, canDeleteRecord } = usePermissions();
 const adapter = createDataAdapter(useDataStore());
 const { errors, applyServerErrors, setErrors } = useFormErrors({ title: "title" });
 
@@ -220,7 +222,7 @@ const breadcrumbs = computed(() => [
 		<template #actions>
 			<template v-if="!editing">
 				<button
-					v-if="isPending || isRejected"
+					v-if="(isPending || isRejected) && canEditRecord('sco', sco)"
 					type="button"
 					class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 					style="border-radius: 6px"
@@ -249,7 +251,7 @@ const breadcrumbs = computed(() => [
 					Reject
 				</button>
 				<button
-					v-if="isApproved && !sco.boq_revision"
+					v-if="isApproved && !sco.boq_revision && canEditRecord('sco', sco)"
 					type="button"
 					class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 					style="border-radius: 6px"
@@ -259,7 +261,7 @@ const breadcrumbs = computed(() => [
 					+ Raise BOQ revision
 				</button>
 				<button
-					v-if="isApproved || isRejected"
+					v-if="(isApproved || isRejected) && canEditRecord('sco', sco)"
 					type="button"
 					class="text-xs px-2.5 py-1 border border-warning-200 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 					style="border-radius: 6px"
@@ -269,6 +271,7 @@ const breadcrumbs = computed(() => [
 					Revise
 				</button>
 				<button
+					v-if="canDeleteRecord('sco', sco)"
 					type="button"
 					class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 					style="border-radius: 6px"

--- a/frontend/src/views/ScoView.vue
+++ b/frontend/src/views/ScoView.vue
@@ -5,6 +5,7 @@
 import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { usePermissions } from "@/composables/usePermissions";
 import StatusBadge from "@/components/StatusBadge.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -14,6 +15,7 @@ import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
 import { fmtINR, fmtCompactINR, fmtDate } from "@/utils/format";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 
 const scosRes = useDocTypeList("Scope Change Order", {
 	fields: [
@@ -92,7 +94,9 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Scope Change Orders" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/sco/new" class="desk-save-btn">+ Raise SCO</RouterLink>
+			<RouterLink v-if="canCreate('sco')" to="/sco/new" class="desk-save-btn"
+				>+ Raise SCO</RouterLink
+			>
 		</template>
 
 		<!-- KPI strip -->


### PR DESCRIPTION
Implements the SCO **roles & permissions** matrix across all 12 personas, on the current (prototype-aligned) **status-based, header-only** SCO model. Per the clarification, the prototype takes precedence — so this is *not* a submittable conversion and adds no line-item table (those were the superseded initial plan); Submit/Cancel don't apply, so "full" = CRWD.

## Matrix (backend — `permissions/setup.py` + `permissions/sco.py`)
| Persona | Access |
|---|---|
| Administrator / System Manager | Full (CRWD) |
| Director (approves) · PM (owns) · QS (quantifies) | Full (CRWD) |
| Estimator · Procurement Officer · Accountant | Read |
| Site Engineer | **Create-own** (CR) — raise + read only their own; cannot approve |
| Foreman · Store Keeper · HR Manager | No access |

- **Own-scope** (`permissions/sco.py`) — a new `permission_query_conditions` + `has_permission` hook scopes the Site Engineer to change orders they created (create freely, read own only). Anyone holding a broader SCO role is unaffected. Approval stays gated to `BOQ_APPROVE_ROLES` (Director / PM / Admin) in `api/sco.py`.
- Verified Custom DocPerms after migrate: Admin/Director/PM/QS `CRWD`, Estimator/Procurement/Accountant `R`, Site Engineer `CR`, Foreman/Store/HR none.

## Workspace
SCO keeps **no own workspace** — it surfaces under **Site Execution** (the `/sco` shortcut), as specified. Read-permitted roles reach records via the list/links.

## Frontend (`roles.js` + Sco views)
- Added an `sco` capability to all 12 personas in `PERSONA_CAPS` matching the matrix.
- Gated **"+ Raise SCO"** (list) + the New-SCO form on `canCreate('sco')`; gated **Edit / Revise / Raise-BOQ-revision / Delete** on `canEditRecord`/`canDeleteRecord` so read-only roles don't see write actions.

## Test
- `test_sco.py` adds a permission-matrix class (5 tests): Estimator read-only, Foreman no access, QS full, Site Engineer create + own-read-only, Site Engineer cannot approve.
- Full suite green except 3 pre-existing `test_purchase_stock` failures (a site NGN-vs-INR party-account currency mismatch on develop, unrelated to this change). `yarn build` + prettier clean.