### PR TITLE
feat: align Expense Entry to PF-04 (Petty Cash | Company, drop reimbursement)

### DIFF
--- a/buildsuite_core/api/expense_entry.py
+++ b/buildsuite_core/api/expense_entry.py
@@ -55,7 +55,7 @@ def list_expenses():
 	list: date, description, holder, source, account, cost type, amount, status."""
 	entries = frappe.get_all(
 		DOCTYPE,
-		fields=["name", "date", "project", "employee", "employee_name", "total_amount", "docstatus", "reimbursable", "description"],
+		fields=["name", "date", "project", "company", "employee", "employee_name", "total_amount", "docstatus", "paid_from", "payment_account", "description"],
 		order_by="date desc, creation desc",
 		limit_page_length=0,
 	)
@@ -88,9 +88,11 @@ def list_expenses():
 				"description": fr.get("description") or e.description or e.name,
 				"project": e.project,
 				"project_name": proj.get(e.project) or e.project,
+				"company": e.company,
 				"employee": e.employee,
 				"employee_name": e.employee_name or e.employee,
-				"source": "Own pocket" if e.reimbursable else "Petty Cash",
+				"source": e.paid_from or "Petty Cash",
+				"payment_account": e.payment_account,
 				"expense_account": fr.get("expense_account"),
 				"cost_type": fr.get("cost_type"),
 				"attachment": fr.get("attachment"),
@@ -116,11 +118,8 @@ def get_expense(name):
 		"payment_account": doc.payment_account,
 		"total_amount": doc.total_amount,
 		"docstatus": doc.docstatus,
-		"reimbursable": doc.reimbursable,
-		"reimbursed": doc.reimbursed,
-		"reimbursed_on": str(doc.reimbursed_on) if doc.reimbursed_on else None,
+		"paid_from": doc.paid_from,
 		"journal_entry": doc.journal_entry,
-		"reimbursement_journal_entry": doc.reimbursement_journal_entry,
 		"description": doc.description,
 		"rows": [
 			{
@@ -147,27 +146,38 @@ def ledger(transaction_type=None, project=None, from_date=None, to_date=None):
 
 @frappe.whitelist()
 def save_expense(payload):
-	"""Create or edit a draft Expense Entry paid from the caller's petty cash.
+	"""Create or edit a draft Expense Entry (PF-04).
 
-	rows: [{expense_account, amount, description, project?}]. Employee + payment
-	account are resolved server-side so a holder can only spend their own float.
+	rows: [{expense_account, amount, description, project?}]. `paid_from` is either
+	"petty" (Cr the company Petty Cash account, holder mandatory) or "company" (Cr a
+	Bank/Cash account chosen via `company_account`, no holder).
+
+	Holder rules: an ordinary user can only spend their own float, so the holder is
+	forced to their linked Employee. An approver/accountant may raise against any
+	holder by passing `employee`.
 	"""
 	data = frappe.parse_json(payload)
-	employee = _current_employee()
-	if not employee:
-		frappe.throw(_("No active Employee is linked to your user account."))
 
 	project = data.get("project")
 	if not project:
 		frappe.throw(_("A project is required."))
 	company = frappe.db.get_value("Project", project, "company")
 
-	# Out-of-pocket spend parks in Employee Reimbursements (a payable) so it doesn't
-	# touch the petty-cash float; otherwise it's paid straight from Petty Cash.
-	reimbursable = 1 if data.get("reimbursable") else 0
-	if reimbursable:
-		account = pc.resolve_reimbursements_account(company)
+	paid_from = "Company" if data.get("paid_from") == "company" else "Petty Cash"
+
+	if paid_from == "Company":
+		employee = None
+		account = data.get("company_account")
+		if not account:
+			frappe.throw(_("Choose the company Bank/Cash account to pay from."))
+		if frappe.db.get_value("Account", account, "company") != company:
+			frappe.throw(_("The selected account does not belong to {0}.").format(company))
 	else:
+		# Approvers may record on behalf of any holder; everyone else is pinned to their own.
+		employee = data.get("employee") if _can_submit() else None
+		employee = employee or _current_employee()
+		if not employee:
+			frappe.throw(_("No active Employee is linked to your user account."))
 		account = pc.get_petty_cash_account(company)
 		if not account:
 			frappe.throw(_("Petty Cash account not found for {0}.").format(company))
@@ -191,7 +201,7 @@ def save_expense(payload):
 	doc.project = project
 	doc.employee = employee
 	doc.payment_account = account
