### PR TITLE
docs: refresh petty-cash workflow (imprest + employee dimension)

### DIFF
--- a/docs/images/mermaid/petty-cash-workflow.mmd
+++ b/docs/images/mermaid/petty-cash-workflow.mmd
@@ -1,21 +1,21 @@
 %% Petty Cash Request — live workflow (buildsuite_core)
-%% Request -> Disburse (posts a Journal Entry) -> optionally Reverse.
+%% Imprest model (PF-02): Employee requests -> Approver disburses (posts a Journal
+%% Entry, holder stamped via the 'employee' accounting dimension) -> spend via Expense Entry.
 flowchart TD
-    start(["Site user / PM needs cash"]) --> req["Raise Petty Cash Request<br/>project · amount · purpose<br/>requested_by, company from project"]
+    start(["Employee needs a cash float"]) --> req["Raise Petty Cash Request<br/>amount · purpose (no project)<br/>requested_by must be an active Employee<br/>company = the Employee's company"]
     req --> S_REQ{{"Status: Requested"}}
 
-    S_REQ -->|"Requester withdraws<br/>(cancel_request)"| CANC{{"Status: Cancelled"}}
+    S_REQ -->|"Requester withdraws (cancel_request)"| CANC{{"Status: Cancelled"}}
 
-    S_REQ -->|"Approver reviews<br/>Accountant / Director / PM / Admin"| disb["Disburse<br/>pick Bank / Cash account"]
-    disb --> gate{"Account valid?<br/>non-group Bank/Cash in company"}
-    gate -->|"No"| err["Rejected"]
-    gate -->|"Yes"| je1["Post submitted Journal Entry<br/>Dr Petty Cash (employee) / Cr Bank<br/>+ project accounting dimension"]
-    je1 --> S_DIS{{"Status: Disbursed<br/>journal_entry set · float issued"}}
+    S_REQ -->|"Approver reviews<br/>Accountant / Director / PM / Admin"| disb["Disburse — pick the funding source:<br/>a Bank / Cash account, NOT Petty Cash<br/>(source is credited; Petty Cash would be a no-op)"]
+    disb --> je1["Post submitted Journal Entry (imprest)<br/>Dr Petty Cash — holder on the 'employee' dimension<br/>Cr Bank (the funding source)"]
+    je1 --> S_DIS{{"Status: Disbursed · float issued"}}
+    S_DIS -.->|"Reverse (undisburse) — cancels the JE,<br/>back to Requested · API/admin only"| S_REQ
 
-    S_DIS -->|"Reverse disbursement<br/>(undisburse)"| rev["Cancel Journal Entry"]
-    rev --> S_REQ
+    %% How the dimension flows to the ledger and what it unlocks
+    je1 --> gl["On submit, ERPNext copies the 'employee'<br/>dimension from each JE line to its GL Entry<br/>(the Bank leg carries none)"]
+    gl --> rpt["Native reporting (Desk): General Ledger &<br/>Financial Statements FILTER / GROUP BY Employee<br/>— the PF-02 per-holder audit trail"]
+    gl --> bal["App-derived balance (Vue Balances tab):<br/>reads GL Entry.employee ·<br/>disbursed − verified spend = in hand"]
 
-    S_DIS --> bal["Holder float increases<br/>feeds reconciled balance:<br/>disbursed - verified spend = in hand"]
-
-    %% Spend against the float is recorded separately as an Expense Entry
-    bal -.->|"spend recorded via"| exp["Expense Entry workflow<br/>(see expense-entry-workflow)"]
+    %% Spend reduces the float, on the same dimension
+    bal -.->|"spend logged separately as"| exp["Expense Entry — Cr Petty Cash on the same<br/>'employee' dimension, reducing the holder's balance<br/>(see expense-entry-workflow)"]

--- a/docs/images/mermaid/petty-cash-workflow.mmd
+++ b/docs/images/mermaid/petty-cash-workflow.mmd
@@ -1,21 +1,22 @@
 %% Petty Cash Request — live workflow (buildsuite_core)
