### PR TITLE
fix(petty-cash): match prototype disburse button + hide Reverse

### DIFF
--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -11,7 +11,6 @@ import {
 	pettyCashCanDisburse,
 	savePettyCash,
 	disbursePettyCash,
-	undisbursePettyCash,
 	cancelPettyCash,
 	pettyCashHolderBalances,
 	listCashBankAccounts,
@@ -142,23 +141,6 @@ async function confirmDisburse() {
 	}
 }
 
-async function onUndisburse(row) {
-	const ok = await confirmDialog({
-		title: "Reverse disbursement?",
-		message: `Cancel the Journal Entry for ${row.name} and revert it to Requested?`,
-		confirmLabel: "Reverse",
-		destructive: true,
-	});
-	if (!ok) return;
-	try {
-		await undisbursePettyCash(row.name);
-		res.reload?.();
-		loadBalances();
-		showToast("Disbursement reversed.");
-	} catch (err) {
-		showToast(err.message || "Reverse failed", "error");
-	}
-}
 async function onWithdraw(row) {
 	const ok = await confirmDialog({
 		title: "Withdraw request?",
@@ -267,7 +249,7 @@ const rowsForTab = computed(() => {
 					<button
 						v-if="row.status === 'Requested' && canDisburse"
 						type="button"
-						class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded"
+						class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-white rounded-md"
 						@click.stop="openDisburse(row)"
 					>
 						Disburse
@@ -279,14 +261,6 @@ const rowsForTab = computed(() => {
 						@click.stop="onWithdraw(row)"
 					>
 						Withdraw
-					</button>
-					<button
-						v-if="row.status === 'Disbursed' && canDisburse"
-						type="button"
-						class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded"
-						@click.stop="onUndisburse(row)"
-					>
-						Reverse
 					</button>
 				</div>
 			</template>


### PR DESCRIPTION
Two small petty-cash UI fixes:

- **Disburse button** restyled to the prototype's solid green CTA (`bg-brand-600 hover:bg-brand-700 text-white rounded-md`, `px-2 py-1`) — was a light brand-outline variant.
- **Hide the Reverse** (undisburse) button from the request list; removed the now-unused handler + import. The `undisburse` API endpoint stays for programmatic/Desk use.