### PR TITLE
docs: Petty Cash + Expense Entry Mermaid workflows

### DIFF
--- a/docs/images/mermaid/expense-entry-workflow.mmd
+++ b/docs/images/mermaid/expense-entry-workflow.mmd
@@ -1,0 +1,25 @@
+%% Expense Entry — live workflow (buildsuite_core)
+%% Log (draft) -> Verify/submit (posts JE) -> optionally Reimburse; Cancel reverses.
+flowchart TD
+    start(["Holder incurs site spend"]) --> log["Log Expense Entry<br/>lines: expense account · cost type ·<br/>amount · description · receipt"]
+    log --> pay{"Paid from?"}
+    pay -->|"Petty cash float"| pcacct["payment_account = Petty Cash"]
+    pay -->|"Own pocket (reimbursable)"| reacct["payment_account = Employee Reimbursements<br/>(liability)"]
+    pcacct --> DRAFT{{"docstatus 0: Draft<br/>= Pending approval"}}
+    reacct --> DRAFT
+
+    DRAFT -->|"Holder deletes draft"| DEL(["Deleted"])
+    DRAFT -->|"Approver: To Verify queue<br/>Verify = submit"| je1["Post Journal Entry<br/>Dr Expense accounts /<br/>Cr payment_account<br/>tagged employee · project · cost centre"]
+    je1 --> SUBM{{"docstatus 1: Submitted<br/>= Approved / posted"}}
+
+    SUBM --> effect{"Reimbursable?"}
+    effect -->|"No — paid from petty cash"| float["Reduces holder's petty-cash balance<br/>(verified spend)"]
+    effect -->|"Yes — out of pocket"| queue["Appears in To Reimburse queue<br/>does NOT touch the petty float"]
+    queue -->|"Approver reimburses<br/>pick Bank account"| je2["Post Journal Entry<br/>Dr Employee Reimbursements /<br/>Cr Bank (tagged employee)"]
+    je2 --> REIMB{{"reimbursed = 1<br/>reimbursed_on · reimbursement_journal_entry"}}
+
+    SUBM -->|"Approver cancels"| canc["Cancel Journal Entry(s)<br/>incl. reimbursement JE"]
+    canc --> CANCELLED{{"docstatus 2: Cancelled"}}
+
+    %% Balances / ledger
+    float -.-> ledger["Employee petty-cash ledger<br/>approved / pending / available<br/>+ running-balance transaction list"]

--- a/docs/images/mermaid/petty-cash-workflow.mmd
+++ b/docs/images/mermaid/petty-cash-workflow.mmd
@@ -1,0 +1,21 @@
+%% Petty Cash Request — live workflow (buildsuite_core)
+%% Request -> Disburse (posts a Journal Entry) -> optionally Reverse.
+flowchart TD
+    start(["Site user / PM needs cash"]) --> req["Raise Petty Cash Request<br/>project · amount · purpose<br/>requested_by, company from project"]
+    req --> S_REQ{{"Status: Requested"}}
+
+    S_REQ -->|"Requester withdraws<br/>(cancel_request)"| CANC{{"Status: Cancelled"}}
+
+    S_REQ -->|"Approver reviews<br/>Accountant / Director / PM / Admin"| disb["Disburse<br/>pick Bank / Cash account"]
+    disb --> gate{"Account valid?<br/>non-group Bank/Cash in company"}
+    gate -->|"No"| err["Rejected"]
+    gate -->|"Yes"| je1["Post submitted Journal Entry<br/>Dr Petty Cash (employee) / Cr Bank<br/>+ project accounting dimension"]
+    je1 --> S_DIS{{"Status: Disbursed<br/>journal_entry set · float issued"}}
+
+    S_DIS -->|"Reverse disbursement<br/>(undisburse)"| rev["Cancel Journal Entry"]
+    rev --> S_REQ
+
+    S_DIS --> bal["Holder float increases<br/>feeds reconciled balance:<br/>disbursed - verified spend = in hand"]
+
+    %% Spend against the float is recorded separately as an Expense Entry
+    bal -.->|"spend recorded via"| exp["Expense Entry workflow<br/>(see expense-entry-workflow)"]


### PR DESCRIPTION
Adds two `.mmd` flowcharts under `docs/images/mermaid/` (alongside the BOQ diagrams) documenting the live workflows — petty cash (request → disburse → reverse) and expense entry (log → verify → reimburse, petty-cash vs out-of-pocket). Faithful to the implementation: JE postings, account routing, role gating, and the reconciled-balance effect.