### PR TITLE
refactor(ui): align Project Finance landing to the prototype

### DIFF
--- a/frontend/src/utils/workspaceIcons.js
+++ b/frontend/src/utils/workspaceIcons.js
@@ -74,6 +74,14 @@ const PATHS = {
 	"refresh-ccw":
 		'<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/><path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"/><path d="M16 16h5v5"/>',
 	wallet: '<path d="M21 12V7H5a2 2 0 0 1 0-4h14v4"/><path d="M3 5v14a2 2 0 0 0 2 2h16v-5"/><path d="M18 12a2 2 0 0 0 0 4h4v-4Z"/>',
+	"hand-coins":
+		'<path d="M11 15h2a2 2 0 1 0 0-4h-3c-.6 0-1.1.2-1.4.6L3 17"/><path d="m7 21 1.6-1.4c.3-.4.8-.6 1.4-.6h4c1.1 0 2.1-.4 2.8-1.2l4.6-4.4a2 2 0 0 0-2.75-2.91l-4.2 3.9"/><path d="m2 16 6 6"/><circle cx="16" cy="9" r="2.9"/><circle cx="6" cy="5" r="3"/>',
+	receipt:
+		'<path d="M4 2v20l2-1 2 1 2-1 2 1 2-1 2 1 2-1 2 1V2l-2 1-2-1-2 1-2-1-2 1-2-1-2 1Z"/><path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/><path d="M12 17.5v-11"/>',
+	banknote:
+		'<rect width="20" height="12" x="2" y="6" rx="2"/><circle cx="12" cy="12" r="2"/><path d="M6 12h.01M18 12h.01"/>',
+	"users-round":
+		'<path d="M18 21a8 8 0 0 0-16 0"/><circle cx="10" cy="8" r="5"/><path d="M22 20c0-3.37-2-6.5-4-8a5 5 0 0 0-.45-8.3"/>',
 	landmark:
 		'<line x1="3" x2="21" y1="22" y2="22"/><line x1="6" x2="6" y1="18" y2="11"/><line x1="10" x2="10" y1="18" y2="11"/><line x1="14" x2="14" y1="18" y2="11"/><line x1="18" x2="18" y1="18" y2="11"/><polygon points="12 2 20 7 4 7"/>',
 	file: '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>',

--- a/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
+++ b/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
@@ -1,96 +1,167 @@
 <script setup>
-// Project Finance workspace landing — Transactions / Masters / Reports shortcut grids.
-// Every section is dummy data (client-side mock) except Petty Cash, which is live.
+// Project Finance workspace landing — standard workspace pattern (like Site
+// Execution / Subcontract): a prominent Overview CTA + grouped WorkspaceShortcut
+// tiles that open each function in its own page. Role-gated via the session roles
+// (site roles see only Petty Cash + Expenses), mirroring the prototype's
+// store.visibleFinanceTabs. Every section is client-side dummy data except Petty
+// Cash, which is live.
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
+import { storeToRefs } from "pinia";
 import { useFinanceMock } from "@/data/financeMock";
+import { useSessionStore } from "@/stores/session";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
-import { fmtCompactINR } from "@/utils/format";
+import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
+import { fmtINR } from "@/utils/format";
 
 const fin = useFinanceMock();
+const session = useSessionStore();
+const { access } = storeToRefs(session);
+
 const today = new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
 const cashBank = computed(() => fin.totalCashBank);
 
-const TX = [
-	{ label: "Expenses", to: "/project-finance/expenses", icon: "file-text", live: false },
-	{ label: "Petty Cash", to: "/project-finance/petty-cash", icon: "project-finance", live: true },
-	{ label: "Invoices", to: "/project-finance/invoices", icon: "chart-line", live: false },
-	{ label: "Bills", to: "/project-finance/bills", icon: "clipboard-list", live: false },
-	{ label: "Payments", to: "/project-finance/payments", icon: "refresh-ccw", live: false },
+// Role gating — parity with the prototype's visibleFinanceTabs.
+const FINANCE_SITE_ROLES = ["BuildSuite Site Engineer", "BuildSuite Foreman"];
+const FINANCE_FULL_ROLES = [
+	"BuildSuite Director",
+	"BuildSuite PM",
+	"BuildSuite Accountant",
+	"BuildSuite QS",
+	"BuildSuite Administrator",
+	"System Manager",
+	"Administrator",
+];
+const roles = computed(() => access.value?.roles || []);
+const hasAny = (list) => roles.value.some((r) => list.includes(r));
+const visibleSections = computed(() => {
+	if (hasAny(FINANCE_FULL_ROLES))
+		return ["overview", "petty-cash", "expenses", "customers", "suppliers", "subcontractors", "invoices", "bills", "payments", "reports"];
+	if (hasAny(FINANCE_SITE_ROLES)) return ["petty-cash", "expenses"];
+	return [];
+});
+const canSee = (section) => visibleSections.value.includes(section);
+const noAccess = computed(() => !visibleSections.value.length);
+
+const TRANSACTIONS = [
+	{ section: "petty-cash", icon: "hand-coins", label: "Petty Cash", desc: "Request, disburse and track holder balances.", live: true },
+	{ section: "expenses", icon: "receipt", label: "Expenses", desc: "Log site spend and verify claims." },
+	{ section: "invoices", icon: "file-text", label: "Invoices", desc: "Bill customers, receive payments, advances." },
+	{ section: "bills", icon: "banknote", label: "Bills", desc: "Supplier & subcontractor payables." },
+	{ section: "payments", icon: "refresh-ccw", label: "Payments", desc: "Every money movement — review or cancel transactions." },
 ];
 const MASTERS = [
-	{ label: "Customers", to: "/project-finance/customers", icon: "building-2" },
-	{ label: "Suppliers", to: "/project-finance/suppliers", icon: "hard-hat" },
-	{ label: "Subcontractors", to: "/project-finance/subcontractors", icon: "users-2" },
+	{ section: "customers", icon: "users-round", label: "Customers", desc: "Customer master." },
+	{ section: "suppliers", icon: "building-2", label: "Suppliers", desc: "Supplier master." },
+	{ section: "subcontractors", icon: "subcontract", label: "Subcontractors", desc: "Read from the Subcontract module." },
 ];
-const REPORTS = [
-	{ label: "Profit & Loss", slug: "pnl" },
-	{ label: "Financial Position", slug: "position" },
-	{ label: "Aged Receivables & Payables", slug: "aged" },
-	{ label: "Petty Cash Statement", slug: "petty" },
-	{ label: "Expense Summary", slug: "expenses" },
-	{ label: "Cash & Bank Statement", slug: "cashbank" },
+const FINANCE_REPORTS = [
+	{ slug: "pnl", icon: "chart-line", label: "Profit & Loss", desc: "Income vs direct costs and overheads, by project and period." },
+	{ slug: "aged", icon: "clipboard-list", label: "Receivables & Payables", desc: "Aged outstanding — who owes us and who we owe." },
+	{ slug: "position", icon: "wallet", label: "Financial Position", desc: "What we have vs what we owe, and the net position." },
+	{ slug: "petty", icon: "hand-coins", label: "Petty Cash", desc: "Per holder: disbursed, spent, balance, to reimburse." },
+	{ slug: "expenses", icon: "receipt", label: "Expense Summary", desc: "By project, cost type, source or person, with receipts." },
+	{ slug: "cashbank", icon: "banknote", label: "Cash & Bank Statement", desc: "Per account: opening, movements, closing." },
 ];
+
+const txTiles = computed(() => TRANSACTIONS.filter((t) => canSee(t.section)));
+const masterTiles = computed(() => MASTERS.filter((t) => canSee(t.section)));
+const showReports = computed(() => canSee("reports"));
+const showOverview = computed(() => canSee("overview"));
 </script>
 
 <template>
-	<div class="max-w-6xl mx-auto px-4 py-6">
-		<div class="mb-6">
-			<div class="text-xs text-ink-500 mb-1">{{ today }}</div>
-			<h1 class="text-2xl font-semibold text-ink-900">Project Finance</h1>
+	<div class="bg-white min-h-full">
+		<div class="max-w-6xl mx-auto px-6 py-8">
+			<!-- Title strip -->
+			<div class="mb-5">
+				<div class="text-xs text-ink-500 mb-1">{{ today }}</div>
+				<h1 class="text-2xl font-semibold text-ink-900">Project Finance</h1>
+			</div>
+
+			<div v-if="noAccess" class="bg-warning-50 border border-warning-200 rounded-lg px-4 py-6 text-sm text-warning-700">
+				You don't have access to Project Finance.
+			</div>
+
+			<template v-else>
+				<!-- Overview CTA -->
+				<RouterLink
+					v-if="showOverview"
+					to="/project-finance/overview"
+					class="mb-6 block bg-brand-50 border border-brand-200 hover:border-brand-400 hover:shadow-sm p-4 transition-all group rounded-lg"
+				>
+					<div class="flex items-center gap-4">
+						<div class="w-11 h-11 rounded-lg bg-brand-100 text-brand-700 flex items-center justify-center flex-shrink-0">
+							<svg class="w-[22px] h-[22px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath('wallet')" />
+						</div>
+						<div class="flex-1 min-w-0">
+							<div class="text-base font-semibold text-ink-900 group-hover:text-brand-700 transition-colors">Financial Overview</div>
+							<div class="text-xs text-ink-600 mt-0.5">Cash &amp; bank balances, quick actions and alerts.</div>
+						</div>
+						<div class="text-right mr-2">
+							<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Cash &amp; bank</div>
+							<div class="text-lg font-semibold text-ink-900 tabular-nums leading-none">{{ fmtINR(cashBank) }}</div>
+						</div>
+						<div class="text-brand-400 group-hover:text-brand-600 transition-colors text-xl">→</div>
+					</div>
+				</RouterLink>
+
+				<!-- Transactions -->
+				<div v-if="txTiles.length" class="mb-8">
+					<h2 class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2">Transactions</h2>
+					<div class="border-t border-ink-200 mb-3"></div>
+					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+						<WorkspaceShortcut
+							v-for="t in txTiles"
+							:key="t.section"
+							:icon="t.icon"
+							:label="t.label"
+							:description="t.desc"
+							:to="`/project-finance/${t.section}`"
+						>
+							<template v-if="t.live" #badge>
+								<span class="text-[9px] px-1 py-0.5 bg-success-100 text-success-700 font-medium uppercase tracking-wider" style="border-radius: 2px">Live</span>
+							</template>
+						</WorkspaceShortcut>
+					</div>
+				</div>
+
+				<!-- Masters -->
+				<div v-if="masterTiles.length" class="mb-8">
+					<h2 class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2">Masters</h2>
+					<div class="border-t border-ink-200 mb-3"></div>
+					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+						<WorkspaceShortcut
+							v-for="t in masterTiles"
+							:key="t.section"
+							:icon="t.icon"
+							:label="t.label"
+							:description="t.desc"
+							:to="`/project-finance/${t.section}`"
+						/>
+					</div>
+				</div>
+
+				<!-- Reports -->
+				<div v-if="showReports" class="mb-4">
+					<h2 class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2">Reports</h2>
+					<div class="border-t border-ink-200 mb-3"></div>
+					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+						<WorkspaceShortcut
+							v-for="r in FINANCE_REPORTS"
+							:key="r.slug"
+							:icon="r.icon"
+							:label="r.label"
+							:description="r.desc"
+							:to="`/project-finance/report/${r.slug}`"
+						>
+							<template #badge>
+								<span class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 font-medium uppercase tracking-wider" style="border-radius: 2px">Report</span>
+							</template>
+						</WorkspaceShortcut>
+					</div>
+				</div>
+			</template>
 		</div>
-
-		<RouterLink
-			to="/project-finance/overview"
-			class="block mb-6 bg-brand-50 border border-brand-200 hover:border-brand-400 hover:bg-brand-100 rounded-xl p-5 transition-colors"
-		>
-			<div class="flex items-center justify-between gap-3">
-				<div class="flex items-center gap-3">
-					<svg class="w-5 h-5 text-brand-700 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath('project-finance')" />
-					<div>
-						<div class="text-[10px] uppercase tracking-wider text-brand-700 font-medium">Overview</div>
-						<div class="text-sm text-ink-700 mt-0.5">Cash &amp; bank, receivables, payables and what needs attention</div>
-					</div>
-				</div>
-				<div class="text-right">
-					<div class="text-[10px] uppercase tracking-wider text-ink-500">Cash &amp; bank</div>
-					<div class="text-xl font-semibold text-ink-900 tabular-nums">{{ fmtCompactINR(cashBank) }}</div>
-				</div>
-			</div>
-		</RouterLink>
-
-		<section class="mb-6">
-			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-500 mb-2">Transactions</h3>
-			<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
-				<RouterLink v-for="t in TX" :key="t.to" :to="t.to" class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg p-3 transition-colors group">
-					<svg class="w-5 h-5 text-ink-500 group-hover:text-brand-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath(t.icon)" />
-					<div class="text-sm font-medium text-ink-900 mt-2 flex items-center gap-1.5">
-						{{ t.label }}
-						<span v-if="t.live" class="text-[9px] px-1 py-0.5 bg-success-100 text-success-700 rounded uppercase tracking-wider">Live</span>
-					</div>
-				</RouterLink>
-			</div>
-		</section>
-
-		<section class="mb-6">
-			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-500 mb-2">Masters</h3>
-			<div class="grid grid-cols-2 md:grid-cols-3 gap-3">
-				<RouterLink v-for="m in MASTERS" :key="m.to" :to="m.to" class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg p-3 transition-colors group">
-					<svg class="w-5 h-5 text-ink-500 group-hover:text-brand-600 transition-colors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath(m.icon)" />
-					<div class="text-sm font-medium text-ink-900 mt-2">{{ m.label }}</div>
-				</RouterLink>
-			</div>
-		</section>
-
-		<section>
-			<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-500 mb-2">Reports</h3>
-			<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-				<RouterLink v-for="r in REPORTS" :key="r.slug" :to="`/project-finance/report/${r.slug}`" class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg p-3 transition-colors flex items-center gap-2.5 group">
-					<svg class="w-4 h-4 text-ink-500 group-hover:text-brand-600 transition-colors flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="getWorkspaceIconPath('chart-bar')" />
-					<span class="text-sm font-medium text-ink-900 flex-1">{{ r.label }}</span>
-					<span class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 rounded uppercase tracking-wider">Report</span>
-				</RouterLink>
-			</div>
-		</section>
 	</div>
 </template>


### PR DESCRIPTION
## What

Aligns the **Project Finance** workspace landing to the prototype (`buildsuite-core-demo`). The landing shipped in #99 used bare icon cards; the prototype (and the rest of the app — Site Execution, Subcontract) uses the shared `WorkspaceShortcut` tile with an icon chip, label, **description** and arrow.

## Changes

- Rebuild `ProjectFinanceWorkspace.vue` on `WorkspaceShortcut`:
  - **Overview CTA** with a wallet icon chip, the cash & bank figure and a `→` arrow.
  - **Transactions / Masters / Reports** groups with section dividers and descriptive tiles.
  - Petty Cash carries a **Live** badge; each report a **Report** badge.
  - **Role-gate** via session roles (site roles see only Petty Cash + Expenses), mirroring the prototype's `visibleFinanceTabs`.
- Add the missing outline icons (`hand-coins`, `receipt`, `banknote`, `users-round`) to `workspaceIcons.js` so the tiles use the same icon language as the demo.

Purely presentational — no data, routing or API changes. `yarn build` clean.

## Note

Follow-up to the merged #99 (workspace) / #98 (live Petty Cash).
