### PR TITLE
Fix empty tax-template / expense-account pickers on the Subcontractor Bill

### DIFF
--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -19,6 +19,15 @@ WORK_ORDER = "Subcontractor Work Order"
 # --------------------------------------------------------------------------- #
 # Serialisation
 # --------------------------------------------------------------------------- #
+def _effective_company(doc):
+	"""The company the bill's accounting is anchored to — the project's company when there is
+	a project (re-derived so a Draft saved before the anchoring fix still serves the right
+	one for the Vue tax/account pickers), else the stored/default company."""
+	if doc.project:
+		return frappe.db.get_value("Project", doc.project, "company") or doc.company
+	return doc.company
+
+
 def _serialize(doc):
 	return {
 		"name": doc.name,
@@ -29,7 +38,7 @@ def _serialize(doc):
 		"subcontractor_name": doc.subcontractor_name,
 		"project": doc.project,
 		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
-		"company": doc.company,
+		"company": _effective_company(doc),
 		"date": str(doc.date) if doc.date else None,
 		"bill_type": doc.bill_type,
 		"retention_percent": doc.retention_percent,

--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -332,8 +332,26 @@ def delete_bill(name: str):
 # Payment (real ERPNext Payment Entry against the generated PI)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
+def make_payment_entry(name: str):
+	"""Create a DRAFT Payment Entry against the bill's Purchase Invoice and return its name, so
+	the Vue 'Make Payment' button can open it in Desk (/app/payment-entry/<name>) pre-filled for
+	the user to review + submit."""
+	from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+
+	bill = frappe.get_doc(BILL, name)
+	bill.check_permission("read")
+	if not bill.purchase_invoice:
+		frappe.throw(_("This bill has no Purchase Invoice yet — submit it first."))
+
+	pe = get_payment_entry("Purchase Invoice", bill.purchase_invoice)
+	pe.flags.ignore_permissions = True
+	pe.insert()  # draft — the user reviews + submits it in Desk
+	return {"payment_entry": pe.name}
+
+
+@frappe.whitelist()
 def record_payment(name, amount=None, date=None, mode_of_payment=None, paid_from=None, reference_no=None):
-	"""Create + submit a Payment Entry against the bill's Purchase Invoice."""
+	"""Create + submit a Payment Entry against the bill's Purchase Invoice (used by tests / API)."""
 	from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 
 	bill = frappe.get_doc(BILL, name)

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.json
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.json
@@ -87,12 +87,13 @@
    "read_only": 1
   },
   {
-   "description": "Anchors the accounting company. Optional for a direct bill (then the default company is used).",
+   "description": "Anchors the accounting company (the generated Purchase Invoice validates against it).",
    "fieldname": "project",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Project",
-   "options": "Project"
+   "options": "Project",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_hdr",

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.json
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.json
@@ -87,12 +87,12 @@
    "read_only": 1
   },
   {
+   "description": "Anchors the accounting company. Optional for a direct bill (then the default company is used).",
    "fieldname": "project",
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Project",
-   "options": "Project",
-   "reqd": 1
+   "options": "Project"
   },
   {
    "fieldname": "column_break_hdr",

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
@@ -124,11 +124,16 @@ class SubcontractorBill(Document):
 		elif self.subcontractor and not self.subcontractor_name:
 			self.subcontractor_name = frappe.db.get_value("Supplier", self.subcontractor, "supplier_name")
 
-		# Company is anchored to the PROJECT (the accounting dimension the generated PI
-		# validates against), never the Work Order — a WO whose company drifted from its
-		# project's would otherwise make the PI reject the project dimension.
+		# Company: a WO bill (and any bill with a project) anchors to the PROJECT's company —
+		# the accounting dimension the generated PI validates against. A direct bill with no
+		# project has nothing to anchor to, so it uses the site default company (the same one
+		# the New Project screen defaults to).
 		if self.project:
 			self.company = frappe.db.get_value("Project", self.project, "company")
+		elif not self.company:
+			from buildsuite_core.utils.project import default_company
+
+			self.company = default_company()
 
 	def _require_open_work_order(self):
 		status = frappe.db.get_value(WORK_ORDER, self.work_order, "status")

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
@@ -124,16 +124,11 @@ class SubcontractorBill(Document):
 		elif self.subcontractor and not self.subcontractor_name:
 			self.subcontractor_name = frappe.db.get_value("Supplier", self.subcontractor, "supplier_name")
 
-		# Company: a WO bill (and any bill with a project) anchors to the PROJECT's company —
-		# the accounting dimension the generated PI validates against. A direct bill with no
-		# project has nothing to anchor to, so it uses the site default company (the same one
-		# the New Project screen defaults to).
+		# Company is anchored to the PROJECT (required on every bill) — the accounting
+		# dimension the generated PI validates against. Never the Work Order, whose company
+		# could have drifted.
 		if self.project:
 			self.company = frappe.db.get_value("Project", self.project, "company")
-		elif not self.company:
-			from buildsuite_core.utils.project import default_company
-
-			self.company = default_company()
 
 	def _require_open_work_order(self):
 		status = frappe.db.get_value(WORK_ORDER, self.work_order, "status")

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
@@ -74,29 +74,29 @@ class SubcontractorBill(Document):
 	# --- helpers ----------------------------------------------------------
 
 	def _sync_from_work_order(self):
-		"""WO bills inherit party/project/company/retention from the Work Order. Direct bills
-		carry their own (subcontractor + project entered on the form)."""
+		"""WO bills inherit party/project/retention from the Work Order. Direct bills carry
+		their own (subcontractor + project entered on the form)."""
 		if self.work_order and not self.is_direct:
 			wo = frappe.db.get_value(
 				WORK_ORDER,
 				self.work_order,
-				["subcontractor", "subcontractor_name", "project", "company", "retention_percent"],
+				["subcontractor", "subcontractor_name", "project", "retention_percent"],
 				as_dict=True,
 			)
 			if wo:
 				self.subcontractor = wo.subcontractor
 				self.subcontractor_name = wo.subcontractor_name
 				self.project = wo.project
-				self.company = wo.company
 				if self.retention_percent in (None, ""):
 					self.retention_percent = wo.retention_percent
-		else:
-			if self.subcontractor and not self.subcontractor_name:
-				self.subcontractor_name = frappe.db.get_value(
-					"Supplier", self.subcontractor, "supplier_name"
-				)
-			if self.project and not self.company:
-				self.company = frappe.db.get_value("Project", self.project, "company")
+		elif self.subcontractor and not self.subcontractor_name:
+			self.subcontractor_name = frappe.db.get_value("Supplier", self.subcontractor, "supplier_name")
+
+		# Company is anchored to the PROJECT (the accounting dimension the generated PI
+		# validates against), never the Work Order — a WO whose company drifted from its
+		# project's would otherwise make the PI reject the project dimension.
+		if self.project:
+			self.company = frappe.db.get_value("Project", self.project, "company")
 
 	def _require_open_work_order(self):
 		status = frappe.db.get_value(WORK_ORDER, self.work_order, "status")

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
@@ -41,6 +41,7 @@ class SubcontractorBill(Document):
 			self._require_open_work_order()
 		self._assign_ra_no()
 		self._default_expense_account()
+		self._validate_account_companies()
 		self._resolve_tds_rate()
 		self._compute_totals()
 		self._sync_status()
@@ -51,6 +52,37 @@ class SubcontractorBill(Document):
 		from buildsuite_core.utils.subcontract_billing import settings_expense_account_for
 
 		self.expense_account = settings_expense_account_for(self.company)
+
+	def _validate_account_companies(self):
+		"""The tax template, tax-row accounts and expense account must all belong to the bill's
+		company (which is anchored to the project). Caught here with a clear message rather than
+		as a cryptic Purchase Invoice error on submit — the generated PI validates the same."""
+		if not self.company:
+			return
+
+		def _belongs(account, doctype="Account"):
+			company = frappe.db.get_value(doctype, account, "company")
+			return not company or company == self.company
+
+		if self.taxes_and_charges and not _belongs(self.taxes_and_charges, "Purchase Taxes and Charges Template"):
+			frappe.throw(
+				_("Tax template {0} belongs to a different company — pick one for {1} (this project's company).").format(
+					frappe.bold(self.taxes_and_charges), frappe.bold(self.company)
+				)
+			)
+		for t in self.taxes:
+			if t.account_head and not _belongs(t.account_head):
+				frappe.throw(
+					_("Tax row #{0}: account {1} does not belong to company {2}.").format(
+						t.idx, frappe.bold(t.account_head), frappe.bold(self.company)
+					)
+				)
+		if self.expense_account and not _belongs(self.expense_account):
+			frappe.throw(
+				_("Expense account {0} does not belong to company {1}.").format(
+					frappe.bold(self.expense_account), frappe.bold(self.company)
+				)
+			)
 
 	def before_submit(self):
 		if not self.lines:

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.py
@@ -21,11 +21,17 @@ class SubcontractorWorkOrder(Document):
 		self.total_value = total
 
 	def _set_company(self):
-		if self.company:
-			return
+		# Company is ANCHORED to the project's company — the accounting company the bill's
+		# generated Purchase Invoice validates the project against. Always re-derive it (never
+		# just when blank) so a stale value or the user's default company can't drift away from
+		# the project and later break PI posting. Only fall back to a default when there's no
+		# project yet.
 		if self.project:
-			self.company = frappe.db.get_value("Project", self.project, "company")
-		if not self.company:
+			project_company = frappe.db.get_value("Project", self.project, "company")
+			if not project_company:
+				frappe.throw(frappe._("Project {0} has no company set.").format(self.project))
+			self.company = project_company
+		elif not self.company:
 			self.company = frappe.defaults.get_user_default("Company") or frappe.db.get_single_value(
 				"Global Defaults", "default_company"
 			)

--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -33,24 +33,34 @@ def after_migrate():
 	# safe; it is a no-op on every subsequent migrate.
 	drop_legacy_task_type_field()
 	backfill_work_order_company()
+	backfill_bill_company()
 	seed_master_data()
 	setup_record_permissions()
 
 
-def backfill_work_order_company():
-	"""Re-anchor any Subcontractor Work Order whose company drifted from its project's company
-	(historically the WO could inherit the user's default company). Idempotent — the bill's
-	generated PI validates the project against this company, so a mismatch would block posting."""
+def _backfill_project_company(doctype, extra_where=""):
+	"""Re-anchor a doctype's `company` to its project's company where they drifted. Idempotent."""
 	rows = frappe.db.sql(
-		"""select wo.name, p.company as project_company
-		from `tabSubcontractor Work Order` wo join `tabProject` p on p.name = wo.project
-		where wo.company != p.company and p.company is not null and p.company != ''""",
+		f"""select d.name, p.company as project_company
+		from `tab{doctype}` d join `tabProject` p on p.name = d.project
+		where d.company != p.company and p.company is not null and p.company != '' {extra_where}""",
 		as_dict=True,
 	)
 	for r in rows:
-		frappe.db.set_value(
-			"Subcontractor Work Order", r.name, "company", r.project_company, update_modified=False
-		)
+		frappe.db.set_value(doctype, r.name, "company", r.project_company, update_modified=False)
+
+
+def backfill_work_order_company():
+	"""Re-anchor any Subcontractor Work Order whose company drifted from its project's company
+	(historically the WO could inherit the user's default company). The bill's generated PI
+	validates the project against this company, so a mismatch would block posting."""
+	_backfill_project_company("Subcontractor Work Order")
+
+
+def backfill_bill_company():
+	"""Re-anchor DRAFT Subcontractor Bills whose company drifted from their project's — so the
+	Vue tax/account pickers filter to the right company and the PI can post."""
+	_backfill_project_company("Subcontractor Bill", extra_where="and d.docstatus = 0 and d.project is not null")
 
 
 def drop_legacy_task_type_field():

--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -32,8 +32,25 @@ def after_migrate():
 	# native `type` is already populated by backfill_native_task_type() above, so this is
 	# safe; it is a no-op on every subsequent migrate.
 	drop_legacy_task_type_field()
+	backfill_work_order_company()
 	seed_master_data()
 	setup_record_permissions()
+
+
+def backfill_work_order_company():
+	"""Re-anchor any Subcontractor Work Order whose company drifted from its project's company
+	(historically the WO could inherit the user's default company). Idempotent — the bill's
+	generated PI validates the project against this company, so a mismatch would block posting."""
+	rows = frappe.db.sql(
+		"""select wo.name, p.company as project_company
+		from `tabSubcontractor Work Order` wo join `tabProject` p on p.name = wo.project
+		where wo.company != p.company and p.company is not null and p.company != ''""",
+		as_dict=True,
+	)
+	for r in rows:
+		frappe.db.set_value(
+			"Subcontractor Work Order", r.name, "company", r.project_company, update_modified=False
+		)
 
 
 def drop_legacy_task_type_field():

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -583,6 +583,12 @@ def setup_subcontract_permissions():
 	_apply_role_perms("Subcontractor Bill", SUBCONTRACT_BILL_ROLE_PERMS, _SUBMIT_PTYPES)
 	_apply_role_perms("Construction Trade", SUBCONTRACT_MASTER_ROLE_PERMS)
 	_apply_role_perms("Subcontract Delivery Type", SUBCONTRACT_MASTER_ROLE_PERMS)
+	# The bill's billing pickers (expense account, tax template, withholding category) read
+	# ERPNext's accounting masters — grant the finance-facing BuildSuite roles read so the
+	# Vue dropdowns populate for non-admin personas.
+	_billing_read = {role: _READ for role in _BILL_FULL_ROLES + ("BuildSuite Accountant",)}
+	for dt in ("Account", "Purchase Taxes and Charges Template", "Tax Category", "Tax Withholding Category"):
+		_apply_role_perms(dt, _billing_read)
 
 
 def _ensure_workflow_state(name):

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -119,12 +119,10 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		pi = frappe.get_doc("Purchase Invoice", bill.purchase_invoice)
 		self.assertTrue(all(item.expense_account == acct for item in pi.items))
 
-	def test_direct_bill_without_project_uses_default_company(self):
-		# A direct bill needs no project link; with none it falls back to the default company
-		# using the SAME resolution as the New Project screen.
-		from buildsuite_core.utils.project import default_company
+	def test_direct_bill_requires_a_project(self):
+		# The project anchors the accounting company, so a direct bill must have one.
+		from frappe.exceptions import MandatoryError
 
-		default_co = default_company()
 		bill = frappe.get_doc(
 			{
 				"doctype": "Subcontractor Bill",
@@ -134,9 +132,19 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 				"retention_percent": 0,
 				"lines": [{"scope": "One-off charge", "this_period_amount": 5000}],
 			}
-		).insert(ignore_permissions=True)
-		self.assertFalse(bill.project)
-		self.assertEqual(bill.company, default_co)
+		)
+		self.assertRaises(MandatoryError, bill.insert, ignore_permissions=True)
+
+	def test_make_payment_entry_creates_draft_against_pi(self):
+		from buildsuite_core.api.subcontractor_bill import make_payment_entry
+
+		bill = self._direct_bill(self._subcontractor(), amount=100000, retention=10)
+		bill.submit()
+		bill.reload()
+		res = make_payment_entry(bill.name)
+		pe = frappe.get_doc("Payment Entry", res["payment_entry"])
+		self.assertEqual(pe.docstatus, 0)  # draft — user reviews + submits in Desk
+		self.assertTrue(any(r.reference_name == bill.purchase_invoice for r in pe.references))
 
 	def test_tax_account_company_mismatch_rejected(self):
 		# A tax-row account from another company must be rejected up front (the PI would post

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -119,6 +119,25 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		pi = frappe.get_doc("Purchase Invoice", bill.purchase_invoice)
 		self.assertTrue(all(item.expense_account == acct for item in pi.items))
 
