### PR TITLE
feat: complete & wire petty-cash Expense Entry ledger (fix, perms, tests, SPA)

### DIFF
--- a/buildsuite_core/api/expense_entry.py
+++ b/buildsuite_core/api/expense_entry.py
@@ -50,6 +50,41 @@ def context():
 
 
 @frappe.whitelist()
+def get_expense(name):
+	"""Full expense entry (parent + lines) for the detail modal."""
+	doc = frappe.get_doc(DOCTYPE, name)
+	doc.check_permission("read")
+	return {
+		"name": doc.name,
+		"date": str(doc.date) if doc.date else None,
+		"company": doc.company,
+		"project": doc.project,
+		"employee": doc.employee,
+		"employee_name": frappe.db.get_value("Employee", doc.employee, "employee_name") if doc.employee else None,
+		"payment_account": doc.payment_account,
+		"total_amount": doc.total_amount,
+		"docstatus": doc.docstatus,
+		"reimbursable": doc.reimbursable,
+		"reimbursed": doc.reimbursed,
+		"reimbursed_on": str(doc.reimbursed_on) if doc.reimbursed_on else None,
+		"journal_entry": doc.journal_entry,
+		"reimbursement_journal_entry": doc.reimbursement_journal_entry,
+		"description": doc.description,
+		"rows": [
+			{
+				"expense_account": r.expense_account,
+				"cost_type": r.cost_type,
+				"description": r.description,
+				"amount": r.amount,
+				"attachment": r.attachment,
+				"project": r.project,
+			}
+			for r in doc.expense_entry_table
+		],
+	}
+
+
+@frappe.whitelist()
 def ledger(transaction_type=None, project=None, from_date=None, to_date=None):
 	"""Petty-cash transaction ledger for the caller's employee (newest first)."""
 	employee = _current_employee()
@@ -116,6 +151,7 @@ def save_expense(payload):
 				"project": r.get("project") or project,
 				"amount": flt(r.get("amount")),
 				"description": r.get("description"),
+				"attachment": r.get("attachment"),
 			},
 		)
 	doc.flags.ignore_permissions = True

--- a/buildsuite_core/api/expense_entry.py
+++ b/buildsuite_core/api/expense_entry.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Whitelisted endpoints for the Project Finance › Expenses (petty cash) panel.
+
+The signed-in user spends against their petty-cash float by raising an Expense Entry
+(draft = pending approval); a finance approver submits it, which posts the Journal
+Entry and settles the balance. These endpoints resolve the caller's Employee and
+surface their live balance + ledger from utils.petty_cash.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+from buildsuite_core.utils import petty_cash as pc
+
+DOCTYPE = "Expense Entry"
+
+
+def _current_employee(user=None):
+	"""The active Employee linked to the (given or session) user, or None."""
+	return pc.employee_for_user(user or frappe.session.user)
+
+
+def _can_submit():
+	from buildsuite_core.permissions.setup import PETTY_CASH_DISBURSE_ROLES
+
+	return bool(set(frappe.get_roles()) & set(PETTY_CASH_DISBURSE_ROLES))
+
+
+@frappe.whitelist()
+def context():
+	"""The caller's petty-cash position: linked employee + balances, for the panel header."""
+	employee = _current_employee()
+	out = {
+		"employee": employee,
+		"employee_name": frappe.db.get_value("Employee", employee, "employee_name") if employee else None,
+		"can_submit": _can_submit(),
+		"approved": 0,
+		"pending": 0,
+		"available": 0,
+	}
+	if not employee:
+		return out
+	out["approved"] = flt(pc.get_balance_amount_approved(employee))
+	out["pending"] = flt(pc.get_pending_approval_balance(employee))
+	out["available"] = flt(pc.get_total_balance_include_review(employee))
+	return out
+
+
+@frappe.whitelist()
+def ledger(transaction_type=None, project=None, from_date=None, to_date=None):
+	"""Petty-cash transaction ledger for the caller's employee (newest first)."""
+	employee = _current_employee()
+	if not employee:
+		return []
+	return pc.get_transaction_list(employee, transaction_type, project, from_date, to_date)
+
+
+@frappe.whitelist()
+def save_expense(payload):
+	"""Create or edit a draft Expense Entry paid from the caller's petty cash.
+
+	rows: [{expense_account, amount, description, project?}]. Employee + payment
+	account are resolved server-side so a holder can only spend their own float.
+	"""
+	data = frappe.parse_json(payload)
+	employee = _current_employee()
+	if not employee:
+		frappe.throw(_("No active Employee is linked to your user account."))
+
+	project = data.get("project")
+	if not project:
+		frappe.throw(_("A project is required."))
+	company = frappe.db.get_value("Project", project, "company")
+	account = pc.get_petty_cash_account(company)
+	if not account:
+		frappe.throw(_("Petty Cash account not found for {0}.").format(company))
+
+	rows = data.get("rows") or []
+	if not rows:
+		frappe.throw(_("Add at least one expense line."))
+
+	name = data.get("name")
+	if name and frappe.db.exists(DOCTYPE, name):
+		doc = frappe.get_doc(DOCTYPE, name)
+		doc.check_permission("write")
+		if doc.docstatus != 0:
+			frappe.throw(_("Only a draft expense entry can be edited."))
+		doc.set("expense_entry_table", [])
+	else:
+		doc = frappe.new_doc(DOCTYPE)
+
+	doc.date = data.get("date") or frappe.utils.today()
+	doc.company = company
+	doc.project = project
+	doc.employee = employee
+	doc.payment_account = account
+	for r in rows:
+		doc.append(
+			"expense_entry_table",
+			{
+				"employee": employee,
+				"payment_account": account,
+				"expense_account": r.get("expense_account"),
+				"project": r.get("project") or project,
+				"amount": flt(r.get("amount")),
+				"description": r.get("description"),
+			},
+		)
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return {"name": doc.name}
+
+
+@frappe.whitelist()
+def submit_expense(name):
+	"""Approve (submit) a draft Expense Entry — posts the Journal Entry."""
+	if not _can_submit():
+		frappe.throw(_("You are not authorised to approve expense entries."), frappe.PermissionError)
+	doc = frappe.get_doc(DOCTYPE, name)
+	if doc.docstatus != 0:
+		frappe.throw(_("Only a draft expense entry can be approved."))
+	doc.flags.ignore_permissions = True
+	doc.submit()
+	return {"name": doc.name, "journal_entry": doc.journal_entry}
+
+
+@frappe.whitelist()
+def cancel_expense(name):
+	"""Cancel a submitted Expense Entry (reverses its Journal Entry) or delete a draft."""
+	doc = frappe.get_doc(DOCTYPE, name)
+	if doc.docstatus == 1:
+		if not _can_submit():
+			frappe.throw(_("You are not authorised to cancel expense entries."), frappe.PermissionError)
+		doc.flags.ignore_permissions = True
+		doc.cancel()
+		return {"name": name, "cancelled": True}
+	doc.check_permission("delete")
+	frappe.delete_doc(DOCTYPE, name)
+	return {"name": name, "deleted": True}
+
+
+@frappe.whitelist()
+def list_expense_accounts(company):
+	"""Expense (P&L) ledger accounts for the row picker."""
+	return frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "root_type": "Expense"},
+		fields=["name"],
+		order_by="name",
+		limit_page_length=0,
+	)

--- a/buildsuite_core/api/expense_entry.py
+++ b/buildsuite_core/api/expense_entry.py
@@ -74,9 +74,16 @@ def save_expense(payload):
 	if not project:
 		frappe.throw(_("A project is required."))
 	company = frappe.db.get_value("Project", project, "company")
-	account = pc.get_petty_cash_account(company)
-	if not account:
-		frappe.throw(_("Petty Cash account not found for {0}.").format(company))
+
+	# Out-of-pocket spend parks in Employee Reimbursements (a payable) so it doesn't
+	# touch the petty-cash float; otherwise it's paid straight from Petty Cash.
+	reimbursable = 1 if data.get("reimbursable") else 0
+	if reimbursable:
+		account = pc.resolve_reimbursements_account(company)
+	else:
+		account = pc.get_petty_cash_account(company)
+		if not account:
+			frappe.throw(_("Petty Cash account not found for {0}.").format(company))
 
 	rows = data.get("rows") or []
 	if not rows:
@@ -97,6 +104,7 @@ def save_expense(payload):
 	doc.project = project
 	doc.employee = employee
 	doc.payment_account = account
+	doc.reimbursable = reimbursable
 	for r in rows:
 		doc.append(
 			"expense_entry_table",
@@ -104,6 +112,7 @@ def save_expense(payload):
 				"employee": employee,
 				"payment_account": account,
 				"expense_account": r.get("expense_account"),
+				"cost_type": r.get("cost_type") or "Overhead",
 				"project": r.get("project") or project,
 				"amount": flt(r.get("amount")),
 				"description": r.get("description"),
@@ -112,6 +121,39 @@ def save_expense(payload):
 	doc.flags.ignore_permissions = True
 	doc.save()
 	return {"name": doc.name}
+
+
+@frappe.whitelist()
+def to_reimburse():
+	"""Submitted out-of-pocket expenses awaiting reimbursement (approver queue)."""
+	rows = frappe.get_all(
+		DOCTYPE,
+		filters={"docstatus": 1, "reimbursable": 1, "reimbursed": 0},
+		fields=["name", "date", "project", "employee", "employee_name", "company", "total_amount"],
+		order_by="date asc",
+	)
+	return {"rows": rows, "total": sum(flt(r.total_amount) for r in rows)}
+
+
+@frappe.whitelist()
+def reimburse(name, bank_account):
+	"""Pay an employee back for an out-of-pocket expense (posts the reimbursement JE)."""
+	if not _can_submit():
+		frappe.throw(_("You are not authorised to reimburse expenses."), frappe.PermissionError)
+	doc = frappe.get_doc(DOCTYPE, name)
+	je = doc.reimburse(bank_account)
+	return {"name": doc.name, "reimbursement_journal_entry": je}
+
+
+@frappe.whitelist()
+def list_cash_bank_accounts(company):
+	"""Bank/Cash accounts to pay a reimbursement from."""
+	return frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]},
+		fields=["name", "account_type"],
+		order_by="account_type, name",
+	)
 
 
 @frappe.whitelist()

