### PR TITLE
Project Finance workspace (dummy data)

### DIFF
--- a/frontend/src/data/financeMock.js
+++ b/frontend/src/data/financeMock.js
@@ -1,0 +1,176 @@
+// Project Finance — self-contained CLIENT-SIDE MOCK store. Everything in the Project Finance
+// workspace runs on this dummy data (session-scoped, resets on reload) — exactly like the demo —
+// EXCEPT Petty Cash, which is live (see pettyCashApi / FinancePettyCashPanel). Holds the seed
+// arrays + name resolvers + derived getters + mutation actions the panels/reports use.
+
+import { defineStore } from "pinia";
+
+let seq = 1000;
+const uid = (p) => `${p}-${++seq}`;
+const today = () => new Date().toISOString().slice(0, 10);
+const daysBetween = (a, b) => Math.round((new Date(a) - new Date(b)) / 86400000);
+
+export const useFinanceMock = defineStore("financeMock", {
+	state: () => ({
+		companies: [
+			{ id: "ACME-COM", name: "Acme Construction Co", shortName: "Acme", color: "bg-brand-500" },
+			{ id: "ACME-RES", name: "Acme Residential", shortName: "Acme Res", color: "bg-info-500" },
+		],
+		users: [
+			{ id: "USR-001", name: "Anita Rao" },
+			{ id: "USR-005", name: "Kiran Mehta" },
+			{ id: "USR-008", name: "Suresh Nair" },
+		],
+		projects: [
+			{ id: "PROJ-2026-001-A", name: "Block A — Office Tower", code: "BTP-P2-A", company: "ACME-COM" },
+			{ id: "PROJ-2026-002", name: "Riverside Residency", code: "RR-01", company: "ACME-RES" },
+		],
+		financeAccounts: [
+			{ id: "ACC-BANK-01", name: "HDFC Current A/c", type: "Bank", account_no: "50200011223344", opening_balance: 5000000, company: "ACME-COM" },
+			{ id: "ACC-CASH-01", name: "Cash in Hand", type: "Cash", account_no: "", opening_balance: 200000, company: "ACME-COM" },
+		],
+		customers: [
+			{ id: "CUST-001", name: "ABC Constructions", type: "Company", contactPerson: "Rajesh Kumar", phone: "+91 98501 23401", email: "rajesh@abccons.example", gstin: "29AABCC1001A1Z5", company: "ACME-COM" },
+			{ id: "CUST-002", name: "Sunrise Developers", type: "Partnership", contactPerson: "Meera Iyer", phone: "+91 98450 55220", email: "meera@sunrise.example", gstin: "29AAFCS2002B1Z4", company: "ACME-RES" },
+		],
+		suppliers: [
+			{ id: "SUP-001", name: "UltraTech Cement Ltd", type: "Material", contactPerson: "Naveen Rao", phone: "+91 98450 71001", email: "naveen.rao@ultratech.example", gstin: "29AABCU1001A1Z5", company: "ACME-COM" },
+			{ id: "SUP-002", name: "Tata Steel", type: "Material", contactPerson: "Deepak Shah", phone: "+91 90080 22110", email: "deepak@tatasteel.example", gstin: "27AAACT2727Q1ZW", company: "ACME-COM" },
+		],
+		subcontractors: [
+			{ id: "SC-001", name: "Sterling Flooring Co", trade: "Flooring", contactPerson: "Ali Khan", phone: "+91 99001 22334", gstin: "29AASFS3003C1Z3", status: "Active" },
+		],
+		subcontractorBills: [
+			{ id: "SB-2026-0001", supplier: "SC-001", project: "PROJ-2026-001-A", date: "2026-06-05", gross: 204000, retention: 10200, total: 193800, company: "ACME-COM", paymentEntries: [] },
+		],
+		invoices: [
+			{ id: "INV-2026-0001", workflow_state: "Submitted", customer: "CUST-001", project: "PROJ-2026-001-A", date: "2026-06-01", due_date: "2026-07-01", gst_rate: 18, gross: 2500000, tax: 450000, total: 2950000, company: "ACME-COM", lines: [{ id: "INL-1", description: "Block A — RA-3 milestone", amount: 2500000 }], receipts: [{ id: "RCPT-1", date: "2026-07-05", amount: 1000000, account: "ACC-BANK-01" }] },
+			{ id: "INV-2026-0002", workflow_state: "Submitted", customer: "CUST-002", project: "PROJ-2026-002", date: "2026-05-20", due_date: "2026-06-19", gst_rate: 18, gross: 1200000, tax: 216000, total: 1416000, company: "ACME-RES", lines: [{ id: "INL-2", description: "Foundation works", amount: 1200000 }], receipts: [] },
+		],
+		bills: [
+			{ id: "BILL-2026-0001", supplier: "SUP-001", project: "PROJ-2026-001-A", date: "2026-06-10", due_date: "2026-07-10", gst_rate: 18, gross: 450000, tax: 81000, total: 531000, company: "ACME-COM", lines: [{ id: "BLL-1", description: "OPC 53 cement — 900 bags", amount: 450000 }], payments: [{ id: "PMT-1", date: "2026-07-05", amount: 200000, account: "ACC-BANK-01" }] },
+			{ id: "BILL-2026-0002", supplier: "SUP-002", project: "PROJ-2026-001-A", date: "2026-06-18", due_date: "2026-07-18", gst_rate: 18, gross: 780000, tax: 140400, total: 920400, company: "ACME-COM", lines: [{ id: "BLL-2", description: "TMT bars Fe550 — 40 T", amount: 780000 }], payments: [] },
+		],
+		expenses: [
+			{ id: "EXP-2026-0001", date: "2026-06-22", description: "Safety helmets, gloves, jackets", amount: 6400, project: "PROJ-2026-001-A", expense_account: "Site Safety Expenses", cost_type: "Overhead", paid_from: "ACC-CASH-01", holder: "USR-005", status: "Submitted", reimbursed: false, company: "ACME-COM" },
+			{ id: "EXP-2026-0002", date: "2026-07-02", description: "Diesel for concrete pump", amount: 8200, project: "PROJ-2026-001-A", expense_account: "Fuel & Lubricants", cost_type: "Plant & Machinery", paid_from: "ACC-CASH-01", holder: "USR-005", status: "Draft", reimbursed: false, company: "ACME-COM" },
+		],
+		customerAdvances: [
+			{ id: "CADV-2026-0001", customer: "CUST-002", date: "2026-06-15", amount: 500000, account: "ACC-BANK-01", allocated: 0, company: "ACME-RES" },
+		],
+		supplierAdvances: [
+			{ id: "SADV-2026-0001", supplier: "SUP-001", date: "2026-06-05", amount: 150000, account: "ACC-BANK-01", allocated: 0, company: "ACME-COM" },
+		],
+		paymentEntries: [],
+	}),
+
+	getters: {
+		// --- name resolvers ---
+		projectName: (s) => (id) => s.projects.find((p) => p.id === id)?.name || id || "—",
+		userName: (s) => (id) => s.users.find((u) => u.id === id)?.name || id || "—",
+		companyById: (s) => (id) => s.companies.find((c) => c.id === id) || null,
+		accountById: (s) => (id) => s.financeAccounts.find((a) => a.id === id) || null,
+		customerById: (s) => (id) => s.customers.find((c) => c.id === id) || null,
+		supplierById: (s) => (id) => s.suppliers.find((c) => c.id === id) || null,
+		partyName() {
+			return (kind, id) => (kind === "customer" ? this.customerById(id)?.name : this.supplierById(id)?.name) || id;
+		},
+
+		// --- invoices / receivables ---
+		postedInvoices: (s) => s.invoices.filter((i) => i.workflow_state === "Submitted"),
+		invoiceOutstanding: () => (inv) => (inv.total || 0) - (inv.receipts || []).reduce((a, r) => a + (r.amount || 0), 0),
+		openInvoices() {
+			return this.postedInvoices.filter((i) => this.invoiceOutstanding(i) > 0.5);
+		},
+		totalReceivable() {
+			return this.openInvoices.reduce((a, i) => a + this.invoiceOutstanding(i), 0);
+		},
+
+		// --- bills / payables ---
+		billOutstanding: () => (b) => (b.total || 0) - (b.payments || []).reduce((a, p) => a + (p.amount || 0), 0),
+		scBillOutstanding: () => (b) => (b.total || 0) - (b.paymentEntries || []).reduce((a, p) => a + (p.amount || 0), 0),
+		unifiedPayables() {
+			const regular = this.bills.map((b) => ({ kind: "regular", ...b, outstanding: this.billOutstanding(b), retention: 0 }));
+			const sub = this.subcontractorBills.map((b) => ({ kind: "subcontractor", ...b, outstanding: this.scBillOutstanding(b) }));
+			return [...regular, ...sub];
+		},
+		totalPayable() {
+			return this.unifiedPayables.reduce((a, b) => a + (b.outstanding || 0), 0);
+		},
+		retentionHeld: (s) => s.subcontractorBills.reduce((a, b) => a + (b.retention || 0), 0),
+
+		// --- accounts / cash ---
+		accountBalance() {
+			return (accId) => {
+				const acc = this.accountById(accId);
+				if (!acc) return 0;
+				let bal = acc.opening_balance || 0;
+				this.invoices.forEach((i) => (i.receipts || []).forEach((r) => r.account === accId && (bal += r.amount)));
+				this.customerAdvances.forEach((a) => a.account === accId && (bal += a.amount));
+				this.bills.forEach((b) => (b.payments || []).forEach((p) => p.account === accId && (bal -= p.amount)));
+				this.supplierAdvances.forEach((a) => a.account === accId && (bal -= a.amount));
+				return bal;
+			};
+		},
+		sortedFinanceAccounts: (s) => [...s.financeAccounts].sort((a, b) => a.name.localeCompare(b.name)),
+		totalCashBank() {
+			return this.financeAccounts.filter((a) => a.type !== "Petty Cash").reduce((a, acc) => a + this.accountBalance(acc.id), 0);
+		},
+
+		// --- expenses ---
+		verifiedExpenses: (s) => s.expenses.filter((e) => e.status === "Submitted"),
+		expensesToVerify: (s) => s.expenses.filter((e) => e.status === "Draft"),
+
+		// --- aging ---
+		agingBucket: () => (dueDate) => {
+			if (!dueDate) return "Not due";
+			const d = daysBetween(today(), dueDate);
+			if (d <= 0) return "Not due";
+			if (d <= 30) return "0-30d";
+			if (d <= 60) return "31-60d";
+			return "60+d";
+		},
+
+		// --- unified payment register ---
+		allPayments() {
+			const out = [];
+			this.invoices.forEach((i) => (i.receipts || []).forEach((r) => out.push({ id: r.id, date: r.date, type: "Invoice receipt", dir: "in", party: this.customerById(i.customer)?.name, account: r.account, amount: r.amount, ref: i.id })));
+			this.customerAdvances.forEach((a) => out.push({ id: a.id, date: a.date, type: "Customer advance", dir: "in", party: this.customerById(a.customer)?.name, account: a.account, amount: a.amount, ref: a.id }));
+			this.bills.forEach((b) => (b.payments || []).forEach((p) => out.push({ id: p.id, date: p.date, type: "Bill payment", dir: "out", party: this.supplierById(b.supplier)?.name, account: p.account, amount: p.amount, ref: b.id })));
+			this.supplierAdvances.forEach((a) => out.push({ id: a.id, date: a.date, type: "Supplier advance", dir: "out", party: this.supplierById(a.supplier)?.name, account: a.account, amount: a.amount, ref: a.id }));
+			return out.sort((a, b) => new Date(b.date) - new Date(a.date));
+		},
+	},
+
+	actions: {
+		addCustomer(d) { const r = { id: uid("CUST"), allocated: 0, ...d }; this.customers.push(r); return r; },
+		addSupplier(d) { const r = { id: uid("SUP"), ...d }; this.suppliers.push(r); return r; },
+		addInvoice(d) {
+			const gross = (d.lines || []).reduce((a, l) => a + (Number(l.amount) || 0), 0);
+			const tax = Math.round((gross * (Number(d.gst_rate) || 0)) / 100);
+			const r = { id: uid("INV"), workflow_state: "Submitted", gross, tax, total: gross + tax, receipts: [], ...d };
+			this.invoices.unshift(r);
+			return r;
+		},
+		addInvoiceReceipt(id, amount, account) {
+			const inv = this.invoices.find((i) => i.id === id);
+			if (inv) inv.receipts.push({ id: uid("RCPT"), date: today(), amount: Number(amount), account });
+		},
+		addBill(d) {
+			const gross = (d.lines || []).reduce((a, l) => a + (Number(l.amount) || 0), 0);
+			const tax = Math.round((gross * (Number(d.gst_rate) || 0)) / 100);
+			const r = { id: uid("BILL"), gross, tax, total: gross + tax, payments: [], ...d };
+			this.bills.unshift(r);
+			return r;
+		},
+		addBillPayment(id, amount, account) {
+			const b = this.bills.find((x) => x.id === id);
+			if (b) b.payments.push({ id: uid("PMT"), date: today(), amount: Number(amount), account });
+		},
+		addCustomerAdvance(d) { const r = { id: uid("CADV"), date: today(), allocated: 0, ...d }; this.customerAdvances.push(r); return r; },
+		addSupplierAdvance(d) { const r = { id: uid("SADV"), date: today(), allocated: 0, ...d }; this.supplierAdvances.push(r); return r; },
+		addExpense(d) { const r = { id: uid("EXP"), date: today(), status: "Draft", reimbursed: false, ...d }; this.expenses.unshift(r); return r; },
+		submitExpense(id) { const e = this.expenses.find((x) => x.id === id); if (e) e.status = "Submitted"; },
+		cancelExpense(id) { const e = this.expenses.find((x) => x.id === id); if (e) e.status = "Cancelled"; },
+	},
+});

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -419,17 +419,24 @@ const routes = [
 			{
 				path: "project-finance",
 				name: "project-finance",
-				component: () => import("@/views/PlaceholderView.vue"),
-				props: {
-					title: "Project Finance",
-					icon: "💵",
-					desc: "Petty cash, cost summary, project P&L and variance reports.",
-				},
+				component: () => import("@/views/workspaces/ProjectFinanceWorkspace.vue"),
 			},
 			{
 				path: "project-finance/petty-cash",
 				name: "petty-cash",
 				component: () => import("@/views/finance/FinancePettyCashPanel.vue"),
+			},
+			{
+				path: "project-finance/report/:slug",
+				name: "finance-report",
+				component: () => import("@/views/finance/FinanceReportPageView.vue"),
+				props: true,
+			},
+			{
+				path: "project-finance/:section",
+				name: "finance-section",
+				component: () => import("@/views/finance/FinancePageView.vue"),
+				props: true,
 			},
 
 			{

--- a/frontend/src/views/finance/FinanceBillsPanel.vue
+++ b/frontend/src/views/finance/FinanceBillsPanel.vue
@@ -1,0 +1,86 @@
+<script setup>
+import { computed, reactive } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Bills" }];
+const rows = computed(() => fin.unifiedPayables);
+function partyName(b) {
+	return b.kind === "subcontractor" ? fin.subcontractors.find((s) => s.id === b.supplier)?.name || b.supplier : fin.supplierById(b.supplier)?.name || b.supplier;
+}
+
+const form = reactive({ open: false, supplier: "", project: "", date: new Date().toISOString().slice(0, 10), due_date: "", gst_rate: 18, description: "", amount: 0 });
+function createBill() {
+	if (!form.supplier || !(Number(form.amount) > 0)) return;
+	fin.addBill({ supplier: form.supplier, project: form.project, date: form.date, due_date: form.due_date, gst_rate: Number(form.gst_rate), lines: [{ id: "l", description: form.description, amount: Number(form.amount) }] });
+	form.open = false;
+}
+
+const pay = reactive({ open: false, bill: null, amount: 0, account: "" });
+function openPay(b) {
+	if (b.kind === "subcontractor") return; // subcontractor bills are paid from the Subcontract module
+	Object.assign(pay, { open: true, bill: b, amount: b.outstanding, account: fin.financeAccounts[0]?.id || "" });
+}
+function doPay() {
+	if (!(Number(pay.amount) > 0) || !pay.account) return;
+	fin.addBillPayment(pay.bill.id, pay.amount, pay.account);
+	pay.open = false;
+}
+</script>
+
+<template>
+	<DeskPage title="Bills" :breadcrumbs="breadcrumbs">
+		<template #actions><button class="desk-save-btn" @click="form.open = true">+ New Bill</button></template>
+		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<table class="w-full text-xs" style="min-width: 720px">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr><th class="text-left px-3 py-2">Supplier</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Retention</th><th class="text-right px-3 py-2">Outstanding</th><th></th></tr>
+				</thead>
+				<tbody>
+					<tr v-for="b in rows" :key="b.id" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-900">{{ partyName(b) }}<span v-if="b.kind === 'subcontractor'" class="ml-1.5 text-[9px] px-1 py-0.5 bg-info-50 text-info-700 rounded uppercase">Sub</span></td>
+						<td class="px-3 py-2 text-ink-500">{{ fin.projectName(b.project) }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(b.date) }}</td>
+						<td class="px-3 py-2 text-ink-600">{{ b.due_date ? fin.agingBucket(b.due_date) : "—" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(b.total) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-warning-700">{{ b.retention ? fmtINR(b.retention) : "—" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(b.outstanding) }}</td>
+						<td class="px-3 py-2 text-right"><button v-if="b.kind === 'regular' && b.outstanding > 0.5" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openPay(b)">Pay</button></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-lg p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">New bill</h3>
+				<div class="grid grid-cols-2 gap-3">
+					<DeskField label="Supplier" required><DeskSelect v-model="form.supplier"><option value="">—</option><option v-for="s in fin.suppliers" :key="s.id" :value="s.id">{{ s.name }}</option></DeskSelect></DeskField>
+					<DeskField label="Project"><DeskSelect v-model="form.project"><option value="">—</option><option v-for="p in fin.projects" :key="p.id" :value="p.id">{{ p.name }}</option></DeskSelect></DeskField>
+					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
+					<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
+					<DeskField label="GST %"><DeskInput v-model.number="form.gst_rate" type="number" /></DeskField>
+					<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" /></DeskField>
+					<DeskField label="Description" class="col-span-2"><DeskInput v-model="form.description" /></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="createBill">Create</button></div>
+			</div>
+		</div>
+
+		<div v-if="pay.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="pay.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-sm p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">Pay bill</h3>
+				<div class="space-y-3">
+					<DeskField label="Amount"><DeskInput v-model.number="pay.amount" type="number" /></DeskField>
+					<DeskField label="From account"><DeskSelect v-model="pay.account"><option v-for="a in fin.financeAccounts" :key="a.id" :value="a.id">{{ a.name }}</option></DeskSelect></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="pay.open = false">Cancel</button><button class="desk-save-btn" @click="doPay">Pay</button></div>
+			</div>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceCustomersPanel.vue
+++ b/frontend/src/views/finance/FinanceCustomersPanel.vue
@@ -1,0 +1,56 @@
+<script setup>
+import { computed, reactive, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+
+const fin = useFinanceMock();
+const search = ref("");
+const rows = computed(() => {
+	const q = search.value.trim().toLowerCase();
+	return fin.customers.filter((c) => !q || c.name.toLowerCase().includes(q) || (c.gstin || "").toLowerCase().includes(q));
+});
+const columns = [
+	{ key: "name", label: "Name" },
+	{ key: "type", label: "Type" },
+	{ key: "contactPerson", label: "Contact" },
+	{ key: "phone", label: "Phone" },
+	{ key: "gstin", label: "GST no." },
+];
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Customers" }];
+
+const form = reactive({ open: false, name: "", type: "Company", contactPerson: "", phone: "", email: "", gstin: "" });
+function save() {
+	if (!form.name.trim()) return;
+	fin.addCustomer({ name: form.name.trim(), type: form.type, contactPerson: form.contactPerson, phone: form.phone, email: form.email, gstin: form.gstin });
+	form.open = false;
+	Object.assign(form, { name: "", contactPerson: "", phone: "", email: "", gstin: "" });
+}
+</script>
+
+<template>
+	<DeskPage title="Customers" :breadcrumbs="breadcrumbs">
+		<template #actions><button class="desk-save-btn" @click="form.open = true">+ New</button></template>
+		<DeskList v-model="search" :rows="rows" :columns="columns" row-key="id" search-placeholder="Search customers…">
+			<template #cell-type="{ row }"><span class="text-[11px] px-1.5 py-0.5 bg-ink-100 text-ink-700 rounded">{{ row.type }}</span></template>
+			<template #cell-gstin="{ row }"><span class="font-mono text-xs text-ink-500">{{ row.gstin || "—" }}</span></template>
+		</DeskList>
+		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">New customer</h3>
+				<div class="space-y-3">
+					<DeskField label="Name" required><DeskInput v-model="form.name" /></DeskField>
+					<DeskField label="Type"><DeskSelect v-model="form.type"><option>Company</option><option>Individual</option><option>Partnership</option></DeskSelect></DeskField>
+					<DeskField label="Contact person"><DeskInput v-model="form.contactPerson" /></DeskField>
+					<DeskField label="Phone"><DeskInput v-model="form.phone" /></DeskField>
+					<DeskField label="Email"><DeskInput v-model="form.email" /></DeskField>
+					<DeskField label="GST no."><DeskInput v-model="form.gstin" /></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="save">Save</button></div>
+			</div>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -1,0 +1,70 @@
+<script setup>
+import { computed, reactive, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Expenses" }];
+const tab = ref("all");
+const tabs = [
+	{ id: "toverify", label: "To Verify" },
+	{ id: "all", label: "All Expenses" },
+];
+const rows = computed(() => (tab.value === "toverify" ? fin.expensesToVerify : fin.expenses));
+
+const form = reactive({ open: false, date: new Date().toISOString().slice(0, 10), description: "", amount: 0, project: "", expense_account: "", cost_type: "Overhead", paid_from: "" });
+function create() {
+	if (!form.description.trim() || !(Number(form.amount) > 0)) return;
+	fin.addExpense({ date: form.date, description: form.description, amount: Number(form.amount), project: form.project, expense_account: form.expense_account, cost_type: form.cost_type, paid_from: form.paid_from, holder: "USR-005" });
+	form.open = false;
+}
+</script>
+
+<template>
+	<DeskPage title="Expenses" :breadcrumbs="breadcrumbs">
+		<template #actions><button class="desk-save-btn" @click="form.open = true">+ Log Expense</button></template>
+		<div class="border-b border-ink-200 flex mb-4">
+			<button v-for="t in tabs" :key="t.id" class="px-3 py-2 text-xs font-medium" :class="tab === t.id ? 'text-brand-600' : 'text-ink-600'" :style="tab === t.id ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'" @click="tab = t.id">{{ t.label }}</button>
+		</div>
+		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<table class="w-full text-xs" style="min-width: 720px">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Description</th><th class="text-left px-3 py-2">Account</th><th class="text-left px-3 py-2">Cost type</th><th class="text-right px-3 py-2">Amount</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
+				</thead>
+				<tbody>
+					<tr v-for="e in rows" :key="e.id" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(e.date) }}</td>
+						<td class="px-3 py-2 text-ink-900">{{ e.description }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ e.expense_account }}</td>
+						<td class="px-3 py-2 text-ink-600">{{ e.cost_type }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(e.amount) }}</td>
+						<td class="px-3 py-2"><StatusBadge :status="e.status" /></td>
+						<td class="px-3 py-2 text-right"><button v-if="e.status === 'Draft'" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="fin.submitExpense(e.id)">Verify</button></td>
+					</tr>
+					<tr v-if="!rows.length"><td colspan="7" class="px-3 py-4 text-center text-ink-400 italic">No expenses.</td></tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-lg p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">Log expense</h3>
+				<div class="grid grid-cols-2 gap-3">
+					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
+					<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" /></DeskField>
+					<DeskField label="Description" required class="col-span-2"><DeskInput v-model="form.description" /></DeskField>
+					<DeskField label="Project"><DeskSelect v-model="form.project"><option value="">—</option><option v-for="p in fin.projects" :key="p.id" :value="p.id">{{ p.name }}</option></DeskSelect></DeskField>
+					<DeskField label="Cost type"><DeskSelect v-model="form.cost_type"><option>Material</option><option>Labour</option><option>Plant &amp; Machinery</option><option>Subcontract</option><option>Overhead</option></DeskSelect></DeskField>
+					<DeskField label="Expense account"><DeskInput v-model="form.expense_account" /></DeskField>
+					<DeskField label="Paid from"><DeskSelect v-model="form.paid_from"><option value="">—</option><option v-for="a in fin.financeAccounts" :key="a.id" :value="a.id">{{ a.name }}</option></DeskSelect></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="create">Log</button></div>
+			</div>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { computed, reactive, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
+const rows = computed(() => fin.invoices);
+
+const form = reactive({ open: false, customer: "", project: "", date: new Date().toISOString().slice(0, 10), due_date: "", gst_rate: 18, description: "", amount: 0 });
+function createInvoice() {
+	if (!form.customer || !(Number(form.amount) > 0)) return;
+	fin.addInvoice({ customer: form.customer, project: form.project, date: form.date, due_date: form.due_date, gst_rate: Number(form.gst_rate), lines: [{ id: "l", description: form.description, amount: Number(form.amount) }] });
+	form.open = false;
+}
+
+const pay = reactive({ open: false, inv: null, amount: 0, account: "" });
+function openReceive(inv) { Object.assign(pay, { open: true, inv, amount: fin.invoiceOutstanding(inv), account: fin.financeAccounts[0]?.id || "" }); }
+function receive() {
+	if (!(Number(pay.amount) > 0) || !pay.account) return;
+	fin.addInvoiceReceipt(pay.inv.id, pay.amount, pay.account);
+	pay.open = false;
+}
+</script>
+
+<template>
+	<DeskPage title="Invoices" :breadcrumbs="breadcrumbs">
+		<template #actions><button class="desk-save-btn" @click="form.open = true">+ New Invoice</button></template>
+		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<table class="w-full text-xs" style="min-width: 720px">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr><th class="text-left px-3 py-2">Invoice</th><th class="text-left px-3 py-2">Customer</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
+				</thead>
+				<tbody>
+					<tr v-for="i in rows" :key="i.id" class="border-t border-ink-100">
+						<td class="px-3 py-2 font-mono text-[11px]">{{ i.id }}</td>
+						<td class="px-3 py-2 text-ink-900">{{ fin.customerById(i.customer)?.name || i.customer }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ fin.projectName(i.project) }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(i.due_date) }}</td>
+						<td class="px-3 py-2 text-ink-600">{{ fin.agingBucket(i.due_date) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(i.total) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(fin.invoiceOutstanding(i)) }}</td>
+						<td class="px-3 py-2"><StatusBadge :status="i.workflow_state" /></td>
+						<td class="px-3 py-2 text-right"><button v-if="fin.invoiceOutstanding(i) > 0.5" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openReceive(i)">Receive</button></td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+
+		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-lg p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">New invoice</h3>
+				<div class="grid grid-cols-2 gap-3">
+					<DeskField label="Customer" required><DeskSelect v-model="form.customer"><option value="">—</option><option v-for="c in fin.customers" :key="c.id" :value="c.id">{{ c.name }}</option></DeskSelect></DeskField>
+					<DeskField label="Project"><DeskSelect v-model="form.project"><option value="">—</option><option v-for="p in fin.projects" :key="p.id" :value="p.id">{{ p.name }}</option></DeskSelect></DeskField>
+					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
+					<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
+					<DeskField label="GST %"><DeskInput v-model.number="form.gst_rate" type="number" /></DeskField>
+					<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" /></DeskField>
+					<DeskField label="Description" class="col-span-2"><DeskInput v-model="form.description" /></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="createInvoice">Create</button></div>
+			</div>
+		</div>
+
+		<div v-if="pay.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="pay.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-sm p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">Receive payment</h3>
+				<div class="space-y-3">
+					<DeskField label="Amount"><DeskInput v-model.number="pay.amount" type="number" /></DeskField>
+					<DeskField label="Into account"><DeskSelect v-model="pay.account"><option v-for="a in fin.financeAccounts" :key="a.id" :value="a.id">{{ a.name }}</option></DeskSelect></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="pay.open = false">Cancel</button><button class="desk-save-btn" @click="receive">Receive</button></div>
+			</div>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceOverviewPanel.vue
+++ b/frontend/src/views/finance/FinanceOverviewPanel.vue
@@ -1,0 +1,56 @@
+<script setup>
+import { computed } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtDate, fmtINR, fmtCompactINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Overview" }];
+const kpis = computed(() => [
+	{ label: "Cash & bank", value: fin.totalCashBank, color: "text-ink-900" },
+	{ label: "Receivable", value: fin.totalReceivable, color: "text-success-700" },
+	{ label: "Payable", value: fin.totalPayable, color: "text-danger-700" },
+	{ label: "Retention held", value: fin.retentionHeld, color: "text-warning-700" },
+	{ label: "Net position", value: fin.totalCashBank + fin.totalReceivable - fin.totalPayable, color: "text-brand-700" },
+]);
+const recent = computed(() => fin.allPayments.slice(0, 6));
+</script>
+
+<template>
+	<DeskPage title="Finance Overview" :breadcrumbs="breadcrumbs">
+		<div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+			<div v-for="k in kpis" :key="k.label" class="bg-white border border-ink-200 rounded-lg px-3 py-2.5">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">{{ k.label }}</div>
+				<div class="text-base font-semibold tabular-nums mt-0.5" :class="k.color">{{ fmtCompactINR(k.value) }}</div>
+			</div>
+		</div>
+
+		<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Account balances</h3></div>
+				<table class="w-full text-xs">
+					<tbody>
+						<tr v-for="a in fin.sortedFinanceAccounts" :key="a.id" class="border-t border-ink-100">
+							<td class="px-4 py-2 text-ink-900">{{ a.name }} <span class="text-ink-400 text-[10px]">{{ a.type }}</span></td>
+							<td class="px-4 py-2 text-right tabular-nums font-medium">{{ fmtINR(fin.accountBalance(a.id)) }}</td>
+						</tr>
+					</tbody>
+				</table>
+			</section>
+
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Recent movements</h3></div>
+				<table class="w-full text-xs">
+					<tbody>
+						<tr v-for="p in recent" :key="p.id" class="border-t border-ink-100">
+							<td class="px-4 py-2 text-ink-500">{{ fmtDate(p.date) }}</td>
+							<td class="px-4 py-2 text-ink-700">{{ p.type }}</td>
+							<td class="px-4 py-2 text-right tabular-nums font-medium" :class="p.dir === 'in' ? 'text-success-700' : 'text-danger-700'">{{ p.dir === "in" ? "+" : "−" }}{{ fmtINR(p.amount) }}</td>
+						</tr>
+						<tr v-if="!recent.length"><td colspan="3" class="px-4 py-3 text-center text-ink-400 italic">No movements yet.</td></tr>
+					</tbody>
+				</table>
+			</section>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinancePageView.vue
+++ b/frontend/src/views/finance/FinancePageView.vue
@@ -1,0 +1,23 @@
+<script setup>
+// Maps /project-finance/:section to its panel (petty-cash has its own explicit live route).
+import { computed, defineAsyncComponent } from "vue";
+
+const props = defineProps({ section: String });
+
+const panels = {
+	overview: defineAsyncComponent(() => import("@/views/finance/FinanceOverviewPanel.vue")),
+	expenses: defineAsyncComponent(() => import("@/views/finance/FinanceExpensesPanel.vue")),
+	invoices: defineAsyncComponent(() => import("@/views/finance/FinanceInvoicesPanel.vue")),
+	bills: defineAsyncComponent(() => import("@/views/finance/FinanceBillsPanel.vue")),
+	payments: defineAsyncComponent(() => import("@/views/finance/FinancePaymentsPanel.vue")),
+	customers: defineAsyncComponent(() => import("@/views/finance/FinanceCustomersPanel.vue")),
+	suppliers: defineAsyncComponent(() => import("@/views/finance/FinanceSuppliersPanel.vue")),
+	subcontractors: defineAsyncComponent(() => import("@/views/finance/FinanceSubcontractorsPanel.vue")),
+};
+const comp = computed(() => panels[props.section] || null);
+</script>
+
+<template>
+	<component :is="comp" v-if="comp" />
+	<div v-else class="max-w-3xl mx-auto px-6 py-16 text-center text-ink-500">Unknown finance section.</div>
+</template>