+	def test_direct_bill_without_project_uses_default_company(self):
+		# A direct bill needs no project link; with none it falls back to the default company
+		# using the SAME resolution as the New Project screen.
+		from buildsuite_core.utils.project import default_company
+
+		default_co = default_company()
+		bill = frappe.get_doc(
+			{
+				"doctype": "Subcontractor Bill",
+				"is_direct": 1,
+				"subcontractor": self._subcontractor().name,
+				"date": "2026-07-22",
+				"retention_percent": 0,
+				"lines": [{"scope": "One-off charge", "this_period_amount": 5000}],
+			}
+		).insert(ignore_permissions=True)
+		self.assertFalse(bill.project)
+		self.assertEqual(bill.company, default_co)
+
 	def test_tax_account_company_mismatch_rejected(self):
 		# A tax-row account from another company must be rejected up front (the PI would post
 		# to the wrong company's GL). Consistency validated on the bill, not deep in the PI.

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -119,6 +119,21 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		pi = frappe.get_doc("Purchase Invoice", bill.purchase_invoice)
 		self.assertTrue(all(item.expense_account == acct for item in pi.items))
 
+	def test_tax_account_company_mismatch_rejected(self):
+		# A tax-row account from another company must be rejected up front (the PI would post
+		# to the wrong company's GL). Consistency validated on the bill, not deep in the PI.
+		other = frappe.db.get_value("Company", {"name": ["!=", self.company]}, "name")
+		if not other:
+			self.skipTest("needs a second company")
+		other_acct = frappe.db.get_value(
+			"Account", {"company": other, "is_group": 0, "root_type": "Liability"}, "name"
+		)
+		if not other_acct:
+			self.skipTest("no cross-company account available")
+		bill = self._direct_bill(self._subcontractor(), amount=1000, retention=0)
+		bill.append("taxes", {"charge_type": "On Net Total", "account_head": other_acct, "rate": 5})
+		self.assertRaises(frappe.ValidationError, bill.save)
+
 	def test_work_order_company_anchored_to_project(self):
 		# A WO always takes its project's company, even if a different one is supplied — so the
 		# inconsistency that broke PI posting can't be created in the first place.

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -119,6 +119,40 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		pi = frappe.get_doc("Purchase Invoice", bill.purchase_invoice)
 		self.assertTrue(all(item.expense_account == acct for item in pi.items))
 