--- a/buildsuite_core/api/petty_cash.py
+++ b/buildsuite_core/api/petty_cash.py
@@ -140,13 +140,9 @@ def list_cash_bank_accounts(company):
 
 @frappe.whitelist()
 def holder_balances(company=None):
-	"""Total disbursed per holder (the live float handed out). Verified spend lives on the
-	dummy Expenses side, so this is the cash-out figure."""
-	filters = {"status": "Disbursed"}
-	if company:
-		filters["company"] = company
-	rows = frappe.get_all(DOCTYPE, filters=filters, fields=["requested_by", "amount"])
-	out = {}
-	for r in rows:
-		out[r.requested_by] = out.get(r.requested_by, 0) + flt(r.amount)
-	return [{"holder": k, "disbursed": v} for k, v in sorted(out.items())]
+	"""Reconciled per-holder petty-cash position from the GL: disbursed (float in),
+	spent (verified expense out) and the net balance in hand. One view over both the
+	Petty Cash Request (disburse) and Expense Entry (spend) legs."""
+	from buildsuite_core.utils.petty_cash import reconciled_holder_balances
+
+	return reconciled_holder_balances(company)

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.json
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.json
@@ -26,6 +26,12 @@
   "total_amount",
   "column_break_xz9z",
   "description",
+  "section_break_reimburse",
+  "reimbursable",
+  "reimbursed",
+  "column_break_reimburse",
+  "reimbursed_on",
+  "reimbursement_journal_entry",
   "section_break_smez",
   "amended_from"
  ],
@@ -149,6 +155,45 @@
    "fieldname": "journal_entry",
    "fieldtype": "Link",
    "label": "Journal Entry",
+   "options": "Journal Entry",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_reimburse",
+   "fieldtype": "Section Break",
+   "label": "Reimbursement"
+  },
+  {
+   "default": "0",
+   "description": "Paid by the employee from their own pocket — credits Employee Reimbursements (a payable) instead of Petty Cash, and can be reimbursed later.",
+   "fieldname": "reimbursable",
+   "fieldtype": "Check",
+   "label": "Paid Out of Pocket (Reimbursable)"
+  },
+  {
+   "default": "0",
+   "fieldname": "reimbursed",
+   "fieldtype": "Check",
+   "label": "Reimbursed",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_reimburse",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "reimbursed_on",
+   "fieldtype": "Datetime",
+   "label": "Reimbursed On",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "reimbursement_journal_entry",
+   "fieldtype": "Link",
+   "label": "Reimbursement Journal Entry",
+   "no_copy": 1,
    "options": "Journal Entry",
    "read_only": 1
   }

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
@@ -61,7 +61,70 @@ class ExpenseEntry(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry")
+		self.cancel_reimbursement_journal_entry()
 		self.cancel_journal_entry()
+
+	# ------------------------------------------------------------------
+	# Reimbursement (own-pocket spend)
+	# ------------------------------------------------------------------
+
+	def reimburse(self, bank_account):
+		"""Pay the employee back for an out-of-pocket (reimbursable) expense.
+
+		The submit JE credited a reimbursements payable (self.payment_account); this
+		clears it: Dr Employee Reimbursements / Cr bank, tagged with the employee.
+		"""
+		if self.docstatus != 1:
+			frappe.throw(_("Only a submitted expense entry can be reimbursed."))
+		if not self.reimbursable:
+			frappe.throw(_("This expense was not marked reimbursable."))
+		if self.reimbursed:
+			frappe.throw(_("This expense has already been reimbursed."))
+		if not bank_account:
+			frappe.throw(_("Choose the account to pay the reimbursement from."))
+		account = frappe.db.get_value(
+			"Account", bank_account, ["is_group", "company", "account_type"], as_dict=True
+		)
+		if not account or account.is_group or account.company != self.company or account.account_type not in ("Bank", "Cash"):
+			frappe.throw(_("Pick a non-group Bank/Cash account in {0}.").format(self.company))
+
+		default_cc = frappe.db.get_value("Company", self.company, "cost_center")
+		je = frappe.new_doc("Journal Entry")
+		je.update(
+			{
+				"voucher_type": "Journal Entry",
+				"company": self.company,
+				"posting_date": frappe.utils.today(),
+				"user_remark": f"Reimbursement for {self.name}",
+				"reference_doctype": self.doctype,
+				"reference_docname": self.name,
+			}
+		)
+		je.append(
+			"accounts",
+			{"account": self.payment_account, "debit_in_account_currency": flt(self.total_amount), "cost_center": self.cost_center or default_cc, "employee": self.employee, "project": self.project},
+		)
+		je.append(
+			"accounts",
+			{"account": bank_account, "credit_in_account_currency": flt(self.total_amount), "cost_center": self.cost_center or default_cc, "project": self.project},
+		)
+		je.flags.ignore_permissions = True
+		je.insert()
+		je.submit()
+
+		self.db_set("reimbursement_journal_entry", je.name)
+		self.db_set("reimbursed", 1)
+		self.db_set("reimbursed_on", frappe.utils.now_datetime())
+		self.add_comment("Info", _("Reimbursed via {0}").format(je.name))
+		return je.name
+
+	def cancel_reimbursement_journal_entry(self):
+		if not self.reimbursement_journal_entry:
+			return
+		if frappe.db.get_value("Journal Entry", self.reimbursement_journal_entry, "docstatus") == 1:
+			je = frappe.get_doc("Journal Entry", self.reimbursement_journal_entry)
+			je.flags.ignore_permissions = True
+			je.cancel()
 
 	# ------------------------------------------------------------------
 	# Journal Entry

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry_table/expense_entry_table.json
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry_table/expense_entry_table.json
@@ -13,6 +13,7 @@
   "column_break_vnem",
   "expense_account",
   "expense_account_name",
+  "cost_type",
   "column_break_ogch",
   "project",
   "project_name",
@@ -65,6 +66,14 @@
    "fieldtype": "Data",
    "label": "Expense Account Name",
    "read_only": 1
+  },
+  {
+   "default": "Overhead",
+   "fieldname": "cost_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Cost Type",
+   "options": "Material\nLabour\nPlant & Machinery\nSubcontract\nOverhead"
   },
   {
    "fieldname": "section_break_5wop",

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -596,9 +596,25 @@ PETTY_CASH_DISBURSE_ROLES = (
 )
 
 
+# Expense Entry (petty-cash / other spend). Site roles raise a draft (which counts
+# as "pending approval"); finance roles submit it, which posts the Journal Entry.
+# So submit/cancel is held by the finance approvers only, mirroring petty cash.
+_EXPENSE_ENTRY_DRAFT = {"read": 1, "write": 1, "create": 1, "report": 1, "print": 1}
+EXPENSE_ENTRY_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _FULL_SUB,
+	"BuildSuite PM": _FULL_SUB,
+	"BuildSuite Accountant": _FULL_SUB,
+	"BuildSuite Site Engineer": _EXPENSE_ENTRY_DRAFT,
+	"BuildSuite Foreman": _EXPENSE_ENTRY_DRAFT,
+	"BuildSuite QS": _READ,
+}
+
+
 def setup_petty_cash_permissions():
 	_apply_role_perms("Petty Cash Request", PETTY_CASH_ROLE_PERMS)
