### PR TITLE
feat: disburse petty cash directly from a Desk Journal Entry

### DIFF
--- a/buildsuite_core/api/petty_cash.py
+++ b/buildsuite_core/api/petty_cash.py
@@ -160,6 +160,29 @@ def holder_balances(company=None):
 
 
 @frappe.whitelist()
+def disbursement_prefill(request):
+	"""What the Desk Journal Entry form needs to prefill a disbursement from a Petty Cash
+	Request: the company, amount, the Petty Cash account to debit, and the holder to stamp on
+	that leg. Only a Requested request can be disbursed."""
+	from buildsuite_core.utils.petty_cash import employee_for_user, resolve_petty_cash_account
+
+	r = frappe.db.get_value(
+		"Petty Cash Request", request, ["name", "status", "company", "amount", "requested_by", "purpose"], as_dict=True
+	)
+	if not r:
+		return None
+	if r.status != "Requested":
+		frappe.throw(_("Petty Cash Request {0} is {1} — only a Requested one can be disbursed.").format(request, r.status))
+	return {
+		"company": r.company,
+		"amount": flt(r.amount),
+		"petty_cash_account": resolve_petty_cash_account(r.company),
+		"employee": employee_for_user(r.requested_by),
+		"remark": f"Petty cash {r.name}: {r.purpose or ''}"[:140],
+	}
+
+
+@frappe.whitelist()
 def statement(employee):
 	"""A holder's personal petty-cash statement: disbursements in + petty-cash expenses
 	out, newest first. Cancelled entries are omitted (no balance impact); drafts are

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -368,14 +368,17 @@ CUSTOM_FIELD = {
 	],
 	"Journal Entry": [
 		{
-			# Back-link to the Petty Cash Request whose disbursement posted this JE.
+			# Links this JE to a Petty Cash Request. The app sets it when disbursing; a Desk
+			# user can also set it by hand to disburse a request directly — on submit the
+			# request flips to Disbursed and the holder is stamped on the Petty Cash leg
+			# (buildsuite_core.utils.petty_cash JE hooks). Editable so the manual path works.
 			"fieldname": "petty_cash_request",
 			"fieldtype": "Link",
 			"label": "Petty Cash Request",
 			"options": "Petty Cash Request",
 			"insert_after": "voucher_type",
-			"read_only": 1,
 			"no_copy": 1,
+			"description": "Disburses the linked Requested petty cash request when this entry is submitted.",
 			"module": "BuildSuite Core",
 		},
 	],

--- a/buildsuite_core/hooks.py
+++ b/buildsuite_core/hooks.py
@@ -231,6 +231,14 @@ doc_events = {
 	"Company":{
 		"on_update":"buildsuite_core.utils.petty_cash.create_account",
 	},
+	# Direct-in-Desk petty cash disbursement: a Journal Entry linked to a Petty Cash Request
+	# (the `petty_cash_request` field) disburses it on submit / reverts on cancel, and carries
+	# the holder on its Petty Cash leg — mirroring the Vue app's disburse flow.
+	"Journal Entry": {
+		"validate": "buildsuite_core.utils.petty_cash.stamp_holder_on_petty_cash_je",
+		"on_submit": "buildsuite_core.utils.petty_cash.sync_petty_cash_request_on_je_submit",
+		"on_cancel": "buildsuite_core.utils.petty_cash.revert_petty_cash_request_on_je_cancel",
+	},
 	# Hierarchy date-boundary checks — a child's schedule must sit within its
 	# parent project (and end >= start on the record itself).
 	"Work Package": {"validate": "buildsuite_core.utils.date_bounds.validate_work_package_dates"},
@@ -391,6 +399,7 @@ doctype_js = {
     "Purchase Order": "public/js/purchase_order.js",
     "Purchase Invoice": "public/js/purchase_invoice.js",
     "Purchase Receipt": "public/js/purchase_receipt.js",
+    "Journal Entry": "public/js/journal_entry.js",
 }
 
 doctype_list_js = {"Task": "public/js/task_list.js"}

--- a/buildsuite_core/public/js/journal_entry.js
+++ b/buildsuite_core/public/js/journal_entry.js
@@ -1,0 +1,42 @@
+// Petty cash disbursement, posted by hand in Desk (bigger teams that skip the Vue app).
+// Pick a Petty Cash Request in the `petty_cash_request` field and this prefills the company,
+// the amount, and the Petty Cash outflow line (Dr Petty Cash, holder stamped). The accountant
+// only has to add the Cr Bank/Cash source. On submit the server hooks flip the request to
+// Disbursed (buildsuite_core.utils.petty_cash). Only Requested requests are selectable.
+frappe.ui.form.on("Journal Entry", {
+	setup(frm) {
+		frm.set_query("petty_cash_request", () => ({ filters: { status: "Requested" } }));
+	},
+
+	petty_cash_request(frm) {
+		const request = frm.doc.petty_cash_request;
+		if (!request) return;
+
+		frappe.call({
+			method: "buildsuite_core.api.petty_cash.disbursement_prefill",
+			args: { request },
+			callback: ({ message }) => {
+				if (!message) return;
+
+				const prefill = () => {
+					// Reuse an existing Petty Cash line if one is already there, else add one.
+					let row = (frm.doc.accounts || []).find((a) => a.account === message.petty_cash_account);
+					if (!row) row = frm.add_child("accounts");
+					frappe.model.set_value(row.doctype, row.name, "account", message.petty_cash_account);
+					frappe.model.set_value(row.doctype, row.name, "debit_in_account_currency", message.amount);
+					frappe.model.set_value(row.doctype, row.name, "credit_in_account_currency", 0);
+					if (message.employee) frappe.model.set_value(row.doctype, row.name, "employee", message.employee);
+					if (message.remark && !frm.doc.user_remark) frm.set_value("user_remark", message.remark);
+					frm.refresh_field("accounts");
+				};
+
+				// Set the company first — changing it can clear the accounts grid, so prefill after.
+				if (message.company && frm.doc.company !== message.company) {
+					frm.set_value("company", message.company).then(prefill);
+				} else {
+					prefill();
+				}
+			},
+		});
+	},
+});

--- a/buildsuite_core/tests/test_petty_cash.py
+++ b/buildsuite_core/tests/test_petty_cash.py
@@ -139,3 +139,61 @@ class TestPettyCash(BuildSuiteTestCase):
 		petty = resolve_petty_cash_account(self.company)
 		req = self._request()
 		self.assertRaises(frappe.ValidationError, req.disburse, petty)
+
+	def test_direct_desk_je_disburses_and_stamps_holder(self):
+		# Bigger teams post the disbursement Journal Entry by hand in Desk instead of using
+		# the app. Linking the JE to the request + submitting must disburse it and stamp the
+		# holder on the Petty Cash leg (so the GL/reconciliation attributes the float), even
+		# when the accountant left the employee blank.
+		from buildsuite_core.utils.petty_cash import resolve_petty_cash_account
+
+		holder = frappe.db.get_value("Employee", {"user_id": "Administrator", "status": "Active"}, "name")
+		req = self._request(amount=8000)
+		petty = resolve_petty_cash_account(self.company)
+		bank = self._cash_account()
+
+		je = frappe.new_doc("Journal Entry")
+		je.company = self.company
+		je.posting_date = "2026-07-20"
+		je.petty_cash_request = req.name
+		je.append("accounts", {"account": petty, "debit_in_account_currency": 8000})  # employee left blank
+		je.append("accounts", {"account": bank, "credit_in_account_currency": 8000})
+		je.flags.ignore_permissions = True
+		je.insert()
+		je.submit()
+
+		# Holder auto-stamped on the Petty Cash leg → GL carries the employee dimension.
+		je.reload()
+		petty_line = next(a for a in je.accounts if a.account == petty)
+		self.assertEqual(petty_line.employee, holder)
+		self.assertEqual(
+			frappe.db.get_value("GL Entry", {"voucher_no": je.name, "account": petty, "is_cancelled": 0}, "employee"),
+			holder,
+		)
+
+		# Submitting the JE disbursed the request.
+		req.reload()
+		self.assertEqual(req.status, "Disbursed")
+		self.assertEqual(req.journal_entry, je.name)
+		self.assertEqual(req.paid_from, bank)
+
+		# Cancelling the JE reverts it to Requested.
+		je.cancel()
+		req.reload()
+		self.assertEqual(req.status, "Requested")
+		self.assertFalse(req.journal_entry)
+
+	def test_disbursement_prefill(self):
+		from buildsuite_core.api.petty_cash import disbursement_prefill
+		from buildsuite_core.utils.petty_cash import resolve_petty_cash_account
+
+		holder = frappe.db.get_value("Employee", {"user_id": "Administrator", "status": "Active"}, "name")
+		req = self._request(amount=6000)
+		data = disbursement_prefill(req.name)
+		self.assertEqual(data["company"], self.company)
+		self.assertEqual(flt(data["amount"]), 6000)
+		self.assertEqual(data["petty_cash_account"], resolve_petty_cash_account(self.company))
+		self.assertEqual(data["employee"], holder)
+		# A disbursed request can't be prefilled for another disbursement.
+		req.disburse(self._cash_account())
+		self.assertRaises(frappe.ValidationError, disbursement_prefill, req.name)

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 
 import frappe
 from frappe import _
-from frappe.utils import flt, formatdate, getdate
+from frappe.utils import flt, formatdate, getdate, now_datetime
 
 PETTY_CASH_ACCOUNT_NAME = "Petty Cash"
 PETTY_CASH_PARENT_ACCOUNT = "Cash In Hand"
@@ -106,6 +106,10 @@ def post_disbursement_journal_entry(doc):
 	)
 
 	je.flags.ignore_permissions = True
+	# The request's disburse() drives the state change itself; tell the JE hooks to stand
+	# down so they don't also flip the request (which would double-save it). The hooks are
+	# for JEs posted by hand in Desk, which have no such orchestration.
+	je.flags.ignore_petty_cash_sync = True
 	je.insert()
 	je.submit()
 	return je.name
@@ -121,7 +125,108 @@ def cancel_disbursement_journal_entry(doc):
 
 	je = frappe.get_doc("Journal Entry", doc.journal_entry)
 	je.flags.ignore_permissions = True
+	je.flags.ignore_petty_cash_sync = True  # cancel_disbursement() reverts the request itself
 	je.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Direct Journal Entry disbursement (Desk, no Vue app)
+# ---------------------------------------------------------------------------
+# Bigger teams often post the disbursement Journal Entry straight in Desk instead of using
+# the app. These hooks make that path behave like the app: link the JE to a Petty Cash
+# Request (the `petty_cash_request` field), and on submit the request flips to Disbursed;
+# on cancel it reverts. The holder is stamped on the Petty Cash leg so the GL / per-holder
+# reconciliation still attributes the float.
+
+
+def _je_funding_account(doc, company):
+	"""The credited Bank/Cash source on a disbursement JE (Dr Petty Cash / Cr source)."""
+	petty = get_petty_cash_account(company)
+	for row in doc.get("accounts") or []:
+		if flt(row.credit_in_account_currency) > 0 and row.account != petty:
+			return row.account
+	return None
+
+
+def stamp_holder_on_petty_cash_je(doc, method=None):
+	"""validate hook: a JE linked to a Petty Cash Request must carry the holder on its Petty
+	Cash line, so the GL and the per-holder reconciliation attribute the float. Auto-fill it
+	from the request's holder when a Desk user left it blank. Idempotent — the app's JE already
+	has it set, so this is a no-op there."""
+	request = doc.get("petty_cash_request")
+	if not request:
+		return
+
+	company, requested_by = frappe.db.get_value(
+		"Petty Cash Request", request, ["company", "requested_by"]
+	) or (None, None)
+	holder = employee_for_user(requested_by)
+	if not holder:
+		return
+
+	petty = get_petty_cash_account(company) if company else None
+	if not petty:
+		return
+	for row in doc.get("accounts") or []:
+		if row.account == petty and not row.get("employee"):
+			row.employee = holder
+
+
+def sync_petty_cash_request_on_je_submit(doc, method=None):
+	"""on_submit hook: submitting a JE linked to a Requested Petty Cash Request disburses it —
+	the same end state as the app's disburse(), for JEs posted by hand in Desk."""
+	if doc.flags.get("ignore_petty_cash_sync"):
+		return
+	request = doc.get("petty_cash_request")
+	if not request:
+		return
+
+	status, company, linked = frappe.db.get_value(
+		"Petty Cash Request", request, ["status", "company", "journal_entry"]
+	)
+	if status == "Disbursed":
+		if linked and linked != doc.name:
+			frappe.throw(_("Petty Cash Request {0} is already disbursed by {1}.").format(request, linked))
+		return
+	if status != "Requested":
+		frappe.throw(
+			_("Petty Cash Request {0} is {1} — only a Requested one can be disbursed.").format(request, status)
+		)
+
+	frappe.db.set_value(
+		"Petty Cash Request",
+		request,
+		{
+			"status": "Disbursed",
+			"journal_entry": doc.name,
+			"paid_from": _je_funding_account(doc, company),
+			"disbursed_by": frappe.session.user,
+			"disbursed_on": now_datetime(),
+		},
+	)
+	frappe.get_doc("Petty Cash Request", request).add_comment(
+		"Comment", _("Disbursed via Journal Entry {0}").format(doc.name)
+	)
+
+
+def revert_petty_cash_request_on_je_cancel(doc, method=None):
+	"""on_cancel hook: cancelling a JE that disbursed a request reverts it to Requested."""
+	if doc.flags.get("ignore_petty_cash_sync"):
+		return
+	request = doc.get("petty_cash_request")
+	if not request:
+		return
+	if frappe.db.get_value("Petty Cash Request", request, "status") != "Disbursed":
+		return
+
+	frappe.db.set_value(
+		"Petty Cash Request",
+		request,
+		{"status": "Requested", "journal_entry": None, "paid_from": None, "disbursed_by": None, "disbursed_on": None},
+	)
+	frappe.get_doc("Petty Cash Request", request).add_comment(
+		"Comment", _("Disbursement reversed — Journal Entry {0} cancelled").format(doc.name)
+	)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Bigger teams often post the disbursement **Journal Entry by hand in Desk** instead of using the Vue app. This makes that path behave exactly like the app's disburse — including the employee dimension the GL/reconciliation depends on.

