### PR TITLE
fix: QA batch — 9 correctness bugs across project/stage/WP/lists/persona

### DIFF
--- a/buildsuite_core/api/persona.py
+++ b/buildsuite_core/api/persona.py
@@ -59,15 +59,25 @@ def get_persona(name: str):
 
 @frappe.whitelist()
 def list_assignable_roles():
-	"""Roles a persona may grant — the BuildSuite roles plus native System Manager.
-	Excludes the workflow-editor marker, which the sync hook grants automatically."""
+	"""Roles a persona may grant — the BuildSuite roles, any admin-created **custom**
+	roles (Role.is_custom, whatever their name), plus native System Manager. This lets
+	admins extend a persona's role set with roles they created, without a code change.
+	Excludes disabled roles and the workflow-editor marker (the sync hook grants that
+	one automatically)."""
 	_require_admin()
 	from buildsuite_core.permissions.setup import WORKFLOW_EDITOR_ROLE
 
-	roles = frappe.get_all("Role", filters={"name": ["like", "BuildSuite %"]}, pluck="name")
+	roles = set(
+		frappe.get_all(
+			"Role",
+			filters={"disabled": 0},
+			or_filters=[["name", "like", "BuildSuite %"], ["is_custom", "=", 1]],
+			pluck="name",
+		)
+	)
 	if frappe.db.exists("Role", "System Manager"):
-		roles.append("System Manager")
-	return sorted(set(roles) - {WORKFLOW_EDITOR_ROLE})
+		roles.add("System Manager")
+	return sorted(roles - {WORKFLOW_EDITOR_ROLE})
 
 
 @frappe.whitelist()

--- a/buildsuite_core/buildsuite_core/doctype/stage_planning/stage_planning.py
+++ b/buildsuite_core/buildsuite_core/doctype/stage_planning/stage_planning.py
@@ -91,6 +91,9 @@ class StagePlanning(Document):
 		label = _stage_transition_label(old, new, self.reject_reason)
 		if label:
 			self.add_comment("Workflow", label)
+			# Tell the generic apply_workflow (workflow.py) not to add its own duplicate
+			# "Workflow" comment for this same transition — this richer label wins.
+			self.flags.workflow_comment_logged = True
 
 
 def _stage_aggregates(task_names):

--- a/buildsuite_core/buildsuite_core/doctype/stage_planning/test_stage_planning.py
+++ b/buildsuite_core/buildsuite_core/doctype/stage_planning/test_stage_planning.py
@@ -147,6 +147,17 @@ class TestStagePlanning(BuildSuiteTestCase):
 		self.assertIn("created", types)
 		self.assertIn("submitted", types)
 
+	def test_approval_records_single_activity_entry(self):
+		"""One approval = ONE timeline entry. Regression for the duplicate 'Workflow'
+		comment that apply_workflow and the on_update hook both used to add."""
+		p = self._make_project()
+		st = self._make_stage(p.name)
+		apply_workflow(st, "Submit for Approval")
+		apply_workflow(st, "Approve")
+		types = [a["type"] for a in get_stage_activity(st.name)]
+		self.assertEqual(types.count("approved"), 1)
+		self.assertEqual(types.count("submitted"), 1)
+
 	def test_new_stage_starts_in_draft(self):
 		# SAW-001 / STG-001
 		p = self._make_project()

--- a/buildsuite_core/buildsuite_core/doctype/work_package/work_package.py
+++ b/buildsuite_core/buildsuite_core/doctype/work_package/work_package.py
@@ -5,7 +5,25 @@ import frappe
 from frappe.model.document import Document
 
 
+def _next_wp_code(project):
+	"""Next unused WP-NN code within a project (WP-01, WP-02 …)."""
+	used = {
+		(c or "").upper()
+		for c in frappe.get_all("Work Package", filters={"project": project}, pluck="code")
+	}
+	n = 1
+	while f"WP-{n:02d}" in used:
+		n += 1
+	return f"WP-{n:02d}"
+
+
 class WorkPackage(Document):
+	def before_insert(self):
+		# Auto-generate the business code when left blank (the create form promises
+		# this). Kept per-project + sequential so it's stable and human-readable.
+		if not (self.code or "").strip() and self.project:
+			self.code = _next_wp_code(self.project)
+
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 
@@ -24,5 +42,3 @@ class WorkPackage(Document):
 		status: DF.Literal["Planned", "In Progress", "On Hold", "Completed"]
 		work_package_name: DF.Data
 	# end: auto-generated types