-%% Imprest model (PF-02): Employee requests -> Approver disburses (posts a Journal
-%% Entry, holder stamped via the 'employee' accounting dimension) -> spend via Expense Entry.
+%% Imprest model (PF-02). Highlights how the HOLDER is captured on the ledger:
+%% requested_by (User) -> Employee -> stamped on the JE line as the 'employee'
+%% accounting dimension -> propagated to GL Entry natively by ERPNext's get_gl_dict
+%% (the CustomJournalEntry override that used to copy it by hand is now removed).
 flowchart TD
-    start(["Employee needs a cash float"]) --> req["Raise Petty Cash Request<br/>amount · purpose (no project)<br/>requested_by must be an active Employee<br/>company = the Employee's company"]
-    req --> S_REQ{{"Status: Requested"}}
+    start(["Employee needs a cash float"]) --> req["Raise Petty Cash Request<br/>amount · purpose (no project)<br/>requested_by = a User"]
+    req --> emp["Resolve holder: employee_for_user(requested_by)<br/>→ active Employee (required)<br/>company = the Employee's company"]
+    emp --> S_REQ{{"Status: Requested"}}
 
     S_REQ -->|"Requester withdraws (cancel_request)"| CANC{{"Status: Cancelled"}}
 
-    S_REQ -->|"Approver reviews<br/>Accountant / Director / PM / Admin"| disb["Disburse — pick the funding source:<br/>a Bank / Cash account, NOT Petty Cash<br/>(source is credited; Petty Cash would be a no-op)"]
-    disb --> je1["Post submitted Journal Entry (imprest)<br/>Dr Petty Cash — holder on the 'employee' dimension<br/>Cr Bank (the funding source)"]
-    je1 --> S_DIS{{"Status: Disbursed · float issued"}}
-    S_DIS -.->|"Reverse (undisburse) — cancels the JE,<br/>back to Requested · API/admin only"| S_REQ
+    S_REQ -->|"Approver disburses — pick a Bank/Cash<br/>source, NOT Petty Cash"| je1["Post submitted Journal Entry (imprest)<br/>Dr Petty Cash · employee = holder  ← dimension on the LINE<br/>Cr Bank (funding source) · no employee"]
 
-    %% How the dimension flows to the ledger and what it unlocks
-    je1 --> gl["On submit, ERPNext copies the 'employee'<br/>dimension from each JE line to its GL Entry<br/>(the Bank leg carries none)"]
-    gl --> rpt["Native reporting (Desk): General Ledger &<br/>Financial Statements FILTER / GROUP BY Employee<br/>— the PF-02 per-holder audit trail"]
-    gl --> bal["App-derived balance (Vue Balances tab):<br/>reads GL Entry.employee ·<br/>disbursed − verified spend = in hand"]
+    je1 --> prop["On submit: ERPNext get_gl_dict(item=line) copies the<br/>'employee' ACCOUNTING DIMENSION from each line → its GL Entry.<br/>Native — replaces the REMOVED CustomJournalEntry override<br/>that used to copy it by hand (a stale build_gl_map copy)."]
+    prop --> S_DIS{{"Status: Disbursed · float issued"}}
+    S_DIS -.->|"Reverse (undisburse) → cancel JE, back to Requested · API/admin only"| S_REQ
 
-    %% Spend reduces the float, on the same dimension
-    bal -.->|"spend logged separately as"| exp["Expense Entry — Cr Petty Cash on the same<br/>'employee' dimension, reducing the holder's balance<br/>(see expense-entry-workflow)"]
+    prop --> rpt["GL Entry.employee → NATIVE Desk reporting:<br/>General Ledger & Financial Statements<br/>filter / group by Employee (the PF-02 audit trail)"]
+    prop --> bal["GL Entry.employee → Vue Balances tab (SQL):<br/>disbursed − verified spend = in hand"]
+
+    bal -.->|"spend logged separately as"| exp["Expense Entry — Cr Petty Cash on the SAME<br/>'employee' dimension, reducing the balance<br/>(see expense-entry-workflow)"]


### PR DESCRIPTION
Updates docs/images/mermaid/petty-cash-workflow.mmd to the current implementation: Employee-only requests (no project, company from the Employee), disburse from a real Bank/Cash source, and how the `employee` accounting dimension flows from the JE line to GL Entry — unlocking native GL/Financial-Statement grouping by Employee plus the app-derived per-holder balance.