### PR TITLE
feat: expense BOQ cost code + single-company scoping for finance

### DIFF
--- a/buildsuite_core/api/company.py
+++ b/buildsuite_core/api/company.py
@@ -1,23 +1,19 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
 
+"""Company scope for the SPA. Single-company for now — see the single-company seam."""
+
 import frappe
+
+from buildsuite_core.utils.project import default_company
 
 
 @frappe.whitelist()
-def get_default_company():
-	"""The site's default company (Global Defaults → Default Company), used to
-	pre-fill the project create form.
+def active_company():
+	"""The company finance transactions (and their pickers) are scoped to right now.
 
-	Reads the Global Defaults `default_company` field directly. `frappe.db.get_single_value`
-	is a raw DB read (no client-side permission check), so it works for every persona —
-	unlike `frappe.client.get_value` on the Single, which 403s for non-admins. We do NOT
-	use `get_global_default("default_company")`: the Single registers its value under the
-	`company` key, so that lookup returns None even when a default company is set. The
-	`company` global default is kept only as a fallback.
+	Same resolver the server-side company guards use, so the frontend picker filters agree
+	with them. `window.sysdefaults.company` is not reliably present (e.g. the standalone Vite
+	dev server), so the SPA fetches this instead. Multi-company later: derive from context.
 	"""
-	return (
-		frappe.db.get_single_value("Global Defaults", "default_company")
-		or frappe.defaults.get_global_default("company")
-		or ""
-	)
+	return default_company()

--- a/buildsuite_core/api/expense_entry.py
+++ b/buildsuite_core/api/expense_entry.py
@@ -23,6 +23,19 @@ def _current_employee(user=None):
 	return pc.employee_for_user(user or frappe.session.user)
 
 
+def _cost_code_fields(cost_code):
+	"""Flatten the picker's cost-code object → the four stored line fields (same shape as
+	subcontractor lines). Accepts the {type, group_code, item_code, label} object or None."""
+	if not cost_code or not isinstance(cost_code, dict):
+		return {"cost_code_type": "", "cost_code_group": "", "cost_code_item": "", "cost_code_label": ""}
+	return {
+		"cost_code_type": "Item" if cost_code.get("type") == "item" else "Group",
+		"cost_code_group": cost_code.get("group_code") or "",
+		"cost_code_item": cost_code.get("item_code") or "",
+		"cost_code_label": cost_code.get("label") or "",
+	}
+
+
 def _can_submit():
 	from buildsuite_core.permissions.setup import PETTY_CASH_DISBURSE_ROLES
 
@@ -67,7 +80,7 @@ def list_expenses():
 	for r in frappe.get_all(
 		"Expense Entry Table",
 		filters={"parent": ["in", names]},
-		fields=["parent", "expense_account", "cost_type", "attachment", "description"],
+		fields=["parent", "expense_account", "cost_code_label", "attachment", "description"],
 		order_by="idx asc",
 	):
 		first.setdefault(r.parent, r)
@@ -94,7 +107,7 @@ def list_expenses():
 				"source": e.paid_from or "Petty Cash",
 				"payment_account": e.payment_account,
 				"expense_account": fr.get("expense_account"),
-				"cost_type": fr.get("cost_type"),
+				"cost_code": fr.get("cost_code_label"),
 				"attachment": fr.get("attachment"),
 				"amount": e.total_amount,
 				"status": status_map.get(e.docstatus, "Draft"),
@@ -124,7 +137,17 @@ def get_expense(name):
 		"rows": [
 			{
 				"expense_account": r.expense_account,
-				"cost_type": r.cost_type,
+				# Reconstruct the cost-code object the picker binds to (see subcontract lines).
+				"cost_code": (
+					{
+						"type": (r.cost_code_type or "").lower(),
+						"group_code": r.cost_code_group or "",
+						"item_code": r.cost_code_item or None,
+						"label": r.cost_code_label or "",
+					}
+					if r.cost_code_label
+					else None
+				),
 				"description": r.description,
 				"amount": r.amount,
 				"attachment": r.attachment,
@@ -209,7 +232,7 @@ def save_expense(payload):
 				"employee": employee,
 				"payment_account": account,
 				"expense_account": r.get("expense_account"),
-				"cost_type": r.get("cost_type") or "Overhead",
+				**_cost_code_fields(r.get("cost_code")),
 				"project": r.get("project") or project,
 				"amount": flt(r.get("amount")),
 				"description": r.get("description"),

--- a/buildsuite_core/api/expense_entry.py
+++ b/buildsuite_core/api/expense_entry.py
@@ -248,10 +248,14 @@ def save_expense(payload):
 def list_cash_bank_accounts(project=None, company=None):
 	"""Bank/Cash accounts a Company-paid expense can be drawn from (excludes Petty Cash).
 