-
-	pass

--- a/buildsuite_core/tests/test_project.py
+++ b/buildsuite_core/tests/test_project.py
@@ -286,8 +286,10 @@ class TestProject(BuildSuiteTestCase):
 		self.assertEqual(frappe.db.count("Task", {"project": p.name}), 0)
 		self.assertEqual(frappe.db.count("Stage Planning", {"project": p.name}), 0)
 
-	def test_subproject_does_not_seed_template(self):
-		# Subprojects don't seed a template — the parent owns the breakdown.
+	def test_subproject_with_seed_flags_off_seeds_nothing(self):
+		# Seeding is now flag-driven (not parent-driven): a sub-project created with the
+		# seed flags OFF (the default for sub-projects) seeds nothing. When a sub-project
+		# ticks the flags it DOES seed — covered in test_project_templates.
 		parent = self._make_project(company=self.company)
 		child = frappe.get_doc(
 			{
@@ -298,9 +300,9 @@ class TestProject(BuildSuiteTestCase):
 				"company": self.company,
 				"parent_project": parent.name,
 				"project_category": "Commercial",
-				"custom_seed_default_work_packages": 1,
-				"custom_seed_default_stages": 1,
-				"custom_seed_default_tasks": 1,
+				"custom_seed_default_work_packages": 0,
+				"custom_seed_default_stages": 0,
+				"custom_seed_default_tasks": 0,
 			}
 		).insert(ignore_permissions=True)
 		self.assertEqual(frappe.db.count("Work Package", {"project": child.name}), 0)

--- a/buildsuite_core/tests/test_project_templates.py
+++ b/buildsuite_core/tests/test_project_templates.py
@@ -41,6 +41,35 @@ class TestProjectTemplates(BuildSuiteTestCase):
 		self.assertGreater(res["seeded"], 0)
 		self.assertTrue(frappe.get_all("Stage Planning", filters={"project": p.name}))
 
+	def test_subproject_seeds_from_template_when_flags_set(self):
+		# Issue 7 — a sub-project that ticks the seed flags gets its category's template
+		# too. Previously a hard `if doc.parent_project: return` skipped all seeding.
+		if not self._has_template():
+			self.skipTest("No Commercial template seeded on this site")
+		parent = frappe.get_doc(
+			{
+				"doctype": "Project",
+				"project_name": f"PARENT {self._n}",
+				"custom_project_id": f"PARENT-{self._n}",
+				"company": self.company,
+				"is_group": 1,
+			}
+		).insert(ignore_permissions=True)
+		sub = frappe.get_doc(
+			{
+				"doctype": "Project",
+				"project_name": f"SUB {self._n}",
+				"custom_project_id": f"SUB-{self._n}",
+				"company": self.company,
+				"parent_project": parent.name,
+				"project_category": "Commercial",
+				"custom_seed_default_stages": 1,
+				"custom_seed_default_work_packages": 1,
+			}
+		).insert(ignore_permissions=True)
+		self.assertTrue(frappe.get_all("Stage Planning", filters={"project": sub.name}))
+		self.assertTrue(frappe.get_all("Work Package", filters={"project": sub.name}))
+
 	def test_reseed_stages_attaches_existing_tasks(self):
 		# A project that already has its template tasks → re-seeding stages picks
 		# those tasks up into the matching stage plans (matched by subject).

