### PR TITLE
Live Petty Cash (disburse posts a Journal Entry)

### DIFF
--- a/buildsuite_core/api/petty_cash.py
+++ b/buildsuite_core/api/petty_cash.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Whitelisted endpoints for the Petty Cash Request — the live part of the Project Finance
+workspace. Request → Disburse (posts a Journal Entry) → optionally reverse. Disbursing is
+gated to the finance approver roles."""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+DOCTYPE = "Petty Cash Request"
+
+
+def _can_disburse():
+	from buildsuite_core.permissions.setup import PETTY_CASH_DISBURSE_ROLES
+
+	return bool(set(frappe.get_roles()) & set(PETTY_CASH_DISBURSE_ROLES))
+
+
+def _serialize(doc):
+	comments = frappe.get_all(
+		"Comment",
+		filters={"reference_doctype": DOCTYPE, "reference_name": doc.name, "comment_type": "Comment"},
+		fields=["owner", "creation", "content"],
+		order_by="creation asc",
+	)
+	return {
+		"name": doc.name,
+		"project": doc.project,
+		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
+		"requested_by": doc.requested_by,
+		"request_date": str(doc.request_date) if doc.request_date else None,
+		"amount": doc.amount,
+		"purpose": doc.purpose,
+		"status": doc.status,
+		"company": doc.company,
+		"paid_from": doc.paid_from,
+		"disbursed_by": doc.disbursed_by,
+		"disbursed_on": str(doc.disbursed_on) if doc.disbursed_on else None,
+		"journal_entry": doc.journal_entry,
+		"can_disburse": _can_disburse(),
+		"is_mine": doc.requested_by == frappe.session.user,
+		"activity": [
+			{"by": c.owner, "at": str(c.creation), "text": frappe.utils.strip_html(c.content or "").strip()}
+			for c in comments
+		],
+	}
+
+
+@frappe.whitelist()
+def can_disburse():
+	return {"can_disburse": _can_disburse()}
+
+
+@frappe.whitelist()
+def get_request(name: str):
+	doc = frappe.get_doc(DOCTYPE, name)
+	doc.check_permission("read")
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def save_request(payload):
+	"""Create or edit a Requested petty cash request."""
+	data = frappe.parse_json(payload)
+	name = data.get("name")
+	if name and frappe.db.exists(DOCTYPE, name):
+		doc = frappe.get_doc(DOCTYPE, name)
+		doc.check_permission("write")
+		if doc.status != "Requested":
+			frappe.throw(_("Only a Requested petty cash request can be edited."))
+	else:
+		doc = frappe.new_doc(DOCTYPE)
+
+	doc.project = data.get("project")
+	doc.amount = flt(data.get("amount"))
+	doc.purpose = data.get("purpose")
+	if data.get("request_date"):
+		doc.request_date = data.get("request_date")
+	if data.get("requested_by") and _can_disburse():
+		doc.requested_by = data.get("requested_by")  # an approver may raise on behalf of a holder
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def disburse(name, paid_from):
+	doc = frappe.get_doc(DOCTYPE, name)
+	if not _can_disburse():
+		frappe.throw(_("You are not authorised to disburse petty cash."), frappe.PermissionError)
+	doc.disburse(paid_from)
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def undisburse(name: str):
+	"""Reverse a disbursement (cancel the JE, revert to Requested)."""
+	doc = frappe.get_doc(DOCTYPE, name)
+	if not _can_disburse():
+		frappe.throw(_("You are not authorised to reverse a disbursement."), frappe.PermissionError)
+	doc.cancel_disbursement()
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def cancel_request(name: str):
+	"""Withdraw a Requested request (mark Cancelled)."""
+	doc = frappe.get_doc(DOCTYPE, name)
+	doc.check_permission("write")
+	if doc.status != "Requested":
+		frappe.throw(_("Only a Requested request can be cancelled."))
+	doc.status = "Cancelled"
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def delete_request(name: str):
+	doc = frappe.get_doc(DOCTYPE, name)
+	doc.check_permission("delete")
+	if doc.status == "Disbursed":
+		frappe.throw(_("Reverse the disbursement before deleting."))
+	frappe.delete_doc(DOCTYPE, name)
+	return {"ok": True}
+
+
+@frappe.whitelist()
+def list_cash_bank_accounts(company):
+	"""Cash/Bank ledger accounts to disburse from, for the given company."""
+	return frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]},
+		fields=["name", "account_type"],
+		order_by="account_type, name",
+	)
+
+
+@frappe.whitelist()
+def holder_balances(company=None):
+	"""Total disbursed per holder (the live float handed out). Verified spend lives on the
+	dummy Expenses side, so this is the cash-out figure."""
+	filters = {"status": "Disbursed"}
+	if company:
+		filters["company"] = company
+	rows = frappe.get_all(DOCTYPE, filters=filters, fields=["requested_by", "amount"])
+	out = {}
+	for r in rows:
+		out[r.requested_by] = out.get(r.requested_by, 0) + flt(r.amount)
+	return [{"holder": k, "disbursed": v} for k, v in sorted(out.items())]

--- a/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
+++ b/buildsuite_core/buildsuite_core/doctype/buildsuite_core_settings/buildsuite_core_settings.json
@@ -8,7 +8,9 @@
   "project_naming",
   "rate_master_update_threshold",
   "subcontract_section",
-  "default_subcontractor_expense_account"
+  "default_subcontractor_expense_account",
+  "finance_section",
+  "default_petty_cash_account"
  ],
  "fields": [
   {
@@ -40,6 +42,18 @@
    "fieldname": "default_subcontractor_expense_account",
    "fieldtype": "Link",
    "label": "Default Subcontractor Expense Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "finance_section",
+   "fieldtype": "Section Break",
+   "label": "Project Finance"
+  },
+  {
+   "description": "The Petty Cash ledger a disbursement's Journal Entry debits. Falls back to a per-company 'Petty Cash' account.",
+   "fieldname": "default_petty_cash_account",
+   "fieldtype": "Link",
+   "label": "Default Petty Cash Account",
    "options": "Account"
   }
  ],

--- a/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.json
+++ b/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.json
@@ -1,0 +1,156 @@
+{
+ "actions": [],
+ "autoname": "PCR-.YYYY.-.#####",
+ "creation": "2026-07-23 00:00:00.000000",
+ "doctype": "DocType",
+ "engine": "InnoDB",
+ "field_order": [
+  "project",
+  "requested_by",
+  "request_date",
+  "column_break_hdr",
+  "amount",
+  "status",
+  "company",
+  "purpose_section",
+  "purpose",
+  "disbursement_section",
+  "paid_from",
+  "disbursed_by",
+  "column_break_disb",
+  "disbursed_on",
+  "journal_entry"
+ ],
+ "fields": [
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Project",
+   "options": "Project",
+   "reqd": 1
+  },
+  {
+   "default": "__user",
+   "fieldname": "requested_by",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Requested By",
+   "options": "User"
+  },
+  {
+   "default": "Today",
+   "fieldname": "request_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Request Date"
+  },
+  {
+   "fieldname": "column_break_hdr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "reqd": 1
+  },
+  {
+   "default": "Requested",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "Requested\nDisbursed\nCancelled",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "project.company",
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company",
+   "read_only": 1
+  },
+  {
+   "fieldname": "purpose_section",
+   "fieldtype": "Section Break",
+   "label": "Purpose"
+  },
+  {
+   "fieldname": "purpose",
+   "fieldtype": "Small Text",
+   "label": "Purpose",
+   "reqd": 1
+  },
+  {
+   "fieldname": "disbursement_section",
+   "fieldtype": "Section Break",
+   "label": "Disbursement"
+  },
+  {
+   "description": "The cash/bank account the money is paid from (set on disburse).",
+   "fieldname": "paid_from",
+   "fieldtype": "Link",
+   "label": "Paid From",
+   "options": "Account",
+   "read_only": 1
+  },
+  {
+   "fieldname": "disbursed_by",
+   "fieldtype": "Link",
+   "label": "Disbursed By",
+   "options": "User",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_disb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "disbursed_on",
+   "fieldtype": "Datetime",
+   "label": "Disbursed On",
+   "read_only": 1
+  },
+  {
+   "description": "The Journal Entry posted on disburse (Dr Petty Cash / Cr paid-from).",
+   "fieldname": "journal_entry",
+   "fieldtype": "Link",
+   "label": "Journal Entry",
+   "options": "Journal Entry",
+   "no_copy": 1,
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2026-07-23 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Petty Cash Request",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": [],
+ "title_field": "project",
+ "track_changes": 1
+}

--- a/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.py
+++ b/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from frappe.model.document import Document
+from frappe.utils import flt, now_datetime
+
+
+class PettyCashRequest(Document):
+	def validate(self):
+		# Company is anchored to the project (the accounting dimension the Journal Entry posts
+		# against) — never a stale/default value.
+		if self.project:
+			self.company = frappe.db.get_value("Project", self.project, "company")
+		if not self.requested_by:
+			self.requested_by = frappe.session.user
+
+	def on_trash(self):
+		if self.status == "Disbursed":
+			frappe.throw(_("A disbursed request can't be deleted — cancel the disbursement first."))
+
+	# --- actions ----------------------------------------------------------
+	def disburse(self, paid_from):
+		"""Record the cash going out to the holder and post the Journal Entry."""
+		from buildsuite_core.utils.petty_cash import post_disbursement_journal_entry
+
+		if self.status != "Requested":
+			frappe.throw(_("Only a Requested petty cash request can be disbursed (this is {0}).").format(self.status))
+		if not paid_from:
+			frappe.throw(_("Select the cash/bank account to pay from."))
+		acc = frappe.db.get_value("Account", paid_from, ["company", "account_type", "is_group"], as_dict=True)
+		if not acc or acc.is_group:
+			frappe.throw(_("Pick a valid ledger account."))
+		if acc.company != self.company:
+			frappe.throw(_("Account {0} does not belong to company {1}.").format(paid_from, self.company))
+
+		self.paid_from = paid_from
+		self.disbursed_by = frappe.session.user
+		self.disbursed_on = now_datetime()
+		self.journal_entry = post_disbursement_journal_entry(self)
+		self.status = "Disbursed"
+		self.save(ignore_permissions=True)
+		self.add_comment("Comment", _("Disbursed {0} from {1}").format(frappe.format(flt(self.amount), {"fieldtype": "Currency"}), paid_from))
+
+	def cancel_disbursement(self):
+		"""Reverse a disbursement — cancel the Journal Entry and revert to Requested."""
+		from buildsuite_core.utils.petty_cash import cancel_disbursement_journal_entry
+
+		if self.status != "Disbursed":
+			frappe.throw(_("Only a disbursed request can be reversed."))
+		cancel_disbursement_journal_entry(self)
+		self.status = "Requested"
+		self.paid_from = None
+		self.disbursed_by = None
+		self.disbursed_on = None
+		self.journal_entry = None
+		self.save(ignore_permissions=True)
+		self.add_comment("Comment", _("Disbursement reversed"))

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -366,6 +366,19 @@ CUSTOM_FIELD = {
 			"module": "BuildSuite Core",
 		},
 	],
+	"Journal Entry": [
+		{
+			# Back-link to the Petty Cash Request whose disbursement posted this JE.
+			"fieldname": "petty_cash_request",
+			"fieldtype": "Link",
+			"label": "Petty Cash Request",
+			"options": "Petty Cash Request",
+			"insert_after": "voucher_type",
+			"read_only": 1,
+			"no_copy": 1,
+			"module": "BuildSuite Core",
+		},
+	],
 	"Purchase Order Item": [
 		{
 			"fieldname": "custom_rate_master",

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -574,6 +574,36 @@ def setup_sco_permissions():
 	_apply_role_perms("Scope Change Order", SCO_ROLE_PERMS)
 
 
+# --- Project Finance — Petty Cash -------------------------------------------
+# Site roles (Site Engineer / Foreman) raise + manage their own requests; finance
+# roles have full access. Disbursing is gated in the API by PETTY_CASH_DISBURSE_ROLES,
+# not a DocPerm (any writer can save a request; only approvers can disburse).
+_PETTY_CASH_SITE = {"read": 1, "write": 1, "create": 1, "report": 1, "print": 1}
+PETTY_CASH_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Director": _FULL,
+	"BuildSuite PM": _FULL,
+	"BuildSuite Accountant": _FULL,
+	"BuildSuite Site Engineer": _PETTY_CASH_SITE,
+	"BuildSuite Foreman": _PETTY_CASH_SITE,
+	"BuildSuite QS": _READ,
+}
+PETTY_CASH_DISBURSE_ROLES = (
+	"BuildSuite Accountant",
+	"BuildSuite Director",
+	"BuildSuite PM",
+	"BuildSuite Administrator",
+)
+
+
+def setup_petty_cash_permissions():
+	_apply_role_perms("Petty Cash Request", PETTY_CASH_ROLE_PERMS)
+	# The disburse Journal Entry + its account picker read accounting masters.
+	_read = {role: _READ for role in PETTY_CASH_DISBURSE_ROLES}
+	for dt in ("Account", "Journal Entry"):
+		_apply_role_perms(dt, _read)
+
+
 def setup_subcontract_permissions():
 	# Subcontractors are native Suppliers (supplier_type="Subcontractor") — grant the
 	# BuildSuite roles CRUD on Supplier so the Vue "Subcontractor" screens work.
@@ -664,6 +694,7 @@ def setup_record_permissions():
 	setup_linked_master_permissions()
 	setup_subcontract_permissions()
 	setup_sco_permissions()
+	setup_petty_cash_permissions()
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()
 	setup_subcontractor_wo_workflow()

--- a/buildsuite_core/tests/test_petty_cash.py
+++ b/buildsuite_core/tests/test_petty_cash.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Petty Cash Request → Journal Entry on disburse (the live part of Project Finance)."""
+
+import frappe
+from frappe.utils import flt
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestPettyCash(BuildSuiteTestCase):
+	def setUp(self):
+		super().setUp()
+		self.company = frappe.db.get_single_value("Global Defaults", "default_company") or self.company
+		self.project = self._make_project(company=self.company).name
+
+	def _cash_account(self):
+		acc = frappe.db.get_value(
+			"Account", {"company": self.company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]}, "name"
+		)
+		if acc:
+			return acc
+		from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+		return _ensure_account(self.company, "Cash", "Asset", "Cash", "Current Assets")
+
+	def _request(self, amount=15000, purpose="Diesel + site consumables"):
+		return frappe.get_doc(
+			{
+				"doctype": "Petty Cash Request",
+				"project": self.project,
+				"request_date": "2026-07-20",
+				"amount": amount,
+				"purpose": purpose,
+			}
+		).insert(ignore_permissions=True)
+
+	def test_company_anchored_to_project(self):
+		req = self._request()
+		self.assertEqual(req.company, frappe.db.get_value("Project", self.project, "company"))
+
+	def test_disburse_posts_journal_entry(self):
+		req = self._request(amount=15000)
+		bank = self._cash_account()
+		req.disburse(bank)
+		req.reload()
+
+		self.assertEqual(req.status, "Disbursed")
+		self.assertTrue(req.journal_entry)
+		self.assertEqual(req.paid_from, bank)
+
+		je = frappe.get_doc("Journal Entry", req.journal_entry)
+		self.assertEqual(je.docstatus, 1)
+		debit = [a for a in je.accounts if flt(a.debit_in_account_currency) > 0]
+		credit = [a for a in je.accounts if flt(a.credit_in_account_currency) > 0]
+		# Dr Petty Cash 15000 / Cr bank 15000, both carrying the project dimension.
+		self.assertEqual(flt(debit[0].debit_in_account_currency), 15000)
+		self.assertEqual(credit[0].account, bank)
+		self.assertEqual(flt(credit[0].credit_in_account_currency), 15000)
+		self.assertTrue(all(a.project == self.project for a in je.accounts))
+
+	def test_cancel_disbursement_reverses_je(self):
+		req = self._request()
+		req.disburse(self._cash_account())
+		req.reload()
+		je = req.journal_entry
+		req.cancel_disbursement()
+		req.reload()
+		self.assertEqual(req.status, "Requested")
+		self.assertFalse(req.journal_entry)
+		self.assertEqual(frappe.db.get_value("Journal Entry", je, "docstatus"), 2)
+
+	def test_disburse_blocked_when_not_requested(self):
+		req = self._request()
+		req.disburse(self._cash_account())
+		req.reload()
+		# Already disbursed — a second disburse must fail.
+		self.assertRaises(frappe.ValidationError, req.disburse, self._cash_account())
+
+	def test_disburse_rejects_cross_company_account(self):
+		other = frappe.db.get_value("Company", {"name": ["!=", self.company]}, "name")
+		if not other:
+			self.skipTest("needs a second company")
+		other_acc = frappe.db.get_value(
+			"Account", {"company": other, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]}, "name"
+		)
+		if not other_acc:
+			self.skipTest("no cross-company cash account")
+		req = self._request()
+		self.assertRaises(frappe.ValidationError, req.disburse, other_acc)

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Petty Cash Request → Journal Entry.
+
+Disbursing a petty cash request moves money out of a bank/cash account into the company's
+Petty Cash account via a submitted Journal Entry (Dr Petty Cash / Cr paid-from), carrying the
+project accounting dimension. Cancelling the disbursement cancels the JE."""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+PETTY_CASH_ACCOUNT_NAME = "Petty Cash"
+
+
+def resolve_petty_cash_account(company):
+	"""The company's Petty Cash ledger — the BuildSuite Core Settings default (if it belongs to
+	the company), else a per-company 'Petty Cash' asset account, created if absent."""
+	default = frappe.db.get_single_value("BuildSuite Core Settings", "default_petty_cash_account")
+	if default and frappe.db.get_value("Account", default, "company") == company:
+		return default
+	from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+	return _ensure_account(company, PETTY_CASH_ACCOUNT_NAME, "Asset", "Cash", "Current Assets")
+
+
+def post_disbursement_journal_entry(doc):
+	"""Build + submit the disbursement JE and return its name."""
+	petty = resolve_petty_cash_account(doc.company)
+	amount = flt(doc.amount)
+
+	je = frappe.new_doc("Journal Entry")
+	je.voucher_type = "Journal Entry"
+	je.company = doc.company
+	je.posting_date = str(doc.request_date) if doc.request_date else None
+	je.user_remark = (f"Petty cash {doc.name}: {doc.purpose or ''}")[:140]
+	if frappe.get_meta("Journal Entry").has_field("petty_cash_request"):
+		je.petty_cash_request = doc.name
+	je.append("accounts", {"account": petty, "debit_in_account_currency": amount, "project": doc.project})
+	je.append(
+		"accounts", {"account": doc.paid_from, "credit_in_account_currency": amount, "project": doc.project}
+	)
+	je.flags.ignore_permissions = True
+	je.insert()
+	je.submit()
+	return je.name
+
+
+def cancel_disbursement_journal_entry(doc):
+	if not doc.journal_entry or not frappe.db.exists("Journal Entry", doc.journal_entry):
+		return
+	je = frappe.get_doc("Journal Entry", doc.journal_entry)
+	if je.docstatus == 1:
+		je.flags.ignore_permissions = True
+		je.cancel()

--- a/frontend/src/data/pettyCashApi.js
+++ b/frontend/src/data/pettyCashApi.js
@@ -1,0 +1,25 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Live Petty Cash Request endpoints (buildsuite_core.api.petty_cash.*). Request → Disburse
+// (posts a Journal Entry) → reverse. The rest of the Project Finance workspace is mock data.
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.petty_cash.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const pettyCashCanDisburse = () => call("can_disburse", {});
+export const getPettyCash = (name) => call("get_request", { name });
+export const savePettyCash = (payload) => call("save_request", { payload: JSON.stringify(payload) });
+export const disbursePettyCash = (name, paidFrom) => call("disburse", { name, paid_from: paidFrom });
+export const undisbursePettyCash = (name) => call("undisburse", { name });
+export const cancelPettyCash = (name) => call("cancel_request", { name });
+export const deletePettyCash = (name) => call("delete_request", { name });
+export const listCashBankAccounts = (company) => call("list_cash_bank_accounts", { company });
+export const pettyCashHolderBalances = (company) => call("holder_balances", { company });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -61,6 +61,7 @@ const PAGE_TITLES = {
 	workforce: "Workforce",
 	"scope-change": "Scope Change",
 	"project-finance": "Project Finance",
+	"petty-cash": "Petty Cash",
 	accounting: "Accounting",
 	buying: "Buying",
 	stock: "Stock",
@@ -424,6 +425,11 @@ const routes = [
 					icon: "💵",
 					desc: "Petty cash, cost summary, project P&L and variance reports.",
 				},
+			},
+			{
+				path: "project-finance/petty-cash",
+				name: "petty-cash",
+				component: () => import("@/views/finance/FinancePettyCashPanel.vue"),
 			},
 
 			{

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -1,0 +1,340 @@
+<script setup>
+// Petty Cash — the LIVE part of Project Finance. Request → Disburse (posts a Journal Entry
+// server-side) → reverse. Everything else in the finance workspace is mock data.
+
+import { computed, reactive, ref } from "vue";
+import { useSessionStore } from "@/stores/session";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import { useDocTypeList } from "@/composables/useDocTypeList";
+import {
+	pettyCashCanDisburse,
+	savePettyCash,
+	disbursePettyCash,
+	undisbursePettyCash,
+	cancelPettyCash,
+	pettyCashHolderBalances,
+} from "@/data/pettyCashApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const session = useSessionStore();
+const confirmDialog = useConfirm();
+
+const canDisburse = ref(false);
+pettyCashCanDisburse()
+	.then((r) => (canDisburse.value = !!r.can_disburse))
+	.catch(() => {});
+
+const res = useDocTypeList("Petty Cash Request", {
+	fields: [
+		"name",
+		"project",
+		"requested_by",
+		"request_date",
+		"amount",
+		"purpose",
+		"status",
+		"company",
+		"paid_from",
+		"disbursed_by",
+	],
+	orderBy: "request_date desc",
+	pageLength: 0,
+	cache: "buildsuite-petty-cash-list",
+});
+const all = computed(() => res.data || []);
+
+const tab = ref("disburse");
+const search = ref("");
+const tabs = computed(() => [
+	...(canDisburse.value ? [{ id: "disburse", label: "To Disburse", count: requested.value.length }] : []),
+	{ id: "all", label: "All Requests", count: all.value.length },
+	{ id: "balances", label: "Balances", count: null },
+	{ id: "mine", label: "My Requests", count: mine.value.length },
+]);
+if (!canDisburse.value) tab.value = "mine";
+
+const requested = computed(() => all.value.filter((r) => r.status === "Requested"));
+const mine = computed(() => all.value.filter((r) => r.requested_by === session.user));
+const filteredAll = computed(() => {
+	const q = search.value.trim().toLowerCase();
+	if (!q) return all.value;
+	return all.value.filter(
+		(r) =>
+			(r.name || "").toLowerCase().includes(q) ||
+			(r.purpose || "").toLowerCase().includes(q) ||
+			(r.requested_by || "").toLowerCase().includes(q) ||
+			(r.project || "").toLowerCase().includes(q),
+	);
+});
+
+const columns = [
+	{ key: "requested_by", label: "Holder" },
+	{ key: "purpose", label: "Purpose" },
+	{ key: "project", label: "Project" },
+	{ key: "request_date", label: "Date" },
+	{ key: "amount", label: "Amount", align: "right" },
+	{ key: "status", label: "Status" },
+	{ key: "actions", label: "" },
+];
+
+// --- balances ---
+const balances = ref([]);
+async function loadBalances() {
+	try {
+		balances.value = await pettyCashHolderBalances();
+	} catch (err) {
+		showToast(err.message || "Failed to load balances", "error");
+	}
+}
+loadBalances();
+
+// --- request modal ---
+const reqForm = reactive({ open: false, project: "", amount: 0, purpose: "", saving: false });
+function openRequest() {
+	Object.assign(reqForm, { open: true, project: "", amount: 0, purpose: "", saving: false });
+}
+async function submitRequest() {
+	if (!reqForm.project) return showToast("Pick a project.", "error");
+	if (!(Number(reqForm.amount) > 0)) return showToast("Enter an amount.", "error");
+	if (!reqForm.purpose.trim()) return showToast("Enter a purpose.", "error");
+	reqForm.saving = true;
+	try {
+		await savePettyCash({ project: reqForm.project, amount: reqForm.amount, purpose: reqForm.purpose });
+		reqForm.open = false;
+		res.reload?.();
+		showToast("Petty cash requested.");
+	} catch (err) {
+		showToast(err.message || "Failed to save", "error");
+	} finally {
+		reqForm.saving = false;
+	}
+}
+
+// --- disburse modal ---
+const disb = reactive({ open: false, row: null, paidFrom: "", saving: false });
+function openDisburse(row) {
+	Object.assign(disb, { open: true, row, paidFrom: "", saving: false });
+}
+async function confirmDisburse() {
+	if (!disb.paidFrom) return showToast("Pick the account to pay from.", "error");
+	disb.saving = true;
+	try {
+		await disbursePettyCash(disb.row.name, disb.paidFrom);
+		disb.open = false;
+		res.reload?.();
+		loadBalances();
+		showToast("Disbursed — Journal Entry posted.");
+	} catch (err) {
+		showToast(err.message || "Disburse failed", "error");
+	} finally {
+		disb.saving = false;
+	}
+}
+
+async function onUndisburse(row) {
+	const ok = await confirmDialog({
+		title: "Reverse disbursement?",
+		message: `Cancel the Journal Entry for ${row.name} and revert it to Requested?`,
+		confirmLabel: "Reverse",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await undisbursePettyCash(row.name);
+		res.reload?.();
+		loadBalances();
+		showToast("Disbursement reversed.");
+	} catch (err) {
+		showToast(err.message || "Reverse failed", "error");
+	}
+}
+async function onWithdraw(row) {
+	const ok = await confirmDialog({
+		title: "Withdraw request?",
+		message: `Cancel your petty cash request ${row.name}?`,
+		confirmLabel: "Withdraw",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await cancelPettyCash(row.name);
+		res.reload?.();
+		showToast("Request withdrawn.");
+	} catch (err) {
+		showToast(err.message || "Withdraw failed", "error");
+	}
+}
+
+function accountFilters(company) {
+	return [
+		["account_type", "in", ["Bank", "Cash"]],
+		["is_group", "=", 0],
+		["company", "=", company],
+	];
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Project Finance", to: "/project-finance" },
+	{ label: "Petty Cash" },
+];
+const rowsForTab = computed(() => {
+	if (tab.value === "disburse") return requested.value;
+	if (tab.value === "mine") return mine.value;
+	return filteredAll.value;
+});
+</script>
+
+<template>
+	<DeskPage title="Petty Cash" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button type="button" class="desk-save-btn" @click="openRequest">+ Request</button>
+		</template>
+
+		<!-- tabs -->
+		<div class="border-b border-ink-200 flex overflow-x-auto scrollbar-thin mb-4">
+			<button
+				v-for="t in tabs"
+				:key="t.id"
+				type="button"
+				class="px-3 py-2 text-xs font-medium whitespace-nowrap"
+				:class="tab === t.id ? 'text-brand-600' : 'text-ink-600 hover:text-ink-900'"
+				:style="tab === t.id ? 'border-bottom: 2px solid currentColor; margin-bottom: -1px;' : 'border-bottom: 2px solid transparent; margin-bottom: -1px;'"
+				@click="tab = t.id"
+			>
+				{{ t.label }}<span v-if="t.count !== null" class="ml-1 text-ink-500 tabular-nums">({{ t.count }})</span>
+			</button>
+		</div>
+
+		<!-- balances -->
+		<div v-if="tab === 'balances'" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+			<table class="w-full text-xs">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr>
+						<th class="text-left px-3 py-2">Holder</th>
+						<th class="text-right px-3 py-2">Disbursed (float out)</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="b in balances" :key="b.holder" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-900">{{ b.holder }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(b.disbursed) }}</td>
+					</tr>
+					<tr v-if="!balances.length">
+						<td colspan="2" class="px-3 py-4 text-center text-ink-400 italic">No disbursements yet.</td>
+					</tr>
+				</tbody>
+			</table>
+			<p class="px-3 py-2 text-[11px] text-ink-400 border-t border-ink-100">
+				Verified spend against these floats is tracked on the Expenses tab.
+			</p>
+		</div>
+
+		<!-- request lists -->
+		<DeskList
+			v-else
+			v-model="search"
+			:rows="rowsForTab"
+			:columns="columns"
+			row-key="name"
+			:search-placeholder="tab === 'all' ? 'Search requests…' : ''"
+		>
+			<template #cell-requested_by="{ row }">
+				<span class="text-xs text-ink-900">{{ row.requested_by }}</span>
+			</template>
+			<template #cell-purpose="{ row }">
+				<span class="text-xs text-ink-700">{{ (row.purpose || "").slice(0, 60) }}</span>
+			</template>
+			<template #cell-project="{ row }">
+				<span class="text-xs text-ink-500">{{ row.project }}</span>
+			</template>
+			<template #cell-request_date="{ row }">
+				<span class="text-xs text-ink-500">{{ fmtDate(row.request_date) }}</span>
+			</template>
+			<template #cell-amount="{ row }">
+				<span class="text-xs tabular-nums font-medium">{{ fmtINR(row.amount) }}</span>
+			</template>
+			<template #cell-status="{ row }">
+				<StatusBadge :status="row.status" />
+			</template>
+			<template #cell-actions="{ row }">
+				<div class="flex justify-end gap-2">
+					<button
+						v-if="row.status === 'Requested' && canDisburse"
+						type="button"
+						class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded"
+						@click.stop="openDisburse(row)"
+					>
+						Disburse
+					</button>
+					<button
+						v-if="row.status === 'Requested' && row.requested_by === session.user"
+						type="button"
+						class="text-[11px] px-2 py-0.5 border border-ink-200 text-ink-600 rounded"
+						@click.stop="onWithdraw(row)"
+					>
+						Withdraw
+					</button>
+					<button
+						v-if="row.status === 'Disbursed' && canDisburse"
+						type="button"
+						class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded"
+						@click.stop="onUndisburse(row)"
+					>
+						Reverse
+					</button>
+				</div>
+			</template>
+			<template #empty>
+				<div class="text-sm text-ink-500">{{ res.loading ? "Loading…" : "Nothing here." }}</div>
+			</template>
+		</DeskList>
+
+		<!-- request modal -->
+		<div v-if="reqForm.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="reqForm.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">Request petty cash</h3>
+				<div class="space-y-3">
+					<DeskField label="Project" required>
+						<DeskLinkPicker v-model="reqForm.project" doctype="Project" label-field="project_name" value-field="name" placeholder="Pick a project…" />
+					</DeskField>
+					<DeskField label="Amount" required><DeskInput v-model.number="reqForm.amount" type="number" min="0" /></DeskField>
+					<DeskField label="Purpose" required><DeskInput v-model="reqForm.purpose" placeholder="What is it for?" /></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5">
+					<button class="desk-btn" @click="reqForm.open = false">Cancel</button>
+					<button class="desk-save-btn" :disabled="reqForm.saving" @click="submitRequest">{{ reqForm.saving ? "Saving…" : "Request" }}</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- disburse modal -->
+		<div v-if="disb.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="disb.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-1">Disburse {{ fmtINR(disb.row?.amount) }}</h3>
+				<p class="text-xs text-ink-500 mb-4">to {{ disb.row?.requested_by }} · posts a Journal Entry (Dr Petty Cash / Cr the account).</p>
+				<DeskField label="Pay from" required>
+					<DeskLinkPicker
+						v-model="disb.paidFrom"
+						doctype="Account"
+						label-field="name"
+						value-field="name"
+						:filters="accountFilters(disb.row?.company)"
+						placeholder="Bank / Cash account…"
+					/>
+				</DeskField>
+				<div class="flex justify-end gap-2 mt-5">
+					<button class="desk-btn" @click="disb.open = false">Cancel</button>
+					<button class="desk-save-btn" :disabled="disb.saving" @click="confirmDisburse">{{ disb.saving ? "Posting…" : "Disburse" }}</button>
+				</div>
+			</div>
+		</div>
+	</DeskPage>
+</template>


### PR DESCRIPTION
## What
The **live** Petty Cash piece of Project Finance (the rest of the workspace lands as dummy data in a follow-up PR).

### Backend
- New **Petty Cash Request** doctype: `Requested → Disbursed → Cancelled`. Company anchored to the project.
- **Disburse** posts + submits a **Journal Entry** — Dr the per-company **Petty Cash** account / Cr the chosen bank/cash account — carrying the project accounting dimension. **Reverse** cancels the JE and reverts to Requested.
- JE back-link custom field (`petty_cash_request`); a **BuildSuite Core Settings → Default Petty Cash Account**; role perms (site roles raise their own; finance roles disburse — disburse gated in the API, not a DocPerm); `api/petty_cash.py`.

### Frontend
- A live **Petty Cash** panel (`/project-finance/petty-cash`) with **To Disburse / All Requests / Balances / My Requests** tabs, a request modal, and a disburse modal (company-scoped bank/cash account picker).

## Testing
- **5 new backend tests** (disburse posts the JE with the right Dr/Cr + project dimension; reverse cancels it; company anchored to project; disburse guarded for non-Requested / cross-company account). Full suite green (216). `yarn build` clean. Migrate syncs the doctype + custom field + settings + perms.