--- a/frontend/src/views/finance/FinancePaymentsPanel.vue
+++ b/frontend/src/views/finance/FinancePaymentsPanel.vue
@@ -1,0 +1,51 @@
+<script setup>
+import { computed, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const search = ref("");
+const dir = ref("");
+const rows = computed(() => {
+	const q = search.value.trim().toLowerCase();
+	return fin.allPayments.filter(
+		(p) => (!dir.value || p.dir === dir.value) && (!q || (p.type || "").toLowerCase().includes(q) || (p.party || "").toLowerCase().includes(q) || (p.ref || "").toLowerCase().includes(q)),
+	);
+});
+const totalIn = computed(() => fin.allPayments.filter((p) => p.dir === "in").reduce((a, p) => a + p.amount, 0));
+const totalOut = computed(() => fin.allPayments.filter((p) => p.dir === "out").reduce((a, p) => a + p.amount, 0));
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Payments" }];
+</script>
+
+<template>
+	<DeskPage title="Payments" :breadcrumbs="breadcrumbs">
+		<div class="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
+			<div class="bg-white border border-ink-200 rounded-lg px-3 py-2"><div class="text-[10px] uppercase tracking-wider text-ink-500">Money in</div><div class="text-base font-semibold text-success-700 tabular-nums">{{ fmtINR(totalIn) }}</div></div>
+			<div class="bg-white border border-ink-200 rounded-lg px-3 py-2"><div class="text-[10px] uppercase tracking-wider text-ink-500">Money out</div><div class="text-base font-semibold text-danger-700 tabular-nums">{{ fmtINR(totalOut) }}</div></div>
+			<div class="bg-white border border-ink-200 rounded-lg px-3 py-2"><div class="text-[10px] uppercase tracking-wider text-ink-500">Net</div><div class="text-base font-semibold text-ink-900 tabular-nums">{{ fmtINR(totalIn - totalOut) }}</div></div>
+		</div>
+		<div class="flex items-center gap-2 mb-2">
+			<input v-model="search" placeholder="Search type / party / ref…" class="desk-input max-w-xs" />
+			<DeskSelect v-model="dir" class="!w-40"><option value="">Direction: Any</option><option value="in">Money in</option><option value="out">Money out</option></DeskSelect>
+		</div>
+		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<table class="w-full text-xs" style="min-width: 640px">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Type</th><th class="text-left px-3 py-2">Party</th><th class="text-left px-3 py-2">Account</th><th class="text-right px-3 py-2">Amount</th></tr>
+				</thead>
+				<tbody>
+					<tr v-for="p in rows" :key="p.id" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(p.date) }}</td>
+						<td class="px-3 py-2 text-ink-900">{{ p.type }}</td>
+						<td class="px-3 py-2 text-ink-700">{{ p.party || "—" }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ fin.accountById(p.account)?.name || p.account }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium" :class="p.dir === 'in' ? 'text-success-700' : 'text-danger-700'">{{ p.dir === "in" ? "+" : "−" }}{{ fmtINR(p.amount) }}</td>
+					</tr>
+					<tr v-if="!rows.length"><td colspan="5" class="px-3 py-4 text-center text-ink-400 italic">No movements.</td></tr>
+				</tbody>
+			</table>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceReportPageView.vue
+++ b/frontend/src/views/finance/FinanceReportPageView.vue
@@ -1,0 +1,21 @@
+<script setup>
+// Maps /project-finance/report/:slug to its report component.
+import { computed, defineAsyncComponent } from "vue";
+
+const props = defineProps({ slug: String });
+
+const reports = {
+	pnl: defineAsyncComponent(() => import("@/views/finance/reports/PnlReport.vue")),
+	position: defineAsyncComponent(() => import("@/views/finance/reports/FinancialPositionReport.vue")),
+	aged: defineAsyncComponent(() => import("@/views/finance/reports/AgedReport.vue")),
+	petty: defineAsyncComponent(() => import("@/views/finance/reports/PettyCashReport.vue")),
+	expenses: defineAsyncComponent(() => import("@/views/finance/reports/ExpenseSummaryReport.vue")),
+	cashbank: defineAsyncComponent(() => import("@/views/finance/reports/CashBankStatementReport.vue")),
+};
+const comp = computed(() => reports[props.slug] || null);
+</script>
+
+<template>
+	<component :is="comp" v-if="comp" />
+	<div v-else class="max-w-3xl mx-auto px-6 py-16 text-center text-ink-500">Unknown report.</div>
+</template>