-	Accepts a project (company is derived from it, matching save_expense) or a company.
+	Scoped to the active (default) company; a project or company can override it (a project's
+	company is used, matching save_expense). See the single-company seam.
 	"""
+	from buildsuite_core.utils.project import default_company
+
 	if project and not company:
 		company = frappe.db.get_value("Project", project, "company")
+	company = company or default_company()
 	if not company:
 		return []
 	petty = pc.get_petty_cash_account(company)

--- a/buildsuite_core/api/petty_cash.py
+++ b/buildsuite_core/api/petty_cash.py
@@ -128,12 +128,15 @@ def delete_request(name: str):
 
 
 @frappe.whitelist()
-def list_cash_bank_accounts(company):
-	"""Cash/Bank ledger accounts to disburse FROM (the funding source), for the given
-	company — excluding the Petty Cash account itself, since crediting Petty Cash on a
-	disbursement (Dr Petty Cash / Cr Petty Cash) would be a no-op."""
+def list_cash_bank_accounts(company=None):
+	"""Bank/Cash ledger accounts to disburse FROM (the funding source) — excluding the Petty
+	Cash account itself, since crediting Petty Cash on a disbursement (Dr Petty Cash / Cr Petty
+	Cash) would be a no-op. Scoped to the active (default) company unless one is passed; see the
+	single-company seam."""
 	from buildsuite_core.utils.petty_cash import get_petty_cash_account
+	from buildsuite_core.utils.project import default_company
 
+	company = company or default_company()
 	filters = {"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]}
 	petty = get_petty_cash_account(company)
 	if petty:

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
@@ -62,7 +62,30 @@ class ExpenseEntry(Document):
 					_("Row #{0}: Both Expense Account and Payment Account are required.").format(idx)
 				)
 
+		self.validate_single_company()
 		self.set_description()
+
+	def validate_single_company(self):
+		"""Every account + the holder must belong to this entry's company, else the Journal
+		Entry is rejected (ERPNext surfaces it as a cryptic multi-currency error). Multi-company
+		is a later version; today all finance posts to one company. The company itself is the
+		project's (see accounting-company-anchored-to-project) — the seam stays, this only
+		enforces consistency within whatever that company is."""
+		for idx, row in enumerate(self.expense_entry_table, start=1):
+			for account in (row.expense_account, row.payment_account):
+				if account and frappe.db.get_value("Account", account, "company") != self.company:
+					frappe.throw(
+						_("Row #{0}: Account {1} does not belong to company {2}.").format(
+							idx, frappe.bold(account), frappe.bold(self.company)
+						)
+					)
+
+		if self.employee and frappe.db.get_value("Employee", self.employee, "company") != self.company:
+			frappe.throw(
+				_("Holder {0} does not belong to company {1}.").format(
+					frappe.bold(self.employee), frappe.bold(self.company)
+				)
+			)
 
 	def on_submit(self):
 		self.create_journal_entry()

--- a/buildsuite_core/buildsuite_core/doctype/expense_entry_table/expense_entry_table.json
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry_table/expense_entry_table.json
@@ -13,7 +13,10 @@
   "column_break_vnem",
   "expense_account",
   "expense_account_name",
-  "cost_type",
+  "cost_code_type",
+  "cost_code_group",
+  "cost_code_item",
+  "cost_code_label",
   "column_break_ogch",
   "project",
   "project_name",
@@ -68,12 +71,31 @@
    "read_only": 1
   },
   {
-   "default": "Overhead",
-   "fieldname": "cost_type",
+   "fieldname": "cost_code_type",
    "fieldtype": "Select",
+   "label": "Cost Code Type",
+   "options": "\nGroup\nItem",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cost_code_group",
+   "fieldtype": "Data",
+   "label": "Cost Code Group",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cost_code_item",
+   "fieldtype": "Data",
+   "label": "Cost Code Item",
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "cost_code_label",
+   "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Cost Type",
-   "options": "Material\nLabour\nPlant & Machinery\nSubcontract\nOverhead"
+   "label": "Cost Code",
+   "read_only": 1
   },
   {
    "fieldname": "section_break_5wop",

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -165,6 +165,32 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		self.assertEqual(line.cost_code_label, "G1 · Substructure")
 		self.assertEqual(line.cost_code_type, "Group")
 
+	def test_cross_company_account_rejected(self):
+		# Single-company guard: an account from another company can't ride on the entry
+		# (would otherwise fail at JE posting as a cryptic multi-currency error).
+		other = next((c for c in ("_Test Company 4", "_Test Company 6", "_Test Company 3") if frappe.db.exists("Company", c) and c != self.company), None)
+		if not other:
+			self.skipTest("no second company to test cross-company rejection")
+		doc = frappe.get_doc(
+			{
+				"doctype": "Expense Entry",
+				"date": "2026-07-21",
+				"company": other,  # accounts below belong to self.company, not `other`
+				"project": self.project,
+				"paid_from": "Company",
+				"expense_entry_table": [
+					{
+						"payment_account": self._bank(),
+						"expense_account": self._expense_account(),
+						"project": self.project,
+						"amount": 100,
+						"description": "Cross-company",
+					}
+				],
+			}
+		)
+		self.assertRaises(frappe.ValidationError, doc.insert, ignore_permissions=True)
+
 	def test_holder_required_for_petty_cash(self):
 		# PF-04: petty-cash spend must name the holder whose float it draws down.
 		doc = frappe.get_doc(

--- a/buildsuite_core/tests/test_petty_cash_ledger.py
+++ b/buildsuite_core/tests/test_petty_cash_ledger.py
@@ -76,7 +76,7 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		req.disburse(self._bank())
 		return req
 
-	def _expense_entry(self, amount, submit=False, paid_from="Petty Cash", cost_type="Overhead"):
+	def _expense_entry(self, amount, submit=False, paid_from="Petty Cash", cost_code_label=None):
 		# PF-04: Petty Cash → Cr the holder's float (holder stamped); Company → Cr a
 		# Bank/Cash account, no holder.
 		if paid_from == "Company":
@@ -85,6 +85,16 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 		else:
 			account = self.petty
 			employee = self.employee
+		line = {
+			"employee": employee,
+			"payment_account": account,
+			"expense_account": self._expense_account(),
+			"project": self.project,
+			"amount": amount,
+			"description": "Diesel",
+		}
+		if cost_code_label:
+			line.update({"cost_code_type": "Group", "cost_code_group": "G1", "cost_code_label": cost_code_label})
 		doc = frappe.get_doc(
 			{
 				"doctype": "Expense Entry",
@@ -94,17 +104,7 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 				"employee": employee,
 				"payment_account": account,
 				"paid_from": paid_from,
-				"expense_entry_table": [
-					{
-						"employee": employee,
-						"payment_account": account,
-						"expense_account": self._expense_account(),
-						"cost_type": cost_type,
-						"project": self.project,
-						"amount": amount,
-						"description": "Diesel",
-					}
-				],
+				"expense_entry_table": [line],
 			}
 		).insert(ignore_permissions=True)
 		if submit:
@@ -159,9 +159,11 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 			flt(pc.get_total_balance_include_review(self.employee)),
 		)
 
-	def test_cost_type_stored(self):
-		ee = self._expense_entry(1000, cost_type="Material")
-		self.assertEqual(ee.expense_entry_table[0].cost_type, "Material")
+	def test_cost_code_stored(self):
+		ee = self._expense_entry(1000, cost_code_label="G1 · Substructure")
+		line = ee.expense_entry_table[0]
+		self.assertEqual(line.cost_code_label, "G1 · Substructure")
+		self.assertEqual(line.cost_code_type, "Group")
 
 	def test_holder_required_for_petty_cash(self):
 		# PF-04: petty-cash spend must name the holder whose float it draws down.
@@ -178,7 +180,6 @@ class TestPettyCashLedger(BuildSuiteTestCase):
 					{
 						"payment_account": self.petty,
 						"expense_account": self._expense_account(),
-						"cost_type": "Overhead",
 						"project": self.project,
 						"amount": 500,
 						"description": "No holder",

--- a/frontend/src/composables/useActiveCompany.js
+++ b/frontend/src/composables/useActiveCompany.js
@@ -1,22 +1,44 @@
 // The company every finance transaction (and its pickers) is scoped to.
 //
-// Single-company for now: the site's default company, exposed to the browser as
-// `window.sysdefaults.company` — the same value the backend's
-// `buildsuite_core.utils.project.default_company()` resolves to, so the picker filters
-// and the server-side company guard always agree.
+// Single-company for now: the site's default company, resolved by the backend
+// `buildsuite_core.utils.project.default_company()` — the SAME value the server-side company
+// guard uses, so picker filters and the guard always agree. We fetch it (once, cached) rather
+// than read `window.sysdefaults.company`, which isn't reliably injected (e.g. the standalone
+// Vite dev server) and can also point at a different company than default_company() resolves.
 //
-// This is the ONE seam for company scope. When multi-company ships, change this to derive
-// the company from context (the active project, or a user selection) and every picker +
-// guard that reads it follows automatically — no hardcoded default company scattered around.
-export function useActiveCompany() {
-	return (typeof window !== "undefined" && window.sysdefaults?.company) || null;
+// This is the ONE seam for company scope. When multi-company ships, change this to derive the
+// company from context (the active project, or a user selection) and every picker + guard that
+// reads it follows automatically — no hardcoded default company scattered around.
+import { computed, ref } from "vue";
+import { frappeRequest } from "frappe-ui-frappe-request";
+
+// Module-cached so the round-trip happens once per app load, shared by every caller.
+const company = ref((typeof window !== "undefined" && window.sysdefaults?.company) || null);
+let started = false;
+function ensureLoaded() {
+	if (started) return;
+	started = true;
+	frappeRequest({ url: "buildsuite_core.api.company.active_company" })
+		.then((c) => {
+			if (c) company.value = c;
+		})
+		.catch(() => {
+			/* keep the sysdefaults fallback */
+		});
 }
 
-// Convenience: a DeskLinkPicker `:filters` fragment that limits a company-partitioned
-// doctype (Account, Employee, Project, …) to the active company. Empty when the company is
-// unknown, so the picker degrades to unfiltered rather than showing nothing (the server
-// guard still blocks a cross-company save).
+// Returns a ref that resolves to the active company (may start null, then fill in). Pickers
+// bind it via a reactive filter, and DeskLinkPicker re-queries when the filter changes.
+export function useActiveCompany() {
+	ensureLoaded();
+	return company;
+}
+
+// A reactive DeskLinkPicker `:filters` fragment limiting a company-partitioned doctype
+// (Account, Employee, Project, …) to the active company. Empty until the company is known, so
+// the picker degrades to unfiltered rather than showing nothing (the server guard still blocks
+// a cross-company save), then narrows once it resolves.
 export function activeCompanyFilter() {
-	const company = useActiveCompany();
-	return company ? [["company", "=", company]] : [];
+	const c = useActiveCompany();
+	return computed(() => (c.value ? [["company", "=", c.value]] : []));
 }

--- a/frontend/src/composables/useActiveCompany.js
+++ b/frontend/src/composables/useActiveCompany.js
@@ -1,0 +1,22 @@
+// The company every finance transaction (and its pickers) is scoped to.
+//
+// Single-company for now: the site's default company, exposed to the browser as
+// `window.sysdefaults.company` — the same value the backend's
+// `buildsuite_core.utils.project.default_company()` resolves to, so the picker filters
+// and the server-side company guard always agree.
+//
+// This is the ONE seam for company scope. When multi-company ships, change this to derive
+// the company from context (the active project, or a user selection) and every picker +
+// guard that reads it follows automatically — no hardcoded default company scattered around.
+export function useActiveCompany() {
+	return (typeof window !== "undefined" && window.sysdefaults?.company) || null;
+}
+
+// Convenience: a DeskLinkPicker `:filters` fragment that limits a company-partitioned
+// doctype (Account, Employee, Project, …) to the active company. Empty when the company is
+// unknown, so the picker degrades to unfiltered rather than showing nothing (the server
+// guard still blocks a cross-company save).
+export function activeCompanyFilter() {
+	const company = useActiveCompany();
+	return company ? [["company", "=", company]] : [];
+}

--- a/frontend/src/data/expenseEntryApi.js
+++ b/frontend/src/data/expenseEntryApi.js
@@ -23,6 +23,6 @@ export const saveExpense = (payload) => call("save_expense", { payload: JSON.str
 export const submitExpense = (name) => call("submit_expense", { name });
 export const cancelExpense = (name) => call("cancel_expense", { name });
 export const listExpenseAccounts = (company) => call("list_expense_accounts", { company });
-// Company Bank/Cash accounts a Company-paid expense can draw from (excludes Petty Cash).
-// Company is derived from the project, matching save_expense.
-export const listExpensePayAccounts = (project) => call("list_cash_bank_accounts", { project });
+// Bank/Cash accounts a Company-paid expense can draw from — the active (default) company,
+// excluding Petty Cash. See the single-company seam.
+export const listExpensePayAccounts = () => call("list_cash_bank_accounts", {});

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -291,11 +291,11 @@ async function save() {
 	}
 }
 
-const expenseAccountFilters = [
+const expenseAccountFilters = computed(() => [
 	["root_type", "=", "Expense"],
 	["is_group", "=", 0],
-	...companyFilter,
-];
+	...companyFilter.value,
+]);
 </script>
 
 <template>

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -196,25 +196,18 @@ function resetForm() {
 	Object.assign(form, { date: new Date().toISOString().slice(0, 10), amount: null, description: "", project: "", expense_account: "", cost_code: null, paid_from: "petty", company_account: "", employee: "", attachment: "", uploading: false, saving: false });
 }
 
-// Company Bank/Cash accounts for the Company-paid source (company derived from the
-// project server-side). Petty-cash spend needs no account: it Crs the holder's float.
+// Bank/Cash accounts for the Company-paid source — the active (default) company, excluding
+// Petty Cash. Petty-cash spend needs no account: it Crs the holder's float.
 const payAccounts = ref([]);
 async function loadPayAccounts() {
-	if (!form.project) { payAccounts.value = []; return; }
 	try {
-		payAccounts.value = await listExpensePayAccounts(form.project);
+		payAccounts.value = await listExpensePayAccounts();
 	} catch {
 		payAccounts.value = [];
 	}
 }
 function onPaidFromChange() {
-	if (form.paid_from === "company") loadPayAccounts();
-}
-function onProjectChange() {
-	// Company accounts are per-company; a new project may mean a new company.
-	form.company_account = "";
-	payAccounts.value = [];
-	if (form.paid_from === "company") loadPayAccounts();
+	if (form.paid_from === "company" && !payAccounts.value.length) loadPayAccounts();
 }
 
 function openNew() {
@@ -474,7 +467,7 @@ const expenseAccountFilters = computed(() => [
 							<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" min="0" placeholder="0" /></DeskField>
 						</div>
 						<DeskField label="Description" required><DeskInput v-model="form.description" placeholder="What was bought?" /></DeskField>
-						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Pick a project…" @update:model-value="onProjectChange" /></DeskField>
+						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Pick a project…" /></DeskField>
 						<div class="grid grid-cols-2 gap-3">
 							<DeskField label="Expense account" required><DeskLinkPicker v-model="form.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Pick an account…" /></DeskField>
 							<DeskField label="Cost code">

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -10,6 +10,7 @@ import { showToast } from "@/utils/appToast";
 import {
 	expenseContext,
 	listExpenses,
+	getExpense,
 	saveExpense,
 	submitExpense,
 	cancelExpense,
@@ -20,6 +21,7 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import CostCodePicker from "@/components/CostCodePicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
@@ -177,16 +179,15 @@ async function onDelete(e) {
 }
 
 // --- create / edit form modal ---
-const COST_TYPES = ["Material", "Labour", "Plant & Machinery", "Subcontract", "Overhead"];
 const PAID_FROM = [
 	{ value: "petty", label: "Petty Cash" },
 	{ value: "company", label: "Company" },
 ];
 const modalOpen = ref(false);
 const editingId = ref(null);
-const form = reactive({ date: "", amount: null, description: "", project: "", expense_account: "", cost_type: "Overhead", paid_from: "petty", company_account: "", attachment: "", uploading: false, saving: false });
+const form = reactive({ date: "", amount: null, description: "", project: "", expense_account: "", cost_code: null, paid_from: "petty", company_account: "", employee: "", attachment: "", uploading: false, saving: false });
 function resetForm() {
-	Object.assign(form, { date: new Date().toISOString().slice(0, 10), amount: null, description: "", project: "", expense_account: "", cost_type: "Overhead", paid_from: "petty", company_account: "", employee: "", attachment: "", uploading: false, saving: false });
+	Object.assign(form, { date: new Date().toISOString().slice(0, 10), amount: null, description: "", project: "", expense_account: "", cost_code: null, paid_from: "petty", company_account: "", employee: "", attachment: "", uploading: false, saving: false });
 }
 
 // Company Bank/Cash accounts for the Company-paid source (company derived from the
@@ -216,16 +217,20 @@ function openNew() {
 	payAccounts.value = [];
 	modalOpen.value = true;
 }
-function openEdit(e) {
+async function openEdit(e) {
 	editingId.value = e.name;
 	resetForm();
+	// The list row only carries the cost-code label; fetch the full entry so the picker
+	// binds the { type, group_code, item_code, label } object and edits round-trip.
+	const full = await getExpense(e.name).catch(() => null);
+	const row = full?.rows?.[0] || {};
 	Object.assign(form, {
 		date: e.date,
 		amount: e.amount,
 		description: e.description,
 		project: e.project,
-		expense_account: e.expense_account || "",
-		cost_type: e.cost_type || "Overhead",
+		expense_account: row.expense_account || e.expense_account || "",
+		cost_code: row.cost_code || null,
 		paid_from: e.source === "Company" ? "company" : "petty",
 		company_account: e.source === "Company" ? e.payment_account || "" : "",
 		employee: e.employee || "",
@@ -268,7 +273,7 @@ async function save() {
 			paid_from: form.paid_from,
 			company_account: form.paid_from === "company" ? form.company_account : undefined,
 			employee: canVerify.value && form.paid_from === "petty" ? form.employee || undefined : undefined,
-			rows: [{ expense_account: form.expense_account, cost_type: form.cost_type, amount: form.amount, description: form.description, attachment: form.attachment }],
+			rows: [{ expense_account: form.expense_account, cost_code: form.cost_code, amount: form.amount, description: form.description, attachment: form.attachment }],
 		});
 		modalOpen.value = false;
 		await refresh();
@@ -324,7 +329,7 @@ const expenseAccountFilters = [
 							<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span><div class="text-[10px] text-ink-400">{{ projectName(e) }}</div></td>
 							<td class="px-4 py-2.5 text-ink-700">{{ holderName(e) }}</td>
 							<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
-							<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_type }}</td>
+							<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 							<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
 							<td class="px-4 py-2.5 text-right"><button type="button" class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-white rounded-md" @click.stop="onSubmit(e)">Submit</button></td>
 						</tr>
@@ -363,7 +368,7 @@ const expenseAccountFilters = [
 								<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span><div class="text-[10px] text-ink-400">{{ projectName(e) }}</div></td>
 								<td class="px-4 py-2.5 text-ink-700">{{ holderName(e) }}</td>
 								<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
-								<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_type }}</td>
+								<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 								<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
 								<td class="px-4 py-2.5"><StatusBadge :status="e.status" size="xs" /></td>
 							</tr>
@@ -396,7 +401,7 @@ const expenseAccountFilters = [
 								<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span></td>
 								<td class="px-4 py-2.5 text-ink-500">{{ projectName(e) }}</td>
 								<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
-								<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_type }}</td>
+								<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 								<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
 								<td class="px-4 py-2.5"><StatusBadge :status="e.status" size="xs" /></td>
 							</tr>
@@ -426,8 +431,8 @@ const expenseAccountFilters = [
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Holder</div><div class="text-ink-900 mt-0.5">{{ holderName(detail) }}</div></div>
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Project</div><div class="text-ink-900 mt-0.5">{{ projectName(detail) }}</div></div>
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Paid from</div><div class="mt-0.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="sourceChipClass(detail.source)">{{ detail.source }}</span></div></div>
-							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Expense account</div><div class="text-ink-900 mt-0.5">{{ detail.expense_account || detail.cost_type }}</div></div>
-							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Cost type</div><div class="text-ink-900 mt-0.5">{{ detail.cost_type }}</div></div>
+							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Expense account</div><div class="text-ink-900 mt-0.5">{{ detail.expense_account || "—" }}</div></div>
+							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Cost code</div><div class="text-ink-900 mt-0.5">{{ detail.cost_code || "—" }}</div></div>
 						</div>
 						<div>
 							<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1.5">Receipt</div>
@@ -465,7 +470,9 @@ const expenseAccountFilters = [
 						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" placeholder="Pick a project…" @update:model-value="onProjectChange" /></DeskField>
 						<div class="grid grid-cols-2 gap-3">
 							<DeskField label="Expense account" required><DeskLinkPicker v-model="form.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Pick an account…" /></DeskField>
-							<DeskField label="Cost type"><DeskSelect v-model="form.cost_type"><option v-for="c in COST_TYPES" :key="c" :value="c">{{ c }}</option></DeskSelect></DeskField>
+							<DeskField label="Cost code">
+								<CostCodePicker v-model="form.cost_code" :project-id="form.project" placeholder="— Pick cost code —" />
+							</DeskField>
 						</div>
 						<div class="grid grid-cols-2 gap-3">
 							<DeskField label="Paid from">

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -23,7 +23,13 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import CostCodePicker from "@/components/CostCodePicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
+
+// Every account/project/employee picker is scoped to the active (default) company. This is
+// the single-company seam — see useActiveCompany. Empty pre-boot → picker unfiltered, but
+// the server-side company guard still blocks a cross-company save.
+const companyFilter = activeCompanyFilter();
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Expenses" }];
 const confirmDialog = useConfirm();
@@ -288,6 +294,7 @@ async function save() {
 const expenseAccountFilters = [
 	["root_type", "=", "Expense"],
 	["is_group", "=", 0],
+	...companyFilter,
 ];
 </script>
 
@@ -467,7 +474,7 @@ const expenseAccountFilters = [
 							<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" min="0" placeholder="0" /></DeskField>
 						</div>
 						<DeskField label="Description" required><DeskInput v-model="form.description" placeholder="What was bought?" /></DeskField>
-						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" placeholder="Pick a project…" @update:model-value="onProjectChange" /></DeskField>
+						<DeskField label="Project" required><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Pick a project…" @update:model-value="onProjectChange" /></DeskField>
 						<div class="grid grid-cols-2 gap-3">
 							<DeskField label="Expense account" required><DeskLinkPicker v-model="form.expense_account" doctype="Account" label-field="name" value-field="name" :filters="expenseAccountFilters" placeholder="Pick an account…" /></DeskField>
 							<DeskField label="Cost code">
@@ -486,7 +493,7 @@ const expenseAccountFilters = [
 							</DeskField>
 						</div>
 						<DeskField v-if="canVerify && form.paid_from === 'petty'" label="Holder (petty cash float)">
-							<DeskLinkPicker v-model="form.employee" doctype="Employee" label-field="employee_name" value-field="name" placeholder="Defaults to you…" />
+							<DeskLinkPicker v-model="form.employee" doctype="Employee" label-field="employee_name" value-field="name" :filters="companyFilter" placeholder="Defaults to you…" />
 						</DeskField>
 						<p v-if="form.paid_from === 'petty'" class="text-[11px] text-ink-500 -mt-1">
 							Paid from the holder's petty-cash float. If they fronted the money themselves, this simply pushes their balance negative — the amount owed back to them, settled on the next disbursement.

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -118,9 +118,9 @@ const disb = reactive({ open: false, row: null, paidFrom: "", accounts: [], savi
 async function openDisburse(row) {
 	Object.assign(disb, { open: true, row, paidFrom: "", accounts: [], saving: false });
 	try {
-		// The funding source — Bank/Cash accounts EXCLUDING Petty Cash (Cr must be a real
-		// source, never Petty Cash itself, which would make the JE a no-op).
-		disb.accounts = await listCashBankAccounts(row.company);
+		// The funding source — Bank/Cash accounts for the active (default) company, EXCLUDING
+		// Petty Cash (Cr must be a real source, never Petty Cash itself, a no-op JE).
+		disb.accounts = await listCashBankAccounts();
 	} catch (err) {
 		showToast(err.message || "Failed to load accounts", "error");
 	}


### PR DESCRIPTION
Follow-up to #112 (merged), carrying the 4 commits pushed to that branch after it merged.

## BOQ Cost Code on expenses (matches prototype)
- Expense Entry line drops the placeholder **Cost Type** dropdown and gains a **BOQ Cost Code** picker (`cost_code_type/group/item/label`, same shape as subcontractor lines). Uses the existing `CostCodePicker` (reads the project's approved BOQ). Editing round-trips the full cost-code object.
- List/detail show the cost-code label instead of cost type.

## Single-company scoping (multi-company deferred, not deleted)
- New **`useActiveCompany()` seam** — one source of company scope, fetched from `buildsuite_core.api.company.active_company` (the same `default_company()` resolver the server guard uses). `window.sysdefaults.company` isn't reliable (absent on the Vite dev server), so we fetch it; reactive + cached.
- **Expense modal pickers** (project, expense account, holder) filter to the active company; BOQ cost codes follow via the default-company project.
- **Source-account pickers** — petty-cash disburse "Pay from" and the expense Company-paid account — now draw **Bank/Cash accounts for the default company** (excluding Petty Cash), instead of the request's / project's company (projects still exist under both `XCorp` and `XCorp (Demo)`, which surfaced the wrong company's accounts).
- **`ExpenseEntry.validate_single_company()`** guards that every account + the holder belong to the entry's company — replacing ERPNext's cryptic "check Multi Currency" error (what a cross-company account actually triggers) with a clear message, on every path.

Nothing multi-company is removed: company stays anchored to the project; the guard enforces consistency within whatever that company is, and the seam flips to context-derived later.

## Verification
- `test_petty_cash` (7) + `test_petty_cash_ledger` (12, incl. `cost_code`, `cross_company_account_rejected`, `statement`) green.
- Frontend builds clean.
- **Requires `bench migrate`** (Expense Entry Table: `cost_type` → `cost_code_*`).