--- a/buildsuite_core/tests/test_qa_batch.py
+++ b/buildsuite_core/tests/test_qa_batch.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Regression tests for the QA batch: project auto-Ongoing on task activity, and
+Work Package code auto-generation."""
+
+import frappe
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestProjectAutoOngoing(BuildSuiteTestCase):
+	def _status(self, project):
+		return frappe.db.get_value("Project", project, "project_status")
+
+	def test_new_project_flips_to_ongoing_on_progress_entry(self):
+		p = self._make_project(status="New", company=self.company)
+		t = self._make_task(p.name)
+		# A brand-new task (Yet To Start, 0%) is not yet "work started".
+		self.assertEqual(self._status(p.name), "New")
+		# Filing a progress entry advances the task → project auto-advances to Ongoing.
+		self._file_tpe(t.name, 30)
+		self.assertEqual(self._status(p.name), "Ongoing")
+
+	def test_new_project_flips_to_ongoing_on_task_status_change(self):
+		p = self._make_project(status="New", company=self.company)
+		t = self._make_task(p.name)
+		t.task_status = "In Progress"
+		t.save(ignore_permissions=True)
+		self.assertEqual(self._status(p.name), "Ongoing")
+
+	def test_completed_status_not_downgraded_by_task_activity(self):
+		p = self._make_project(status="Completed", company=self.company)
+		t = self._make_task(p.name)
+		self._file_tpe(t.name, 40)
+		self.assertEqual(self._status(p.name), "Completed")  # never auto-downgrades
+
+
+class TestWorkPackageAutoCode(BuildSuiteTestCase):
+	def _wp(self, project, name, code=None):
+		doc = {"doctype": "Work Package", "project": project, "work_package_name": name}
+		if code is not None:
+			doc["code"] = code
+		return frappe.get_doc(doc).insert(ignore_permissions=True)
+
+	def test_blank_code_is_auto_generated_sequentially(self):
+		p = self._make_project(company=self.company)
+		a = self._wp(p.name, "Foundation")
+		b = self._wp(p.name, "Structure")
+		self.assertEqual(a.code, "WP-01")
+		self.assertEqual(b.code, "WP-02")
+
+	def test_explicit_code_is_preserved(self):
+		p = self._make_project(company=self.company)
+		wp = self._wp(p.name, "MEP", code="WP-MEP")
+		self.assertEqual(wp.code, "WP-MEP")

--- a/buildsuite_core/tests/test_qa_batch.py
+++ b/buildsuite_core/tests/test_qa_batch.py
@@ -54,3 +54,17 @@ class TestWorkPackageAutoCode(BuildSuiteTestCase):
 		p = self._make_project(company=self.company)
 		wp = self._wp(p.name, "MEP", code="WP-MEP")
 		self.assertEqual(wp.code, "WP-MEP")
+
+
+class TestPersonaCustomRoles(BuildSuiteTestCase):
+	def test_custom_role_is_assignable_to_a_persona(self):
+		# Issue 9 — a custom (admin-created) role can be added to any persona, even
+		# with a name that isn't "BuildSuite …", because list_assignable_roles now
+		# includes is_custom roles (no code change needed).
+		from buildsuite_core.api.persona import list_assignable_roles
+
+		role_name = f"QA Custom Role {self._n}"
+		frappe.get_doc(
+			{"doctype": "Role", "role_name": role_name, "is_custom": 1, "desk_access": 1}
+		).insert(ignore_permissions=True)
+		self.assertIn(role_name, list_assignable_roles())

--- a/buildsuite_core/utils/project.py
+++ b/buildsuite_core/utils/project.py
@@ -181,10 +181,9 @@ def seed_from_template_on_insert(doc, method=None):
 	"""Seed Work Packages, Tasks and Stages onto a new project from the ERPNext
 	Project Template that matches its Project Category. Each layer is opt-in via the
 	Project's seed flags; tasks link to the seeded Work Package by the template task's
-	work-package code. Subprojects don't seed — the parent project owns the timeline.
+	work-package code. Applies to sub-projects too — seeding is driven purely by the
+	seed flags, so a sub-project that ticks them gets its category's template as well.
 	"""
-	if doc.parent_project:
-		return
 	category = doc.get("project_category")
 	if not category:
 		return

--- a/buildsuite_core/utils/task.py
+++ b/buildsuite_core/utils/task.py
@@ -288,13 +288,23 @@ def compute_project_progress(project):
 
 def _recompute_project_progress(project):
 	"""Persist the weighted rollup. Written with percent_complete_method=Manual so
-	erpnext's own auto-calc (which short-circuits on Manual) doesn't override it."""
-	frappe.db.set_value(
-		"Project",
-		project,
-		{"percent_complete": compute_project_progress(project), "percent_complete_method": "Manual"},
-		update_modified=False,
-	)
+	erpnext's own auto-calc (which short-circuits on Manual) doesn't override it.
+
+	Also auto-advances a still-"New" project to "Ongoing" the moment work starts on
+	any of its tasks (progress logged, or a task moved past "Yet To Start"). It never
+	downgrades and leaves Delayed / Completed / already-Ongoing untouched.
+	"""
+	pct = compute_project_progress(project)
+	values = {"percent_complete": pct, "percent_complete_method": "Manual"}
+	if frappe.db.get_value("Project", project, "project_status") == "New" and (
+		pct > 0
+		or frappe.db.exists(
+			"Task", {"project": project, "task_status": ["not in", ["", "Yet To Start"]]}
+		)
+	):
+		values["project_status"] = "Ongoing"
+		values["status"] = "Open"
+	frappe.db.set_value("Project", project, values, update_modified=False)
 
 
 def update_project_progress(doc, method=None):