--- a/frontend/src/views/finance/FinanceSubcontractorsPanel.vue
+++ b/frontend/src/views/finance/FinanceSubcontractorsPanel.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { computed, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+
+const fin = useFinanceMock();
+const search = ref("");
+const rows = computed(() => {
+	const q = search.value.trim().toLowerCase();
+	return fin.subcontractors.filter((c) => !q || c.name.toLowerCase().includes(q) || (c.trade || "").toLowerCase().includes(q));
+});
+const columns = [
+	{ key: "name", label: "Name" },
+	{ key: "trade", label: "Trade" },
+	{ key: "contactPerson", label: "Contact" },
+	{ key: "phone", label: "Phone" },
+	{ key: "gstin", label: "GST no." },
+	{ key: "status", label: "Status" },
+];
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Subcontractors" }];
+</script>
+
+<template>
+	<DeskPage title="Subcontractors" :breadcrumbs="breadcrumbs">
+		<DeskList v-model="search" :rows="rows" :columns="columns" row-key="id" search-placeholder="Search subcontractors…">
+			<template #cell-gstin="{ row }"><span class="font-mono text-xs text-ink-500">{{ row.gstin || "—" }}</span></template>
+			<template #cell-status="{ row }"><StatusBadge :status="row.status" /></template>
+			<template #empty>
+				<div class="text-sm text-ink-500">Subcontractors are managed in the Subcontract workspace. This is a read-only finance view.</div>
+			</template>
+		</DeskList>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceSuppliersPanel.vue
+++ b/frontend/src/views/finance/FinanceSuppliersPanel.vue
@@ -1,0 +1,56 @@
+<script setup>
+import { computed, reactive, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+
+const fin = useFinanceMock();
+const search = ref("");
+const rows = computed(() => {
+	const q = search.value.trim().toLowerCase();
+	return fin.suppliers.filter((c) => !q || c.name.toLowerCase().includes(q) || (c.gstin || "").toLowerCase().includes(q));
+});
+const columns = [
+	{ key: "name", label: "Name" },
+	{ key: "type", label: "Type" },
+	{ key: "contactPerson", label: "Contact" },
+	{ key: "phone", label: "Phone" },
+	{ key: "gstin", label: "GST no." },
+];
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Suppliers" }];
+
+const form = reactive({ open: false, name: "", type: "Material", contactPerson: "", phone: "", email: "", gstin: "" });
+function save() {
+	if (!form.name.trim()) return;
+	fin.addSupplier({ name: form.name.trim(), type: form.type, contactPerson: form.contactPerson, phone: form.phone, email: form.email, gstin: form.gstin });
+	form.open = false;
+	Object.assign(form, { name: "", contactPerson: "", phone: "", email: "", gstin: "" });
+}
+</script>
+
+<template>
+	<DeskPage title="Suppliers" :breadcrumbs="breadcrumbs">
+		<template #actions><button class="desk-save-btn" @click="form.open = true">+ New</button></template>
+		<DeskList v-model="search" :rows="rows" :columns="columns" row-key="id" search-placeholder="Search suppliers…">
+			<template #cell-type="{ row }"><span class="text-[11px] px-1.5 py-0.5 bg-ink-100 text-ink-700 rounded">{{ row.type }}</span></template>
+			<template #cell-gstin="{ row }"><span class="font-mono text-xs text-ink-500">{{ row.gstin || "—" }}</span></template>
+		</DeskList>
+		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">New supplier</h3>
+				<div class="space-y-3">
+					<DeskField label="Name" required><DeskInput v-model="form.name" /></DeskField>
+					<DeskField label="Type"><DeskSelect v-model="form.type"><option>Material</option><option>Service</option><option>Both</option></DeskSelect></DeskField>
+					<DeskField label="Contact person"><DeskInput v-model="form.contactPerson" /></DeskField>
+					<DeskField label="Phone"><DeskInput v-model="form.phone" /></DeskField>
+					<DeskField label="Email"><DeskInput v-model="form.email" /></DeskField>
+					<DeskField label="GST no."><DeskInput v-model="form.gstin" /></DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="save">Save</button></div>
+			</div>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/reports/AgedReport.vue
+++ b/frontend/src/views/finance/reports/AgedReport.vue
@@ -1,0 +1,45 @@
+<script setup>
+import { computed } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Aged" }];
+
+const receivables = computed(() =>
+	fin.openInvoices.map((i) => ({ party: fin.customerById(i.customer)?.name || i.customer, due: i.due_date, bucket: fin.agingBucket(i.due_date), amount: fin.invoiceOutstanding(i) })),
+);
+const payables = computed(() =>
+	fin.unifiedPayables
+		.filter((b) => b.outstanding > 0.5)
+		.map((b) => ({ party: (b.kind === "subcontractor" ? fin.subcontractors.find((s) => s.id === b.supplier)?.name : fin.supplierById(b.supplier)?.name) || b.supplier, due: b.due_date, bucket: b.due_date ? fin.agingBucket(b.due_date) : "—", amount: b.outstanding, retention: b.retention || 0 })),
+);
+</script>
+
+<template>
+	<DeskPage title="Aged Receivables & Payables" :breadcrumbs="breadcrumbs">
+		<div class="grid grid-cols-1 xl:grid-cols-2 gap-4">
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-success-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-success-800">Receivables</h3></div>
+				<table class="w-full text-xs">
+					<thead class="bg-white text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Customer</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Bucket</th><th class="text-right px-3 py-2">Outstanding</th></tr></thead>
+					<tbody>
+						<tr v-for="(r, i) in receivables" :key="i" class="border-t border-ink-100"><td class="px-3 py-2 text-ink-900">{{ r.party }}</td><td class="px-3 py-2 text-ink-500">{{ fmtDate(r.due) }}</td><td class="px-3 py-2 text-ink-600">{{ r.bucket }}</td><td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(r.amount) }}</td></tr>
+						<tr v-if="!receivables.length"><td colspan="4" class="px-3 py-3 text-center text-ink-400 italic">Nothing outstanding.</td></tr>
+					</tbody>
+				</table>
+			</section>
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-danger-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-danger-800">Payables</h3></div>
+				<table class="w-full text-xs">
+					<thead class="bg-white text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Supplier</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Bucket</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-right px-3 py-2">Retention</th></tr></thead>
+					<tbody>
+						<tr v-for="(r, i) in payables" :key="i" class="border-t border-ink-100"><td class="px-3 py-2 text-ink-900">{{ r.party }}</td><td class="px-3 py-2 text-ink-500">{{ fmtDate(r.due) }}</td><td class="px-3 py-2 text-ink-600">{{ r.bucket }}</td><td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(r.amount) }}</td><td class="px-3 py-2 text-right tabular-nums text-warning-700">{{ r.retention ? fmtINR(r.retention) : "—" }}</td></tr>
+						<tr v-if="!payables.length"><td colspan="5" class="px-3 py-3 text-center text-ink-400 italic">Nothing outstanding.</td></tr>
+					</tbody>
+				</table>
+			</section>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/reports/CashBankStatementReport.vue
+++ b/frontend/src/views/finance/reports/CashBankStatementReport.vue
@@ -1,0 +1,53 @@
+<script setup>
+import { computed, ref } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Cash & Bank" }];
+const cashBankAccounts = computed(() => fin.financeAccounts.filter((a) => a.type !== "Petty Cash"));
+const selected = ref(cashBankAccounts.value[0]?.id || "");
+
+const movements = computed(() =>
+	fin.allPayments
+		.filter((p) => p.account === selected.value)
+		.slice()
+		.reverse(),
+);
+const opening = computed(() => fin.accountById(selected.value)?.opening_balance || 0);
+const rowsWithRunning = computed(() => {
+	let run = opening.value;
+	return movements.value.map((p) => {
+		run += p.dir === "in" ? p.amount : -p.amount;
+		return { ...p, running: run };
+	});
+});
+const closing = computed(() => fin.accountBalance(selected.value));
+</script>
+
+<template>
+	<DeskPage title="Cash & Bank Statement" :breadcrumbs="breadcrumbs">
+		<div class="flex items-center gap-2 mb-3">
+			<select v-model="selected" class="desk-input !w-64">
+				<option v-for="a in cashBankAccounts" :key="a.id" :value="a.id">{{ a.name }}</option>
+			</select>
+		</div>
+		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto max-w-3xl">
+			<table class="w-full text-xs">
+				<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Type</th><th class="text-right px-3 py-2">In</th><th class="text-right px-3 py-2">Out</th><th class="text-right px-3 py-2">Balance</th></tr></thead>
+				<tbody>
+					<tr class="border-t border-ink-100 bg-ink-50/50"><td class="px-3 py-2 text-ink-500" colspan="4">Opening balance</td><td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(opening) }}</td></tr>
+					<tr v-for="p in rowsWithRunning" :key="p.id" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(p.date) }}</td>
+						<td class="px-3 py-2 text-ink-700">{{ p.type }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-success-700">{{ p.dir === "in" ? fmtINR(p.amount) : "" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-danger-700">{{ p.dir === "out" ? fmtINR(p.amount) : "" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(p.running) }}</td>
+					</tr>
+					<tr class="border-t-2 border-ink-200 font-semibold"><td class="px-3 py-2" colspan="4">Closing balance</td><td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(closing) }}</td></tr>
+				</tbody>
+			</table>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/reports/ExpenseSummaryReport.vue
+++ b/frontend/src/views/finance/reports/ExpenseSummaryReport.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { computed } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Expense Summary" }];
+const byType = computed(() => {
+	const m = {};
+	fin.verifiedExpenses.forEach((e) => {
+		const k = e.cost_type || "Uncategorised";
+		m[k] = m[k] || { count: 0, total: 0 };
+		m[k].count++;
+		m[k].total += e.amount;
+	});
+	return Object.entries(m).map(([k, v]) => ({ category: k, ...v }));
+});
+const total = computed(() => byType.value.reduce((a, r) => a + r.total, 0));
+</script>
+
+<template>
+	<DeskPage title="Expense Summary" :breadcrumbs="breadcrumbs">
+		<div class="bg-white border border-ink-200 rounded-lg overflow-hidden max-w-xl">
+			<table class="w-full text-sm">
+				<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-4 py-2">Cost type</th><th class="text-right px-4 py-2">Count</th><th class="text-right px-4 py-2">Total</th></tr></thead>
+				<tbody>
+					<tr v-for="r in byType" :key="r.category" class="border-t border-ink-100"><td class="px-4 py-2 text-ink-900">{{ r.category }}</td><td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ r.count }}</td><td class="px-4 py-2 text-right tabular-nums font-medium">{{ fmtINR(r.total) }}</td></tr>
+					<tr v-if="!byType.length"><td colspan="3" class="px-4 py-4 text-center text-ink-400 italic">No verified expenses.</td></tr>
+					<tr v-if="byType.length" class="border-t-2 border-ink-200 font-semibold"><td class="px-4 py-2">Total</td><td></td><td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(total) }}</td></tr>
+				</tbody>
+			</table>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/reports/FinancialPositionReport.vue
+++ b/frontend/src/views/finance/reports/FinancialPositionReport.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { computed } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Financial Position" }];
+
+const bank = computed(() => fin.financeAccounts.filter((a) => a.type === "Bank").reduce((s, a) => s + fin.accountBalance(a.id), 0));
+const cash = computed(() => fin.financeAccounts.filter((a) => a.type === "Cash").reduce((s, a) => s + fin.accountBalance(a.id), 0));
+const advPaid = computed(() => fin.supplierAdvances.reduce((s, a) => s + (a.amount - a.allocated), 0));
+const advRecd = computed(() => fin.customerAdvances.reduce((s, a) => s + (a.amount - a.allocated), 0));
+const payableReg = computed(() => fin.bills.reduce((s, b) => s + fin.billOutstanding(b), 0));
+const payableSub = computed(() => fin.subcontractorBills.reduce((s, b) => s + fin.scBillOutstanding(b), 0));
+
+const have = computed(() => [
+	{ label: "Bank balance", value: bank.value },
+	{ label: "Cash in hand", value: cash.value },
+	{ label: "Customers owe us", value: fin.totalReceivable },
+	{ label: "Advances paid to suppliers", value: advPaid.value },
+]);
+const owe = computed(() => [
+	{ label: "Suppliers", value: payableReg.value },
+	{ label: "Subcontractors", value: payableSub.value },
+	{ label: "Retention held", value: fin.retentionHeld },
+	{ label: "Advances received from customers", value: advRecd.value },
+]);
+const haveTotal = computed(() => have.value.reduce((s, r) => s + r.value, 0));
+const oweTotal = computed(() => owe.value.reduce((s, r) => s + r.value, 0));
+</script>
+
+<template>
+	<DeskPage title="Financial Position" :breadcrumbs="breadcrumbs">
+		<div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-3xl">
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-success-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-success-800">What we have</h3></div>
+				<table class="w-full text-sm">
+					<tbody>
+						<tr v-for="r in have" :key="r.label" class="border-t border-ink-100"><td class="px-4 py-2 text-ink-700">{{ r.label }}</td><td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(r.value) }}</td></tr>
+						<tr class="border-t-2 border-ink-200 font-semibold"><td class="px-4 py-2">Total assets</td><td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(haveTotal) }}</td></tr>
+					</tbody>
+				</table>
+			</section>
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-danger-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-danger-800">What we owe</h3></div>
+				<table class="w-full text-sm">
+					<tbody>
+						<tr v-for="r in owe" :key="r.label" class="border-t border-ink-100"><td class="px-4 py-2 text-ink-700">{{ r.label }}</td><td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(r.value) }}</td></tr>
+						<tr class="border-t-2 border-ink-200 font-semibold"><td class="px-4 py-2">Total liabilities</td><td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(oweTotal) }}</td></tr>
+					</tbody>
+				</table>
+			</section>
+		</div>
+		<div class="mt-4 bg-white border border-ink-200 rounded-lg px-4 py-3 max-w-3xl flex items-center justify-between">
+			<span class="text-sm font-semibold text-ink-900">Net position</span>
+			<span class="text-lg font-bold tabular-nums text-brand-700">{{ fmtINR(haveTotal - oweTotal) }}</span>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/reports/PettyCashReport.vue
+++ b/frontend/src/views/finance/reports/PettyCashReport.vue
@@ -1,0 +1,31 @@
+<script setup>
+// The one report backed by LIVE data — per-holder disbursed float from Petty Cash Requests.
+import { ref } from "vue";
+import { pettyCashHolderBalances } from "@/data/pettyCashApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtINR } from "@/utils/format";
+
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Petty Cash Statement" }];
+const rows = ref([]);
+const loading = ref(true);
+pettyCashHolderBalances()
+	.then((r) => (rows.value = r))
+	.catch(() => {})
+	.finally(() => (loading.value = false));
+</script>
+
+<template>
+	<DeskPage title="Petty Cash Statement" :breadcrumbs="breadcrumbs">
+		<div class="bg-white border border-ink-200 rounded-lg overflow-hidden max-w-xl">
+			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Float disbursed per holder (live)</h3></div>
+			<table class="w-full text-sm">
+				<tbody>
+					<tr v-for="b in rows" :key="b.holder" class="border-t border-ink-100"><td class="px-4 py-2 text-ink-900">{{ b.holder }}</td><td class="px-4 py-2 text-right tabular-nums font-medium">{{ fmtINR(b.disbursed) }}</td></tr>
+					<tr v-if="!rows.length && !loading"><td colspan="2" class="px-4 py-4 text-center text-ink-400 italic">No disbursements yet.</td></tr>
+					<tr v-if="loading"><td colspan="2" class="px-4 py-4 text-center text-ink-400">Loading…</td></tr>
+				</tbody>
+			</table>
+			<p class="px-4 py-2 text-[11px] text-ink-400 border-t border-ink-100">Verified spend against these floats is tracked on the (dummy) Expenses tab.</p>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/reports/PnlReport.vue
+++ b/frontend/src/views/finance/reports/PnlReport.vue
@@ -1,0 +1,48 @@
+<script setup>
+import { computed } from "vue";
+import { useFinanceMock } from "@/data/financeMock";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Profit & Loss" }];
+
+const income = computed(() => fin.postedInvoices.reduce((a, i) => a + (i.gross || 0), 0));
+const byCostType = (t) => fin.verifiedExpenses.filter((e) => e.cost_type === t).reduce((a, e) => a + e.amount, 0);
+const materials = computed(() => byCostType("Material") + fin.bills.reduce((a, b) => a + (b.gross || 0), 0));
+const labour = computed(() => byCostType("Labour"));
+const plant = computed(() => byCostType("Plant & Machinery"));
+const subcontract = computed(() => fin.subcontractorBills.reduce((a, b) => a + (b.gross || 0), 0) + byCostType("Subcontract"));
+const overheads = computed(() => byCostType("Overhead"));
+const directCosts = computed(() => materials.value + labour.value + plant.value + subcontract.value);
+const grossProfit = computed(() => income.value - directCosts.value);
+const netProfit = computed(() => grossProfit.value - overheads.value);
+const pct = (v) => (income.value ? ((v / income.value) * 100).toFixed(1) + "%" : "—");
+
+const lines = computed(() => [
+	{ label: "Income", value: income.value, bold: true },
+	{ label: "Materials", value: -materials.value, indent: true },
+	{ label: "Labour", value: -labour.value, indent: true },
+	{ label: "Plant & Machinery", value: -plant.value, indent: true },
+	{ label: "Subcontract", value: -subcontract.value, indent: true },
+	{ label: "Gross profit", value: grossProfit.value, bold: true, rule: true },
+	{ label: "Overheads", value: -overheads.value, indent: true },
+	{ label: "Net profit", value: netProfit.value, bold: true, rule: true },
+]);
+</script>
+
+<template>
+	<DeskPage title="Profit & Loss" :breadcrumbs="breadcrumbs">
+		<div class="bg-white border border-ink-200 rounded-lg overflow-hidden max-w-2xl">
+			<table class="w-full text-sm">
+				<tbody>
+					<tr v-for="(l, i) in lines" :key="i" :class="[l.rule ? 'border-t-2 border-ink-200' : 'border-t border-ink-100', l.bold ? 'font-semibold text-ink-900' : 'text-ink-700']">
+						<td class="px-4 py-2" :class="l.indent ? 'pl-8 text-ink-600' : ''">{{ l.label }}</td>
+						<td class="px-4 py-2 text-right tabular-nums" :class="l.value < 0 ? 'text-danger-700' : ''">{{ fmtINR(Math.abs(l.value)) }}</td>
+						<td class="px-4 py-2 text-right text-[11px] text-ink-400 tabular-nums">{{ pct(Math.abs(l.value)) }}</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
+++ b/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
@@ -1,0 +1,96 @@
+<script setup>
+// Project Finance workspace landing — Transactions / Masters / Reports shortcut grids.
+// Every section is dummy data (client-side mock) except Petty Cash, which is live.
+import { computed } from "vue";
+import { RouterLink } from "vue-router";
+import { useFinanceMock } from "@/data/financeMock";
+import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
+import { fmtCompactINR } from "@/utils/format";
+
+const fin = useFinanceMock();
+const today = new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
+const cashBank = computed(() => fin.totalCashBank);
+
+const TX = [
+	{ label: "Expenses", to: "/project-finance/expenses", icon: "file-text", live: false },
+	{ label: "Petty Cash", to: "/project-finance/petty-cash", icon: "project-finance", live: true },
+	{ label: "Invoices", to: "/project-finance/invoices", icon: "chart-line", live: false },
+	{ label: "Bills", to: "/project-finance/bills", icon: "clipboard-list", live: false },
+	{ label: "Payments", to: "/project-finance/payments", icon: "refresh-ccw", live: false },
+];
+const MASTERS = [
+	{ label: "Customers", to: "/project-finance/customers", icon: "building-2" },
+	{ label: "Suppliers", to: "/project-finance/suppliers", icon: "hard-hat" },
+	{ label: "Subcontractors", to: "/project-finance/subcontractors", icon: "users-2" },
+];
+const REPORTS = [
+	{ label: "Profit & Loss", slug: "pnl" },
+	{ label: "Financial Position", slug: "position" },
+	{ label: "Aged Receivables & Payables", slug: "aged" },
+	{ label: "Petty Cash Statement", slug: "petty" },
+	{ label: "Expense Summary", slug: "expenses" },
+	{ label: "Cash & Bank Statement", slug: "cashbank" },
+];
+</script>
+
+<template>
+	<div class="max-w-6xl mx-auto px-4 py-6">
+		<div class="mb-6">
+			<div class="text-xs text-ink-500 mb-1">{{ today }}</div>
+			<h1 class="text-2xl font-semibold text-ink-900">Project Finance</h1>
+		</div>
+
+		<RouterLink
+			to="/project-finance/overview"
+			class="block mb-6 bg-brand-50 border border-brand-200 hover:border-brand-400 hover:bg-brand-100 rounded-xl p-5 transition-colors"
+		>
+			<div class="flex items-center justify-between gap-3">
+				<div class="flex items-center gap-3">
+					<svg class="w-5 h-5 text-brand-700 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath('project-finance')" />
+					<div>
+						<div class="text-[10px] uppercase tracking-wider text-brand-700 font-medium">Overview</div>
+						<div class="text-sm text-ink-700 mt-0.5">Cash &amp; bank, receivables, payables and what needs attention</div>
+					</div>
+				</div>
+				<div class="text-right">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Cash &amp; bank</div>
+					<div class="text-xl font-semibold text-ink-900 tabular-nums">{{ fmtCompactINR(cashBank) }}</div>
+				</div>
+			</div>
+		</RouterLink>
+
+		<section class="mb-6">
+			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-500 mb-2">Transactions</h3>
+			<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+				<RouterLink v-for="t in TX" :key="t.to" :to="t.to" class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg p-3 transition-colors group">
+					<svg class="w-5 h-5 text-ink-500 group-hover:text-brand-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath(t.icon)" />
+					<div class="text-sm font-medium text-ink-900 mt-2 flex items-center gap-1.5">
+						{{ t.label }}
+						<span v-if="t.live" class="text-[9px] px-1 py-0.5 bg-success-100 text-success-700 rounded uppercase tracking-wider">Live</span>
+					</div>
+				</RouterLink>
+			</div>
+		</section>
+
+		<section class="mb-6">
+			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-500 mb-2">Masters</h3>
+			<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
+				<RouterLink v-for="m in MASTERS" :key="m.to" :to="m.to" class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg p-3 transition-colors group">
+					<svg class="w-5 h-5 text-ink-500 group-hover:text-brand-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath(m.icon)" />
+					<div class="text-sm font-medium text-ink-900 mt-2">{{ m.label }}</div>
+				</RouterLink>
+			</div>
+		</section>
+
+		<section>
+			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-500 mb-2">Reports</h3>
+			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+				<RouterLink v-for="r in REPORTS" :key="r.slug" :to="`/project-finance/report/${r.slug}`" class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg p-3 transition-colors flex items-center gap-2.5 group">
+					<svg class="w-4 h-4 text-ink-500 group-hover:text-brand-600 transition-colors flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath('chart-bar')" />
+					<span class="text-sm font-medium text-ink-900 flex-1">{{ r.label }}</span>
+					<span class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 rounded uppercase tracking-wider">Report</span>
+				</RouterLink>
+			</div>
+		</section>
+	</div>
+</template>


### PR DESCRIPTION
## What
The **Project Finance workspace** — every view on a **self-contained client-side mock** (session-scoped, exactly like the demo). The **Petty Cash** section is live (that lives in its own PR; this branch stacks on it).

- **Workspace shell**: Transactions / Masters / Reports shortcut grids with the app's monochrome line icons; an Overview CTA showing cash & bank.
- **Mock store** (`financeMock`): seed accounts / customers / suppliers / subcontractors / invoices / bills / expenses / advances + name resolvers + derived getters (KPIs, aging, unified payables, account balances, payment register) + create/receive/pay actions. Resets on reload.
- **Panels**: Overview, Invoices (create + receive), Bills (unified payables incl. subcontractor bills, create + pay), Payments register, Expenses (log + verify), Customers / Suppliers / Subcontractors masters.
- **Reports**: Profit & Loss, Financial Position, Aged Receivables & Payables, Expense Summary, Cash & Bank Statement — plus a **Petty Cash Statement** that reads **live** per-holder disbursed balances.

## Notes
- Base is the `feat/petty-cash` branch (this stacks on the live Petty Cash PR). When that merges, this retargets to `develop`.
- `yarn build` clean; frontend-only (no backend changes beyond the petty-cash PR).
