### PR TITLE
feat: holder names show a user avatar (petty cash + expenses)

### DIFF
--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -23,6 +23,7 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import CostCodePicker from "@/components/CostCodePicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import UserAvatar from "@/components/UserAvatar.vue";
 import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
@@ -327,7 +328,7 @@ const expenseAccountFilters = computed(() => [
 						<tr v-for="e in toSubmit" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/40 cursor-pointer" @click="openDetail(e)">
 							<td class="px-4 py-2.5 text-ink-500">{{ fmtDate(e.date) }}</td>
 							<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span><div class="text-[10px] text-ink-400">{{ projectName(e) }}</div></td>
-							<td class="px-4 py-2.5 text-ink-700">{{ holderName(e) }}</td>
+							<td class="px-4 py-2.5 text-ink-700"><div class="flex items-center gap-1.5"><UserAvatar :name="holderName(e)" size="xs" /><span>{{ holderName(e) }}</span></div></td>
 							<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
 							<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 							<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
@@ -366,7 +367,7 @@ const expenseAccountFilters = computed(() => [
 							<tr v-for="e in allExpenses" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30 cursor-pointer" @click="openDetail(e)">
 								<td class="px-4 py-2.5 text-ink-500">{{ fmtDate(e.date) }}</td>
 								<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span><div class="text-[10px] text-ink-400">{{ projectName(e) }}</div></td>
-								<td class="px-4 py-2.5 text-ink-700">{{ holderName(e) }}</td>
+								<td class="px-4 py-2.5 text-ink-700"><div class="flex items-center gap-1.5"><UserAvatar :name="holderName(e)" size="xs" /><span>{{ holderName(e) }}</span></div></td>
 								<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
 								<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 								<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
@@ -428,7 +429,7 @@ const expenseAccountFilters = computed(() => [
 						</div>
 						<div class="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Date</div><div class="text-ink-900 mt-0.5">{{ fmtDate(detail.date) }}</div></div>
-							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Holder</div><div class="text-ink-900 mt-0.5">{{ holderName(detail) }}</div></div>
+							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Holder</div><div class="mt-0.5 flex items-center gap-1.5"><UserAvatar :name="holderName(detail)" size="xs" /><span class="text-ink-900">{{ holderName(detail) }}</span></div></div>
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Project</div><div class="text-ink-900 mt-0.5">{{ projectName(detail) }}</div></div>
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Paid from</div><div class="mt-0.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full" :class="sourceChipClass(detail.source)">{{ detail.source }}</span></div></div>
 							<div><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Expense account</div><div class="text-ink-900 mt-0.5">{{ detail.expense_account || "—" }}</div></div>

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -21,6 +21,7 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import UserAvatar from "@/components/UserAvatar.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const session = useSessionStore();
@@ -205,7 +206,7 @@ const rowsForTab = computed(() => {
 				</thead>
 				<tbody>
 					<tr v-for="b in balances" :key="b.employee || b.holder" class="border-t border-ink-100">
-						<td class="px-3 py-2 text-ink-900">{{ b.holder }}</td>
+						<td class="px-3 py-2 text-ink-900"><div class="flex items-center gap-1.5"><UserAvatar :name="b.holder" size="xs" /><span>{{ b.holder }}</span></div></td>
 						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.disbursed) }}</td>
 						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.spent) }}</td>
 						<td class="px-3 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">
@@ -234,7 +235,7 @@ const rowsForTab = computed(() => {
 			:search-placeholder="tab === 'all' ? 'Search requests…' : ''"
 		>
 			<template #cell-requested_by="{ row }">
-				<span class="text-xs text-ink-900">{{ row.requested_by }}</span>
+				<div class="flex items-center gap-1.5"><UserAvatar :user-id="row.requested_by" size="xs" /><span class="text-xs text-ink-900">{{ row.requested_by }}</span></div>
 			</template>
 			<template #cell-purpose="{ row }">
 				<span class="text-xs text-ink-700">{{ (row.purpose || "").slice(0, 60) }}</span>


### PR DESCRIPTION
Matches the prototype — every holder name in the finance surfaces is now preceded by a user avatar.

## Where
- **Petty Cash → Balances** tab (Holder column)
- **Petty Cash** request list (Holder / requested-by column)
- **Expenses** tables (To Submit + All Expenses) and the expense detail modal (Holder)

## How
Uses the existing `UserAvatar` component — no new component. It renders the user's photo when a linked User resolves, otherwise a colored initials circle:
- Request holders are a **User** → `:user-id`
- Expense/balance holders are an **Employee** → `:name` (initials + deterministic color; the component already supports name-only rendering)

Frontend-only, no backend or data changes; build is clean.