### PR TITLE
fix: project BOQ tab, task summary wording, stage done/total, Gantt marker

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/stage_planning/stage_planning.json
+++ b/buildsuite_core/buildsuite_core/doctype/stage_planning/stage_planning.json
@@ -17,6 +17,7 @@
   "planned_completion_pct",
   "task_count",
   "mean_progress",
+  "completed_task_count",
   "section_break_desc",
   "description",
   "reject_reason",
@@ -100,6 +101,13 @@
    "fieldname": "mean_progress",
    "fieldtype": "Percent",
    "label": "Mean Progress",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "completed_task_count",
+   "fieldtype": "Int",
+   "label": "Completed Task Count",
    "read_only": 1
   },
   {

--- a/buildsuite_core/buildsuite_core/doctype/stage_planning/stage_planning.py
+++ b/buildsuite_core/buildsuite_core/doctype/stage_planning/stage_planning.py
@@ -65,9 +65,10 @@ class StagePlanning(Document):
 			frappe.throw(_("A rejection reason is required to reject this stage."))
 
 		# Server-maintained aggregates for the list: real nested-task count + mean
-		# task progress (the list derives status from mean_progress, not dates).
+		# task progress (the list derives status from mean_progress, not dates) +
+		# the count of member tasks actually completed (for the "done / total" chip).
 		task_names = [r.task for r in (self.stage_planning_tasks or []) if r.task]
-		self.task_count, self.mean_progress = _stage_aggregates(task_names)
+		self.task_count, self.mean_progress, self.completed_task_count = _stage_aggregates(task_names)
 
 	def _stage_tasks_changed(self, before):
 		"""Whether stage_planning_tasks differ from the persisted version — rows
@@ -97,28 +98,34 @@ class StagePlanning(Document):
 
 
 def _stage_aggregates(task_names):
-	"""(task_count, mean_progress) for member task names. Mean is the simple average
-	of member task progress; (0, 0) when the stage has no tasks."""
+	"""(task_count, mean_progress, completed_task_count) for member task names.
+	Mean is the simple average of member task progress; completed counts tasks at
+	100% progress (which is how a Completed task_status is stored — see utils/task.py).
+	(0, 0, 0) when the stage has no tasks."""
 	count = len(task_names)
 	if not count:
-		return 0, 0
+		return 0, 0, 0
 	rows = frappe.get_all("Task", filters={"name": ["in", task_names]}, fields=["progress"])
 	mean = sum(flt(r.progress) for r in rows) / len(rows) if rows else 0
-	return count, round(mean)
+	completed = sum(1 for r in rows if flt(r.progress) >= 100)
+	return count, round(mean), completed
 
 
 def recompute_stage_aggregates(stage):
-	"""Set task_count + mean_progress on a Stage Planning from its current child rows
-	and member task progress, via db.set_value (no save) — safe to call from a Task
-	hook when a member task's progress changes."""
+	"""Set task_count + mean_progress + completed_task_count on a Stage Planning from
+	its current child rows and member task progress, via db.set_value (no save) — safe
+	to call from a Task hook when a member task's progress changes."""
 	task_names = frappe.get_all(
 		"Stage Planning Task",
 		filters={"parent": stage, "parenttype": "Stage Planning"},
 		pluck="task",
 	)
-	count, mean = _stage_aggregates([t for t in task_names if t])
+	count, mean, completed = _stage_aggregates([t for t in task_names if t])
 	frappe.db.set_value(
-		"Stage Planning", stage, {"task_count": count, "mean_progress": mean}, update_modified=False
+		"Stage Planning",
+		stage,
+		{"task_count": count, "mean_progress": mean, "completed_task_count": completed},
+		update_modified=False,
 	)
 
 

--- a/buildsuite_core/tests/test_stage_planning.py
+++ b/buildsuite_core/tests/test_stage_planning.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+"""Tests for Stage Planning server-maintained aggregates — task_count,
+mean_progress and completed_task_count (the "done / total" chip in the list).
+completed_task_count must be a real count of member tasks at 100%, not the old
+mean-progress estimate that rounded to 0 for stages under ~50% done."""
+
+import frappe
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestStagePlanningAggregates(BuildSuiteTestCase):
+	def _make_stage(self, project, tasks):
+		return frappe.get_doc(
+			{
+				"doctype": "Stage Planning",
+				"project": project,
+				"stage_name": f"Stage {self._n}",
+				"stage_planning_tasks": [{"task": t} for t in tasks],
+			}
+		).insert(ignore_permissions=True)
+
+	def _complete(self, task):
+		task.task_status = "Completed"
+		task.save(ignore_permissions=True)
+
+	def test_completed_task_count_counts_completed_only(self):
+		p = self._make_project(company=self.company)
+		t1 = self._make_task(p.name, task_status="Completed")
+		t2 = self._make_task(p.name, task_status="Yet To Start")
+		t3 = self._make_task(p.name, task_status="In Progress")
+		stage = self._make_stage(p.name, [t1.name, t2.name, t3.name])
+
+		# One of three tasks is completed at insert time.
+		self.assertEqual(stage.task_count, 3)
+		self.assertEqual(stage.completed_task_count, 1)
+
+	def test_completed_task_count_updates_when_member_task_completes(self):
+		p = self._make_project(company=self.company)
+		t1 = self._make_task(p.name, task_status="Yet To Start")
+		t2 = self._make_task(p.name, task_status="Yet To Start")
+		stage = self._make_stage(p.name, [t1.name, t2.name])
+		self.assertEqual(stage.completed_task_count, 0)
+
+		# Completing a member task recomputes the stage aggregate via the Task hook.
+		self._complete(t1)
+		self.assertEqual(
+			frappe.db.get_value("Stage Planning", stage.name, "completed_task_count"), 1
+		)
+
+		self._complete(t2)
+		self.assertEqual(
+			frappe.db.get_value("Stage Planning", stage.name, "completed_task_count"), 2
+		)
+
+	def test_empty_stage_has_zero_completed(self):
+		p = self._make_project(company=self.company)
+		stage = self._make_stage(p.name, [])
+		self.assertEqual(stage.task_count, 0)
+		self.assertEqual(stage.completed_task_count, 0)

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -482,28 +482,71 @@ const attachmentCount = computed(() => {
 	if (Array.isArray(raw?.value)) return raw.value.length;
 	return null;
 });
-const boqs = computed(() =>
-	store
-		.boqsByProject(resolvedProjectId.value)
-		.slice()
-		.sort((a, b) => (b.preparedDate || "").localeCompare(a.preparedDate || "")),
-);
-const activeBoq = computed(
-	() =>
-		store.activeBoqForProject(resolvedProjectId.value) ||
-		boqs.value.find((b) => b.status === "Approved"),
-);
+// BOQ tab — backend-backed (like the standalone BOQ module). Fetch the project's
+// BOQs straight from the server, scoped to the project + its subprojects, so a BOQ
+// created for the project actually shows here. (The old store.boqsByProject read
+// the seed/localStorage store, which is never hydrated from the backend, so real
+// BOQs never appeared.) The transform mirrors BoqView so the row shape is identical.
+const boqsResource = ref(null);
+function loadBoqsResource() {
+	if (!resolvedProjectId.value) {
+		boqsResource.value = null;
+		return;
+	}
+	boqsResource.value = adapter.list("BOQ", {
+		fields: [
+			"name",
+			"title",
+			"project",
+			"revision",
+			"status",
+			"source_sco",
+			"planned_amount",
+			"actual_amount",
+			"prepared_date",
+		],
+		filters: { project: ["in", taskProjectIds.value] },
+		orderBy: "creation desc",
+		pageLength: 500,
+		cache: `buildsuite-project-detail-boq:${taskFilterKey.value}`,
+		transform(rows) {
+			return rows.map((b) => {
+				const planned = b.planned_amount || 0;
+				const actual = b.actual_amount || 0;
+				const variance = actual - planned;
+				return {
+					id: b.name,
+					title: b.title || b.name,
+					projectId: b.project || "",
+					revision: b.revision,
+					status: b.status,
+					sourceScoId: b.source_sco || "",
+					preparedDate: b.prepared_date,
+					totals: { planned, actual, variance, variancePct: planned ? (variance / planned) * 100 : 0 },
+				};
+			});
+		},
+	});
+}
+watch(taskFilterKey, loadBoqsResource, { immediate: true });
+
+const boqs = computed(() => {
+	const raw = boqsResource.value?.data;
+	const list = Array.isArray(raw) ? raw : Array.isArray(raw?.value) ? raw.value : [];
+	return list.slice().sort((a, b) => (b.preparedDate || "").localeCompare(a.preparedDate || ""));
+});
+const activeBoq = computed(() => boqs.value.find((b) => b.status === "Approved") || null);
 
 // Cost rollups for the summary strip. Planned honours the active BOQ's
 // planned total when one exists, otherwise falls back to the project budget.
 // Actual is 0 until an Approved BOQ exists and its actuals have been
 // recalculated.
 const plannedCost = computed(() => {
-	if (activeBoq.value) return store.boqTotals(activeBoq.value.id).planned;
+	if (activeBoq.value) return activeBoq.value.totals.planned;
 	return project.value?.budget || 0;
 });
 const actualCost = computed(() => {
-	if (activeBoq.value) return store.boqTotals(activeBoq.value.id).actual;
+	if (activeBoq.value) return activeBoq.value.totals.actual;
 	return 0;
 });
 const costDeviation = computed(() => actualCost.value - plannedCost.value);
@@ -1243,7 +1286,7 @@ usePageTitle(() => project.value?.name);
 					<span class="text-xs text-ink-500">
 						<span class="text-ink-900 font-medium">{{ taskStats.total }} tasks</span>
 						· {{ taskStats.completed }} completed · {{ taskStats.inProgress }} in
-						progress · {{ taskStats.open }} open
+						progress · {{ taskStats.yetToStart }} yet to start
 					</span>
 					<RouterLink
 						v-if="canCreate('task')"
@@ -1513,8 +1556,8 @@ usePageTitle(() => project.value?.name);
 							<DeskLink :to="`/boq/${activeBoq.id}`" class="font-mono">{{
 								activeBoq.id
 							}}</DeskLink>
-							({{ fmtCompactINR(store.boqTotals(activeBoq.id).planned) }} planned ·
-							{{ fmtCompactINR(store.boqTotals(activeBoq.id).actual) }} actual)
+							({{ fmtCompactINR(activeBoq.totals.planned) }} planned ·
+							{{ fmtCompactINR(activeBoq.totals.actual) }} actual)
 						</template>
 					</span>
 					<RouterLink
@@ -1552,14 +1595,10 @@ usePageTitle(() => project.value?.name);
 						}}</span>
 					</template>
 					<template #cell-planned="{ row }">