## How it works
1. On a Journal Entry, set the **Petty Cash Request** field (now editable; its picker is **filtered to Requested requests only** — disbursed ones don't show up).
2. Picking a request **prefills** the company, the **amount**, and the **Petty Cash outflow line** (Dr Petty Cash, holder stamped). The accountant only adds the **Cr Bank/Cash** source.
3. On **submit**, the request flips to **Disbursed** — linking the JE, funding source, and who/when — and the **holder is auto-stamped** on the Petty Cash leg if left blank, so the GL and per-holder balances still attribute the float.
4. On **cancel**, the request reverts to **Requested**.

## Pieces
- Server hooks (`buildsuite_core.utils.petty_cash`): `stamp_holder_on_petty_cash_je` (validate), `sync_petty_cash_request_on_je_submit` (on_submit), `revert_petty_cash_request_on_je_cancel` (on_cancel), wired in `hooks.py`.
- Desk client script `public/js/journal_entry.js` + `api.petty_cash.disbursement_prefill` (the filter + prefill).
- The `petty_cash_request` custom field is made editable.
- The Vue disburse/undisburse path is **flag-guarded** (`ignore_petty_cash_sync`) so it drives the state itself and the hooks don't double-fire.
- Guard: a request already disbursed by another JE can't be re-disbursed.

## Verification
- `test_petty_cash` (9) green — adds a direct-Desk-JE test (holder auto-stamped on the leg + GL, request Disbursed, cancel reverts) and a `disbursement_prefill` test.
- `test_petty_cash_ledger` (12) + `test_subcontractor_bill` (15) green — the JE hooks no-op on non-petty JEs.
- **Requires `bench migrate`** (the `petty_cash_request` field is now editable) and `bench build` (Desk client script).