-	# The disburse Journal Entry + its account picker read accounting masters.
+	_apply_role_perms("Expense Entry", EXPENSE_ENTRY_ROLE_PERMS, _SUBMIT_PTYPES)
+	# The disburse / expense Journal Entry + its account picker read accounting masters.
 	_read = {role: _READ for role in PETTY_CASH_DISBURSE_ROLES}
 	for dt in ("Account", "Journal Entry"):
 		_apply_role_perms(dt, _read)

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Employee petty-cash ledger — Expense Entry spend + the balance / transaction
+endpoints in utils.petty_cash, and the reconciliation that tags the holder
+Employee on a Petty Cash Request disbursement so issued float and later spend
+share one ledger."""
+
+import frappe
+from frappe.utils import flt
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+from buildsuite_core.utils import petty_cash as pc
+
+
+class TestPettyCashLedger(BuildSuiteTestCase):
+	def setUp(self):
+		super().setUp()
+		self.company = frappe.db.get_single_value("Global Defaults", "default_company") or self.company
+		self.project = self._make_project(company=self.company).name
+		self.petty = pc.resolve_petty_cash_account(self.company)
+		self.user = self._make_user()
+		self.employee = self._make_employee(self.user)
+
+	# --- fixtures --------------------------------------------------------
+	def _make_user(self):
+		return frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": f"pc-{self._n}@example.com",
+				"first_name": "PC Holder",
+				"send_welcome_email": 0,
+			}
+		).insert(ignore_permissions=True).name
+
+	def _make_employee(self, user_id):
+		try:
+			return frappe.get_doc(
+				{
+					"doctype": "Employee",
+					"first_name": f"PC Holder {self._n}",
+					"employee_name": f"PC Holder {self._n}",
+					"company": self.company,
+					"status": "Active",
+					"date_of_joining": "2020-01-01",
+					"date_of_birth": "1990-01-01",
+					"gender": frappe.db.get_value("Gender", {}, "name") or "Male",
+					"user_id": user_id,
+				}
+			).insert(ignore_permissions=True).name
+		except Exception as e:  # HR not configured on the site — skip the suite cleanly
+			self.skipTest(f"cannot create Employee: {e}")
+
+	def _account(self, name, root_type, account_type, parent):
+		from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+		return _ensure_account(self.company, name, root_type, account_type, parent)
+
+	def _bank(self):
+		return self._account("Cash", "Asset", "Cash", "Current Assets")
+
+	def _expense_account(self):
+		return self._account("Site Expenses", "Expense", "Expense Account", "Expenses")
+
+	def _disburse(self, amount):
+		req = frappe.get_doc(
+			{
+				"doctype": "Petty Cash Request",
+				"project": self.project,
+				"request_date": "2026-07-20",
+				"amount": amount,
+				"purpose": "Float",
+				"requested_by": self.user,
+			}
+		).insert(ignore_permissions=True)
+		req.disburse(self._bank())
+		return req
+
+	def _expense_entry(self, amount, submit=False):
+		doc = frappe.get_doc(
+			{
+				"doctype": "Expense Entry",
+				"date": "2026-07-21",
+				"company": self.company,
+				"project": self.project,
+				"employee": self.employee,
+				"payment_account": self.petty,
+				"expense_entry_table": [
+					{
+						"employee": self.employee,
+						"payment_account": self.petty,
+						"expense_account": self._expense_account(),
+						"project": self.project,
+						"amount": amount,
+						"description": "Diesel",
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+		if submit:
+			doc.submit()
+		return doc
+
+	# --- tests -----------------------------------------------------------
+	def test_disburse_tags_employee_on_ledger(self):
+		self._disburse(10000)
+		# Issued float debits the employee's Petty Cash → shows as approved balance.
+		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), 10000)
+
+	def test_pending_vs_approved_balance(self):
+		self._disburse(10000)
+		# A draft Expense Entry is "pending approval" and not yet in the GL balance.
+		self._expense_entry(3000, submit=False)
+		self.assertEqual(flt(pc.get_pending_approval_balance(self.employee)), 3000)
+		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), 10000)
+		# include-review nets drafts out: 10000 posted − 3000 pending.
+		self.assertEqual(flt(pc.get_total_balance_include_review(self.employee)), 7000)
+
+	def test_submitted_expense_reduces_approved_balance(self):
+		self._disburse(10000)
+		ee = self._expense_entry(3000, submit=True)
+		self.assertTrue(ee.journal_entry)
+		# Submitting posts Cr Petty Cash → approved balance drops, nothing pending.
+		self.assertEqual(flt(pc.get_pending_approval_balance(self.employee)), 0)
+		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), 7000)
+
+	def test_transaction_list_running_balance(self):
+		self._disburse(10000)
+		self._expense_entry(3000, submit=True)
+		rows = pc.get_transaction_list(self.employee)
+		self.assertEqual(len(rows), 2)
+		# Newest first; the latest row's running balance is the net position.
+		self.assertEqual(flt(rows[0]["balance"]), 7000)
+
+	def test_misspelled_alias_matches(self):
+		self._disburse(5000)
+		self.assertEqual(
+			flt(pc.get_total_balance_inculde_review(self.employee)),
+			flt(pc.get_total_balance_include_review(self.employee)),
+		)

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -132,6 +132,16 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		# Newest first; the latest row's running balance is the net position.
 		self.assertEqual(flt(rows[0]["balance"]), 7000)
 
+	def test_reconciled_holder_balances(self):
+		self._disburse(10000)
+		self._expense_entry(3000, submit=True)
+		rows = pc.reconciled_holder_balances(self.company)
+		mine = [r for r in rows if r["employee"] == self.employee]
+		self.assertEqual(len(mine), 1)
+		self.assertEqual(flt(mine[0]["disbursed"]), 10000)
+		self.assertEqual(flt(mine[0]["spent"]), 3000)
+		self.assertEqual(flt(mine[0]["balance"]), 7000)
+
 	def test_misspelled_alias_matches(self):
 		self._disburse(5000)
 		self.assertEqual(

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -76,7 +76,8 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		req.disburse(self._bank())
 		return req
 
-	def _expense_entry(self, amount, submit=False):
+	def _expense_entry(self, amount, submit=False, reimbursable=False, cost_type="Overhead"):
+		account = pc.resolve_reimbursements_account(self.company) if reimbursable else self.petty
 		doc = frappe.get_doc(
 			{
 				"doctype": "Expense Entry",
@@ -84,12 +85,14 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 				"company": self.company,
 				"project": self.project,
 				"employee": self.employee,
-				"payment_account": self.petty,
+				"payment_account": account,
+				"reimbursable": 1 if reimbursable else 0,
 				"expense_entry_table": [
 					{
 						"employee": self.employee,
-						"payment_account": self.petty,
+						"payment_account": account,
 						"expense_account": self._expense_account(),
+						"cost_type": cost_type,
 						"project": self.project,
 						"amount": amount,
 						"description": "Diesel",
@@ -148,3 +151,26 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 			flt(pc.get_total_balance_inculde_review(self.employee)),
 			flt(pc.get_total_balance_include_review(self.employee)),
 		)
+
+	def test_cost_type_stored(self):
+		ee = self._expense_entry(1000, cost_type="Material")
+		self.assertEqual(ee.expense_entry_table[0].cost_type, "Material")
+
+	def test_own_pocket_expense_does_not_touch_petty_balance(self):
+		self._disburse(10000)
+		# Out-of-pocket spend books to Employee Reimbursements, not the petty float.
+		self._expense_entry(2000, submit=True, reimbursable=True)
+		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), 10000)
+		mine = [r for r in pc.reconciled_holder_balances(self.company) if r["employee"] == self.employee][0]
+		self.assertEqual(flt(mine["spent"]), 0)
+
+	def test_reimburse_posts_je_and_flags(self):
+		ee = self._expense_entry(2000, submit=True, reimbursable=True)
+		je = ee.reimburse(self._bank())
+		ee.reload()
+		self.assertTrue(ee.reimbursed)
+		self.assertEqual(ee.reimbursement_journal_entry, je)
+		self.assertEqual(frappe.db.get_value("Journal Entry", je, "docstatus"), 1)
+		# Non-reimbursable can't be reimbursed.
+		petty = self._expense_entry(500, submit=True)
+		self.assertRaises(frappe.ValidationError, petty.reimburse, self._bank())

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -61,6 +61,15 @@ def resolve_petty_cash_account(company):
 # ---------------------------------------------------------------------------
 
 
+def employee_for_user(user):
+	"""The active Employee linked to a User, or None. Petty Cash Requests are raised
+	by a User (requested_by); the employee ledger (GL Entry.employee) keys on Employee,
+	so we resolve the link to keep issued float and later spend on one ledger."""
+	if not user:
+		return None
+	return frappe.db.get_value("Employee", {"user_id": user, "status": "Active"}, "name")
+
+
 def post_disbursement_journal_entry(doc):
 	"""Build + submit the disbursement JE and return its name."""
 	amount = flt(doc.amount)
@@ -68,6 +77,9 @@ def post_disbursement_journal_entry(doc):
 		frappe.throw(_("Disbursement amount must be greater than zero."))
 
 	petty = resolve_petty_cash_account(doc.company)
+	# Tag the holder on the Petty Cash (debit) line so the issued float lands in the
+	# same employee ledger the balance / transaction endpoints read.
+	employee = employee_for_user(doc.requested_by)
 
 	je = frappe.new_doc("Journal Entry")
 	je.voucher_type = "Journal Entry"
@@ -79,7 +91,7 @@ def post_disbursement_journal_entry(doc):
 
 	je.append(
 		"accounts",
-		{"account": petty, "debit_in_account_currency": amount, "project": doc.project},
+		{"account": petty, "debit_in_account_currency": amount, "project": doc.project, "employee": employee},
 	)
 	je.append(
 		"accounts",
@@ -170,7 +182,7 @@ def _pending_expense_total(employee, account):
 		FROM `tabExpense Entry Table` eet
 		INNER JOIN `tabExpense Entry` et ON et.name = eet.parent
 		WHERE eet.employee = %(employee)s
-			AND eet.mode_of_payment_account = %(account)s
+			AND eet.payment_account = %(account)s
 			AND et.docstatus = 0
 		""",
 		{"employee": employee, "account": account},

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -18,6 +18,25 @@ from frappe.utils import flt, formatdate, getdate
 
 PETTY_CASH_ACCOUNT_NAME = "Petty Cash"
 PETTY_CASH_PARENT_ACCOUNT = "Cash In Hand"
+REIMBURSEMENTS_ACCOUNT_NAME = "Employee Reimbursements"
+
+
+def resolve_reimbursements_account(company):
+	"""The company's Employee Reimbursements liability — where out-of-pocket expense
+	spend is parked until the employee is paid back. Created on first use."""
+	existing = frappe.db.get_value(
+		"Account",
+		{"account_name": REIMBURSEMENTS_ACCOUNT_NAME, "company": company, "is_group": 0},
+		"name",
+	)
+	if existing:
+		return existing
+
+	from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+	# Plain liability (not account_type "Payable") so GL posting doesn't force ERPNext
+	# party handling — the holder is carried on our own `employee` dimension instead.
+	return _ensure_account(company, REIMBURSEMENTS_ACCOUNT_NAME, "Liability", None, "Current Liabilities")
 
 
 # ---------------------------------------------------------------------------

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -174,6 +174,62 @@ def _draft_journal_balance(employee, account):
 	return flt(balance[0][0]) if balance else 0.0
 
 
