### PR TITLE
feat: disburse from the Petty Cash Request Desk form (dialog approach)

### DIFF
--- a/buildsuite_core/hooks.py
+++ b/buildsuite_core/hooks.py
@@ -400,6 +400,7 @@ doctype_js = {
     "Purchase Invoice": "public/js/purchase_invoice.js",
     "Purchase Receipt": "public/js/purchase_receipt.js",
     "Journal Entry": "public/js/journal_entry.js",
+    "Petty Cash Request": "public/js/petty_cash_request.js",
 }
 
 doctype_list_js = {"Task": "public/js/task_list.js"}

--- a/buildsuite_core/public/js/petty_cash_request.js
+++ b/buildsuite_core/public/js/petty_cash_request.js
@@ -1,0 +1,62 @@
+// Approach 2 — disburse from the Petty Cash Request Desk form itself (the "less intrusive"
+// alternative to posting a Journal Entry by hand). A Requested request shows a "Disburse"
+// button; clicking it opens a dialog that mirrors the Vue app's disburse modal (amount,
+// holder, and the Bank/Cash funding source). It calls the SAME server endpoint the Vue
+// frontend uses — buildsuite_core.api.petty_cash.disburse → PettyCashRequest.disburse() —
+// so the accounting (Dr Petty Cash [holder] / Cr source, holder on the dimension) is
+// identical. No changes to the Journal Entry doctype.
+frappe.ui.form.on("Petty Cash Request", {
+	refresh(frm) {
+		if (frm.is_new() || frm.doc.status !== "Requested") return;
+		frm.add_custom_button(__("Disburse"), () => openDisburseDialog(frm)).addClass("btn-primary");
+	},
+});
+
+function openDisburseDialog(frm) {
+	// Funding sources: Bank/Cash accounts for the request's company, excluding Petty Cash
+	// itself (the same list the Vue disburse modal shows).
+	frappe.call({
+		method: "buildsuite_core.api.petty_cash.list_cash_bank_accounts",
+		args: { company: frm.doc.company },
+	}).then(({ message }) => {
+		const accounts = message || [];
+		if (!accounts.length) {
+			frappe.msgprint(__("No Bank/Cash account found for {0}.", [frm.doc.company]));
+			return;
+		}
+
+		const amount = format_currency(frm.doc.amount, frappe.defaults.get_default("currency"));
+		const dialog = new frappe.ui.Dialog({
+			title: __("Disburse {0}", [amount]),
+			fields: [
+				{
+					fieldtype: "HTML",
+					options: `<p class="text-muted" style="margin-bottom:12px">${__("To")} <b>${frappe.utils.escape_html(frm.doc.requested_by || "")}</b> · ${__("posts a Journal Entry (Dr Petty Cash / Cr the source account).")}</p>`,
+				},
+				{
+					fieldtype: "Select",
+					fieldname: "paid_from",
+					label: __("Pay from account"),
+					reqd: 1,
+					options: accounts.map((a) => a.name).join("\n"),
+					default: accounts[0].name,
+				},
+			],
+			primary_action_label: __("Disburse"),
+			primary_action(values) {
+				dialog.disable_primary_action();
+				frappe.call({
+					method: "buildsuite_core.api.petty_cash.disburse",
+					args: { name: frm.doc.name, paid_from: values.paid_from },
+					freeze: true,
+					freeze_message: __("Posting disbursement…"),
+				}).then(() => {
+					dialog.hide();
+					frappe.show_alert({ message: __("Disbursed — Journal Entry posted."), indicator: "green" });
+					frm.reload_doc();
+				}).catch(() => dialog.enable_primary_action());
+			},
+		});
+		dialog.show();
+	});
+}


### PR DESCRIPTION
**Approach 2 of 2** for disbursing petty cash in ERPNext Desk — the *less intrusive* alternative to posting a Journal Entry by hand. Kept on its own branch so both approaches can be shown side by side.

## What it does
On a **Requested** Petty Cash Request, a **Disburse** button appears. Clicking it opens a dialog that mirrors the Vue app's disburse modal:
- **Amount** + **holder** shown in the header
- **Pay from account** — Bank/Cash for the request's company, excluding Petty Cash

It calls the **exact same endpoint the Vue frontend uses** — `api.petty_cash.disburse` → `PettyCashRequest.disburse()` — so the posting (Dr Petty Cash [holder] / Cr source, holder on the accounting dimension) is identical.

## Why it's "less intrusive"
- **No changes to the Journal Entry doctype** — no extra field, no `doc_events`, no JE client script.
- Just one client script on Petty Cash Request + a `doctype_js` line. Reuses the existing whitelisted endpoints already on develop.

## The two approaches, for comparison
- **Approach 1 (already on `develop`)** — post a Journal Entry, set its *Petty Cash Request* field; it prefills the amount + Petty Cash line and disburses on submit. More native to accountants who live in Journal Entries, but it adds a field + hooks to the JE doctype.
- **Approach 2 (this PR)** — a Disburse button + dialog on the request form; nothing on the JE.

## Notes
- Purely additive (client script only); no backend or schema change, so no migrate needed — `bench build` for the asset.
- Role-gated server-side (`disburse` requires the petty-cash disburse roles).