### PR TITLE
Fix/procurement ratemaster issues

### DIFF
--- a/buildsuite_core/api/procurement.py
+++ b/buildsuite_core/api/procurement.py
@@ -165,7 +165,7 @@ def _attach_items(pr: dict) -> None:
 	items = frappe.get_all(
 		"Purchase Receipt Item",
 		filters={"parent": pr["name"], "parenttype": "Purchase Receipt"},
-		fields=["item_name", "received_qty", "rejected_qty", "uom"],
+		fields=["item_name", "received_qty", "rejected_qty", "uom", "purchase_order"],
 	)
 	pr["items"] = [{"item": i.item_name, "qty": i.received_qty, "uom": i.uom} for i in items]
 	pr["item_count"] = len(items)
@@ -173,9 +173,13 @@ def _attach_items(pr: dict) -> None:
 
 
 def _receipt_status(items: list[dict]) -> str:
-	"""Full (clean) / Partial (some rejected) / Short (all rejected)."""
-	received = sum(flt(i.received_qty) for i in items)
-	rejected = sum(flt(i.rejected_qty) for i in items)
-	if rejected <= 0:
+	"""Full / Partial, based on how much of the linked order has been received."""
+	po_names = {i.purchase_order for i in items if i.get("purchase_order")}
+	if not po_names:
 		return "Full"
-	return "Short" if rejected >= received else "Partial"
+	pos = frappe.get_all(
+		"Purchase Order",
+		filters={"name": ["in", list(po_names)]},
+		fields=["per_received"],
+	)
+	return "Full" if all(flt(p.per_received) >= 100 for p in pos) else "Partial"

--- a/buildsuite_core/api/rate_master.py
+++ b/buildsuite_core/api/rate_master.py
@@ -27,7 +27,7 @@ def list_rate_masters(start=0, page_length=10, search=None, category=None, with_
 			"name", "rate_code", "rate_name", "category", "uom",
 			"current_rate", "previous_rate", "effective_date", "modified_by",
 		],
-		order_by="rate_code asc",
+		order_by="modified desc",
 		start=cint(start),
 		page_length=cint(page_length),
 	)

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -17,7 +17,7 @@ const shortcuts = [
 	{
 		label: "Material Consumption",
 		icon: "stock",
-		href: "/app/stock-entry?stock_entry_type=Material Consumption for Manufacture",
+		href: "/app/stock-entry?stock_entry_type=Material Issue",
 	},
 	{ label: "Suppliers", icon: "building-2", href: "/app/supplier" },
 	{ label: "Items & Rates", icon: "tag", to: "/rate-master" },

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -20,7 +20,7 @@ const shortcuts = [
 		href: "/app/stock-entry?stock_entry_type=Material Issue",
 	},
 	{ label: "Suppliers", icon: "building-2", href: "/app/supplier" },
-	{ label: "Items & Rates", icon: "tag", to: "/rate-master" },
+	{ label: "Items & Rates", icon: "tag", href: "/app/item" },
 ];
 
 // Report tiles are configured per workspace in Workspace Setting.


### PR DESCRIPTION
- Material Consumption shortcut now filters Stock Entry by "Material Issue"

- Recent site receipts pill now reflects the order's received percent  (per_received): fully received -> Full, otherwise -> Partial. Earlier it only checked rejected qty, so partial deliveries wrongly showed Full.

- Rate Master list now sorts by recency (most recently modified first)  instead of alphabetical rate code.