-	doc.reimbursable = reimbursable
+	doc.paid_from = paid_from
 	for r in rows:
 		doc.append(
 			"expense_entry_table",
@@ -212,36 +222,23 @@ def save_expense(payload):
 
 
 @frappe.whitelist()
-def to_reimburse():
-	"""Submitted out-of-pocket expenses awaiting reimbursement (approver queue)."""
-	rows = frappe.get_all(
-		DOCTYPE,
-		filters={"docstatus": 1, "reimbursable": 1, "reimbursed": 0},
-		fields=["name", "date", "project", "employee", "employee_name", "company", "total_amount"],
-		order_by="date asc",
-	)
-	return {"rows": rows, "total": sum(flt(r.total_amount) for r in rows)}
+def list_cash_bank_accounts(project=None, company=None):
+	"""Bank/Cash accounts a Company-paid expense can be drawn from (excludes Petty Cash).
 
-
-@frappe.whitelist()
-def reimburse(name, bank_account):
-	"""Pay an employee back for an out-of-pocket expense (posts the reimbursement JE)."""
-	if not _can_submit():
-		frappe.throw(_("You are not authorised to reimburse expenses."), frappe.PermissionError)
-	doc = frappe.get_doc(DOCTYPE, name)
-	je = doc.reimburse(bank_account)
-	return {"name": doc.name, "reimbursement_journal_entry": je}
-
-
-@frappe.whitelist()
-def list_cash_bank_accounts(company):
-	"""Bank/Cash accounts to pay a reimbursement from."""
-	return frappe.get_all(
+	Accepts a project (company is derived from it, matching save_expense) or a company.
+	"""
+	if project and not company:
+		company = frappe.db.get_value("Project", project, "company")
+	if not company:
+		return []
+	petty = pc.get_petty_cash_account(company)
+	accounts = frappe.get_all(
 		"Account",
 		filters={"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]},
 		fields=["name", "account_type"],
 		order_by="account_type, name",
 	)
+	return [a for a in accounts if a.name != petty]
 
 
 @frappe.whitelist()

--- a/buildsuite_core/api/petty_cash.py
+++ b/buildsuite_core/api/petty_cash.py
@@ -154,3 +154,97 @@ def holder_balances(company=None):
 	from buildsuite_core.utils.petty_cash import reconciled_holder_balances
 
 	return reconciled_holder_balances(company)
+
+
+@frappe.whitelist()
+def statement(employee):
+	"""A holder's personal petty-cash statement: disbursements in + petty-cash expenses
+	out, newest first. Cancelled entries are omitted (no balance impact); drafts are
+	included so pending spend is visible. Date/project/account/status filtering is left
+	to the caller — the whole ledger is returned so the report can filter interactively.
+	"""
+	if not employee:
+		return []
+
+	# Whitelisted: without this any signed-in user could read another holder's statement.
+	if not frappe.has_permission("Employee", doc=employee):
+		raise frappe.PermissionError
+
+	rows = []
+
+	# Disbursements — money into the holder's float. The holder raised the request
+	# (requested_by), so resolve the employee's User to find them.
+	user_id = frappe.db.get_value("Employee", employee, "user_id")
+	if user_id:
+		for d in frappe.get_all(
+			DOCTYPE,
+			filters={"requested_by": user_id, "status": "Disbursed"},
+			fields=["name", "project", "request_date", "disbursed_on", "amount", "purpose"],
+		):
+			date = (str(d.disbursed_on)[:10] if d.disbursed_on else None) or (
+				str(d.request_date) if d.request_date else None
+			)
+			rows.append(
+				{
+					"key": f"d-{d.name}",
+					"date": date,
+					"kind": "Disbursement",
+					"description": d.purpose or d.name,
+					"project": d.project,
+					"account": None,
+					"status": "Disbursed",
+					"in": flt(d.amount),
+					"out": 0.0,
+					"ref": d.name,
+				}
+			)
+
+	# Petty-cash expenses — money out of the float (drafts + submitted, never cancelled).
+	entries = frappe.get_all(
+		"Expense Entry",
+		filters={"employee": employee, "paid_from": "Petty Cash", "docstatus": ["<", 2]},
+		fields=["name", "date", "project", "total_amount", "docstatus", "description"],
+	)
+	first = {}
+	if entries:
+		for r in frappe.get_all(
+			"Expense Entry Table",
+			filters={"parent": ["in", [e.name for e in entries]]},
+			fields=["parent", "expense_account", "description"],
+			order_by="idx asc",
+		):
+			first.setdefault(r.parent, r)
+
+	status_map = {0: "Draft", 1: "Submitted"}
+	for e in entries:
+		fr = first.get(e.name) or {}
+		rows.append(
+			{
+				"key": f"e-{e.name}",
+				"date": str(e.date) if e.date else None,
+				"kind": "Expense",
+				"description": fr.get("description") or e.description or e.name,
+				"project": e.project,
+				"account": fr.get("expense_account"),
+				"status": status_map.get(e.docstatus, "Draft"),
+				"in": 0.0,
+				"out": flt(e.total_amount),
+				"ref": e.name,
+			}
+		)
+
+	# Resolve project titles in one query.
+	pids = list({r["project"] for r in rows if r["project"]})
+	pnames = (
+		{
+			p.name: p.project_name
+			for p in frappe.get_all("Project", filters={"name": ["in", pids]}, fields=["name", "project_name"])
+		}
+		if pids
+		else {}
+	)
+	for r in rows:
+		r["project_name"] = pnames.get(r["project"]) or r["project"]
+
+	rows.sort(key=lambda r: (r["date"] or ""), reverse=True)
+	return rows

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.json
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.json
@@ -15,6 +15,7 @@
   "cost_center",
   "journal_entry",
   "section_break_0rwm",
+  "paid_from",
   "payment_account",
   "payment_account_name",
   "column_break_oofb",
@@ -26,12 +27,6 @@
   "total_amount",
   "column_break_xz9z",
   "description",
-  "section_break_reimburse",
-  "reimbursable",
-  "reimbursed",
-  "column_break_reimburse",
-  "reimbursed_on",
-  "reimbursement_journal_entry",
   "section_break_smez",
   "amended_from"
  ],
@@ -92,6 +87,15 @@
   {
    "fieldname": "column_break_oofb",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "Petty Cash",
+   "fieldname": "paid_from",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "label": "Paid From",
+   "options": "Petty Cash\nCompany",
+   "reqd": 1
   },
   {
    "fieldname": "payment_account",
@@ -155,45 +159,6 @@
    "fieldname": "journal_entry",
    "fieldtype": "Link",
    "label": "Journal Entry",
-   "options": "Journal Entry",
-   "read_only": 1
-  },
-  {
-   "fieldname": "section_break_reimburse",
-   "fieldtype": "Section Break",
-   "label": "Reimbursement"
-  },
-  {
-   "default": "0",
-   "description": "Paid by the employee from their own pocket — credits Employee Reimbursements (a payable) instead of Petty Cash, and can be reimbursed later.",
-   "fieldname": "reimbursable",
-   "fieldtype": "Check",
-   "label": "Paid Out of Pocket (Reimbursable)"
-  },
-  {
-   "default": "0",
-   "fieldname": "reimbursed",
-   "fieldtype": "Check",
-   "label": "Reimbursed",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_reimburse",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "reimbursed_on",
-   "fieldtype": "Datetime",
-   "label": "Reimbursed On",
-   "no_copy": 1,
-   "read_only": 1
-  },
-  {
-   "fieldname": "reimbursement_journal_entry",
-   "fieldtype": "Link",
-   "label": "Reimbursement Journal Entry",
-   "no_copy": 1,
    "options": "Journal Entry",
    "read_only": 1
   }

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
@@ -34,6 +34,7 @@ class ExpenseEntry(Document):
 		expense_entry_table: DF.Table[ExpenseEntryTable]
 		journal_entry: DF.Link | None
 		naming_series: DF.Literal["EE-.YY.-"]
+		paid_from: DF.Literal["Petty Cash", "Company"]
 		payment_account: DF.Link
 		payment_account_name: DF.Data | None
 		project: DF.Link
@@ -43,6 +44,13 @@ class ExpenseEntry(Document):
 	def validate(self):
 		if not self.expense_entry_table:
 			frappe.throw(_("At least one expense row is required."))
+
+		# PF-04: holder is mandatory when paid from Petty Cash (drives the per-holder
+		# balance); a Company-paid expense has no holder.
+		if self.paid_from == "Petty Cash" and not self.employee:
+			frappe.throw(_("Holder (Employee) is required when Paid From is Petty Cash."))
+		if self.paid_from == "Company":
+			self.employee = None
 
 		self.total_amount = sum(flt(row.amount) for row in self.expense_entry_table)
 
@@ -61,70 +69,7 @@ class ExpenseEntry(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry")
-		self.cancel_reimbursement_journal_entry()
 		self.cancel_journal_entry()
-
-	# ------------------------------------------------------------------
-	# Reimbursement (own-pocket spend)
-	# ------------------------------------------------------------------
-
-	def reimburse(self, bank_account):
-		"""Pay the employee back for an out-of-pocket (reimbursable) expense.
-
-		The submit JE credited a reimbursements payable (self.payment_account); this
-		clears it: Dr Employee Reimbursements / Cr bank, tagged with the employee.
-		"""
-		if self.docstatus != 1:
-			frappe.throw(_("Only a submitted expense entry can be reimbursed."))
-		if not self.reimbursable:
-			frappe.throw(_("This expense was not marked reimbursable."))
-		if self.reimbursed:
-			frappe.throw(_("This expense has already been reimbursed."))
-		if not bank_account:
-			frappe.throw(_("Choose the account to pay the reimbursement from."))
-		account = frappe.db.get_value(
-			"Account", bank_account, ["is_group", "company", "account_type"], as_dict=True
-		)
-		if not account or account.is_group or account.company != self.company or account.account_type not in ("Bank", "Cash"):
-			frappe.throw(_("Pick a non-group Bank/Cash account in {0}.").format(self.company))
-
-		default_cc = frappe.db.get_value("Company", self.company, "cost_center")
-		je = frappe.new_doc("Journal Entry")
-		je.update(
-			{
-				"voucher_type": "Journal Entry",
-				"company": self.company,
-				"posting_date": frappe.utils.today(),
-				"user_remark": f"Reimbursement for {self.name}",
-				"reference_doctype": self.doctype,
-				"reference_docname": self.name,
-			}
-		)
-		je.append(
-			"accounts",
-			{"account": self.payment_account, "debit_in_account_currency": flt(self.total_amount), "cost_center": self.cost_center or default_cc, "employee": self.employee, "project": self.project},
-		)
-		je.append(
-			"accounts",
-			{"account": bank_account, "credit_in_account_currency": flt(self.total_amount), "cost_center": self.cost_center or default_cc, "project": self.project},
-		)
-		je.flags.ignore_permissions = True
-		je.insert()
-		je.submit()
-
-		self.db_set("reimbursement_journal_entry", je.name)
-		self.db_set("reimbursed", 1)
-		self.db_set("reimbursed_on", frappe.utils.now_datetime())
-		self.add_comment("Info", _("Reimbursed via {0}").format(je.name))
-		return je.name
-
-	def cancel_reimbursement_journal_entry(self):
-		if not self.reimbursement_journal_entry:
-			return
-		if frappe.db.get_value("Journal Entry", self.reimbursement_journal_entry, "docstatus") == 1:
-			je = frappe.get_doc("Journal Entry", self.reimbursement_journal_entry)
-			je.flags.ignore_permissions = True
-			je.cancel()
 
 	# ------------------------------------------------------------------
 	# Journal Entry
@@ -133,19 +78,22 @@ class ExpenseEntry(Document):
 	def create_journal_entry(self):
 		accounting_dimensions = get_accounting_dimensions() or []
 		default_cost_center = frappe.db.get_value("Company", self.company, "cost_center")
+		# PF-04: the holder rides on the CREDIT (Petty Cash) leg only, and only when paid
+		# from petty cash. The expense debit carries project/cost dimensions, not the holder;
+		# a Company-paid credit (Bank/Cash) has no holder.
+		holder = self.employee if self.paid_from == "Petty Cash" else None
 
 		accounts = []
 		for row in self.expense_entry_table:
 			cost_center = row.cost_center or self.cost_center or default_cost_center
 
-			# Debit: expense account
+			# Debit: expense account (project cost — no holder)
 			accounts.append(
-				self.get_account_row(row, row.expense_account, flt(row.amount), 0, cost_center, accounting_dimensions)
+				self.get_account_row(row, row.expense_account, flt(row.amount), 0, cost_center, accounting_dimensions, employee=None)
 			)
-			# Credit: payment account (Petty Cash / Reimbursements). The holder is carried
-			# on the `employee` dimension — ERPNext won't accept a party on these accounts.
+			# Credit: payment account — Petty Cash (holder stamped) or the company's Bank/Cash
 			accounts.append(
-				self.get_account_row(row, row.payment_account, 0, flt(row.amount), cost_center, accounting_dimensions)
+				self.get_account_row(row, row.payment_account, 0, flt(row.amount), cost_center, accounting_dimensions, employee=holder)
 			)
 
 		if not accounts:
@@ -183,7 +131,7 @@ class ExpenseEntry(Document):
 
 		self.db_set("journal_entry", None)
 
-	def get_account_row(self, row, account, debit, credit, cost_center, accounting_dimensions):
+	def get_account_row(self, row, account, debit, credit, cost_center, accounting_dimensions, employee=None):
 		entry = {
 			"account": account,
 			"debit_in_account_currency": debit or 0,
@@ -191,10 +139,15 @@ class ExpenseEntry(Document):
 			"cost_center": cost_center,
 			"project": row.project or self.project,
 			"user_remark": row.description,
-			"employee": row.employee or self.employee,
 		}
+		# The holder is set explicitly (PF-04: Petty Cash credit leg only), so don't let the
+		# generic dimension loop re-stamp `employee` onto the expense debit.
+		if employee:
+			entry["employee"] = employee
 
 		for dimension in accounting_dimensions:
+			if dimension == "employee":
+				continue
 			value = row.get(dimension) or self.get(dimension)
 			if value:
 				entry[dimension] = value

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -199,6 +199,25 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		# The submitted expense forced the holder off entirely (Company mode).
 		self.assertFalse(ee.employee)
 
+	def test_statement_combines_disbursement_and_expense(self):
+		from buildsuite_core.api.petty_cash import statement
+
+		self._disburse(10000)
+		self._expense_entry(3000, submit=True, paid_from="Petty Cash")
+		rows = statement(self.employee)
+		# One disbursement (money in) + one petty-cash expense (money out).
+		kinds = sorted(r["kind"] for r in rows)
+		self.assertEqual(kinds, ["Disbursement", "Expense"])
+		disb = next(r for r in rows if r["kind"] == "Disbursement")
+		exp = next(r for r in rows if r["kind"] == "Expense")
+		self.assertEqual(flt(disb["in"]), 10000)
+		self.assertEqual(flt(exp["out"]), 3000)
+		self.assertEqual(exp["status"], "Submitted")
+		# A Company-paid expense never appears on the holder's petty-cash statement.
+		self._expense_entry(500, submit=True, paid_from="Company")
+		refs = [r["ref"] for r in statement(self.employee)]
+		self.assertEqual(len(refs), 2)
+
 	def test_own_pocket_pushes_petty_balance_negative(self):
 		# PF-04: with no float disbursed, petty-cash spend simply drives the holder's
 		# balance negative — the amount owed back to them ("owed to holder").

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -76,20 +76,27 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		req.disburse(self._bank())
 		return req
 
-	def _expense_entry(self, amount, submit=False, reimbursable=False, cost_type="Overhead"):
-		account = pc.resolve_reimbursements_account(self.company) if reimbursable else self.petty
+	def _expense_entry(self, amount, submit=False, paid_from="Petty Cash", cost_type="Overhead"):
+		# PF-04: Petty Cash → Cr the holder's float (holder stamped); Company → Cr a
+		# Bank/Cash account, no holder.
+		if paid_from == "Company":
+			account = self._bank()
+			employee = None
+		else:
+			account = self.petty
+			employee = self.employee
 		doc = frappe.get_doc(
 			{
 				"doctype": "Expense Entry",
 				"date": "2026-07-21",
 				"company": self.company,
 				"project": self.project,
-				"employee": self.employee,
+				"employee": employee,
 				"payment_account": account,
-				"reimbursable": 1 if reimbursable else 0,
+				"paid_from": paid_from,
 				"expense_entry_table": [
 					{
-						"employee": self.employee,
+						"employee": employee,
 						"payment_account": account,
 						"expense_account": self._expense_account(),
 						"cost_type": cost_type,
@@ -156,21 +163,49 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		ee = self._expense_entry(1000, cost_type="Material")
 		self.assertEqual(ee.expense_entry_table[0].cost_type, "Material")
 
-	def test_own_pocket_expense_does_not_touch_petty_balance(self):
+	def test_holder_required_for_petty_cash(self):
+		# PF-04: petty-cash spend must name the holder whose float it draws down.
+		doc = frappe.get_doc(
+			{
+				"doctype": "Expense Entry",
+				"date": "2026-07-21",
+				"company": self.company,
+				"project": self.project,
+				"employee": None,
+				"payment_account": self.petty,
+				"paid_from": "Petty Cash",
+				"expense_entry_table": [
+					{
+						"payment_account": self.petty,
+						"expense_account": self._expense_account(),
+						"cost_type": "Overhead",
+						"project": self.project,
+						"amount": 500,
+						"description": "No holder",
+					}
+				],
+			}
+		)
+		self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
+	def test_company_paid_expense_carries_no_holder(self):
 		self._disburse(10000)
-		# Out-of-pocket spend books to Employee Reimbursements, not the petty float.
-		self._expense_entry(2000, submit=True, reimbursable=True)
+		# Company-paid spend Crs a Bank/Cash account, not the holder's float, so the
+		# petty balance is untouched and the credit leg carries no employee.
+		ee = self._expense_entry(2000, submit=True, paid_from="Company")
 		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), 10000)
 		mine = [r for r in pc.reconciled_holder_balances(self.company) if r["employee"] == self.employee][0]
 		self.assertEqual(flt(mine["spent"]), 0)
+		# The submitted expense forced the holder off entirely (Company mode).
+		self.assertFalse(ee.employee)
 
-	def test_reimburse_posts_je_and_flags(self):
-		ee = self._expense_entry(2000, submit=True, reimbursable=True)
-		je = ee.reimburse(self._bank())
-		ee.reload()
-		self.assertTrue(ee.reimbursed)
-		self.assertEqual(ee.reimbursement_journal_entry, je)
-		self.assertEqual(frappe.db.get_value("Journal Entry", je, "docstatus"), 1)
-		# Non-reimbursable can't be reimbursed.
-		petty = self._expense_entry(500, submit=True)
-		self.assertRaises(frappe.ValidationError, petty.reimburse, self._bank())
+	def test_own_pocket_pushes_petty_balance_negative(self):
+		# PF-04: with no float disbursed, petty-cash spend simply drives the holder's
+		# balance negative — the amount owed back to them ("owed to holder").
+		self._expense_entry(2000, submit=True, paid_from="Petty Cash")
+		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), -2000)
+		mine = [r for r in pc.reconciled_holder_balances(self.company) if r["employee"] == self.employee][0]
+		self.assertEqual(flt(mine["balance"]), -2000)
+		# A later disbursement settles the negative balance.
+		self._disburse(5000)
+		self.assertEqual(flt(pc.get_balance_amount_approved(self.employee)), 3000)

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -18,25 +18,6 @@ from frappe.utils import flt, formatdate, getdate
 
 PETTY_CASH_ACCOUNT_NAME = "Petty Cash"
 PETTY_CASH_PARENT_ACCOUNT = "Cash In Hand"
-REIMBURSEMENTS_ACCOUNT_NAME = "Employee Reimbursements"
-
-
-def resolve_reimbursements_account(company):
-	"""The company's Employee Reimbursements liability — where out-of-pocket expense
-	spend is parked until the employee is paid back. Created on first use."""
-	existing = frappe.db.get_value(
-		"Account",
-		{"account_name": REIMBURSEMENTS_ACCOUNT_NAME, "company": company, "is_group": 0},
-		"name",
-	)
-	if existing:
-		return existing
-
-	from buildsuite_core.utils.subcontract_billing import _ensure_account
-
-	# Plain liability (not account_type "Payable") so GL posting doesn't force ERPNext
-	# party handling — the holder is carried on our own `employee` dimension instead.
-	return _ensure_account(company, REIMBURSEMENTS_ACCOUNT_NAME, "Liability", None, "Current Liabilities")
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/data/expenseEntryApi.js
+++ b/frontend/src/data/expenseEntryApi.js
@@ -23,6 +23,6 @@ export const saveExpense = (payload) => call("save_expense", { payload: JSON.str
 export const submitExpense = (name) => call("submit_expense", { name });
 export const cancelExpense = (name) => call("cancel_expense", { name });
 export const listExpenseAccounts = (company) => call("list_expense_accounts", { company });
-export const expenseToReimburse = () => call("to_reimburse", {});
-export const reimburseExpense = (name, bankAccount) => call("reimburse", { name, bank_account: bankAccount });
-export const listReimburseAccounts = (company) => call("list_cash_bank_accounts", { company });
+// Company Bank/Cash accounts a Company-paid expense can draw from (excludes Petty Cash).
+// Company is derived from the project, matching save_expense.
+export const listExpensePayAccounts = (project) => call("list_cash_bank_accounts", { project });

--- a/frontend/src/data/pettyCashApi.js
+++ b/frontend/src/data/pettyCashApi.js
@@ -23,3 +23,4 @@ export const cancelPettyCash = (name) => call("cancel_request", { name });
 export const deletePettyCash = (name) => call("delete_request", { name });
 export const listCashBankAccounts = (company) => call("list_cash_bank_accounts", { company });
 export const pettyCashHolderBalances = (company) => call("holder_balances", { company });
+export const pettyCashStatement = (employee) => call("statement", { employee });

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -13,6 +13,7 @@ import {
 	saveExpense,
 	submitExpense,
 	cancelExpense,
+	listExpensePayAccounts,
 } from "@/data/expenseEntryApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
@@ -179,17 +180,40 @@ async function onDelete(e) {
 const COST_TYPES = ["Material", "Labour", "Plant & Machinery", "Subcontract", "Overhead"];
 const PAID_FROM = [
 	{ value: "petty", label: "Petty Cash" },
-	{ value: "own", label: "Own pocket" },
+	{ value: "company", label: "Company" },
 ];
 const modalOpen = ref(false);
 const editingId = ref(null);
-const form = reactive({ date: "", amount: null, description: "", project: "", expense_account: "", cost_type: "Overhead", paid_from: "petty", attachment: "", uploading: false, saving: false });
+const form = reactive({ date: "", amount: null, description: "", project: "", expense_account: "", cost_type: "Overhead", paid_from: "petty", company_account: "", attachment: "", uploading: false, saving: false });
 function resetForm() {
-	Object.assign(form, { date: new Date().toISOString().slice(0, 10), amount: null, description: "", project: "", expense_account: "", cost_type: "Overhead", paid_from: "petty", attachment: "", uploading: false, saving: false });
+	Object.assign(form, { date: new Date().toISOString().slice(0, 10), amount: null, description: "", project: "", expense_account: "", cost_type: "Overhead", paid_from: "petty", company_account: "", employee: "", attachment: "", uploading: false, saving: false });
 }
+
+// Company Bank/Cash accounts for the Company-paid source (company derived from the
+// project server-side). Petty-cash spend needs no account: it Crs the holder's float.
+const payAccounts = ref([]);
+async function loadPayAccounts() {
+	if (!form.project) { payAccounts.value = []; return; }
+	try {
+		payAccounts.value = await listExpensePayAccounts(form.project);
+	} catch {
+		payAccounts.value = [];
+	}
+}
+function onPaidFromChange() {
+	if (form.paid_from === "company") loadPayAccounts();
+}
+function onProjectChange() {
+	// Company accounts are per-company; a new project may mean a new company.
+	form.company_account = "";
+	payAccounts.value = [];
+	if (form.paid_from === "company") loadPayAccounts();
+}
+
 function openNew() {
 	editingId.value = null;
 	resetForm();
+	payAccounts.value = [];
 	modalOpen.value = true;
 }
 function openEdit(e) {
@@ -202,10 +226,13 @@ function openEdit(e) {
 		project: e.project,
 		expense_account: e.expense_account || "",
 		cost_type: e.cost_type || "Overhead",
-		paid_from: e.source === "Own pocket" ? "own" : "petty",
+		paid_from: e.source === "Company" ? "company" : "petty",
+		company_account: e.source === "Company" ? e.payment_account || "" : "",
+		employee: e.employee || "",
 		attachment: e.attachment || "",
 	});
 	closeDetail();
+	if (form.paid_from === "company") loadPayAccounts();
 	modalOpen.value = true;
 }
 async function uploadReceipt(ev) {
@@ -231,13 +258,16 @@ async function save() {
 	if (!(Number(form.amount) > 0)) return showToast("Enter an amount greater than zero.", "error");
 	if (!form.project) return showToast("Pick a project.", "error");
 	if (!form.expense_account) return showToast("Pick an expense account.", "error");
+	if (form.paid_from === "company" && !form.company_account) return showToast("Pick the company account to pay from.", "error");
 	form.saving = true;
 	try {
 		await saveExpense({
 			name: editingId.value || undefined,
 			project: form.project,
 			date: form.date,
-			reimbursable: form.paid_from === "own",
+			paid_from: form.paid_from,
+			company_account: form.paid_from === "company" ? form.company_account : undefined,
+			employee: canVerify.value && form.paid_from === "petty" ? form.employee || undefined : undefined,
 			rows: [{ expense_account: form.expense_account, cost_type: form.cost_type, amount: form.amount, description: form.description, attachment: form.attachment }],
 		});
 		modalOpen.value = false;
@@ -432,14 +462,28 @@ const expenseAccountFilters = [
 							<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" min="0" placeholder="0" /></DeskField>
 						</div>
 						<DeskField label="Description" required><DeskInput v-model="form.description" placeholder="What was bought?" /></DeskField>
-						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" placeholder="Pick a project…" /></DeskField>
+						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" placeholder="Pick a project…" @update:model-value="onProjectChange" /></DeskField>
 						<div class="grid grid-cols-2 gap-3">
 							<DeskField label="Expense account" required><DeskLinkPicker v-model="form.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Pick an account…" /></DeskField>
 							<DeskField label="Cost type"><DeskSelect v-model="form.cost_type"><option v-for="c in COST_TYPES" :key="c" :value="c">{{ c }}</option></DeskSelect></DeskField>
 						</div>
-						<DeskField label="Paid from">
-							<DeskSelect v-model="form.paid_from"><option v-for="p in PAID_FROM" :key="p.value" :value="p.value">{{ p.label }}</option></DeskSelect>
+						<div class="grid grid-cols-2 gap-3">
+							<DeskField label="Paid from">
+								<DeskSelect v-model="form.paid_from" @update:model-value="onPaidFromChange"><option v-for="p in PAID_FROM" :key="p.value" :value="p.value">{{ p.label }}</option></DeskSelect>
+							</DeskField>
+							<DeskField v-if="form.paid_from === 'company'" label="Company account" required>
+								<DeskSelect v-model="form.company_account">
+									<option value="" disabled>Pick an account…</option>
+									<option v-for="a in payAccounts" :key="a.name" :value="a.name">{{ a.name }}</option>
+								</DeskSelect>
+							</DeskField>
+						</div>
+						<DeskField v-if="canVerify && form.paid_from === 'petty'" label="Holder (petty cash float)">
+							<DeskLinkPicker v-model="form.employee" doctype="Employee" label-field="employee_name" value-field="name" placeholder="Defaults to you…" />
 						</DeskField>
+						<p v-if="form.paid_from === 'petty'" class="text-[11px] text-ink-500 -mt-1">
+							Paid from the holder's petty-cash float. If they fronted the money themselves, this simply pushes their balance negative — the amount owed back to them, settled on the next disbursement.
+						</p>
 						<DeskField label="Receipt (optional)">
 							<label class="inline-flex items-center gap-2 text-xs cursor-pointer px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 rounded-md" :class="form.attachment ? 'text-success-700' : 'text-ink-700'">
 								{{ form.uploading ? "Uploading…" : form.attachment ? "✓ Receipt attached" : "📷 Attach receipt" }}

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -226,7 +226,10 @@ const rowsForTab = computed(() => {
 						<td class="px-3 py-2 text-ink-900">{{ b.holder }}</td>
 						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.disbursed) }}</td>
 						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.spent) }}</td>
-						<td class="px-3 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">{{ fmtINR(b.balance) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">
+							<template v-if="b.balance < 0">{{ fmtINR(-b.balance) }} owed to holder</template>
+							<template v-else>{{ fmtINR(b.balance) }}</template>
+						</td>
 					</tr>
 					<tr v-if="!balances.length">
 						<td colspan="4" class="px-3 py-4 text-center text-ink-400 italic">No petty-cash activity yet.</td>
@@ -235,6 +238,7 @@ const rowsForTab = computed(() => {
 			</table>
 			<p class="px-3 py-2 text-[11px] text-ink-400 border-t border-ink-100">
 				Balance in hand = disbursed float − approved expenses (from the Expenses tab).
+				A negative balance means the holder fronted their own money — it's owed back to them and cleared on the next disbursement.
 			</p>
 		</div>
 

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -1,6 +1,6 @@
 <script setup>
 // Petty Cash — the LIVE part of Project Finance. Request → Disburse (posts a Journal Entry
-// server-side) → reverse. Everything else in the finance workspace is mock data.
+// server-side). Everything else in the finance workspace is mock data.
 
 import { computed, reactive, ref } from "vue";
 import { useSessionStore } from "@/stores/session";
@@ -11,7 +11,6 @@ import {
 	pettyCashCanDisburse,
 	savePettyCash,
 	disbursePettyCash,
-	undisbursePettyCash,
 	cancelPettyCash,
 	pettyCashHolderBalances,
 	listCashBankAccounts,
@@ -142,23 +141,6 @@ async function confirmDisburse() {
 	}
 }
 
-async function onUndisburse(row) {
-	const ok = await confirmDialog({
-		title: "Reverse disbursement?",
-		message: `Cancel the Journal Entry for ${row.name} and revert it to Requested?`,
-		confirmLabel: "Reverse",
-		destructive: true,
-	});
-	if (!ok) return;
-	try {
-		await undisbursePettyCash(row.name);
-		res.reload?.();
-		loadBalances();
-		showToast("Disbursement reversed.");
-	} catch (err) {
-		showToast(err.message || "Reverse failed", "error");
-	}
-}
 async function onWithdraw(row) {
 	const ok = await confirmDialog({
 		title: "Withdraw request?",
@@ -283,14 +265,6 @@ const rowsForTab = computed(() => {
 						@click.stop="onWithdraw(row)"
 					>
 						Withdraw
-					</button>
-					<button
-						v-if="row.status === 'Disbursed' && canDisburse"
-						type="button"
-						class="text-[11px] px-2 py-0.5 border border-ink-200 text-danger-700 rounded"
-						@click.stop="onUndisburse(row)"
-					>
-						Reverse
 					</button>
 				</div>
 			</template>

--- a/frontend/src/views/finance/reports/PettyCashReport.vue
+++ b/frontend/src/views/finance/reports/PettyCashReport.vue
@@ -1,52 +1,255 @@
 <script setup>
-// LIVE petty-cash statement — reconciled per holder from the GL: disbursed float
-// in, verified expense out, and the net balance in hand. Both legs (Petty Cash
-// Request disburse + Expense Entry spend) roll into one figure.
-import { computed, ref } from "vue";
-import { pettyCashHolderBalances } from "@/data/pettyCashApi";
+// Petty Cash report — a LIVE personal statement per holder. Nothing renders until a
+// holder is picked (deep-linkable via ?holder=). One combined ledger over both legs:
+// Petty Cash Request disbursements (money in) and petty-cash Expense Entries (money
+// out, drafts + submitted). Filters — date · project · expense account · status ·
+// entry type — plus CSV export (summary block + ledger, properly quoted).
+import { ref, computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { pettyCashHolderBalances, pettyCashStatement } from "@/data/pettyCashApi";
+import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import { fmtINR } from "@/utils/format";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtINR, fmtDate } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Petty Cash Statement" }];
-const rows = ref([]);
-const loading = ref(true);
-pettyCashHolderBalances()
-	.then((r) => (rows.value = r))
-	.catch(() => {})
-	.finally(() => (loading.value = false));
+const route = useRoute();
+const router = useRouter();
 
-const totals = computed(() =>
-	rows.value.reduce(
-		(a, b) => ({ disbursed: a.disbursed + (b.disbursed || 0), spent: a.spent + (b.spent || 0), balance: a.balance + (b.balance || 0) }),
-		{ disbursed: 0, spent: 0, balance: 0 },
-	),
+// --- holders (with activity) ---
+const holders = ref([]);
+pettyCashHolderBalances()
+	.then((r) => (holders.value = r))
+	.catch(() => {});
+const holderOptions = computed(() =>
+	holders.value.map((h) => ({ value: h.employee, label: h.holder, hint: h.balance < 0 ? `${fmtINR(-h.balance)} owed` : `${fmtINR(h.balance)} in hand` })),
 );
+const holder = ref(route.query.holder || null);
+const selectedHolder = computed(() => holders.value.find((h) => h.employee === holder.value) || null);
+function holderName(id) {
+	return holders.value.find((h) => h.employee === id)?.holder || id;
+}
+
+// --- statement rows for the picked holder ---
+const rows = ref([]);
+const loading = ref(false);
+async function loadStatement() {
+	if (!holder.value) {
+		rows.value = [];
+		return;
+	}
+	loading.value = true;
+	try {
+		rows.value = await pettyCashStatement(holder.value);
+	} catch (err) {
+		rows.value = [];
+		showToast(err.message || "Failed to load statement", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(
+	holder,
+	(v) => {
+		router.replace({ query: v ? { holder: v } : {} }).catch(() => {});
+		loadStatement();
+	},
+	{ immediate: true },
+);
+
+// --- filters ---
+const from = ref("");
+const to = ref("");
+const projectFilter = ref(null);
+const accountFilter = ref(null);
+const statusFilter = ref("");
+const entryType = ref(""); // '' all | 'disbursement' | 'expense'
+
+const projectOptions = computed(() => {
+	const seen = new Map();
+	for (const r of rows.value) if (r.project && !seen.has(r.project)) seen.set(r.project, r.project_name || r.project);
+	return [...seen].map(([value, label]) => ({ value, label }));
+});
+const accountOptions = computed(() => {
+	const set = new Set();
+	for (const r of rows.value) if (r.account) set.add(r.account);
+	return [...set].map((a) => ({ value: a, label: a }));
+});
+function projectName(id) {
+	return id ? rows.value.find((r) => r.project === id)?.project_name || id : "—";
+}
+function inPeriod(d) {
+	return (!from.value || d >= from.value) && (!to.value || d <= to.value);
+}
+
+const filteredRows = computed(() => {
+	if (!holder.value) return [];
+	return rows.value.filter((r) => {
+		if (!inPeriod(r.date)) return false;
+		if (projectFilter.value && r.project !== projectFilter.value) return false;
+		if (r.kind === "Disbursement") {
+			// Disbursements carry no expense account or expense status — an expense-only
+			// filter (account / status) or the expense-only entry type hides them.
+			if (entryType.value === "expense" || accountFilter.value || statusFilter.value) return false;
+			return true;
+		}
+		if (entryType.value === "disbursement") return false;
+		if (accountFilter.value && r.account !== accountFilter.value) return false;
+		if (statusFilter.value && r.status !== statusFilter.value) return false;
+		return true;
+	});
+});
+
+// --- summary (filtered window; balance in hand is all-time from the reconciled ledger) ---
+const totalIn = computed(() => filteredRows.value.reduce((a, r) => a + (r.in || 0), 0));
+const verifiedOut = computed(() => filteredRows.value.filter((r) => r.kind === "Expense" && r.status === "Submitted").reduce((a, r) => a + r.out, 0));
+const pendingOut = computed(() => filteredRows.value.filter((r) => r.kind === "Expense" && r.status === "Draft").reduce((a, r) => a + r.out, 0));
+const balanceInHand = computed(() => (selectedHolder.value ? selectedHolder.value.balance : 0));
+
+const hasFilters = computed(() => from.value || to.value || projectFilter.value || accountFilter.value || statusFilter.value || entryType.value);
+function clearFilters() {
+	from.value = "";
+	to.value = "";
+	projectFilter.value = null;
+	accountFilter.value = null;
+	statusFilter.value = "";
+	entryType.value = "";
+}
+
+// --- CSV export (summary block + ledger; fields quoted) ---
+function csvCell(v) {
+	const s = String(v ?? "");
+	return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+function exportCsv() {
+	if (!holder.value) return;
+	const lines = [];
+	lines.push(["Petty Cash Statement"].map(csvCell).join(","));
+	lines.push(["Holder", holderName(holder.value)].map(csvCell).join(","));
+	lines.push(["Period", `${from.value || "Beginning"} to ${to.value || "Today"}`].map(csvCell).join(","));
+	if (projectFilter.value) lines.push(["Project", projectName(projectFilter.value)].map(csvCell).join(","));
+	if (accountFilter.value) lines.push(["Expense account", accountFilter.value].map(csvCell).join(","));
+	if (statusFilter.value) lines.push(["Status", statusFilter.value].map(csvCell).join(","));
+	lines.push(["Generated", new Date().toLocaleString("en-IN")].map(csvCell).join(","));
+	lines.push("");
+	lines.push(["Disbursed (period)", totalIn.value].map(csvCell).join(","));
+	lines.push(["Submitted spend (period)", verifiedOut.value].map(csvCell).join(","));
+	lines.push(["Pending spend (period)", pendingOut.value].map(csvCell).join(","));
+	lines.push(["Balance in hand (all-time)", balanceInHand.value].map(csvCell).join(","));
+	lines.push("");
+	lines.push(["Date", "Entry", "Description", "Project", "Expense Account", "Status", "Money In", "Money Out", "Ref"].map(csvCell).join(","));
+	for (const r of filteredRows.value.slice().reverse()) {
+		lines.push([r.date, r.kind, r.description, projectName(r.project), r.account || "", r.status, r.in || "", r.out || "", r.ref].map(csvCell).join(","));
+	}
+	const blob = new Blob(["﻿" + lines.join("\r\n")], { type: "text/csv;charset=utf-8;" });
+	const a = document.createElement("a");
+	a.href = URL.createObjectURL(blob);
+	a.download = `petty-cash-${holderName(holder.value).replace(/\s+/g, "-").toLowerCase()}-${new Date().toISOString().slice(0, 10)}.csv`;
+	a.click();
+	URL.revokeObjectURL(a.href);
+}
 </script>
 
 <template>
 	<DeskPage title="Petty Cash Statement" :breadcrumbs="breadcrumbs">
-		<div class="bg-white border border-ink-200 rounded-lg overflow-hidden max-w-2xl">
-			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Balance in hand per holder (live)</h3></div>
-			<table class="w-full text-sm">
-				<thead class="text-ink-500 uppercase text-[10px]"><tr><th class="text-left px-4 py-2">Holder</th><th class="text-right px-4 py-2">Disbursed</th><th class="text-right px-4 py-2">Verified spend</th><th class="text-right px-4 py-2">Balance</th></tr></thead>
-				<tbody>
-					<tr v-for="b in rows" :key="b.employee || b.holder" class="border-t border-ink-100">
-						<td class="px-4 py-2 text-ink-900">{{ b.holder }}</td>
-						<td class="px-4 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.disbursed) }}</td>
-						<td class="px-4 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.spent) }}</td>
-						<td class="px-4 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">{{ fmtINR(b.balance) }}</td>
-					</tr>
-					<tr v-if="!rows.length && !loading"><td colspan="4" class="px-4 py-4 text-center text-ink-400 italic">No petty-cash activity yet.</td></tr>
-					<tr v-if="loading"><td colspan="4" class="px-4 py-4 text-center text-ink-400">Loading…</td></tr>
-					<tr v-if="rows.length" class="border-t-2 border-ink-200 font-semibold">
-						<td class="px-4 py-2">Total</td>
-						<td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(totals.disbursed) }}</td>
-						<td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(totals.spent) }}</td>
-						<td class="px-4 py-2 text-right tabular-nums">{{ fmtINR(totals.balance) }}</td>
-					</tr>
-				</tbody>
-			</table>
-			<p class="px-4 py-2 text-[11px] text-ink-400 border-t border-ink-100">Balance = disbursed float − approved expenses. Per-holder movement detail is on the Expenses › Ledger tab.</p>
+		<div class="space-y-4">
+			<!-- Holder picker -->
+			<div class="flex items-end gap-3 flex-wrap">
+				<div class="w-72">
+					<label class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1">Petty cash holder <span class="text-danger-600">*</span></label>
+					<DeskSearchableSelect v-model="holder" :options="holderOptions" placeholder="— Pick a holder —" search-placeholder="Search holders…" />
+				</div>
+				<button v-if="holder" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md mb-0.5" @click="exportCsv">⇩ Export CSV</button>
+			</div>
+
+			<div v-if="!holder" class="bg-white border border-ink-200 rounded-lg px-4 py-16 text-center text-sm text-ink-500">
+				Pick a petty cash holder to see their personal statement — disbursements received, spend logged, and balance in hand.
+			</div>
+
+			<template v-else>
+				<!-- Summary strip -->
+				<div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+					<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Disbursed (period)</div>
+						<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(totalIn) }}</div>
+					</div>
+					<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Submitted spend (period)</div>
+						<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(verifiedOut) }}</div>
+					</div>
+					<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Pending spend (period)</div>
+						<div class="text-base font-semibold tabular-nums mt-0.5" :class="pendingOut > 0 ? 'text-warning-700' : 'text-ink-900'">{{ fmtINR(pendingOut) }}</div>
+					</div>
+					<div class="border px-3 py-2 rounded-md" :class="balanceInHand < 0 ? 'bg-danger-50 border-danger-200' : 'bg-brand-50 border-brand-200'">
+						<div class="text-[10px] uppercase tracking-wider font-medium" :class="balanceInHand < 0 ? 'text-danger-700' : 'text-brand-700'">Balance in hand (all-time)</div>
+						<div class="text-base font-semibold tabular-nums mt-0.5" :class="balanceInHand < 0 ? 'text-danger-700' : 'text-ink-900'">
+							<template v-if="balanceInHand < 0">{{ fmtINR(-balanceInHand) }} owed</template>
+							<template v-else>{{ fmtINR(balanceInHand) }}</template>
+						</div>
+					</div>
+				</div>
+
+				<!-- Filters -->
+				<div class="flex items-center gap-2 flex-wrap">
+					<div class="flex items-center gap-1.5">
+						<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">From</span>
+						<input v-model="from" type="date" class="text-xs px-2 py-1 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200" />
+						<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">To</span>
+						<input v-model="to" type="date" class="text-xs px-2 py-1 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200" />
+					</div>
+					<div class="w-48"><DeskSearchableSelect v-model="projectFilter" :options="projectOptions" placeholder="All projects" search-placeholder="Search projects…" allow-clear /></div>
+					<div class="w-52"><DeskSearchableSelect v-model="accountFilter" :options="accountOptions" placeholder="All expense accounts" search-placeholder="Search accounts…" allow-clear /></div>
+					<select v-model="statusFilter" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+						<option value="">All statuses</option>
+						<option value="Draft">Draft</option>
+						<option value="Submitted">Submitted</option>
+					</select>
+					<select v-model="entryType" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+						<option value="">All entries</option>
+						<option value="disbursement">Disbursements only</option>
+						<option value="expense">Expenses only</option>
+					</select>
+					<button v-if="hasFilters" type="button" class="text-[11px] text-danger-600 hover:underline" @click="clearFilters">Clear filters</button>
+					<span class="text-[11px] text-ink-400 ml-auto">{{ filteredRows.length }} entr{{ filteredRows.length === 1 ? "y" : "ies" }}</span>
+				</div>
+
+				<!-- Ledger -->
+				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+					<table v-if="filteredRows.length" class="w-full text-xs">
+						<thead class="text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200 bg-ink-50">
+							<tr>
+								<th class="text-left px-4 py-2">Date</th>
+								<th class="text-left px-4 py-2">Entry</th>
+								<th class="text-left px-4 py-2">Description</th>
+								<th class="text-left px-4 py-2">Project</th>
+								<th class="text-left px-4 py-2">Expense account</th>
+								<th class="text-left px-4 py-2">Status</th>
+								<th class="text-right px-4 py-2">In</th>
+								<th class="text-right px-4 py-2">Out</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr v-for="r in filteredRows" :key="r.key" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30">
+								<td class="px-4 py-2.5 text-ink-500 whitespace-nowrap">{{ fmtDate(r.date) }}</td>
+								<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="r.kind === 'Disbursement' ? 'bg-success-50 text-success-700' : 'bg-info-50 text-info-700'">{{ r.kind }}</span></td>
+								<td class="px-4 py-2.5 text-ink-900">{{ r.description }}</td>
+								<td class="px-4 py-2.5 text-ink-500">{{ projectName(r.project) }}</td>
+								<td class="px-4 py-2.5 text-ink-600">{{ r.account || "—" }}</td>
+								<td class="px-4 py-2.5"><StatusBadge :status="r.status" size="xs" /></td>
+								<td class="px-4 py-2.5 text-right tabular-nums text-success-700">{{ r.in ? fmtINR(r.in) : "" }}</td>
+								<td class="px-4 py-2.5 text-right tabular-nums text-danger-700">{{ r.out ? fmtINR(r.out) : "" }}</td>
+							</tr>
+						</tbody>
+					</table>
+					<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "No entries match the filters." }}</div>
+				</section>
+				<p class="text-[11px] text-ink-400">
+					Disbursement rows hide automatically when an expense-only filter (account / status) is applied. Balance in hand is all-time; the other totals respect the filters.
+					A negative balance is money the holder fronted — owed back to them, cleared on the next disbursement.
+				</p>
+			</template>
 		</div>
 	</DeskPage>
 </template>

--- a/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
+++ b/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
@@ -59,7 +59,7 @@ const FINANCE_REPORTS = [
 	{ slug: "pnl", icon: "chart-line", label: "Profit & Loss", desc: "Income vs direct costs and overheads, by project and period." },
 	{ slug: "aged", icon: "clipboard-list", label: "Receivables & Payables", desc: "Aged outstanding — who owes us and who we owe." },
 	{ slug: "position", icon: "wallet", label: "Financial Position", desc: "What we have vs what we owe, and the net position." },
-	{ slug: "petty", icon: "hand-coins", label: "Petty Cash", desc: "Per holder: disbursed, spent, balance, to reimburse." },
+	{ slug: "petty", icon: "hand-coins", label: "Petty Cash", desc: "Per holder: disbursed, spent, balance in hand." },
 	{ slug: "expenses", icon: "receipt", label: "Expense Summary", desc: "By project, cost type, source or person, with receipts." },
 	{ slug: "cashbank", icon: "banknote", label: "Cash & Bank Statement", desc: "Per account: opening, movements, closing." },
 ];


### PR DESCRIPTION
Aligns the Expense Entry flow to spec **PF-04**, building on the PF-02 petty-cash imprest model and the Employee accounting dimension.

## What changes
- **`paid_from` = Petty Cash | Company.** The old "Own pocket" / reimbursement flow is removed entirely — no `Employee Reimbursements` account, no `reimburse()` payout, no `reimbursed` / `reimbursed_on` / `reimbursement_journal_entry` fields, and no To-Reimburse queue/endpoints.
- **Holder on the credit leg only.** The petty-cash credit carries the holder (`employee`); the expense debit and a Company-paid Bank/Cash credit carry none. `get_account_row` skips the `employee` accounting dimension so it is never double-stamped from the row/parent.
- **Holder rules.** Mandatory when Paid From is Petty Cash. Ordinary users can only spend their own float; approvers/accountants may record against any holder (a holder picker appears for them).
- **Own-pocket = negative balance.** Fronting your own money simply pushes the Petty Cash balance negative — the amount *owed to holder*, settled on the next disbursement. Surfaced distinctly in the Balances tab (`₹X owed to holder`) instead of a separate liability.
- **Company-paid spend** draws from a Bank/Cash account (picker excludes Petty Cash); company is derived from the project server-side.

## Divergence from the doc
- Keeps `cost_type` (the app's cost-code structure lives on Subcontractor Bill Lines); full `cost_code` adoption is deferred, as discussed.

## Verification
- `test_petty_cash_ledger` (10) + `test_petty_cash` (7) green — including new holder-required, Company-paid-no-holder, and own-pocket-negative-balance cases.
- Frontend builds clean.
- **Requires `bench migrate` on deploy** (adds `paid_from`, drops the reimbursement fields).