-						<span class="tabular-nums">{{
-							fmtCompactINR(store.boqTotals(row.id).planned)
-						}}</span>
+						<span class="tabular-nums">{{ fmtCompactINR(row.totals.planned) }}</span>
 					</template>
 					<template #cell-actual="{ row }">
-						<span class="tabular-nums text-ink-700">{{
-							fmtCompactINR(store.boqTotals(row.id).actual)
-						}}</span>
+						<span class="tabular-nums text-ink-700">{{ fmtCompactINR(row.totals.actual) }}</span>
 					</template>
 					<template #cell-preparedDate="{ row }">
 						<span class="text-xs text-ink-500">{{ fmtDate(row.preparedDate) }}</span>

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1690,7 +1690,8 @@ onBeforeUnmount(() => {
 										width: '2px',
 										height: ROW_HEIGHT + 'px',
 									}"
-									class="bg-ink-900 pointer-events-none"
+									class="bg-ink-900 cursor-help"
+									:title="'Stage planned end · ' + fmtShort(sb.group.plannedEnd)"
 								></div>
 							</template>
 
@@ -2261,7 +2262,10 @@ onBeforeUnmount(() => {
 						><span class="absolute inset-y-0 left-0 w-3/5 bg-brand-600"></span></span
 					>Overdue <span class="text-ink-500">⏱</span>
 				</div>
-				<div class="ml-auto flex items-center gap-1.5">
+				<div v-if="groupBy === 'stage'" class="ml-auto flex items-center gap-1.5">
+					<span class="inline-block w-0.5 h-3 bg-ink-900"></span>Stage planned end
+				</div>
+				<div class="flex items-center gap-1.5" :class="{ 'ml-auto': groupBy !== 'stage' }">
 					<span class="w-px h-3 bg-danger-500/60"></span>Today
 				</div>
 			</div>

--- a/frontend/src/views/StagePlanningsView.vue
+++ b/frontend/src/views/StagePlanningsView.vue
@@ -71,12 +71,14 @@ function statusClass(s) {
 
 // "Completed tasks (by planned progress) / total tasks in the stage." The completed
 // figure is the progress-weighted equivalent: total × mean task progress. Both
-// task_count and mean_progress are server-maintained aggregates on the record
-// (Frappe's list API can't return the child table to count them client-side).
+// task_count and completed_task_count are server-maintained aggregates on the
+// record (Frappe's list API can't return the child table to count them
+// client-side). completed_task_count is the real count of member tasks at 100%
+// — the old "mean_progress × total" estimate rounded to 0 unless the stage was
+// well past half done.
 function taskCountDisplay(row) {
 	const total = Number(row.task_count) || 0;
-	const meanPct = Number(row.mean_progress) || 0;
-	const completed = Math.round((total * meanPct) / 100);
+	const completed = Number(row.completed_task_count) || 0;
 	return `${completed} / ${total}`;
 }
 
@@ -130,6 +132,7 @@ function onRowClick(row) {
 				'planned_end',
 				'task_count',
 				'mean_progress',
+				'completed_task_count',
 				'workflow_state',
 			]"
 			:columns="[
@@ -142,7 +145,7 @@ function onRowClick(row) {
 					key: 'task_count',
 					label: 'Tasks (done / total)',
 					align: 'right',
-					fields: ['task_count', 'mean_progress'],
+					fields: ['task_count', 'completed_task_count'],
 				},
 				{ key: 'workflow_state', label: 'State' },
 				{ key: '_status', label: 'Status', fields: ['mean_progress'] },

--- a/frontend/src/views/project-detail/tabs/OverviewTab.vue
+++ b/frontend/src/views/project-detail/tabs/OverviewTab.vue
@@ -21,11 +21,11 @@ const emit = defineEmits(["edit"]);
 const store = useDataStore();
 
 function plannedCost() {
-	if (props.activeBoq) return store.boqTotals(props.activeBoq.id).planned;
+	if (props.activeBoq) return props.activeBoq.totals?.planned || 0;
 	return props.project?.budget || 0;
 }
 function actualCost() {
-	if (props.activeBoq) return store.boqTotals(props.activeBoq.id).actual;
+	if (props.activeBoq) return props.activeBoq.totals?.actual || 0;
 	return 0;
 }
 function costDeviation() {

--- a/frontend/src/views/project-detail/useProjectDetailListFilters.js
+++ b/frontend/src/views/project-detail/useProjectDetailListFilters.js
@@ -113,7 +113,9 @@ export function useProjectDetailListFilters({ project, subs, workPackages, tasks
 			total: all.length,
 			completed: all.filter((t) => t.status === "Completed").length,
 			inProgress: all.filter((t) => t.status === "In Progress").length,
-			open: all.filter((t) => t.status === "Open").length,
+			// "Yet To Start" is the default task_status (see loadTasksResource transform);
+			// there is no "Open" status, so match the row pills' vocabulary here.
+			yetToStart: all.filter((t) => t.status === "Yet To Start").length,
 		};
 	});
 


### PR DESCRIPTION
Four independent fixes reported while walking the demo.

## 1. BOQ created for a project doesn't show under the project's BOQ tab
The tab read `store.boqsByProject(...)` — the seed/localStorage Pinia store, which is **never hydrated from the backend** — while the BOQ module lists from the server. So real BOQs appeared in the global BOQ list but never under the project.
**Fix:** fetch the project's BOQs from the server (`adapter.list("BOQ")`, filtered on `project in [project, …subprojects]`), reusing the BOQ module's transform (`totals{planned,actual,…}`). Replaced the `store.boqTotals(...)` reads in `ProjectDetailView` and `OverviewTab` with the fetched per-row totals.

## 2. Task tab summary said "0 open"
`taskStats.open` filtered `status === "Open"`, but a task's default status is **"Yet To Start"** — there is no "Open" — so it was always 0.
**Fix:** count and label it **"yet to start"**, matching the row status pills' vocabulary.

## 3. Stage Planning "done / total" chip always "0 / N"
The numerator was estimated as `round(mean_progress × total / 100)`, which floors to 0 until a stage is ~half done — never a true completed count.
**Fix:** added a server-maintained **`completed_task_count`** (member tasks at 100% — how a Completed task_status is stored) alongside `task_count`/`mean_progress`; the list now shows it. Recomputed on task save via the existing Stage-aggregate hook, and backfilled across existing stages. New regression tests in `test_stage_planning.py` (3 tests, green).

## 4. Gantt: unlabelled vertical line on a stage's summary bar
It marks the stage's **planned end** date but had no tooltip/label (`pointer-events-none`).
**Fix:** added a hover tooltip (`Stage planned end · <date>`) and a **"Stage planned end"** legend entry (shown in By-Stage grouping), matching the existing "Today" legend.

## Verification
- `bench --site … migrate` adds `completed_task_count`; 606 existing stages backfilled.
- `run-tests` — test_stage_planning (3) + test_task (11) green.
- `yarn build` clean.

Requires a migrate on deploy (new Int field on Stage Planning).