+	def test_work_order_company_anchored_to_project(self):
+		# A WO always takes its project's company, even if a different one is supplied — so the
+		# inconsistency that broke PI posting can't be created in the first place.
+		other = frappe.db.get_value("Company", {"name": ["!=", self.company]}, "name")
+		if not other:
+			self.skipTest("needs a second company")
+		wo = frappe.get_doc(
+			{
+				"doctype": "Subcontractor Work Order",
+				"subcontractor": self._subcontractor().name,
+				"project": self.project,
+				"company": other,  # deliberately wrong
+				"date": "2026-07-01",
+				"retention_percent": 5,
+				"lines": [{"scope": "X", "uom": "Nos", "qty": 1, "rate": 1}],
+			}
+		).insert(ignore_permissions=True)
+		self.assertEqual(wo.company, frappe.db.get_value("Project", self.project, "company"))
+
+	def test_bill_company_follows_project_not_work_order(self):
+		# A WO whose company has drifted from its project's must not leak that company onto
+		# the bill (the PI validates the project against the company). Anchor to the project.
+		other = frappe.db.get_value("Company", {"name": ["!=", self.company]}, "name")
+		if not other:
+			self.skipTest("needs a second company to simulate the drift")
+		sub = self._subcontractor()
+		wo = self._work_order(sub, qty=100, rate=85)
+		frappe.db.set_value("Subcontractor Work Order", wo.name, "company", other)  # drift
+		self._certified_mb(wo, qty=40)
+		bill = frappe.get_doc({"doctype": "Subcontractor Bill", "work_order": wo.name, "date": "2026-07-20"})
+		bill.fetch_lines()
+		bill.insert(ignore_permissions=True)
+		self.assertEqual(bill.company, frappe.db.get_value("Project", self.project, "company"))
+
 	def test_submit_via_api_with_db_loaded_date(self):
 		# Regression: the API submit path reloads the bill from the DB, so `date` is a
 		# datetime.date — the PI's get_due_date() is strictly typed str|None and must not trip.

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -119,6 +119,15 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		pi = frappe.get_doc("Purchase Invoice", bill.purchase_invoice)
 		self.assertTrue(all(item.expense_account == acct for item in pi.items))
 
+	def test_submit_via_api_with_db_loaded_date(self):
+		# Regression: the API submit path reloads the bill from the DB, so `date` is a
+		# datetime.date — the PI's get_due_date() is strictly typed str|None and must not trip.
+		from buildsuite_core.api.subcontractor_bill import submit_bill
+
+		bill = self._direct_bill(self._subcontractor(), amount=100000, retention=10)
+		res = submit_bill(bill.name)
+		self.assertTrue(res["purchase_invoice"])
+
 	def test_pi_generation_is_idempotent(self):
 		bill = self._direct_bill(self._subcontractor())
 		bill.submit()

--- a/buildsuite_core/utils/project.py
+++ b/buildsuite_core/utils/project.py
@@ -36,6 +36,18 @@ def sync_project_status(doc, method=None):
 		doc.percent_complete = compute_project_progress(doc.name)
 
 