+def reconciled_holder_balances(company=None):
+	"""Per-holder petty-cash position from the GL, reconciling the two legs into one
+	view (the prototype's Balances tab): disbursed = float in (debits), spent = float
+	out (credits), balance = net in hand. Keyed on the holder Employee, so it needs the
+	disbursement / expense JEs to carry `employee` (they do).
+	"""
+	conditions = "a.account_name = %(petty)s AND gle.is_cancelled = 0 AND gle.employee IS NOT NULL AND gle.employee != ''"
+	params = {"petty": PETTY_CASH_ACCOUNT_NAME}
+	if company:
+		conditions += " AND a.company = %(company)s"
+		params["company"] = company
+
+	rows = frappe.db.sql(
+		f"""
+		SELECT gle.employee AS employee,
+			COALESCE(SUM(gle.debit), 0) AS disbursed,
+			COALESCE(SUM(gle.credit), 0) AS spent
+		FROM `tabGL Entry` gle
+		INNER JOIN `tabAccount` a ON a.name = gle.account
+		WHERE {conditions}
+		GROUP BY gle.employee
+		""",
+		params,
+		as_dict=True,
+	)
+
+	name_map = {
+		e.name: e.employee_name
+		for e in (
+			frappe.get_all(
+				"Employee",
+				filters={"name": ("in", [r.employee for r in rows])},
+				fields=["name", "employee_name"],
+			)
+			if rows
+			else []
+		)
+	}
+
+	out = []
+	for r in rows:
+		disbursed = flt(r.disbursed)
+		spent = flt(r.spent)
+		out.append(
+			{
+				"employee": r.employee,
+				"holder": name_map.get(r.employee) or r.employee,
+				"disbursed": disbursed,
+				"spent": spent,
+				"balance": round(disbursed - spent, 2),
+			}
+		)
+	out.sort(key=lambda x: x["balance"], reverse=True)
+	return out
+
+
 def _pending_expense_total(employee, account):
 	"""Total of expense lines awaiting approval against the petty cash account."""
 	total = frappe.db.sql(

--- a/frontend/src/data/expenseEntryApi.js
+++ b/frontend/src/data/expenseEntryApi.js
@@ -21,3 +21,6 @@ export const saveExpense = (payload) => call("save_expense", { payload: JSON.str
 export const submitExpense = (name) => call("submit_expense", { name });
 export const cancelExpense = (name) => call("cancel_expense", { name });
 export const listExpenseAccounts = (company) => call("list_expense_accounts", { company });
+export const expenseToReimburse = () => call("to_reimburse", {});
+export const reimburseExpense = (name, bankAccount) => call("reimburse", { name, bank_account: bankAccount });
+export const listReimburseAccounts = (company) => call("list_cash_bank_accounts", { company });

--- a/frontend/src/data/expenseEntryApi.js
+++ b/frontend/src/data/expenseEntryApi.js
@@ -16,6 +16,7 @@ async function call(method, args) {
 }
 
 export const expenseContext = () => call("context", {});
+export const getExpense = (name) => call("get_expense", { name });
 export const expenseLedger = (filters = {}) => call("ledger", filters);
 export const saveExpense = (payload) => call("save_expense", { payload: JSON.stringify(payload) });
 export const submitExpense = (name) => call("submit_expense", { name });

--- a/frontend/src/data/expenseEntryApi.js
+++ b/frontend/src/data/expenseEntryApi.js
@@ -1,0 +1,23 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Live Expense Entry endpoints (buildsuite_core.api.expense_entry.*). The signed-in
+// holder spends against their petty-cash float; a finance approver submits to post
+// the Journal Entry. Balances + ledger come from the employee petty-cash ledger.
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.expense_entry.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const expenseContext = () => call("context", {});
+export const expenseLedger = (filters = {}) => call("ledger", filters);
+export const saveExpense = (payload) => call("save_expense", { payload: JSON.stringify(payload) });
+export const submitExpense = (name) => call("submit_expense", { name });
+export const cancelExpense = (name) => call("cancel_expense", { name });
+export const listExpenseAccounts = (company) => call("list_expense_accounts", { company });

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -13,10 +13,13 @@ import {
 	saveExpense,
 	submitExpense,
 	cancelExpense,
+	expenseToReimburse,
+	reimburseExpense,
 } from "@/data/expenseEntryApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
@@ -59,6 +62,7 @@ const tabs = computed(() => {
 	const t = [];
 	if (canSubmit.value) {
 		t.push({ id: "verify", label: "To Verify", count: drafts.value.length, alert: true });
+		t.push({ id: "reimburse", label: "To Reimburse", count: reimburseRows.value.length, alert: true });
 		t.push({ id: "all", label: "All", count: entries.value.length });
 	}
 	t.push({ id: "mine", label: "My Expenses", count: null });
@@ -89,16 +93,57 @@ async function loadLedger() {
 	}
 }
 
+// --- reimbursement queue (approvers) ---
+const reimburseRows = ref([]);
+const reimburseTotal = ref(0);
+async function loadReimburse() {
+	try {
+		const r = await expenseToReimburse();
+		reimburseRows.value = r.rows || [];
+		reimburseTotal.value = r.total || 0;
+	} catch (err) {
+		showToast(err.message || "Failed to load reimbursements", "error");
+	}
+}
+if (canSubmit.value) loadReimburse();
+
+const reimb = reactive({ open: false, row: null, bank: "", saving: false });
+function openReimburse(row) {
+	Object.assign(reimb, { open: true, row, bank: "", saving: false });
+}
+const reimburseAccountFilters = computed(() => [
+	["account_type", "in", ["Bank", "Cash"]],
+	["is_group", "=", 0],
+	["company", "=", reimb.row?.company],
+]);
+async function confirmReimburse() {
+	if (!reimb.bank) return showToast("Pick the account to pay from.", "error");
+	reimb.saving = true;
+	try {
+		await reimburseExpense(reimb.row.name, reimb.bank);
+		reimb.open = false;
+		loadReimburse();
+		res.reload?.();
+		showToast("Reimbursed — Journal Entry posted.");
+	} catch (err) {
+		showToast(err.message || "Reimburse failed", "error");
+	} finally {
+		reimb.saving = false;
+	}
+}
+
 function openTab(t) {
 	tab.value = t;
 	if (t === "ledger" && !ledgerRows.value.length) loadLedger();
+	if (t === "reimburse") loadReimburse();
 }
 
 // --- create modal ---
-const blankRow = () => ({ expense_account: "", amount: 0, description: "" });
-const form = reactive({ open: false, project: "", date: new Date().toISOString().slice(0, 10), rows: [blankRow()], saving: false });
+const COST_TYPES = ["Material", "Labour", "Plant & Machinery", "Subcontract", "Overhead"];
+const blankRow = () => ({ expense_account: "", cost_type: "Overhead", amount: 0, description: "" });
+const form = reactive({ open: false, project: "", date: new Date().toISOString().slice(0, 10), reimbursable: false, rows: [blankRow()], saving: false });
 function openForm() {
-	Object.assign(form, { open: true, project: "", date: new Date().toISOString().slice(0, 10), rows: [blankRow()], saving: false });
+	Object.assign(form, { open: true, project: "", date: new Date().toISOString().slice(0, 10), reimbursable: false, rows: [blankRow()], saving: false });
 }
 const formTotal = computed(() => form.rows.reduce((s, r) => s + (Number(r.amount) || 0), 0));
 function addRow() {
@@ -114,7 +159,7 @@ async function submitForm() {
 	if (!rows.length) return showToast("Add at least one line with an account and amount.", "error");
 	form.saving = true;
 	try {
-		await saveExpense({ project: form.project, date: form.date, rows });
+		await saveExpense({ project: form.project, date: form.date, reimbursable: form.reimbursable, rows });
 		form.open = false;
 		res.reload?.();
 		loadContext();
@@ -211,7 +256,7 @@ const expenseAccountFilters = [
 		</div>
 
 		<!-- entries (verify / all / mine) -->
-		<div v-if="activeTab !== 'ledger'" class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+		<div v-if="activeTab === 'verify' || activeTab === 'all' || activeTab === 'mine'" class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
 			<table class="w-full text-xs" style="min-width: 720px">
 				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
 					<tr><th class="text-left px-3 py-2">ID</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Project</th><th class="text-right px-3 py-2">Amount</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
@@ -231,6 +276,27 @@ const expenseAccountFilters = [
 						</td>
 					</tr>
 					<tr v-if="!tableRows.length"><td colspan="6" class="px-3 py-8 text-center text-ink-400 italic">{{ res.loading ? "Loading…" : "Nothing here." }}</td></tr>
+				</tbody>
+			</table>
+		</div>
+
+		<!-- to reimburse (approvers) -->
+		<div v-else-if="activeTab === 'reimburse'" class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<table class="w-full text-xs" style="min-width: 720px">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr><th class="text-left px-3 py-2">ID</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Employee</th><th class="text-left px-3 py-2">Project</th><th class="text-right px-3 py-2">Amount</th><th></th></tr>
+				</thead>
+				<tbody>
+					<tr v-for="row in reimburseRows" :key="row.name" class="border-t border-ink-100">
+						<td class="px-3 py-2 font-mono text-ink-400 text-[10px]">{{ row.name }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(row.date) }}</td>
+						<td class="px-3 py-2 text-ink-900">{{ row.employee_name || row.employee }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ row.project }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(row.total_amount) }}</td>
+						<td class="px-3 py-2 text-right"><button type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openReimburse(row)">Reimburse</button></td>
+					</tr>
+					<tr v-if="reimburseRows.length" class="border-t-2 border-ink-200 font-semibold"><td colspan="4" class="px-3 py-2">Total to reimburse</td><td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(reimburseTotal) }}</td><td></td></tr>
+					<tr v-if="!reimburseRows.length"><td colspan="6" class="px-3 py-8 text-center text-ink-400 italic">Nothing awaiting reimbursement.</td></tr>
 				</tbody>
 			</table>
 		</div>
@@ -265,10 +331,11 @@ const expenseAccountFilters = [
 				</div>
 				<div class="border border-ink-200 rounded-lg overflow-hidden mb-3">
 					<table class="w-full text-xs">
-						<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Expense account</th><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
+						<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Expense account</th><th class="text-left px-3 py-2 w-36">Cost type</th><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
 						<tbody>
 							<tr v-for="(r, i) in form.rows" :key="i" class="border-t border-ink-100">
 								<td class="px-2 py-1.5"><DeskLinkPicker v-model="r.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Expense account…" /></td>
+								<td class="px-2 py-1.5"><DeskSelect v-model="r.cost_type"><option v-for="c in COST_TYPES" :key="c" :value="c">{{ c }}</option></DeskSelect></td>
 								<td class="px-2 py-1.5"><DeskInput v-model="r.description" placeholder="What was it for?" /></td>
 								<td class="px-2 py-1.5"><DeskInput v-model.number="r.amount" type="number" min="0" class="text-right" /></td>
 								<td class="px-2 py-1.5 text-center"><button type="button" class="text-ink-400 hover:text-danger-600" @click="removeRow(i)">✕</button></td>
@@ -276,14 +343,33 @@ const expenseAccountFilters = [
 						</tbody>
 					</table>
 				</div>
-				<div class="flex items-center justify-between mb-4">
+				<div class="flex items-center justify-between mb-3">
 					<button type="button" class="text-xs text-brand-700 hover:underline" @click="addRow">+ Add line</button>
 					<div class="text-sm">Total <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(formTotal) }}</span></div>
 				</div>
-				<p class="text-[11px] text-ink-500 mb-4">Paid from your Petty Cash float. Saved as a draft pending a finance approver.</p>
+				<label class="flex items-center gap-2 text-xs text-ink-700 mb-3 cursor-pointer">
+					<input v-model="form.reimbursable" type="checkbox" class="rounded border-ink-300" />
+					I paid out of my own pocket — reimburse me
+				</label>
+				<p class="text-[11px] text-ink-500 mb-4">{{ form.reimbursable ? "Booked to Employee Reimbursements (a payable); pay it out from the To Reimburse queue." : "Paid from your Petty Cash float." }} Saved as a draft pending a finance approver.</p>
 				<div class="flex justify-end gap-2">
 					<button class="desk-btn" @click="form.open = false">Cancel</button>
 					<button class="desk-save-btn" :disabled="form.saving" @click="submitForm">{{ form.saving ? "Saving…" : "Save" }}</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- reimburse modal -->
+		<div v-if="reimb.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="reimb.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-1">Reimburse {{ fmtINR(reimb.row?.total_amount) }}</h3>
+				<p class="text-xs text-ink-500 mb-4">to {{ reimb.row?.employee_name || reimb.row?.employee }} · posts a Journal Entry (Dr Employee Reimbursements / Cr the account).</p>
+				<DeskField label="Pay from" required>
+					<DeskLinkPicker v-model="reimb.bank" doctype="Account" label-field="name" value-field="name" :filters="reimburseAccountFilters" placeholder="Bank / Cash account…" />
+				</DeskField>
+				<div class="flex justify-end gap-2 mt-5">
+					<button class="desk-btn" @click="reimb.open = false">Cancel</button>
+					<button class="desk-save-btn" :disabled="reimb.saving" @click="confirmReimburse">{{ reimb.saving ? "Posting…" : "Reimburse" }}</button>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -46,10 +46,34 @@ const res = useDocTypeList("Expense Entry", {
 });
 const entries = computed(() => res.data || []);
 function statusLabel(d) {
-	return d === 2 ? "Cancelled" : d === 1 ? "Approved" : "Pending Approval";
+	if (d === 2) return "Cancelled";
+	if (d === 1) return "Approved";
+	return "Pending Approval";
 }
 
-const tab = ref("entries");
+// Draft = pending a finance approver's verification (the demo's Draft → Submitted).
+const drafts = computed(() => entries.value.filter((e) => e.docstatus === 0));
+const mine = computed(() => entries.value.filter((e) => e.employee === ctx.value.employee));
+
+const tabs = computed(() => {
+	const t = [];
+	if (canSubmit.value) {
+		t.push({ id: "verify", label: "To Verify", count: drafts.value.length, alert: true });
+		t.push({ id: "all", label: "All", count: entries.value.length });
+	}
+	t.push({ id: "mine", label: "My Expenses", count: null });
+	t.push({ id: "ledger", label: "Ledger", count: null });
+	return t;
+});
+const tab = ref(null);
+const activeTab = computed(() =>
+	tab.value && tabs.value.some((t) => t.id === tab.value) ? tab.value : tabs.value[0]?.id,
+);
+const tableRows = computed(() => {
+	if (activeTab.value === "verify") return drafts.value;
+	if (activeTab.value === "mine") return mine.value;
+	return entries.value;
+});
 
 // --- ledger ---
 const ledgerRows = ref([]);
@@ -114,8 +138,8 @@ async function onApprove(row) {
 		await submitExpense(row.name);
 		res.reload?.();
 		loadContext();
-		if (tab.value === "ledger") loadLedger();
-		showToast("Approved — Journal Entry posted.");
+		if (activeTab.value === "ledger") loadLedger();
+		showToast("Verified — Journal Entry posted.");
 	} catch (err) {
 		showToast(err.message || "Approve failed", "error");
 	}
@@ -171,19 +195,29 @@ const expenseAccountFilters = [
 		</div>
 
 		<!-- tabs -->
-		<div class="border-b border-ink-200 flex mb-4">
-			<button type="button" class="px-3 py-2 text-xs font-medium" :class="tab === 'entries' ? 'text-brand-600' : 'text-ink-600'" :style="tab === 'entries' ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'" @click="openTab('entries')">Entries</button>
-			<button type="button" class="px-3 py-2 text-xs font-medium" :class="tab === 'ledger' ? 'text-brand-600' : 'text-ink-600'" :style="tab === 'ledger' ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'" @click="openTab('ledger')">Ledger</button>
+		<div class="border-b border-ink-200 flex mb-4 overflow-x-auto scrollbar-thin">
+			<button
+				v-for="t in tabs"
+				:key="t.id"
+				type="button"
+				class="px-3 py-2 text-xs font-medium whitespace-nowrap"
+				:class="activeTab === t.id ? 'text-brand-600' : 'text-ink-600 hover:text-ink-900'"
+				:style="activeTab === t.id ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'"
+				@click="openTab(t.id)"
+			>
+				{{ t.label
+				}}<span v-if="t.count !== null" class="ml-1 tabular-nums" :class="t.alert && t.count > 0 ? 'text-warning-700 font-semibold' : 'text-ink-400'">({{ t.count }})</span>
+			</button>
 		</div>
 
-		<!-- entries -->
-		<div v-if="tab === 'entries'" class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+		<!-- entries (verify / all / mine) -->
+		<div v-if="activeTab !== 'ledger'" class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
 			<table class="w-full text-xs" style="min-width: 720px">
 				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
 					<tr><th class="text-left px-3 py-2">ID</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Project</th><th class="text-right px-3 py-2">Amount</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
 				</thead>
 				<tbody>
-					<tr v-for="row in entries" :key="row.name" class="border-t border-ink-100">
+					<tr v-for="row in tableRows" :key="row.name" class="border-t border-ink-100">
 						<td class="px-3 py-2 font-mono text-ink-400 text-[10px]">{{ row.name }}</td>
 						<td class="px-3 py-2 text-ink-500">{{ fmtDate(row.date) }}</td>
 						<td class="px-3 py-2 text-ink-500">{{ row.project }}</td>
@@ -191,12 +225,12 @@ const expenseAccountFilters = [
 						<td class="px-3 py-2"><StatusBadge :status="statusLabel(row.docstatus)" /></td>
 						<td class="px-3 py-2 text-right">
 							<div class="flex justify-end gap-2">
-								<button v-if="row.docstatus === 0 && canSubmit" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onApprove(row)">Approve</button>
+								<button v-if="row.docstatus === 0 && canSubmit" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onApprove(row)">Verify</button>
 								<button v-if="row.docstatus !== 2" type="button" class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded" @click="onCancel(row)">{{ row.docstatus === 1 ? "Cancel" : "Delete" }}</button>
 							</div>
 						</td>
 					</tr>
-					<tr v-if="!entries.length"><td colspan="6" class="px-3 py-8 text-center text-ink-400 italic">{{ res.loading ? "Loading…" : "No expense entries yet." }}</td></tr>
+					<tr v-if="!tableRows.length"><td colspan="6" class="px-3 py-8 text-center text-ink-400 italic">{{ res.loading ? "Loading…" : "Nothing here." }}</td></tr>
 				</tbody>
 			</table>
 		</div>

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -7,8 +7,10 @@ import { computed, reactive, ref } from "vue";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import FileUploadHandler from "frappe-ui-file-upload-handler";
 import {
 	expenseContext,
+	getExpense,
 	expenseLedger,
 	saveExpense,
 	submitExpense,
@@ -132,6 +134,35 @@ async function confirmReimburse() {
 	}
 }
 
+// --- detail modal ---
+const detail = reactive({ open: false, loading: false, doc: null });
+async function openDetail(name) {
+	Object.assign(detail, { open: true, loading: true, doc: null });
+	try {
+		detail.doc = await getExpense(name);
+	} catch (err) {
+		showToast(err.message || "Failed to load entry", "error");
+		detail.open = false;
+	} finally {
+		detail.loading = false;
+	}
+}
+function detailApprove() {
+	const d = detail.doc;
+	detail.open = false;
+	onApprove(d);
+}
+function detailCancel() {
+	const d = detail.doc;
+	detail.open = false;
+	onCancel(d);
+}
+function detailReimburse() {
+	const d = detail.doc;
+	detail.open = false;
+	openReimburse(d);
+}
+
 function openTab(t) {
 	tab.value = t;
 	if (t === "ledger" && !ledgerRows.value.length) loadLedger();
@@ -140,7 +171,28 @@ function openTab(t) {
 
 // --- create modal ---
 const COST_TYPES = ["Material", "Labour", "Plant & Machinery", "Subcontract", "Overhead"];
-const blankRow = () => ({ expense_account: "", cost_type: "Overhead", amount: 0, description: "" });
+const blankRow = () => ({ expense_account: "", cost_type: "Overhead", amount: 0, description: "", attachment: "" });
+
+// --- receipt upload (per row) ---
+const uploadingRow = ref(-1);
+async function uploadReceipt(e, i) {
+	const file = e.target.files?.[0];
+	if (!file) return;
+	uploadingRow.value = i;
+	try {
+		const handler = new FileUploadHandler();
+		const res = await handler.upload(file, { private: true });
+		const url = res?.file_url || res?.message?.file_url || "";
+		if (!url) throw new Error("no url");
+		form.rows[i].attachment = url;
+		showToast("Receipt attached.");
+	} catch {
+		showToast("Upload failed.", "error");
+	} finally {
+		uploadingRow.value = -1;
+		if (e.target) e.target.value = "";
+	}
+}
 const form = reactive({ open: false, project: "", date: new Date().toISOString().slice(0, 10), reimbursable: false, rows: [blankRow()], saving: false });
 function openForm() {
 	Object.assign(form, { open: true, project: "", date: new Date().toISOString().slice(0, 10), reimbursable: false, rows: [blankRow()], saving: false });
@@ -262,7 +314,7 @@ const expenseAccountFilters = [
 					<tr><th class="text-left px-3 py-2">ID</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Project</th><th class="text-right px-3 py-2">Amount</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
 				</thead>
 				<tbody>
-					<tr v-for="row in tableRows" :key="row.name" class="border-t border-ink-100">
+					<tr v-for="row in tableRows" :key="row.name" class="border-t border-ink-100 hover:bg-brand-50/30 cursor-pointer" @click="openDetail(row.name)">
 						<td class="px-3 py-2 font-mono text-ink-400 text-[10px]">{{ row.name }}</td>
 						<td class="px-3 py-2 text-ink-500">{{ fmtDate(row.date) }}</td>
 						<td class="px-3 py-2 text-ink-500">{{ row.project }}</td>
@@ -270,8 +322,8 @@ const expenseAccountFilters = [
 						<td class="px-3 py-2"><StatusBadge :status="statusLabel(row.docstatus)" /></td>
 						<td class="px-3 py-2 text-right">
 							<div class="flex justify-end gap-2">
-								<button v-if="row.docstatus === 0 && canSubmit" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onApprove(row)">Verify</button>
-								<button v-if="row.docstatus !== 2" type="button" class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded" @click="onCancel(row)">{{ row.docstatus === 1 ? "Cancel" : "Delete" }}</button>
+								<button v-if="row.docstatus === 0 && canSubmit" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click.stop="onApprove(row)">Verify</button>
+								<button v-if="row.docstatus !== 2" type="button" class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded" @click.stop="onCancel(row)">{{ row.docstatus === 1 ? "Cancel" : "Delete" }}</button>
 							</div>
 						</td>
 					</tr>
@@ -331,13 +383,19 @@ const expenseAccountFilters = [
 				</div>
 				<div class="border border-ink-200 rounded-lg overflow-hidden mb-3">
 					<table class="w-full text-xs">
-						<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Expense account</th><th class="text-left px-3 py-2 w-36">Cost type</th><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
+						<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Expense account</th><th class="text-left px-3 py-2 w-36">Cost type</th><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="text-center px-3 py-2 w-20">Receipt</th><th class="w-8"></th></tr></thead>
 						<tbody>
 							<tr v-for="(r, i) in form.rows" :key="i" class="border-t border-ink-100">
 								<td class="px-2 py-1.5"><DeskLinkPicker v-model="r.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Expense account…" /></td>
 								<td class="px-2 py-1.5"><DeskSelect v-model="r.cost_type"><option v-for="c in COST_TYPES" :key="c" :value="c">{{ c }}</option></DeskSelect></td>
 								<td class="px-2 py-1.5"><DeskInput v-model="r.description" placeholder="What was it for?" /></td>
 								<td class="px-2 py-1.5"><DeskInput v-model.number="r.amount" type="number" min="0" class="text-right" /></td>
+								<td class="px-2 py-1.5 text-center">
+									<label class="cursor-pointer text-[11px]" :class="r.attachment ? 'text-success-700' : 'text-brand-700 hover:underline'">
+										{{ uploadingRow === i ? "Uploading…" : r.attachment ? "✓ Attached" : "Attach" }}
+										<input type="file" class="hidden" accept="image/*,application/pdf" @change="uploadReceipt($event, i)" />
+									</label>
+								</td>
 								<td class="px-2 py-1.5 text-center"><button type="button" class="text-ink-400 hover:text-danger-600" @click="removeRow(i)">✕</button></td>
 							</tr>
 						</tbody>
@@ -370,6 +428,57 @@ const expenseAccountFilters = [
 				<div class="flex justify-end gap-2 mt-5">
 					<button class="desk-btn" @click="reimb.open = false">Cancel</button>
 					<button class="desk-save-btn" :disabled="reimb.saving" @click="confirmReimburse">{{ reimb.saving ? "Posting…" : "Reimburse" }}</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- detail modal -->
+		<div v-if="detail.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="detail.open = false">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[85vh] overflow-y-auto">
+				<div class="flex items-center gap-2 px-5 py-3 border-b border-ink-200 sticky top-0 bg-white">
+					<span class="font-mono text-xs text-ink-500">{{ detail.doc?.name || "" }}</span>
+					<StatusBadge v-if="detail.doc" :status="statusLabel(detail.doc.docstatus)" />
+					<span v-if="detail.doc?.reimbursable" class="text-[9px] px-1 py-0.5 bg-info-50 text-info-700 font-medium uppercase tracking-wider" style="border-radius: 2px">{{ detail.doc.reimbursed ? "Reimbursed" : "Out of pocket" }}</span>
+					<button type="button" class="ml-auto text-ink-400 hover:text-ink-900" @click="detail.open = false">✕</button>
+				</div>
+
+				<div v-if="detail.loading" class="px-5 py-10 text-center text-ink-400 text-sm">Loading…</div>
+				<div v-else-if="detail.doc" class="px-5 py-4">
+					<div class="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-4 text-xs">
+						<div><div class="text-[10px] uppercase tracking-wider text-ink-500">Date</div><div class="text-ink-900 mt-0.5">{{ fmtDate(detail.doc.date) }}</div></div>
+						<div><div class="text-[10px] uppercase tracking-wider text-ink-500">Project</div><div class="text-ink-900 mt-0.5">{{ detail.doc.project }}</div></div>
+						<div><div class="text-[10px] uppercase tracking-wider text-ink-500">Employee</div><div class="text-ink-900 mt-0.5">{{ detail.doc.employee_name || detail.doc.employee }}</div></div>
+						<div><div class="text-[10px] uppercase tracking-wider text-ink-500">Paid from</div><div class="text-ink-900 mt-0.5">{{ detail.doc.payment_account }}</div></div>
+						<div><div class="text-[10px] uppercase tracking-wider text-ink-500">Total</div><div class="text-ink-900 mt-0.5 tabular-nums font-medium">{{ fmtINR(detail.doc.total_amount) }}</div></div>
+						<div v-if="detail.doc.reimbursed_on"><div class="text-[10px] uppercase tracking-wider text-ink-500">Reimbursed</div><div class="text-ink-900 mt-0.5">{{ fmtDate(detail.doc.reimbursed_on) }}</div></div>
+					</div>
+
+					<div class="border border-ink-200 rounded-lg overflow-x-auto mb-3">
+						<table class="w-full text-xs">
+							<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Expense account</th><th class="text-left px-3 py-2">Cost type</th><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2">Amount</th><th class="text-center px-3 py-2">Receipt</th></tr></thead>
+							<tbody>
+								<tr v-for="(r, i) in detail.doc.rows" :key="i" class="border-t border-ink-100">
+									<td class="px-3 py-2 text-ink-900">{{ r.expense_account }}</td>
+									<td class="px-3 py-2 text-ink-600">{{ r.cost_type }}</td>
+									<td class="px-3 py-2 text-ink-500">{{ r.description || "—" }}</td>
+									<td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(r.amount) }}</td>
+									<td class="px-3 py-2 text-center"><a v-if="r.attachment" :href="r.attachment" target="_blank" rel="noopener" class="text-brand-700 hover:underline">View</a><span v-else class="text-ink-300">—</span></td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+
+					<div v-if="detail.doc.journal_entry || detail.doc.reimbursement_journal_entry" class="text-[11px] text-ink-500 space-x-3 mb-1">
+						<span v-if="detail.doc.journal_entry">Posting JE: <span class="font-mono text-ink-700">{{ detail.doc.journal_entry }}</span></span>
+						<span v-if="detail.doc.reimbursement_journal_entry">Reimbursement JE: <span class="font-mono text-ink-700">{{ detail.doc.reimbursement_journal_entry }}</span></span>
+					</div>
+				</div>
+
+				<div v-if="detail.doc" class="flex items-center justify-end gap-2 px-5 py-3 border-t border-ink-200 sticky bottom-0 bg-white">
+					<button v-if="detail.doc.docstatus === 0 && canSubmit" type="button" class="text-xs px-3 py-1.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="detailApprove">Verify</button>
+					<button v-if="detail.doc.docstatus === 1 && detail.doc.reimbursable && !detail.doc.reimbursed && canSubmit" type="button" class="text-xs px-3 py-1.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="detailReimburse">Reimburse</button>
+					<button v-if="detail.doc.docstatus !== 2" type="button" class="text-xs px-3 py-1.5 border border-ink-200 text-danger-700 rounded" @click="detailCancel">{{ detail.doc.docstatus === 1 ? "Cancel" : "Delete" }}</button>
+					<button type="button" class="desk-btn" @click="detail.open = false">Close</button>
 				</div>
 			</div>
 		</div>

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -1,69 +1,256 @@
 <script setup>
+// Project Finance › Expenses — LIVE. The signed-in holder logs spend against their
+// petty-cash float as an Expense Entry (draft = pending approval); a finance approver
+// approves it, posting the Journal Entry. Balances + ledger come from the employee
+// petty-cash ledger (buildsuite_core.utils.petty_cash).
 import { computed, reactive, ref } from "vue";
-import { useFinanceMock } from "@/data/financeMock";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import { useDocTypeList } from "@/composables/useDocTypeList";
+import {
+	expenseContext,
+	expenseLedger,
+	saveExpense,
+	submitExpense,
+	cancelExpense,
+} from "@/data/expenseEntryApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
-import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
-const fin = useFinanceMock();
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Expenses" }];
-const tab = ref("all");
-const tabs = [
-	{ id: "toverify", label: "To Verify" },
-	{ id: "all", label: "All Expenses" },
-];
-const rows = computed(() => (tab.value === "toverify" ? fin.expensesToVerify : fin.expenses));
+const confirmDialog = useConfirm();
 
-const form = reactive({ open: false, date: new Date().toISOString().slice(0, 10), description: "", amount: 0, project: "", expense_account: "", cost_type: "Overhead", paid_from: "" });
-function create() {
-	if (!form.description.trim() || !(Number(form.amount) > 0)) return;
-	fin.addExpense({ date: form.date, description: form.description, amount: Number(form.amount), project: form.project, expense_account: form.expense_account, cost_type: form.cost_type, paid_from: form.paid_from, holder: "USR-005" });
-	form.open = false;
+// --- caller's petty-cash position ---
+const ctx = ref({ employee: null, employee_name: null, can_submit: false, approved: 0, pending: 0, available: 0 });
+async function loadContext() {
+	try {
+		ctx.value = await expenseContext();
+	} catch (err) {
+		showToast(err.message || "Failed to load balance", "error");
+	}
 }
+loadContext();
+const canSubmit = computed(() => !!ctx.value.can_submit);
+const hasEmployee = computed(() => !!ctx.value.employee);
+
+// --- entries list ---
+const res = useDocTypeList("Expense Entry", {
+	fields: ["name", "date", "project", "employee", "total_amount", "docstatus", "payment_account"],
+	orderBy: "creation desc",
+	pageLength: 0,
+	cache: "buildsuite-expense-entry-list",
+});
+const entries = computed(() => res.data || []);
+function statusLabel(d) {
+	return d === 2 ? "Cancelled" : d === 1 ? "Approved" : "Pending Approval";
+}
+
+const tab = ref("entries");
+
+// --- ledger ---
+const ledgerRows = ref([]);
+const ledgerLoading = ref(false);
+async function loadLedger() {
+	ledgerLoading.value = true;
+	try {
+		ledgerRows.value = await expenseLedger();
+	} catch (err) {
+		showToast(err.message || "Failed to load ledger", "error");
+	} finally {
+		ledgerLoading.value = false;
+	}
+}
+
+function openTab(t) {
+	tab.value = t;
+	if (t === "ledger" && !ledgerRows.value.length) loadLedger();
+}
+
+// --- create modal ---
+const blankRow = () => ({ expense_account: "", amount: 0, description: "" });
+const form = reactive({ open: false, project: "", date: new Date().toISOString().slice(0, 10), rows: [blankRow()], saving: false });
+function openForm() {
+	Object.assign(form, { open: true, project: "", date: new Date().toISOString().slice(0, 10), rows: [blankRow()], saving: false });
+}
+const formTotal = computed(() => form.rows.reduce((s, r) => s + (Number(r.amount) || 0), 0));
+function addRow() {
+	form.rows.push(blankRow());
+}
+function removeRow(i) {
+	form.rows.splice(i, 1);
+	if (!form.rows.length) form.rows.push(blankRow());
+}
+async function submitForm() {
+	if (!form.project) return showToast("Pick a project.", "error");
+	const rows = form.rows.filter((r) => r.expense_account && Number(r.amount) > 0);
+	if (!rows.length) return showToast("Add at least one line with an account and amount.", "error");
+	form.saving = true;
+	try {
+		await saveExpense({ project: form.project, date: form.date, rows });
+		form.open = false;
+		res.reload?.();
+		loadContext();
+		showToast("Expense entry saved — pending approval.");
+	} catch (err) {
+		showToast(err.message || "Failed to save", "error");
+	} finally {
+		form.saving = false;
+	}
+}
+
+// --- actions ---
+async function onApprove(row) {
+	const ok = await confirmDialog({
+		title: "Approve expense entry?",
+		message: `Post ${fmtINR(row.total_amount)} for ${row.name}? This posts a Journal Entry against petty cash.`,
+		confirmLabel: "Approve & post",
+	});
+	if (!ok) return;
+	try {
+		await submitExpense(row.name);
+		res.reload?.();
+		loadContext();
+		if (tab.value === "ledger") loadLedger();
+		showToast("Approved — Journal Entry posted.");
+	} catch (err) {
+		showToast(err.message || "Approve failed", "error");
+	}
+}
+async function onCancel(row) {
+	const submitted = row.docstatus === 1;
+	const ok = await confirmDialog({
+		title: submitted ? "Cancel expense entry?" : "Delete draft?",
+		message: submitted ? `Reverse the Journal Entry for ${row.name}?` : `Delete draft ${row.name}?`,
+		confirmLabel: submitted ? "Cancel entry" : "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await cancelExpense(row.name);
+		res.reload?.();
+		loadContext();
+		showToast(submitted ? "Entry cancelled." : "Draft deleted.");
+	} catch (err) {
+		showToast(err.message || "Action failed", "error");
+	}
+}
+
+const expenseAccountFilters = [
+	["root_type", "=", "Expense"],
+	["is_group", "=", 0],
+];
 </script>
 
 <template>
 	<DeskPage title="Expenses" :breadcrumbs="breadcrumbs">
-		<template #actions><button class="desk-save-btn" @click="form.open = true">+ Log Expense</button></template>
-		<div class="border-b border-ink-200 flex mb-4">
-			<button v-for="t in tabs" :key="t.id" class="px-3 py-2 text-xs font-medium" :class="tab === t.id ? 'text-brand-600' : 'text-ink-600'" :style="tab === t.id ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'" @click="tab = t.id">{{ t.label }}</button>
+		<template #actions>
+			<button type="button" class="desk-save-btn" :disabled="!hasEmployee" @click="openForm">+ Log Expense</button>
+		</template>
+
+		<!-- balance strip -->
+		<div v-if="hasEmployee" class="grid grid-cols-3 gap-3 mb-4 max-w-2xl">
+			<div class="bg-white border border-ink-200 rounded-lg px-4 py-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Approved balance</div>
+				<div class="text-lg font-semibold text-ink-900 tabular-nums">{{ fmtINR(ctx.approved) }}</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg px-4 py-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Pending approval</div>
+				<div class="text-lg font-semibold text-warning-700 tabular-nums">{{ fmtINR(ctx.pending) }}</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg px-4 py-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Available (incl. review)</div>
+				<div class="text-lg font-semibold text-brand-700 tabular-nums">{{ fmtINR(ctx.available) }}</div>
+			</div>
 		</div>
-		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+		<div v-else class="bg-warning-50 border border-warning-200 rounded-lg px-4 py-3 mb-4 text-sm text-warning-700 max-w-2xl">
+			Your user account isn't linked to an Employee, so petty-cash spend can't be logged. Ask an administrator to set the Employee's User ID.
+		</div>
+
+		<!-- tabs -->
+		<div class="border-b border-ink-200 flex mb-4">
+			<button type="button" class="px-3 py-2 text-xs font-medium" :class="tab === 'entries' ? 'text-brand-600' : 'text-ink-600'" :style="tab === 'entries' ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'" @click="openTab('entries')">Entries</button>
+			<button type="button" class="px-3 py-2 text-xs font-medium" :class="tab === 'ledger' ? 'text-brand-600' : 'text-ink-600'" :style="tab === 'ledger' ? 'border-bottom:2px solid currentColor;margin-bottom:-1px;' : 'border-bottom:2px solid transparent;margin-bottom:-1px;'" @click="openTab('ledger')">Ledger</button>
+		</div>
+
+		<!-- entries -->
+		<div v-if="tab === 'entries'" class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
 			<table class="w-full text-xs" style="min-width: 720px">
 				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
-					<tr><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Description</th><th class="text-left px-3 py-2">Account</th><th class="text-left px-3 py-2">Cost type</th><th class="text-right px-3 py-2">Amount</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
+					<tr><th class="text-left px-3 py-2">ID</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Project</th><th class="text-right px-3 py-2">Amount</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
 				</thead>
 				<tbody>
-					<tr v-for="e in rows" :key="e.id" class="border-t border-ink-100">
-						<td class="px-3 py-2 text-ink-500">{{ fmtDate(e.date) }}</td>
-						<td class="px-3 py-2 text-ink-900">{{ e.description }}</td>
-						<td class="px-3 py-2 text-ink-500">{{ e.expense_account }}</td>
-						<td class="px-3 py-2 text-ink-600">{{ e.cost_type }}</td>
-						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(e.amount) }}</td>
-						<td class="px-3 py-2"><StatusBadge :status="e.status" /></td>
-						<td class="px-3 py-2 text-right"><button v-if="e.status === 'Draft'" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="fin.submitExpense(e.id)">Verify</button></td>
+					<tr v-for="row in entries" :key="row.name" class="border-t border-ink-100">
+						<td class="px-3 py-2 font-mono text-ink-400 text-[10px]">{{ row.name }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ fmtDate(row.date) }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ row.project }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(row.total_amount) }}</td>
+						<td class="px-3 py-2"><StatusBadge :status="statusLabel(row.docstatus)" /></td>
+						<td class="px-3 py-2 text-right">
+							<div class="flex justify-end gap-2">
+								<button v-if="row.docstatus === 0 && canSubmit" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onApprove(row)">Approve</button>
+								<button v-if="row.docstatus !== 2" type="button" class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded" @click="onCancel(row)">{{ row.docstatus === 1 ? "Cancel" : "Delete" }}</button>
+							</div>
+						</td>
 					</tr>
-					<tr v-if="!rows.length"><td colspan="7" class="px-3 py-4 text-center text-ink-400 italic">No expenses.</td></tr>
+					<tr v-if="!entries.length"><td colspan="6" class="px-3 py-8 text-center text-ink-400 italic">{{ res.loading ? "Loading…" : "No expense entries yet." }}</td></tr>
 				</tbody>
 			</table>
 		</div>
 
+		<!-- ledger -->
+		<div v-else class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<table class="w-full text-xs" style="min-width: 720px">
+				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Voucher</th><th class="text-left px-3 py-2">Project</th><th class="text-right px-3 py-2">In</th><th class="text-right px-3 py-2">Out</th><th class="text-right px-3 py-2">Balance</th></tr>
+				</thead>
+				<tbody>
+					<tr v-for="row in ledgerRows" :key="row.name" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-500">{{ row.posting_date }}</td>
+						<td class="px-3 py-2 text-ink-700">{{ row.title }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ row.project || "—" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-success-700">{{ row.received ? fmtINR(row.received) : "" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-danger-700">{{ row.paid ? fmtINR(row.paid) : "" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(row.balance) }}</td>
+					</tr>
+					<tr v-if="!ledgerRows.length"><td colspan="6" class="px-3 py-8 text-center text-ink-400 italic">{{ ledgerLoading ? "Loading…" : "No petty-cash movements yet." }}</td></tr>
+				</tbody>
+			</table>
+		</div>
+
+		<!-- create modal -->
 		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
-			<div class="bg-white rounded-lg shadow-xl w-full max-w-lg p-5">
-				<h3 class="text-sm font-semibold text-ink-900 mb-4">Log expense</h3>
-				<div class="grid grid-cols-2 gap-3">
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-2xl p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-4">Log petty-cash expense</h3>
+				<div class="grid grid-cols-2 gap-3 mb-3">
+					<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" placeholder="Pick a project…" /></DeskField>
 					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
-					<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" /></DeskField>
-					<DeskField label="Description" required class="col-span-2"><DeskInput v-model="form.description" /></DeskField>
-					<DeskField label="Project"><DeskSelect v-model="form.project"><option value="">—</option><option v-for="p in fin.projects" :key="p.id" :value="p.id">{{ p.name }}</option></DeskSelect></DeskField>
-					<DeskField label="Cost type"><DeskSelect v-model="form.cost_type"><option>Material</option><option>Labour</option><option>Plant &amp; Machinery</option><option>Subcontract</option><option>Overhead</option></DeskSelect></DeskField>
-					<DeskField label="Expense account"><DeskInput v-model="form.expense_account" /></DeskField>
-					<DeskField label="Paid from"><DeskSelect v-model="form.paid_from"><option value="">—</option><option v-for="a in fin.financeAccounts" :key="a.id" :value="a.id">{{ a.name }}</option></DeskSelect></DeskField>
 				</div>
-				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="create">Log</button></div>
+				<div class="border border-ink-200 rounded-lg overflow-hidden mb-3">
+					<table class="w-full text-xs">
+						<thead class="bg-ink-50 text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-3 py-2">Expense account</th><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
+						<tbody>
+							<tr v-for="(r, i) in form.rows" :key="i" class="border-t border-ink-100">
+								<td class="px-2 py-1.5"><DeskLinkPicker v-model="r.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Expense account…" /></td>
+								<td class="px-2 py-1.5"><DeskInput v-model="r.description" placeholder="What was it for?" /></td>
+								<td class="px-2 py-1.5"><DeskInput v-model.number="r.amount" type="number" min="0" class="text-right" /></td>
+								<td class="px-2 py-1.5 text-center"><button type="button" class="text-ink-400 hover:text-danger-600" @click="removeRow(i)">✕</button></td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div class="flex items-center justify-between mb-4">
+					<button type="button" class="text-xs text-brand-700 hover:underline" @click="addRow">+ Add line</button>
+					<div class="text-sm">Total <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(formTotal) }}</span></div>
+				</div>
+				<p class="text-[11px] text-ink-500 mb-4">Paid from your Petty Cash float. Saved as a draft pending a finance approver.</p>
+				<div class="flex justify-end gap-2">
+					<button class="desk-btn" @click="form.open = false">Cancel</button>
+					<button class="desk-save-btn" :disabled="form.saving" @click="submitForm">{{ form.saving ? "Saving…" : "Save" }}</button>
+				</div>
 			</div>
 		</div>
 	</DeskPage>

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -213,27 +213,31 @@ const rowsForTab = computed(() => {
 			</button>
 		</div>
 
-		<!-- balances -->
+		<!-- balances — reconciled: disbursed float in − verified spend out = in hand -->
 		<div v-if="tab === 'balances'" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
 			<table class="w-full text-xs">
 				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
 					<tr>
 						<th class="text-left px-3 py-2">Holder</th>
-						<th class="text-right px-3 py-2">Disbursed (float out)</th>
+						<th class="text-right px-3 py-2">Disbursed</th>
+						<th class="text-right px-3 py-2">Verified spend</th>
+						<th class="text-right px-3 py-2">Balance in hand</th>
 					</tr>
 				</thead>
 				<tbody>
-					<tr v-for="b in balances" :key="b.holder" class="border-t border-ink-100">
+					<tr v-for="b in balances" :key="b.employee || b.holder" class="border-t border-ink-100">
 						<td class="px-3 py-2 text-ink-900">{{ b.holder }}</td>
-						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(b.disbursed) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.disbursed) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.spent) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">{{ fmtINR(b.balance) }}</td>
 					</tr>
 					<tr v-if="!balances.length">
-						<td colspan="2" class="px-3 py-4 text-center text-ink-400 italic">No disbursements yet.</td>
+						<td colspan="4" class="px-3 py-4 text-center text-ink-400 italic">No petty-cash activity yet.</td>
 					</tr>
 				</tbody>
 			</table>
 			<p class="px-3 py-2 text-[11px] text-ink-400 border-t border-ink-100">
-				Verified spend against these floats is tracked on the Expenses tab.
+				Balance in hand = disbursed float − approved expenses (from the Expenses tab).
 			</p>
 		</div>
 

--- a/frontend/src/views/finance/reports/PettyCashReport.vue
+++ b/frontend/src/views/finance/reports/PettyCashReport.vue
@@ -1,6 +1,8 @@
 <script setup>
-// The one report backed by LIVE data — per-holder disbursed float from Petty Cash Requests.
-import { ref } from "vue";
+// LIVE petty-cash statement — reconciled per holder from the GL: disbursed float
+// in, verified expense out, and the net balance in hand. Both legs (Petty Cash
+// Request disburse + Expense Entry spend) roll into one figure.
+import { computed, ref } from "vue";
 import { pettyCashHolderBalances } from "@/data/pettyCashApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import { fmtINR } from "@/utils/format";
@@ -12,20 +14,39 @@ pettyCashHolderBalances()
 	.then((r) => (rows.value = r))
 	.catch(() => {})
 	.finally(() => (loading.value = false));
+
+const totals = computed(() =>
+	rows.value.reduce(
+		(a, b) => ({ disbursed: a.disbursed + (b.disbursed || 0), spent: a.spent + (b.spent || 0), balance: a.balance + (b.balance || 0) }),
+		{ disbursed: 0, spent: 0, balance: 0 },
+	),
+);
 </script>
 
 <template>
 	<DeskPage title="Petty Cash Statement" :breadcrumbs="breadcrumbs">
-		<div class="bg-white border border-ink-200 rounded-lg overflow-hidden max-w-xl">
-			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Float disbursed per holder (live)</h3></div>
+		<div class="bg-white border border-ink-200 rounded-lg overflow-hidden max-w-2xl">
+			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Balance in hand per holder (live)</h3></div>
 			<table class="w-full text-sm">
+				<thead class="text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-4 py-2">Holder</th><th class="text-right px-4 py-2">Disbursed</th><th class="text-right px-4 py-2">Verified spend</th><th class="text-right px-4 py-2">Balance</th></tr></thead>
 				<tbody>
-					<tr v-for="b in rows" :key="b.holder" class="border-t border-ink-100"><td class="px-4 py-2 text-ink-900">{{ b.holder }}</td><td class="px-4 py-2 text-right tabular-nums font-medium">{{ fmtINR(b.disbursed) }}</td></tr>
-					<tr v-if="!rows.length && !loading"><td colspan="2" class="px-4 py-4 text-center text-ink-400 italic">No disbursements yet.</td></tr>
-					<tr v-if="loading"><td colspan="2" class="px-4 py-4 text-center text-ink-400">Loading…</td></tr>
+					<tr v-for="b in rows" :key="b.employee || b.holder" class="border-t border-ink-100">
+						<td class="px-4 py-2 text-ink-900">{{ b.holder }}</td>
+						<td class="px-4 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.disbursed) }}</td>
+						<td class="px-4 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.spent) }}</td>
+						<td class="px-4 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">{{ fmtINR(b.balance) }}</td>
+					</tr>
+					<tr v-if="!rows.length && !loading"><td colspan="4" class="px-4 py-4 text-center text-ink-400 italic">No petty-cash activity yet.</td></tr>
+					<tr v-if="loading"><td colspan="4" class="px-4 py-4 text-center text-ink-400">Loading…</td></tr>
+					<tr v-if="rows.length" class="border-t-2 border-ink-200 font-semibold">
+						<td class="px-4 py-2">Total</td>
+						<td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(totals.disbursed) }}</td>
+						<td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(totals.spent) }}</td>
+						<td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(totals.balance) }}</td>
+					</tr>
 				</tbody>
 			</table>
-			<p class="px-4 py-2 text-[11px] text-ink-400 border-t border-ink-100">Verified spend against these floats is tracked on the (dummy) Expenses tab.</p>
+			<p class="px-4 py-2 text-[11px] text-ink-400 border-t border-ink-100">Balance = disbursed float − approved expenses. Per-holder movement detail is on the Expenses › Ledger tab.</p>
 		</div>
 	</DeskPage>
 </template>


### PR DESCRIPTION
Completes and wires the **employee petty-cash ledger + Expense Entry** that landed recently (the `Expense Entry` doctype and the four documented balance/ledger endpoints). That code was in the tree but had a runtime bug, no permissions, no tests, and no SPA. This PR makes it work end-to-end.

## Backend
- **Bug fix** — `get_pending_approval_balance` / `get_total_balance_include_review` queried `Expense Entry Table.mode_of_payment_account`, which doesn't exist (the field is `payment_account`) → a runtime SQL error on two of the four endpoints. Query the real column.
- **Permissions** — add BuildSuite role perms for Expense Entry: site roles (Site Engineer/Foreman) create drafts = *pending approval*; finance approvers (Accountant/Director/PM/Admin) submit = post the JE. Wired into `setup_petty_cash_permissions()`.
- **Reconcile the two subsystems** — the Petty Cash Request *disbursement* JE now tags the holder **Employee** (resolved from `requested_by`) on the Petty Cash line, so issued float and later Expense-Entry spend share one ledger.

## SPA (Vue)
- `api/expense_entry.py` — whitelisted endpoints: `context` (caller's approved / pending / available balance), `ledger` (running-balance statement), `save_expense` (draft; employee + petty-cash account resolved server-side), `submit_expense` (approver posts JE), `cancel_expense`, `list_expense_accounts`.
- `data/expenseEntryApi.js` + a **live `FinanceExpensesPanel.vue`** (replaces the mock): balance strip, **Entries** tab (log a multi-line expense → draft → approver approves → JE; cancel/delete), **Ledger** tab. Clear notice when the user has no linked Employee.

## Tests
- `test_petty_cash_ledger.py` (5): disburse tags employee; draft = pending vs posted approved; submit reduces approved; transaction-list running balance; misspelled alias. Existing `test_petty_cash` (5) still green.
- SPA endpoints smoke-tested end-to-end (save → pending → approve → JE → ledger).

## Notes / follow-ups
- Requires **`bench migrate`** (installs the Expense Entry doctype + the `employee` custom field on GL Entry / Journal Entry Account).
- The finance **reports** (Expense Summary, etc.) still read the mock store — they are not yet connected to live Expense Entries (out of scope here).
- Balance endpoints require the user's **User↔Employee** link (`Employee.user_id`); the panel shows a notice when it's missing.