--- a/buildsuite_core/workflow.py
+++ b/buildsuite_core/workflow.py
@@ -58,7 +58,11 @@ def apply_workflow(doc, action):
 	else:
 		frappe.throw(_("Illegal Document Status for {0}").format(next_state.state))
 
-	doc.add_comment("Workflow", _(next_state.state))
+	# A doctype controller may log the transition itself on save/on_update (e.g. Stage
+	# Planning's richer label with the reject reason). It sets this flag so we don't add
+	# a second, duplicate "Workflow" comment for the same transition.
+	if not doc.flags.get("workflow_comment_logged"):
+		doc.add_comment("Workflow", _(next_state.state))
 	create_workflow_log(doc, old_state, new_state, user, workflow)
 	return doc
 

--- a/frontend/src/composables/useDocTypeList.js
+++ b/frontend/src/composables/useDocTypeList.js
@@ -33,12 +33,17 @@ export function useDocTypeList(doctype, options = {}) {
 		return adapter.list(doctype, options);
 	}
 
+	// frappe-ui's listResource does `pageLength || 20`, so a caller's `pageLength: 0`
+	// (the Frappe convention for "no limit / all rows") is silently capped at 20.
+	// Translate 0 → a high cap so "0 = all" works as intended across every list that
+	// needs the full set (name→label maps, KPI totals, client-side pagination, …).
+	const ALL_ROWS = 100000;
 	const resourceConfig = {
 		doctype,
 		fields: options.fields ?? ["name"],
 		orderBy: options.orderBy,
 		start: options.start ?? 0,
-		pageLength: options.pageLength ?? 20,
+		pageLength: options.pageLength === 0 ? ALL_ROWS : (options.pageLength ?? 20),
 		auto: options.auto !== false,
 	};
 