+def default_company():
+	"""The company a new record defaults to when none is chosen — the creating user's
+	company, else their user default, else the site default. This is the resolution the New
+	Project screen uses; shared so other docs (e.g. a direct Subcontractor Bill with no
+	project) default their accounting company the same way."""
+	return (
+		frappe.db.get_value("User", frappe.session.user, "company")
+		or frappe.defaults.get_user_default("Company")
+		or frappe.db.get_single_value("Global Defaults", "default_company")
+	)
+
+
 def set_company_on_insert(doc, method=None):
 	"""Default/inherit company before insert (PRJ-005, PRJ-012).
 
@@ -50,13 +62,7 @@ def set_company_on_insert(doc, method=None):
 			return
 
 	if not doc.get("company"):
-		# Inferred from the creating user's company (the Vue form no longer asks
-		# for it), falling back to the site default.
-		doc.company = (
-			frappe.db.get_value("User", frappe.session.user, "company")
-			or frappe.defaults.get_user_default("Company")
-			or frappe.db.get_single_value("Global Defaults", "default_company")
-		)
+		doc.company = default_company()
 
 
 def enforce_company_rules(doc, method=None):

--- a/buildsuite_core/utils/subcontract_billing.py
+++ b/buildsuite_core/utils/subcontract_billing.py
@@ -163,10 +163,13 @@ def generate_purchase_invoice(bill):
 	pi.company = bill.company
 	pi.supplier = supplier
 	pi.currency = frappe.db.get_value("Company", bill.company, "default_currency")
+	# ERPNext's get_due_date() is strictly typed (str | None) — a DB-loaded Date field is a
+	# datetime.date, which pydantic rejects. Pass ISO strings.
+	bill_date = str(bill.date) if bill.date else None
 	pi.set_posting_time = 1
-	pi.posting_date = bill.date
+	pi.posting_date = bill_date
 	pi.bill_no = bill.name
-	pi.bill_date = bill.date
+	pi.bill_date = bill_date
 	pi.project = bill.project
 	pi.update_stock = 0
 	if frappe.get_meta("Purchase Invoice").has_field("subcontractor_bill"):

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -63,3 +63,4 @@ export const getTaxTemplateRows = (template) => billCall("get_tax_template_rows"
 export const listWithholdingCategories = () => billCall("list_withholding_categories", {});
 export const recordBillPayment = (args) => billCall("record_payment", args);
 export const listBillPayments = (name) => billCall("list_payments", { name });
+export const makeBillPaymentEntry = (name) => billCall("make_payment_entry", { name });

--- a/frontend/src/views/NewSubcontractorBillView.vue
+++ b/frontend/src/views/NewSubcontractorBillView.vue
@@ -127,7 +127,7 @@ function validate() {
 			e.lines = "No fresh measured quantity to bill — certify a Measurement Book first.";
 	} else {
 		if (!form.value.subcontractor) e.subcontractor = "Pick a subcontractor.";
-		// Project is optional for a direct bill — without one the default company is used.
+		if (!form.value.project) e.project = "Pick a project.";
 		if (directGross.value <= 0) e.lines = "Add at least one line with an amount.";
 	}
 	errors.value = e;
@@ -320,13 +320,13 @@ const breadcrumbs = computed(() => [
 							placeholder="Pick a subcontractor…"
 						/>
 					</DeskField>
-					<DeskField label="Project" hint="Optional — sets the company. Blank uses the default company." :error="errors.project">
+					<DeskField label="Project" required hint="Sets the accounting company." :error="errors.project">
 						<DeskLinkPicker
 							v-model="form.project"
 							doctype="Project"
 							label-field="project_name"
 							value-field="name"
-							placeholder="— Optional —"
+							placeholder="Pick a project…"
 						/>
 					</DeskField>
 					<DeskField label="Date" required><DeskInput v-model="form.date" type="date" /></DeskField>

--- a/frontend/src/views/NewSubcontractorBillView.vue
+++ b/frontend/src/views/NewSubcontractorBillView.vue
@@ -127,7 +127,7 @@ function validate() {
 			e.lines = "No fresh measured quantity to bill — certify a Measurement Book first.";
 	} else {
 		if (!form.value.subcontractor) e.subcontractor = "Pick a subcontractor.";
-		if (!form.value.project) e.project = "Pick a project.";
+		// Project is optional for a direct bill — without one the default company is used.
 		if (directGross.value <= 0) e.lines = "Add at least one line with an amount.";
 	}
 	errors.value = e;
@@ -320,13 +320,13 @@ const breadcrumbs = computed(() => [
 							placeholder="Pick a subcontractor…"
 						/>
 					</DeskField>
-					<DeskField label="Project" required :error="errors.project">
+					<DeskField label="Project" hint="Optional — sets the company. Blank uses the default company." :error="errors.project">
 						<DeskLinkPicker
 							v-model="form.project"
 							doctype="Project"
 							label-field="project_name"
 							value-field="name"
-							placeholder="Pick a project…"
+							placeholder="— Optional —"
 						/>
 					</DeskField>
 					<DeskField label="Date" required><DeskInput v-model="form.date" type="date" /></DeskField>

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -1,14 +1,17 @@
 <script setup>
-// Subcontractor Bill detail — summary, lines, the Draft-editable billing block
-// (taxes template + rows, TDS, discount, retention, advance) with a live totals
-// waterfall, Submit (generates the Purchase Invoice), Cancel, and a Payment panel
-// (read-through to the generated PI). Country-agnostic: taxes come from any
-// Purchase Taxes and Charges Template.
+// Subcontractor Bill detail — Desk-styled to match the demo: summary strip, lines,
+// Taxes & Charges table, side-by-side Retention/TDS/discount + the live waterfall, and
+// Attachments. Real data throughout — company-scoped tax-template / account / expense pickers,
+// a generated Purchase Invoice, and (on submit) a Desk Payment Entry link-out. Draft-editable.
 
-import { computed, reactive, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
+import { useDocTypeList } from "@/composables/useDocTypeList";
+import { createDataAdapter } from "@/data/adapters";
+import { useDataStore } from "@/stores";
+import FileUploadHandler from "frappe-ui-file-upload-handler";
 import {
 	getBill,
 	saveBill,
@@ -16,30 +19,38 @@ import {
 	cancelBill,
 	deleteBill,
 	getTaxTemplateRows,
-	recordBillPayment,
-	listBillPayments,
+	makeBillPaymentEntry,
 } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
-import DeskField from "@/components/desk/DeskField.vue";
-import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
-import StatusBadge from "@/components/StatusBadge.vue";
+import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const adapter = createDataAdapter(useDataStore());
 
 const bill = ref(null);
-const payments = ref([]);
 const busy = ref(false);
 const savingBilling = ref(false);
+const submitMsg = ref("");
+
+// Discount is stored as two fields (percentage + amount); the UI toggles between them.
+const discType = ref("%");
+const discValue = ref(0);
 
 async function load() {
 	try {
 		bill.value = await getBill(props.id);
-		payments.value = bill.value.purchase_invoice ? await listBillPayments(props.id) : [];
+		if (Number(bill.value.discount_amount) > 0) {
+			discType.value = "₹";
+			discValue.value = Number(bill.value.discount_amount);
+		} else {
+			discType.value = "%";
+			discValue.value = Number(bill.value.additional_discount_percentage) || 0;
+		}
 	} catch (err) {
 		showToast(err.message || "Failed to load bill", "error");
 	}
@@ -48,28 +59,35 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => bill.value?.docstatus === 0);
 const isSubmitted = computed(() => bill.value?.docstatus === 1);
-const payment = computed(() => bill.value?.payment || { paid: 0, outstanding: 0, status: "Unpaid" });
+const editable = computed(() => isDraft.value);
+const payment = computed(() => bill.value?.payment || { paid: 0, outstanding: 0, invoiced: 0, status: "Unpaid" });
+const retPct = computed(() => Number(bill.value?.retention_percent) || 0);
+const taxRatePct = computed(() => (bill.value?.taxes || []).reduce((a, t) => a + (Number(t.rate) || 0), 0));
 
-// --- live waterfall (mirrors the controller; server is authoritative on save) ---
+const statusPills = computed(() => {
+	if (!bill.value) return [];
+	return isSubmitted.value ? [bill.value.status, payment.value.status] : [bill.value.status];
+});
+
+// --- live waterfall (server is authoritative on save) ---
 const wf = computed(() => {
 	const b = bill.value;
 	if (!b) return {};
 	const gross = (b.lines || []).reduce((a, l) => a + (Number(l.this_period_amount) || 0), 0);
-	const pct = Number(b.additional_discount_percentage) || 0;
-	const flat = Number(b.discount_amount) || 0;
-	let netDiscount = 0,
-		grandDiscount = 0;
-	if (b.additional_discount_on === "Net Total") netDiscount = flat || (gross * pct) / 100;
+	const discBase = (base) =>
+		Math.min(discType.value === "%" ? (base * (Number(discValue.value) || 0)) / 100 : Number(discValue.value) || 0, base);
+	const netDiscount = b.additional_discount_on === "Net Total" ? discBase(gross) : 0;
 	const taxable = Math.max(0, gross - netDiscount);
-	const totalTaxes = (b.taxes || []).reduce((a, t) => a + (taxable * (Number(t.rate) || 0)) / 100, 0);
-	const grand = taxable + totalTaxes;
-	if (b.additional_discount_on === "Grand Total") grandDiscount = flat || (grand * pct) / 100;
-	const invoiceValue = Math.max(0, grand - grandDiscount);
+	const taxRows = (b.taxes || []).map((t) => ({ ...t, amount: (taxable * (Number(t.rate) || 0)) / 100 }));
+	const tax = taxRows.reduce((a, t) => a + t.amount, 0);
+	const grandTotal = taxable + tax;
+	const grandDiscount = b.additional_discount_on === "Grand Total" ? discBase(grandTotal) : 0;
+	const invoiceValue = grandTotal - grandDiscount;
 	const tds = b.apply_tds ? (taxable * (Number(b.tds_rate) || 0)) / 100 : 0;
 	const retention = (taxable * (Number(b.retention_percent) || 0)) / 100;
 	const advance = Number(b.advance_recovery) || 0;
-	const net = Math.max(0, invoiceValue - tds - retention - advance);
-	return { gross, netDiscount, taxable, totalTaxes, grand, grandDiscount, invoiceValue, tds, retention, advance, net };
+	const netPayable = Math.max(0, invoiceValue - tds - retention - advance);
+	return { gross, netDiscount, grandDiscount, taxable, taxRows, tax, grandTotal, invoiceValue, tds, retention, advance, netPayable };
 });
 
 // --- taxes editor ---
@@ -83,7 +101,7 @@ async function onPickTemplate(tpl) {
 	}
 }
 function addTaxRow() {
-	bill.value.taxes.push({ charge_type: "On Net Total", account_head: "", description: "", rate: 0 });
+	bill.value.taxes.push({ charge_type: "On Net Total", account_head: "", rate: 0 });
 }
 function removeTaxRow(i) {
 	bill.value.taxes.splice(i, 1);
@@ -107,10 +125,10 @@ async function saveBilling() {
 			apply_tds: b.apply_tds ? 1 : 0,
 			tax_withholding_category: b.tax_withholding_category,
 			additional_discount_on: b.additional_discount_on,
-			additional_discount_percentage: b.additional_discount_percentage,
-			expense_account: b.expense_account,
-			discount_amount: b.discount_amount,
+			additional_discount_percentage: discType.value === "%" ? discValue.value : 0,
+			discount_amount: discType.value === "₹" ? discValue.value : 0,
 			advance_recovery: b.advance_recovery,
+			expense_account: b.expense_account,
 			taxes: (b.taxes || []).map((t) => ({
 				charge_type: t.charge_type,
 				account_head: t.account_head,
@@ -124,7 +142,8 @@ async function saveBilling() {
 				cost_code: l.cost_code_label,
 				amount: l.this_period_amount,
 			}));
-		bill.value = await saveBill(payload);
+		const saved = await saveBill(payload);
+		bill.value = { ...saved };
 		showToast("Billing saved.");
 	} catch (err) {
 		showToast(err.message || "Failed to save", "error");
@@ -137,6 +156,10 @@ async function saveBilling() {
 function onEdit() {
 	router.push(`/subcontractor-bills/${bill.value.name}/edit`);
 }
+function onOpenAccounting() {
+	if (bill.value.purchase_invoice)
+		window.open(`/app/purchase-invoice/${bill.value.purchase_invoice}`, "_blank", "noopener");
+}
 async function onSubmit() {
 	if (wf.value.gross <= 0) {
 		showToast("Nothing to bill — add a line with an amount.", "error");
@@ -144,18 +167,26 @@ async function onSubmit() {
 	}
 	const ok = await confirmDialog({
 		title: `Submit Bill ${bill.value.ra_no}?`,
-		message: `This posts the bill and generates the Purchase Invoice for ${fmtINR(wf.value.net)} net payable. You can't edit it afterwards.`,
+		message: `This posts the bill and generates the Purchase Invoice for ${fmtINR(wf.value.netPayable)} net payable. A submitted bill is read-only.`,
 		confirmLabel: "Submit",
 	});
 	if (!ok) return;
 	busy.value = true;
 	try {
 		bill.value = await submitBill(bill.value.name);
-		showToast(`Purchase Invoice ${bill.value.purchase_invoice} generated — bill submitted.`);
+		submitMsg.value = `Purchase Invoice ${bill.value.purchase_invoice} generated — bill submitted.`;
 	} catch (err) {
 		showToast(err.message || "Submit failed", "error");
 	} finally {
 		busy.value = false;
+	}
+}
+async function onMakePayment() {
+	try {
+		const res = await makeBillPaymentEntry(bill.value.name);
+		window.open(`/app/payment-entry/${res.payment_entry}`, "_blank", "noopener");
+	} catch (err) {
+		showToast(err.message || "Failed to start payment", "error");
 	}
 }
 async function onCancel() {
@@ -192,31 +223,71 @@ async function onDelete() {
 	}
 }
 
-// --- payment ---
-const payForm = reactive({ open: false, amount: 0, date: new Date().toISOString().slice(0, 10), mode_of_payment: "", reference_no: "" });
-function openPay() {
-	payForm.open = true;
-	payForm.amount = payment.value.outstanding;
-}
-async function submitPayment() {
-	busy.value = true;
-	try {
-		const res = await recordBillPayment({
-			name: bill.value.name,
-			amount: payForm.amount,
-			date: payForm.date,
-			mode_of_payment: payForm.mode_of_payment || undefined,
-			reference_no: payForm.reference_no || undefined,
-		});
-		bill.value.payment = res.payment;
-		payments.value = await listBillPayments(bill.value.name);
-		payForm.open = false;
-		showToast("Payment recorded.");
-	} catch (err) {
-		showToast(err.message || "Payment failed", "error");
-	} finally {
-		busy.value = false;
+// --- attachments (real Frappe File on the bill) ---
+const filesRes = useDocTypeList("File", {
+	fields: ["name", "file_name", "file_url", "file_size", "creation", "owner"],
+	filters: [
+		["attached_to_doctype", "=", "Subcontractor Bill"],
+		["attached_to_name", "=", props.id],
+	],
+	orderBy: "creation desc",
+	pageLength: 0,
+	cache: `buildsuite-bill-files-${props.id}`,
+});
+const attachments = computed(() => filesRes.data || []);
+const fileInput = ref(null);
+const uploading = ref(0);
+async function onFilesPicked(e) {
+	const files = Array.from(e.target.files || []);
+	if (!files.length) return;
+	uploading.value += files.length;
+	for (const f of files) {
+		try {
+			await new FileUploadHandler().upload(f, { doctype: "Subcontractor Bill", docname: props.id, private: false });
+		} catch (err) {
+			showToast(`Failed to upload ${f.name}`, "error");
+		} finally {
+			uploading.value--;
+		}
 	}
+	if (e.target) e.target.value = "";
+	filesRes.reload?.();
+}
+async function onDeleteFile(row) {
+	const ok = await confirmDialog({
+		title: "Delete attachment",
+		message: `Delete "${row.file_name}"?`,
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await adapter.remove("File", row.name);
+		filesRes.reload?.();
+	} catch (err) {
+		showToast(err.message || "Failed to delete attachment", "error");
+	}
+}
+function fileIcon(url) {
+	const ext = (url || "").split(".").pop().toLowerCase().split("?")[0];
+	if (["jpg", "jpeg", "png", "gif", "webp", "svg"].includes(ext)) return "🖼️";
+	if (ext === "pdf") return "📕";
+	if (["dwg", "dxf"].includes(ext)) return "📐";
+	if (["doc", "docx"].includes(ext)) return "📝";
+	if (["xls", "xlsx", "csv"].includes(ext)) return "📊";
+	if (["zip", "rar", "7z"].includes(ext)) return "🗜️";
+	return "📄";
+}
+function formatFileSize(bytes) {
+	if (!bytes) return "0 B";
+	const units = ["B", "KB", "MB", "GB"];
+	let i = 0;
+	let n = bytes;
+	while (n >= 1024 && i < units.length - 1) {
+		n /= 1024;
+		i++;
+	}
+	return (i === 0 ? n : n.toFixed(n < 10 ? 1 : 0)) + " " + units[i];
 }
 
 const breadcrumbs = computed(() => [
@@ -225,12 +296,7 @@ const breadcrumbs = computed(() => [
 	{ label: "Subcontractor Bills", to: "/subcontractor-bills" },
 	{ label: bill.value?.name || props.id },
 ]);
-const statusPills = computed(() => {
-	if (!bill.value) return [];
-	const pills = [bill.value.status];
-	if (isSubmitted.value) pills.push(payment.value.status);
-	return pills;
-});
+const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 0], ["company", "=", bill.value.company]] : [["is_group", "=", 0]]));
 </script>
 
 <template>
@@ -242,290 +308,309 @@ const statusPills = computed(() => {
 		:status="statusPills"
 	>
 		<template #actions>
-			<button v-if="isDraft" class="desk-btn" :disabled="busy" @click="onEdit">Edit</button>
-			<button v-if="isDraft" class="desk-save-btn" :disabled="busy" @click="onSubmit">Submit</button>
 			<button
-				v-if="isSubmitted && payment.outstanding > 0.01"
-				class="desk-save-btn"
-				:disabled="busy"
-				@click="openPay"
+				v-if="bill.purchase_invoice"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				title="Open the generated Purchase Invoice in the Accounting desk"
+				@click="onOpenAccounting"
 			>
-				Record payment
+				Open in Accounting →
 			</button>
-			<button v-if="isSubmitted" class="desk-btn" :disabled="busy" @click="onCancel">Cancel</button>
-			<button v-if="isDraft" class="desk-btn text-danger-700" :disabled="busy" @click="onDelete">Delete</button>
+			<button v-if="isDraft" type="button" class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700" style="border-radius: 6px" :disabled="busy" @click="onEdit">Edit</button>
+			<button v-if="isDraft" type="button" class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium" style="border-radius: 6px" :disabled="busy" @click="onSubmit">Submit</button>
+			<template v-if="isSubmitted">
+				<button v-if="payment.status !== 'Paid'" type="button" class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium" style="border-radius: 6px" @click="onMakePayment">Make Payment</button>
+				<button type="button" class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium" style="border-radius: 6px" :disabled="busy" @click="onCancel">Cancel</button>
+			</template>
+			<button v-if="isDraft" type="button" class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700" style="border-radius: 6px" :disabled="busy" @click="onDelete">Delete</button>
 		</template>
 
-		<!-- PI banner -->
-		<div
-			v-if="bill.purchase_invoice"
-			class="mb-4 text-xs bg-success-50 border border-success-100 rounded-md px-3 py-2 text-success-800"
-		>
+		<!-- Submit success + PI reference -->
+		<div v-if="submitMsg" class="mb-4 px-4 py-2.5 bg-success-50 border border-success-200 rounded-md text-xs text-success-700 flex items-center gap-2">
+			<span class="text-sm">✓</span><span class="font-medium">{{ submitMsg }}</span>
+		</div>
+		<div v-else-if="bill.purchase_invoice" class="mb-4 text-xs text-ink-600">
 			Purchase Invoice
-			<DeskLink :to="`/app/purchase-invoice/${bill.purchase_invoice}`" class="font-mono">{{
-				bill.purchase_invoice
-			}}</DeskLink>
-			generated · Invoiced {{ fmtINR(payment.invoiced) }} · Paid {{ fmtINR(payment.paid) }} · Outstanding
-			<span class="font-medium">{{ fmtINR(payment.outstanding) }}</span>
+			<DeskLink :to="`/app/purchase-invoice/${bill.purchase_invoice}`" class="font-mono font-medium text-ink-900">{{ bill.purchase_invoice }}</DeskLink>
+		</div>
+		<div v-if="isSubmitted && payment.status !== 'Paid'" class="mb-4 text-xs text-ink-600">
+			Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(payment.outstanding) }}</span>
+			<span v-if="payment.paid > 0"> · paid {{ fmtINR(payment.paid) }} of {{ fmtINR(payment.invoiced) }}</span>
 		</div>
 
-		<!-- summary strip -->
-		<div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
-			<div class="border border-ink-200 rounded-lg px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-ink-400">
-					{{ bill.is_direct ? "Subcontractor" : "Work Order" }}
-				</div>
-				<DeskLink
-					v-if="!bill.is_direct"
-					:to="`/subcontractor-work-orders/${bill.work_order}`"
-					class="text-xs font-mono"
-					>{{ bill.work_order }}</DeskLink
-				>
-				<div v-else class="text-xs font-medium text-ink-900">{{ bill.subcontractor_name }}</div>
+		<!-- Summary strip -->
+		<div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">{{ bill.is_direct ? "Subcontractor" : "Work Order" }}</div>
+				<DeskLink v-if="!bill.is_direct" :to="`/subcontractor-work-orders/${bill.work_order}`" class="text-sm mt-0.5 block">{{ bill.work_order }}</DeskLink>
+				<div v-else class="text-sm text-ink-900 mt-0.5">{{ bill.subcontractor_name }}</div>
 			</div>
-			<div class="border border-ink-200 rounded-lg px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-ink-400">Date</div>
-				<div class="text-xs text-ink-900">{{ fmtDate(bill.date) }}</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Date</div>
+				<div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(bill.date) }}</div>
 			</div>
-			<div class="border border-ink-200 rounded-lg px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-ink-400">Gross</div>
-				<div class="text-sm font-semibold text-ink-900">{{ fmtINR(wf.gross) }}</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Gross this period</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(wf.gross) }}</div>
 			</div>
-			<div class="border border-ink-200 rounded-lg px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-ink-400">Retention</div>
-				<div class="text-sm font-semibold text-warning-700">{{ fmtINR(wf.retention) }}</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Retention</div>
+				<div class="text-base font-semibold text-warning-700 tabular-nums mt-0.5">{{ fmtINR(wf.retention) }}</div>
+				<div class="text-[10px] text-ink-500">{{ retPct }}% withheld</div>
 			</div>
-			<div class="border border-ink-200 rounded-lg px-3 py-2">
-				<div class="text-[10px] uppercase tracking-wider text-ink-400">Net payable</div>
-				<div class="text-sm font-semibold text-brand-700">{{ fmtINR(wf.net) }}</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Net payable</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(wf.netPayable) }}</div>
 			</div>
 		</div>
 
-		<!-- lines -->
-		<section class="mb-6">
-			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">Bill lines</h3>
-			<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
-				<table class="w-full text-xs" style="min-width: 560px">
-					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+		<!-- Bill lines -->
+		<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Lines — claimed against schedule of values</h3>
+			</div>
+			<div v-if="!bill.is_direct" class="px-4 py-2 bg-info-50 border-b border-info-200 text-[11px] text-ink-700">
+				<span class="font-medium text-ink-900">How qty is computed:</span>
+				This period qty = (Measured to date from Certified MBs) − (Previously billed qty). Read-only on this bill.
+			</div>
+			<div v-else class="px-4 py-2 bg-info-50 border-b border-info-200 text-[11px] text-ink-700">
+				<span class="font-medium text-ink-900">Direct bill</span> — manual charge lines, not tied to a Work Order.
+			</div>
+			<div class="overflow-x-auto">
+				<table class="w-full text-xs" style="min-width: 640px">
+					<thead class="bg-white text-ink-500 uppercase tracking-wider text-[10px]">
 						<tr>
 							<th class="text-left px-3 py-2">Scope</th>
 							<th class="text-left px-3 py-2">Cost code</th>
-							<th class="text-right px-3 py-2">Qty</th>
 							<th class="text-right px-3 py-2">Rate</th>
-							<th class="text-right px-3 py-2">Amount</th>
+							<th class="text-right px-3 py-2">Measured to date</th>
+							<th class="text-right px-3 py-2">Previously billed</th>
+							<th class="text-right px-3 py-2">This period qty</th>
+							<th class="text-right px-3 py-2">This period amount</th>
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="(l, i) in bill.lines" :key="i" class="border-t border-ink-100">
-							<td class="px-3 py-2 text-ink-900">{{ l.scope }}</td>
-							<td class="px-3 py-2 text-ink-500">{{ l.cost_code_label || "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums">
-								{{ l.this_period_qty ? Number(l.this_period_qty).toLocaleString("en-IN") : "—" }}
+						<tr v-for="(l, i) in bill.lines" :key="i" class="border-t border-ink-100 align-top">
+							<td class="px-3 py-2 text-ink-900">{{ l.scope || "—" }}</td>
+							<td class="px-3 py-2">
+								<span v-if="l.cost_code_label" class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-info-50 text-info-700">{{ l.cost_code_label }}</span>
+								<span v-else class="text-ink-300">—</span>
 							</td>
-							<td class="px-3 py-2 text-right tabular-nums">{{ l.rate ? fmtINR(l.rate) : "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(l.this_period_amount) }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ l.rate ? fmtINR(l.rate) + "/" + (l.uom || "") : "—" }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-info-700 font-medium">{{ l.measured_qty_to_date != null ? Number(l.measured_qty_to_date).toLocaleString("en-IN") : "—" }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-500">{{ l.previous_qty != null ? Number(l.previous_qty).toLocaleString("en-IN") : "—" }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">{{ l.this_period_qty != null ? Number(l.this_period_qty).toLocaleString("en-IN") : "—" }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">{{ fmtINR(l.this_period_amount) }}</td>
 						</tr>
 					</tbody>
+					<tfoot>
+						<tr class="border-t-2 border-ink-200 bg-ink-50">
+							<td colspan="6" class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider">Gross bill value</td>
+							<td class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900">{{ fmtINR(wf.gross) }}</td>
+						</tr>
+					</tfoot>
 				</table>
 			</div>
 		</section>
 
-		<div class="grid md:grid-cols-2 gap-6">
-			<!-- taxes editor -->
-			<section>
-				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">Taxes & charges</h3>
-				<DeskField v-if="isDraft" label="Tax template">
-					<DeskLinkPicker
-						:model-value="bill.taxes_and_charges"
-						doctype="Purchase Taxes and Charges Template"
-						label-field="name"
-						value-field="name"
-						:filters="bill.company ? [['company', '=', bill.company]] : []"
-						placeholder="— No tax —"
-						@update:model-value="onPickTemplate"
-					/>
-				</DeskField>
-				<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto mt-2">
-					<table class="w-full text-xs" style="min-width: 420px">
-						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
-							<tr>
-								<th class="text-left px-2 py-2">Account head</th>
-								<th class="text-right px-2 py-2 w-16">Rate %</th>
-								<th class="text-right px-2 py-2 w-24">Amount</th>
-								<th v-if="isDraft" class="w-8"></th>
-							</tr>
-						</thead>
-						<tbody>
-							<tr v-for="(t, i) in bill.taxes" :key="i" class="border-t border-ink-100">
-								<td class="px-2 py-1">
-									<DeskLinkPicker
-										v-if="isDraft"
-										v-model="t.account_head"
-										doctype="Account"
-										label-field="name"
-										value-field="name"
-										:filters="bill.company ? [['is_group', '=', 0], ['company', '=', bill.company]] : [['is_group', '=', 0]]"
-										placeholder="Account…"
-									/>
-									<span v-else>{{ t.account_head }}</span>
-								</td>
-								<td class="px-2 py-1 text-right">
-									<input
-										v-if="isDraft"
-										v-model.number="t.rate"
-										type="number"
-										min="0"
-										step="0.5"
-										class="w-full bg-transparent text-xs text-right tabular-nums py-1 focus:outline-none"
-									/>
-									<span v-else class="tabular-nums">{{ t.rate }}</span>
-								</td>
-								<td class="px-2 py-1 text-right tabular-nums">
-									{{ fmtINR((wf.taxable * (Number(t.rate) || 0)) / 100) }}
-								</td>
-								<td v-if="isDraft" class="px-2 py-1 text-center">
-									<button type="button" class="text-ink-400 hover:text-danger-600" @click="removeTaxRow(i)">✕</button>
-								</td>
-							</tr>
-							<tr v-if="!bill.taxes.length">
-								<td :colspan="isDraft ? 4 : 3" class="px-2 py-3 text-center text-ink-400 italic">
-									No tax. Pick a template or add a row.
-								</td>
-							</tr>
-						</tbody>
-					</table>
-				</div>
-				<button v-if="isDraft" type="button" class="text-xs text-brand-700 hover:underline mt-1" @click="addTaxRow">
-					+ Add tax row
-				</button>
-			</section>
-
-			<!-- adjustments + waterfall -->
-			<section>
-				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">Withholding, discount & recovery</h3>
-				<div class="grid grid-cols-2 gap-3">
-					<DeskField label="Retention (%)">
-						<DeskInput v-model.number="bill.retention_percent" type="number" min="0" step="0.5" :disabled="!isDraft" />
-					</DeskField>
-					<DeskField label="Advance recovery">
-						<DeskInput v-model.number="bill.advance_recovery" type="number" min="0" :disabled="!isDraft" />
-					</DeskField>
-					<DeskField label="Bill type">
-						<select
-							v-model="bill.bill_type"
-							:disabled="!isDraft"
-							class="w-full border border-ink-200 rounded-md text-xs px-2 py-1.5 bg-white"
-						>
-							<option value="Normal">Normal</option>
-							<option value="Final">Final (release retention)</option>
-						</select>
-					</DeskField>
-					<DeskField label="Apply TDS">
-						<label class="flex items-center gap-2 text-xs pt-1.5">
-							<input v-model="bill.apply_tds" type="checkbox" :disabled="!isDraft" class="accent-brand-600" />
-							withholding
-						</label>
-					</DeskField>
-					<DeskField v-if="bill.apply_tds" label="Withholding category" class="col-span-2">
+		<!-- Taxes and Charges -->
+		<section class="mt-6 bg-white border border-ink-200 rounded-lg overflow-hidden">
+			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Taxes and Charges</h3>
+				<div v-if="editable" class="flex items-center gap-2">
+					<label class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Template</label>
+					<div class="w-48">
 						<DeskLinkPicker
-							v-model="bill.tax_withholding_category"
-							doctype="Tax Withholding Category"
+							:model-value="bill.taxes_and_charges"
+							doctype="Purchase Taxes and Charges Template"
 							label-field="name"
 							value-field="name"
-							placeholder="Pick category…"
-							:disabled="!isDraft"
+							:filters="bill.company ? [['company', '=', bill.company]] : []"
+							placeholder="— No tax —"
+							@update:model-value="onPickTemplate"
 						/>
-					</DeskField>
-					<DeskField label="Discount on">
-						<select
-							v-model="bill.additional_discount_on"
-							:disabled="!isDraft"
-							class="w-full border border-ink-200 rounded-md text-xs px-2 py-1.5 bg-white"
-						>
-							<option value="Net Total">Net Total</option>
-							<option value="Grand Total">Grand Total</option>
-						</select>
-					</DeskField>
-					<DeskField label="Discount (%)">
-						<DeskInput v-model.number="bill.additional_discount_percentage" type="number" min="0" step="0.5" :disabled="!isDraft" />
-					</DeskField>
-					<DeskField label="Expense account" class="col-span-2" hint="Where the PI posts the cost. Defaults from settings.">
-						<DeskLinkPicker
-							v-model="bill.expense_account"
-							doctype="Account"
-							label-field="name"
-							value-field="name"
-							:filters="[['root_type', '=', 'Expense'], ['is_group', '=', 0], ['company', '=', bill.company]]"
-							placeholder="Default (Subcontractor Charges)"
-							:disabled="!isDraft"
-						/>
-					</DeskField>
+					</div>
 				</div>
-
-				<!-- waterfall -->
-				<div class="mt-4 bg-ink-50 border border-ink-200 rounded-lg px-3 py-2 text-xs space-y-1">
-					<div class="flex justify-between"><span class="text-ink-600">Gross</span><span class="tabular-nums">{{ fmtINR(wf.gross) }}</span></div>
-					<div v-if="wf.netDiscount" class="flex justify-between text-ink-500"><span>Less discount (net)</span><span class="tabular-nums">−{{ fmtINR(wf.netDiscount) }}</span></div>
-					<div class="flex justify-between border-t border-ink-200 pt-1"><span class="text-ink-600">Taxable</span><span class="tabular-nums">{{ fmtINR(wf.taxable) }}</span></div>
-					<div v-if="wf.totalTaxes" class="flex justify-between text-info-700"><span>Add taxes</span><span class="tabular-nums">+{{ fmtINR(wf.totalTaxes) }}</span></div>
-					<div class="flex justify-between"><span class="text-ink-600">Grand total</span><span class="tabular-nums">{{ fmtINR(wf.grand) }}</span></div>
-					<div v-if="wf.grandDiscount" class="flex justify-between text-ink-500"><span>Less discount (grand)</span><span class="tabular-nums">−{{ fmtINR(wf.grandDiscount) }}</span></div>
-					<div v-if="wf.tds" class="flex justify-between text-warning-700"><span>Less TDS @ {{ bill.tds_rate }}%</span><span class="tabular-nums">−{{ fmtINR(wf.tds) }}</span></div>
-					<div v-if="wf.retention" class="flex justify-between text-warning-700"><span>Less retention</span><span class="tabular-nums">−{{ fmtINR(wf.retention) }}</span></div>
-					<div v-if="wf.advance" class="flex justify-between text-warning-700"><span>Less advance recovery</span><span class="tabular-nums">−{{ fmtINR(wf.advance) }}</span></div>
-					<div class="flex justify-between border-t-2 border-ink-300 pt-1 font-bold text-brand-700"><span>Net payable</span><span class="tabular-nums">{{ fmtINR(wf.net) }}</span></div>
-				</div>
-
-				<button
-					v-if="isDraft"
-					class="desk-save-btn mt-3 w-full"
-					:disabled="savingBilling"
-					@click="saveBilling"
-				>
-					{{ savingBilling ? "Saving…" : "Save billing" }}
-				</button>
-			</section>
-		</div>
-
-		<!-- payments -->
-		<section v-if="isSubmitted" class="mt-6">
-			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">Payments</h3>
-			<div v-if="payForm.open" class="bg-white border border-ink-200 rounded-lg p-3 mb-3 grid grid-cols-2 md:grid-cols-4 gap-3">
-				<DeskField label="Amount"><DeskInput v-model.number="payForm.amount" type="number" min="0" /></DeskField>
-				<DeskField label="Date"><DeskInput v-model="payForm.date" type="date" /></DeskField>
-				<DeskField label="Mode"><DeskInput v-model="payForm.mode_of_payment" placeholder="Bank / Cash / Cheque" /></DeskField>
-				<DeskField label="Reference"><DeskInput v-model="payForm.reference_no" placeholder="NEFT / cheque no." /></DeskField>
-				<div class="col-span-full flex gap-2 justify-end">
-					<button class="desk-btn" @click="payForm.open = false">Cancel</button>
-					<button class="desk-save-btn" :disabled="busy" @click="submitPayment">Save & pay</button>
-				</div>
+				<span v-else class="text-[11px] text-ink-500">{{ bill.taxes_and_charges || "No tax" }}</span>
 			</div>
-			<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<div class="overflow-x-auto">
 				<table class="w-full text-xs" style="min-width: 480px">
-					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<thead class="bg-white text-ink-500 uppercase tracking-wider text-[10px]">
 						<tr>
-							<th class="text-left px-3 py-2">Payment</th>
-							<th class="text-left px-3 py-2">Date</th>
-							<th class="text-left px-3 py-2">Mode</th>
-							<th class="text-left px-3 py-2">Reference</th>
-							<th class="text-right px-3 py-2">Amount</th>
+							<th class="text-left px-3 py-2 w-8">#</th>
+							<th class="text-left px-3 py-2">Account Head</th>
+							<th class="text-right px-3 py-2 w-24">Tax Rate</th>
+							<th class="text-right px-3 py-2 w-32">Amount</th>
+							<th v-if="editable" class="w-8"></th>
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="p in payments" :key="p.payment_entry" class="border-t border-ink-100">
-							<td class="px-3 py-2 font-mono text-[11px]">{{ p.payment_entry }}</td>
-							<td class="px-3 py-2 text-ink-500">{{ fmtDate(p.date) }}</td>
-							<td class="px-3 py-2">{{ p.mode_of_payment || "—" }}</td>
-							<td class="px-3 py-2 text-ink-500">{{ p.reference_no || "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(p.amount) }}</td>
+						<tr v-for="(t, i) in wf.taxRows" :key="i" class="border-t border-ink-100">
+							<td class="px-3 py-1.5 text-ink-500">{{ i + 1 }}</td>
+							<td class="px-3 py-1.5">
+								<DeskLinkPicker
+									v-if="editable"
+									v-model="bill.taxes[i].account_head"
+									doctype="Account"
+									label-field="name"
+									value-field="name"
+									:filters="accountFilters"
+									placeholder="Account…"
+								/>
+								<span v-else class="text-ink-900">{{ t.account_head || "—" }}</span>
+							</td>
+							<td class="px-3 py-1.5 text-right">
+								<input v-if="editable" v-model.number="bill.taxes[i].rate" type="number" min="0" step="0.5" class="w-full bg-transparent text-right tabular-nums focus:outline-none py-1" />
+								<span v-else class="tabular-nums text-ink-700">{{ t.rate }}</span>
+							</td>
+							<td class="px-3 py-1.5 text-right tabular-nums text-ink-900 font-medium">{{ fmtINR(t.amount) }}</td>
+							<td v-if="editable" class="px-2 py-1.5 text-center"><button type="button" class="text-ink-400 hover:text-danger-600" @click="removeTaxRow(i)">✕</button></td>
 						</tr>
-						<tr v-if="!payments.length">
-							<td colspan="5" class="px-3 py-3 text-center text-ink-400 italic">
-								No payments yet.
+						<tr v-if="!wf.taxRows.length"><td :colspan="editable ? 5 : 4" class="px-3 py-3 text-center text-ink-400 italic">No tax. Pick a template or add a row.</td></tr>
+					</tbody>
+					<tfoot v-if="wf.taxRows.length">
+						<tr class="border-t border-ink-200 bg-ink-50"><td colspan="3" class="px-3 py-2 text-right text-[11px] font-semibold uppercase tracking-wider text-ink-700">Total taxes</td><td class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900">{{ fmtINR(wf.tax) }}</td><td v-if="editable"></td></tr>
+					</tfoot>
+				</table>
+			</div>
+			<div v-if="editable" class="px-3 py-2 border-t border-ink-100"><button type="button" class="text-xs text-brand-700 hover:underline" @click="addTaxRow">+ Add row</button></div>
+		</section>
+
+		<!-- Retention/TDS/discount + waterfall -->
+		<section class="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+			<div class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Retention, TDS &amp; discount</h3></div>
+				<div class="p-4 space-y-3 text-xs">
+					<div class="grid grid-cols-2 gap-3">
+						<div>
+							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Retention %</label>
+							<input v-model.number="bill.retention_percent" :readonly="!editable" type="number" min="0" max="20" step="0.5" class="desk-input" />
+						</div>
+						<div>
+							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Advance recovery (₹)</label>
+							<input v-model.number="bill.advance_recovery" :readonly="!editable" type="number" min="0" step="0.01" class="desk-input" />
+						</div>
+					</div>
+					<div class="grid grid-cols-2 gap-3">
+						<div>
+							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Bill type</label>
+							<select v-model="bill.bill_type" :disabled="!editable" class="desk-input"><option value="Normal">Normal</option><option value="Final">Final (release retention)</option></select>
+						</div>
+						<div>
+							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Expense account</label>
+							<DeskLinkPicker
+								v-model="bill.expense_account"
+								doctype="Account"
+								label-field="name"
+								value-field="name"
+								:filters="bill.company ? [['root_type', '=', 'Expense'], ['is_group', '=', 0], ['company', '=', bill.company]] : []"
+								placeholder="Default (Subcontractor Charges)"
+								:disabled="!editable"
+							/>
+						</div>
+					</div>
+					<div>
+						<label class="flex items-center gap-2 py-0.5"><input type="checkbox" v-model="bill.apply_tds" :disabled="!editable" class="accent-brand-600" /><span class="text-ink-800">Apply TDS (withholding)</span></label>
+						<div v-if="bill.apply_tds" class="mt-1.5">
+							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Withholding category</label>
+							<DeskLinkPicker
+								v-model="bill.tax_withholding_category"
+								doctype="Tax Withholding Category"
+								label-field="name"
+								value-field="name"
+								placeholder="Pick category…"
+								:disabled="!editable"
+							/>
+						</div>
+					</div>
+					<div>
+						<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Additional Discount</label>
+						<div class="flex items-center gap-2">
+							<select v-model="bill.additional_discount_on" :disabled="!editable" class="desk-input !w-32"><option>Net Total</option><option>Grand Total</option></select>
+							<input v-model.number="discValue" :readonly="!editable" type="number" min="0" step="0.01" class="desk-input flex-1" />
+							<div class="flex border border-ink-200 rounded-md overflow-hidden">
+								<button type="button" :disabled="!editable" class="px-2.5 py-1" :class="discType === '%' ? 'bg-brand-50 text-brand-700 font-medium' : 'bg-white text-ink-600'" @click="discType = '%'">%</button>
+								<button type="button" :disabled="!editable" class="px-2.5 py-1 border-l border-ink-200" :class="discType === '₹' ? 'bg-brand-50 text-brand-700 font-medium' : 'bg-white text-ink-600'" @click="discType = '₹'">₹</button>
+							</div>
+						</div>
+						<p class="text-[10px] text-ink-400 mt-1">Apply on <span class="font-medium">Net Total</span> (before tax) or <span class="font-medium">Grand Total</span> (after tax).</p>
+					</div>
+					<button v-if="editable" class="desk-save-btn w-full" :disabled="savingBilling" @click="saveBilling">{{ savingBilling ? "Saving…" : "Save billing" }}</button>
+				</div>
+			</div>
+
+			<div class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Net payable</h3></div>
+				<div class="p-4 text-xs">
+					<div class="flex justify-between py-1"><span class="text-ink-600">Gross bill value</span><span class="tabular-nums font-medium">{{ fmtINR(wf.gross) }}</span></div>
+					<div v-if="bill.additional_discount_on === 'Net Total' && wf.netDiscount" class="flex justify-between py-1"><span class="text-ink-500">Less: Discount (on Net Total)</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.netDiscount) }})</span></div>
+					<div class="flex justify-between py-1 border-t border-ink-100"><span class="text-ink-700 font-medium">Taxable value</span><span class="tabular-nums font-medium">{{ fmtINR(wf.taxable) }}</span></div>
+					<div class="flex justify-between py-1"><span class="text-ink-500">Add: Taxes<span v-if="taxRatePct"> (@ {{ taxRatePct }}%)</span></span><span class="tabular-nums text-ink-700">+ {{ fmtINR(wf.tax) }}</span></div>
+					<div class="flex justify-between py-1 border-t border-ink-100"><span class="text-ink-700 font-medium">{{ bill.additional_discount_on === 'Grand Total' ? 'Grand total' : 'Invoice value' }}</span><span class="tabular-nums font-medium">{{ fmtINR(wf.grandTotal) }}</span></div>
+					<template v-if="bill.additional_discount_on === 'Grand Total' && wf.grandDiscount">
+						<div class="flex justify-between py-1"><span class="text-ink-500">Less: Discount (on Grand Total)</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.grandDiscount) }})</span></div>
+						<div class="flex justify-between py-1 border-t border-ink-100"><span class="text-ink-700 font-medium">Invoice value</span><span class="tabular-nums font-medium">{{ fmtINR(wf.invoiceValue) }}</span></div>
+					</template>
+					<div v-if="wf.tds" class="flex justify-between py-1"><span class="text-ink-500">Less: TDS withheld @ {{ bill.tds_rate }}%</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.tds) }})</span></div>
+					<div class="flex justify-between py-1">
+						<span class="text-ink-500">Less: Retention held @ {{ bill.retention_percent }}%</span>
+						<span class="tabular-nums text-warning-700">({{ fmtINR(wf.retention) }})</span>
+					</div>
+					<div class="text-[10px] text-ink-400 -mt-0.5 mb-0.5">Held on your books, released on the final bill.</div>
+					<div v-if="wf.advance" class="flex justify-between py-1"><span class="text-ink-500">Less: Advance recovery</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.advance) }})</span></div>
+					<div class="flex justify-between py-2 border-t-2 border-ink-200 mt-1">
+						<span class="font-semibold text-ink-900">Net payable to subcontractor</span>
+						<span class="tabular-nums font-bold text-base text-brand-700">{{ fmtINR(wf.netPayable) }}</span>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- Attachments -->
+		<section class="mt-6">
+			<input ref="fileInput" type="file" multiple class="hidden" @change="onFilesPicked" />
+			<div class="flex items-center justify-between mb-2 gap-3">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+					Attachments <span v-if="attachments.length" class="text-ink-400 font-normal">({{ attachments.length }})</span>
+				</h3>
+				<button type="button" class="desk-save-btn !text-xs" :disabled="uploading > 0" @click="fileInput?.click()">
+					{{ uploading > 0 ? `Uploading… (${uploading})` : "+ Upload" }}
+				</button>
+			</div>
+			<div v-if="attachments.length" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<table class="w-full text-xs">
+					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="w-8"></th>
+							<th class="text-left px-3 py-1.5">File</th>
+							<th class="text-right px-3 py-1.5">Size</th>
+							<th class="text-left px-3 py-1.5">Uploaded</th>
+							<th class="text-left px-3 py-1.5">By</th>
+							<th class="w-8"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="att in attachments" :key="att.name" class="border-t border-ink-100 hover:bg-brand-50/40">
+							<td class="px-2 py-2 text-base text-center">{{ fileIcon(att.file_url || att.file_name) }}</td>
+							<td class="px-3 py-2">
+								<a v-if="att.file_url" :href="att.file_url" target="_blank" rel="noopener" class="text-brand-700 hover:underline truncate block max-w-xs" :title="att.file_name">{{ att.file_name }}</a>
+								<span v-else class="text-ink-700">{{ att.file_name }}</span>
+							</td>
+							<td class="px-3 py-2 text-right text-ink-600 tabular-nums">{{ formatFileSize(att.file_size) }}</td>
+							<td class="px-3 py-2 text-ink-600">{{ fmtDate(att.creation) }}</td>
+							<td class="px-3 py-2"><FrappeUserBadge :user-id="att.owner" size="xs" /></td>
+							<td class="px-1 py-2 text-center">
+								<button type="button" class="text-xs px-1.5 py-0.5 border border-ink-200 bg-white hover:bg-danger-50 text-danger-700" style="border-radius: 4px" :title="`Delete ${att.file_name}`" @click="onDeleteFile(att)">✕</button>
 							</td>
 						</tr>
 					</tbody>
 				</table>
+			</div>
+			<div v-else class="py-6 text-center border border-dashed border-ink-200 rounded-lg">
+				<div class="text-sm text-ink-500 mb-1">No attachments yet.</div>
+				<div class="text-xs text-ink-400 italic">Invoices, measurement sheets, and site photos go here.</div>
 			</div>
 		</section>
 	</DeskPage>

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -340,6 +340,7 @@ const statusPills = computed(() => {
 						doctype="Purchase Taxes and Charges Template"
 						label-field="name"
 						value-field="name"
+						:filters="bill.company ? [['company', '=', bill.company]] : []"
 						placeholder="— No tax —"
 						@update:model-value="onPickTemplate"
 					/>
@@ -363,6 +364,7 @@ const statusPills = computed(() => {
 										doctype="Account"
 										label-field="name"
 										value-field="name"
+										:filters="bill.company ? [['is_group', '=', 0], ['company', '=', bill.company]] : [['is_group', '=', 0]]"
 										placeholder="Account…"
 									/>
 									<span v-else>{{ t.account_head }}</span>
@@ -453,7 +455,7 @@ const statusPills = computed(() => {
 							doctype="Account"
 							label-field="name"
 							value-field="name"
-							:filters="[['account_type', '=', 'Expense Account'], ['company', '=', bill.company]]"
+							:filters="[['root_type', '=', 'Expense'], ['is_group', '=', 0], ['company', '=', bill.company]]"
 							placeholder="Default (Subcontractor Charges)"
 							:disabled="!isDraft"
 						/>


### PR DESCRIPTION
## Problem
On the Subcontractor Bill (Draft) there was effectively no way to choose the **expense account** for the PI's GL posting, and the tax/account pickers could come up empty:

- The **expense-account picker** filtered on `account_type = 'Expense Account'` — but no company's chart of accounts tags expense ledgers that way (they sit under `root_type = 'Expense'` with a blank `account_type`). The dropdown was empty.
- The **tax-template** and manual **tax-row account** pickers weren't scoped to the bill's company (offered cross-company masters).
- Finance **personas** (non-admin) lacked read permission on ERPNext's accounting masters, so those pickers returned nothing for them.

## Fix
- Expense-account picker → `root_type='Expense'` + `is_group=0` + `company` (now surfaces the company's expense ledgers).
- Tax-template + tax-row account pickers → scoped to the bill's company.
- Granted the subcontract-bill roles + Accountant **read** on `Account`, `Purchase Taxes and Charges Template`, `Tax Category`, `Tax Withholding Category`.

The tax-template selector and the taxes editor already lived on the bill detail (Draft-editable); this makes them — and the expense account — actually selectable so the chosen accounts reflect in the generated PI's Journal Entry.

## Testing
- Verified the fixed filter surfaces 29 expense accounts per company on `bs.local`; permission grant confirmed (BuildSuite Accountant now reads Account). `yarn build` clean.