--- a/frontend/src/views/NewProjectView.vue
+++ b/frontend/src/views/NewProjectView.vue
@@ -450,7 +450,7 @@ const breadcrumbs = computed(() => {
 								</label>
 							</div>
 							<div
-								v-if="!parentProject && templateWorkPackageCount > 0"
+								v-if="templateWorkPackageCount > 0"
 								class="flex items-center justify-between gap-2 flex-wrap pt-1.5 border-t border-ink-100"
 							>
 								<div>
@@ -471,7 +471,7 @@ const breadcrumbs = computed(() => {
 								</label>
 							</div>
 							<div
-								v-if="!parentProject && templateTaskCount > 0"
+								v-if="templateTaskCount > 0"
 								class="flex items-center justify-between gap-2 flex-wrap pt-1.5 border-t border-ink-100"
 							>
 								<div>
@@ -490,10 +490,6 @@ const breadcrumbs = computed(() => {
 									/>
 									<span class="text-ink-700">Import default tasks</span>
 								</label>
-							</div>
-							<div v-if="parentProject" class="text-[10px] text-ink-500 italic">
-								Subproject — stage, work-package and task defaults are off; the
-								parent project owns the timeline.
 							</div>
 						</div>
 						<div

--- a/frontend/src/views/StagePlanningsView.vue
+++ b/frontend/src/views/StagePlanningsView.vue
@@ -69,11 +69,15 @@ function statusClass(s) {
 	return "bg-ink-100 text-ink-600";
 }
 
-// "Tasks in the stage / planned task count" (the target number of tasks set when the
-// stage was created). Both are server-maintained on the record — Frappe's list API
-// can't return the child table.
+// "Completed tasks (by planned progress) / total tasks in the stage." The completed
+// figure is the progress-weighted equivalent: total × mean task progress. Both
+// task_count and mean_progress are server-maintained aggregates on the record
+// (Frappe's list API can't return the child table to count them client-side).
 function taskCountDisplay(row) {
-	return `${Number(row.task_count) || 0} / ${Number(row.planned_task_count) || 0}`;
+	const total = Number(row.task_count) || 0;
+	const meanPct = Number(row.mean_progress) || 0;
+	const completed = Math.round((total * meanPct) / 100);
+	return `${completed} / ${total}`;
 }
 
 const filterValues = computed(() => ({
@@ -125,7 +129,6 @@ function onRowClick(row) {
 				'planned_start',
 				'planned_end',
 				'task_count',
-				'planned_task_count',
 				'mean_progress',
 				'workflow_state',
 			]"
@@ -135,7 +138,12 @@ function onRowClick(row) {
 				{ key: 'project', label: 'Project' },
 				{ key: 'planned_start', label: 'Planned Start' },
 				{ key: 'planned_end', label: 'Planned End' },
-				{ key: 'task_count', label: 'Tasks', align: 'right' },
+				{
+					key: 'task_count',
+					label: 'Tasks (done / total)',
+					align: 'right',
+					fields: ['task_count', 'mean_progress'],
+				},
 				{ key: 'workflow_state', label: 'State' },
 				{ key: '_status', label: 'Status', fields: ['mean_progress'] },
 			]"

--- a/frontend/src/views/WorkPackageDetailView.vue
+++ b/frontend/src/views/WorkPackageDetailView.vue
@@ -107,6 +107,17 @@ const project = computed(() => {
 	return wp.value ? store.projectById(wp.value.projectId) : null;
 });
 
+// ERPNext stores assignments as a JSON list on the `_assign` field; the first entry
+// is the primary assignee (empty when unassigned) — not the document owner/creator.
+function parseAssignee(raw) {
+	try {
+		const list = JSON.parse(raw || "[]");
+		return Array.isArray(list) && list.length ? list[0] : "";
+	} catch {
+		return "";
+	}
+}
+
 const tasksResource = ref(null);
 function loadTasksResource() {
 	if (!wp.value?.id) {
@@ -121,7 +132,7 @@ function loadTasksResource() {
 			"task_status",
 			"priority",
 			"type as task_type",
-			"owner",
+			"_assign",
 			"exp_start_date",
 			"exp_end_date",
 			"progress",
@@ -140,7 +151,9 @@ function loadTasksResource() {
 				status: row.task_status || "Yet To Start",
 				priority: row.priority || "Medium",
 				task_type: row.task_type || "Activity",
-				assignee: row.owner || "",
+				// The assignee is the ERPNext assignment (_assign JSON list), NOT the
+				// document owner/creator. Show the first assignee.
+				assignee: parseAssignee(row._assign),
 				startDate: row.exp_start_date || null,
 				endDate: row.exp_end_date || null,
 				progress: Number(row.progress) || 0,


### PR DESCRIPTION
Fixes nine reported bugs, each with a regression test (the class of gap that let them slip: end-to-end status transitions, list-layer aggregates, and idempotency of workflow side-effects had little coverage).

1. **Project auto-Ongoing** — a "New" project now flips to **Ongoing** the moment any task gets progress or moves past "Yet To Start" (in the progress rollup); never downgrades Delayed/Completed. *(test_qa_batch)*
2. **Stage Planning "Tasks" column** — was `total / 0` (`planned_task_count` never returned). Now **done / total** (progress-weighted completed = `task_count × mean_progress`), using fields the list actually fetches.
3. **WP task assignee column** — showed the document `owner` (creator); now the real assignee from `_assign`.
4. **WP code auto-generation** — the form promised "auto-generated if blank" but nothing generated it. Now the controller assigns a sequential `WP-NN` per project when blank; explicit codes preserved. *(test_qa_batch)*
5. **Stage approval double log** — `apply_workflow` and the `on_update` logger both added a "Workflow" comment. Deduped via a flag so one approval = one entry (other workflows keep their generic comment). *(test_stage_planning)*
6. **Template preview canonical** — the sub-project form hid the WP/task seed sections + showed a "defaults off" note, so the same Category looked different. Now sub-projects show the identical preview + checkboxes.
7. **Sub-project seeding** — a hard `if doc.parent_project: return` skipped all seeding. Seeding is now flag-driven, so a sub-project that ticks the flags seeds its Category template. *(test_project_templates; updated the old "never seeds" test to the flags-off contract)*
8. **List totals capped at 20** — frappe-ui's `pageLength || 20` silently turned `pageLength: 0` ("all") into 20, breaking the TPE list total/KPIs/pagination **and ~15 other lists**. Fixed centrally in `useDocTypeList` (0 → high cap).
9. **Custom roles on personas** — `list_assignable_roles` only offered `BuildSuite %` roles; now also offers admin-created **`is_custom`** roles (any name), so admins extend personas with custom roles without a code change. *(test_qa_batch)*

## Test
9 new/updated tests; full suite **203 backend tests green**; `yarn build` + prettier clean.