### PR TITLE
feat: Project Finance Invoices — live over ERPNext Sales Invoice

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -341,6 +341,69 @@ def list_receipts(name):
 
 
 # --------------------------------------------------------------------------- #
+# Customer advances (on-account receipts, no invoice yet)
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def record_advance(customer, amount, date=None, deposit_to=None, mode_of_payment=None, reference_no=None):
+	"""Receive money from a customer BEFORE (or without) an invoice — a submitted on-account
+	Payment Entry whose full amount stays unallocated until a later invoice draws it down."""
+	from erpnext.accounts.party import get_party_account
+
+	if not customer:
+		frappe.throw(_("Customer is required."))
+	amount = flt(amount)
+	if amount <= 0:
+		frappe.throw(_("Enter an amount greater than zero."))
+	if not deposit_to:
+		frappe.throw(_("Choose the Bank/Cash account to deposit into."))
+
+	company = default_company()
+	if frappe.db.get_value("Account", deposit_to, "company") != company:
+		frappe.throw(_("Account {0} does not belong to company {1}.").format(deposit_to, company))
+
+	receivable = get_party_account("Customer", customer, company)
+	pe = frappe.new_doc("Payment Entry")
+	pe.payment_type = "Receive"
+	pe.company = company
+	pe.posting_date = date or nowdate()
+	pe.party_type = "Customer"
+	pe.party = customer
+	pe.party_account = receivable
+	pe.paid_from = receivable
+	pe.paid_from_account_currency = frappe.db.get_value("Account", receivable, "account_currency")
+	pe.paid_to = deposit_to
+	pe.paid_to_account_currency = frappe.db.get_value("Account", deposit_to, "account_currency")
+	pe.paid_amount = amount
+	pe.received_amount = amount
+	if mode_of_payment:
+		pe.mode_of_payment = mode_of_payment
+	if reference_no:
+		pe.reference_no = reference_no
+		pe.reference_date = date or nowdate()
+	pe.flags.ignore_permissions = True
+	pe.set_missing_values()
+	pe.insert()
+	pe.submit()
+	return {"payment_entry": pe.name}
+
+
+@frappe.whitelist()
+def advances_summary(company=None):
+	"""Total unallocated customer advances held for the active (default) company."""
+	company = company or default_company()
+	total = frappe.db.sql(
+		"""
+		SELECT COALESCE(SUM(unallocated_amount), 0)
+		FROM `tabPayment Entry`
+		WHERE docstatus = 1 AND payment_type = 'Receive' AND party_type = 'Customer'
+			AND company = %(company)s AND unallocated_amount > 0
+		""",
+		{"company": company},
+	)
+	return {"total": flt(total[0][0]) if total else 0}
+
+
+# --------------------------------------------------------------------------- #
 # Pickers
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()

--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -1,0 +1,371 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Whitelisted endpoints for Project Finance › Invoices — the Vue front-end over ERPNext's
+Sales Invoice (money in). An "invoice" IS a Sales Invoice: these endpoints create drafts,
+list them with aging, submit/cancel, and receive payments (a real Payment Entry against the
+SI). Single-company for now — the company is the project's, else the default (see the
+single-company seam). Taxes are country-agnostic (any Sales Taxes and Charges Template)."""
+
+import frappe
+from frappe import _
+from frappe.utils import flt, nowdate
+
+from buildsuite_core.utils.project import default_company
+
+SI = "Sales Invoice"
+SERVICE_ITEM = "Professional Services"
+SERVICE_ITEM_GROUP = "Services"
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _company_for(project=None):
+	if project:
+		return frappe.db.get_value("Project", project, "company") or default_company()
+	return default_company()
+
+
+def ensure_invoice_item():
+	"""A generic non-stock sales Item that invoice lines hang off (the description carries the
+	real detail). Mirrors the Subcontractor Bill's service-item approach."""
+	if frappe.db.exists("Item", SERVICE_ITEM):
+		return SERVICE_ITEM
+	if not frappe.db.exists("Item Group", SERVICE_ITEM_GROUP):
+		parent = frappe.db.get_value("Item Group", {"is_group": 1}, "name") or "All Item Groups"
+		frappe.get_doc(
+			{"doctype": "Item Group", "item_group_name": SERVICE_ITEM_GROUP, "parent_item_group": parent}
+		).insert(ignore_permissions=True)
+	frappe.get_doc(
+		{
+			"doctype": "Item",
+			"item_code": SERVICE_ITEM,
+			"item_name": SERVICE_ITEM,
+			"item_group": SERVICE_ITEM_GROUP,
+			"stock_uom": "Nos",
+			"is_stock_item": 0,
+			"is_sales_item": 1,
+			"is_purchase_item": 0,
+		}
+	).insert(ignore_permissions=True)
+	return SERVICE_ITEM
+
+
+def _income_account(company):
+	acc = frappe.db.get_value("Company", company, "default_income_account")
+	if acc:
+		return acc
+	from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+	return _ensure_account(company, "Sales", "Income", "Income Account", "Income")
+
+
+def _payment_summary(name):
+	si = frappe.db.get_value(
+		SI, name, ["grand_total", "outstanding_amount", "status", "docstatus"], as_dict=True
+	)
+	if not si or si.docstatus == 0:
+		return {"invoiced": 0, "received": 0, "outstanding": 0, "status": "Draft"}
+	invoiced = flt(si.grand_total)
+	outstanding = flt(si.outstanding_amount)
+	received = invoiced - outstanding
+	if si.docstatus == 2:
+		status = "Cancelled"
+	elif outstanding <= 0.01 and invoiced > 0:
+		status = "Paid"
+	elif received > 0.01:
+		status = "Partly Paid"
+	else:
+		status = "Unpaid"
+	return {"invoiced": invoiced, "received": received, "outstanding": outstanding, "status": status}
+
+
+def _serialize(doc):
+	return {
+		"name": doc.name,
+		"customer": doc.customer,
+		"customer_name": doc.customer_name,
+		"project": doc.project,
+		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
+		"company": doc.company,
+		"date": str(doc.posting_date) if doc.posting_date else None,
+		"due_date": str(doc.due_date) if doc.due_date else None,
+		"taxes_and_charges": doc.taxes_and_charges,
+		"docstatus": doc.docstatus,
+		"net_total": doc.net_total,
+		"total_taxes_and_charges": doc.total_taxes_and_charges,
+		"grand_total": doc.grand_total,
+		"items": [
+			{"description": r.description, "qty": r.qty, "rate": r.rate, "amount": r.amount}
+			for r in doc.items
+		],
+		"taxes": [
+			{"description": t.description, "rate": t.rate, "tax_amount": t.tax_amount, "account_head": t.account_head}
+			for t in doc.taxes
+		],
+		"payment": _payment_summary(doc.name),
+	}
+
+
+# --------------------------------------------------------------------------- #
+# Reads
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def list_invoices(project=None, company=None):
+	"""Sales Invoices for the active (default) company, newest first, with the payment summary
+	for aging/status in the panel."""
+	company = company or default_company()
+	filters = {"company": company}
+	if project:
+		filters["project"] = project
+	rows = frappe.get_all(
+		SI,
+		filters=filters,
+		fields=[
+			"name", "customer", "customer_name", "project", "posting_date", "due_date",
+			"grand_total", "outstanding_amount", "status", "docstatus",
+		],
+		order_by="posting_date desc, creation desc",
+		limit_page_length=0,
+	)
+	pids = list({r.project for r in rows if r.project})
+	pnames = (
+		{p.name: p.project_name for p in frappe.get_all("Project", filters={"name": ["in", pids]}, fields=["name", "project_name"])}
+		if pids
+		else {}
+	)
+	out = []
+	for r in rows:
+		invoiced = flt(r.grand_total)
+		outstanding = flt(r.outstanding_amount) if r.docstatus == 1 else invoiced
+		if r.docstatus == 0:
+			pay_status = "Draft"
+		elif r.docstatus == 2:
+			pay_status = "Cancelled"
+		elif outstanding <= 0.01 and invoiced > 0:
+			pay_status = "Paid"
+		elif invoiced - outstanding > 0.01:
+			pay_status = "Partly Paid"
+		else:
+			pay_status = "Unpaid"
+		out.append(
+			{
+				"name": r.name,
+				"customer": r.customer,
+				"customer_name": r.customer_name or r.customer,
+				"project": r.project,
+				"project_name": pnames.get(r.project) or r.project,
+				"date": str(r.posting_date) if r.posting_date else None,
+				"due_date": str(r.due_date) if r.due_date else None,
+				"total": invoiced,
+				"outstanding": outstanding if r.docstatus == 1 else 0,
+				"docstatus": r.docstatus,
+				"status": pay_status,
+			}
+		)
+	return out
+
+
+@frappe.whitelist()
+def get_invoice(name):
+	doc = frappe.get_doc(SI, name)
+	doc.check_permission("read")
+	return _serialize(doc)
+
+
+# --------------------------------------------------------------------------- #
+# Writes
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def save_invoice(payload):
+	"""Create or edit a DRAFT Sales Invoice. payload: {name?, customer, project?, date,
+	due_date?, taxes_and_charges?, items:[{description, qty, rate}]}."""
+	data = frappe.parse_json(payload)
+
+	customer = data.get("customer")
+	if not customer:
+		frappe.throw(_("Customer is required."))
+	items = data.get("items") or []
+	if not items:
+		frappe.throw(_("Add at least one invoice line."))
+
+	project = data.get("project")
+	company = _company_for(project)
+
+	name = data.get("name")
+	if name and frappe.db.exists(SI, name):
+		si = frappe.get_doc(SI, name)
+		si.check_permission("write")
+		if si.docstatus != 0:
+			frappe.throw(_("Only a draft invoice can be edited."))
+		si.set("items", [])
+		si.set("taxes", [])
+	else:
+		si = frappe.new_doc(SI)
+
+	si.company = company
+	si.customer = customer
+	si.currency = frappe.db.get_value("Company", company, "default_currency")
+	si.set_posting_time = 1
+	si.posting_date = data.get("date") or nowdate()
+	si.due_date = data.get("due_date") or si.posting_date
+	si.project = project or None
+
+	item_code = ensure_invoice_item()
+	income = _income_account(company)
+	cost_center = frappe.db.get_value("Company", company, "cost_center")
+	for r in items:
+		qty = flt(r.get("qty")) or 1
+		si.append(
+			"items",
+			{
+				"item_code": item_code,
+				"description": r.get("description") or SERVICE_ITEM,
+				"qty": qty,
+				"rate": flt(r.get("rate")),
+				"income_account": income,
+				"cost_center": cost_center,
+				"project": project or None,
+			},
+		)
+
+	template = data.get("taxes_and_charges")
+	if template:
+		si.taxes_and_charges = template
+		for t in frappe.get_doc("Sales Taxes and Charges Template", template).taxes:
+			si.append(
+				"taxes",
+				{
+					"charge_type": t.charge_type or "On Net Total",
+					"account_head": t.account_head,
+					"description": t.description or t.account_head,
+					"rate": flt(t.rate),
+				},
+			)
+
+	si.flags.ignore_permissions = True
+	si.set_missing_values()
+	si.save()
+	return {"name": si.name}
+
+
+@frappe.whitelist()
+def submit_invoice(name):
+	si = frappe.get_doc(SI, name)
+	si.check_permission("submit")
+	si.flags.ignore_permissions = True
+	si.submit()
+	return {"name": si.name, "payment": _payment_summary(name)}
+
+
+@frappe.whitelist()
+def cancel_invoice(name):
+	si = frappe.get_doc(SI, name)
+	si.check_permission("cancel")
+	si.flags.ignore_permissions = True
+	si.cancel()
+	return {"name": name, "cancelled": True}
+
+
+@frappe.whitelist()
+def delete_invoice(name):
+	si = frappe.get_doc(SI, name)
+	si.check_permission("delete")
+	if si.docstatus != 0:
+		frappe.throw(_("Only a draft invoice can be deleted."))
+	frappe.delete_doc(SI, name)
+	return {"name": name, "deleted": True}
+
+
+# --------------------------------------------------------------------------- #
+# Receive payment (Payment Entry against the SI)
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def record_receipt(name, amount=None, date=None, mode_of_payment=None, deposit_to=None, reference_no=None):
+	"""Create + submit a Payment Entry receiving against the invoice, into a Bank/Cash account."""
+	from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+
+	si = frappe.get_doc(SI, name)
+	si.check_permission("write")
+	if si.docstatus != 1:
+		frappe.throw(_("Submit the invoice before receiving payment."))
+
+	pe = get_payment_entry(SI, name)
+	if date:
+		pe.posting_date = date
+	if deposit_to:
+		if frappe.db.get_value("Account", deposit_to, "company") != pe.company:
+			frappe.throw(_("Account {0} does not belong to company {1}.").format(deposit_to, pe.company))
+		pe.paid_to = deposit_to
+		pe.paid_to_account_currency = frappe.db.get_value("Account", deposit_to, "account_currency")
+	if amount:
+		pe.paid_amount = flt(amount)
+		pe.received_amount = flt(amount)
+		if pe.references:
+			pe.references[0].allocated_amount = flt(amount)
+	if mode_of_payment:
+		pe.mode_of_payment = mode_of_payment
+	if reference_no:
+		pe.reference_no = reference_no
+		pe.reference_date = date or nowdate()
+	pe.flags.ignore_permissions = True
+	pe.insert()
+	pe.submit()
+	return {"payment_entry": pe.name, "payment": _payment_summary(name)}
+
+
+@frappe.whitelist()
+def list_receipts(name):
+	"""Payment Entries allocated to this invoice."""
+	refs = frappe.get_all(
+		"Payment Entry Reference",
+		filters={"reference_doctype": SI, "reference_name": name, "docstatus": 1},
+		fields=["parent", "allocated_amount"],
+	)
+	out = []
+	for r in refs:
+		pe = frappe.db.get_value(
+			"Payment Entry", r.parent, ["posting_date", "mode_of_payment", "reference_no"], as_dict=True
+		)
+		out.append(
+			{
+				"payment_entry": r.parent,
+				"date": str(pe.posting_date) if pe.posting_date else None,
+				"mode_of_payment": pe.mode_of_payment,
+				"reference_no": pe.reference_no,
+				"amount": flt(r.allocated_amount),
+			}
+		)
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# Pickers
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def list_deposit_accounts(company=None):
+	"""Bank/Cash accounts a receipt can be deposited INTO — the active (default) company."""
+	company = company or default_company()
+	return frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]},
+		fields=["name", "account_type"],
+		order_by="account_type, name",
+	)
+
+
+@frappe.whitelist()
+def list_tax_templates(company=None):
+	"""Sales Taxes and Charges Templates for the picker (GST/VAT/none — whatever is seeded)."""
+	filters = {"disabled": 0}
+	if company:
+		filters["company"] = company
+	return frappe.get_all(
+		"Sales Taxes and Charges Template", filters=filters, fields=["name", "title"], order_by="title asc"
+	)
+
+
+@frappe.whitelist()
+def list_payment_modes():
+	return frappe.get_all("Mode of Payment", fields=["name"], order_by="name", pluck="name")

--- a/buildsuite_core/tests/test_invoice.py
+++ b/buildsuite_core/tests/test_invoice.py
@@ -80,6 +80,20 @@ class TestInvoice(BuildSuiteTestCase):
 		self.assertAlmostEqual(rows[0]["outstanding"], 60000, places=2)
 		self.assertEqual(len(list_receipts(name)), 1)
 
+	def test_customer_advance(self):
+		from buildsuite_core.api.invoice import advances_summary, record_advance
+
+		cust = self._customer()
+		cash = self._deposit_account()
+		before = advances_summary(company=self.company)["total"]
+		r = record_advance(cust, amount=15000, date="2026-07-20", deposit_to=cash, mode_of_payment="Cash")
+		pe = frappe.get_doc("Payment Entry", r["payment_entry"])
+		self.assertEqual(pe.payment_type, "Receive")
+		self.assertEqual(pe.party, cust)
+		self.assertEqual(pe.paid_to, cash)
+		self.assertAlmostEqual(flt(pe.unallocated_amount), 15000, places=2)
+		self.assertAlmostEqual(advances_summary(company=self.company)["total"] - before, 15000, places=2)
+
 	def test_draft_has_no_gl_until_submit(self):
 		from buildsuite_core.api.invoice import save_invoice
 

--- a/buildsuite_core/tests/test_invoice.py
+++ b/buildsuite_core/tests/test_invoice.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Project Finance › Invoices — the Vue front-end over ERPNext Sales Invoice: create a draft,
+submit, and receive a payment into a Bank/Cash account."""
+
+import json
+
+import frappe
+from frappe.utils import flt
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestInvoice(BuildSuiteTestCase):
+	def setUp(self):
+		super().setUp()
+		self.company = frappe.db.get_single_value("Global Defaults", "default_company") or self.company
+		self.project = self._make_project(company=self.company).name
+
+	def _customer(self):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Customer",
+					"customer_name": f"Cust {self._n}",
+					"customer_group": frappe.db.get_value("Customer Group", {"is_group": 0}, "name") or "All Customer Groups",
+					"territory": frappe.db.get_value("Territory", {"is_group": 0}, "name") or "All Territories",
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def _deposit_account(self):
+		from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+		return _ensure_account(self.company, "Cash", "Asset", "Cash", "Current Assets")
+
+	def test_create_submit_receive(self):
+		from buildsuite_core.api.invoice import (
+			list_invoices,
+			list_receipts,
+			record_receipt,
+			save_invoice,
+			submit_invoice,
+		)
+
+		cust = self._customer()
+		res = save_invoice(
+			json.dumps(
+				{
+					"customer": cust,
+					"project": self.project,
+					"date": "2026-07-20",
+					"due_date": "2026-08-20",
+					"items": [{"description": "Milestone 1", "qty": 1, "rate": 100000}],
+				}
+			)
+		)
+		name = res["name"]
+		si = frappe.get_doc("Sales Invoice", name)
+		self.assertEqual(si.company, self.company)
+		self.assertEqual(si.project, self.project)
+		self.assertEqual(flt(si.grand_total), 100000)
+
+		submit_invoice(name)
+
+		# Partial receipt into a Bank/Cash account.
+		cash = self._deposit_account()
+		r = record_receipt(name, amount=40000, date="2026-07-25", mode_of_payment="Cash", deposit_to=cash)
+		self.assertAlmostEqual(r["payment"]["received"], 40000, places=2)
+		self.assertAlmostEqual(r["payment"]["outstanding"], 60000, places=2)
+		pe = frappe.get_doc("Payment Entry", r["payment_entry"])
+		self.assertEqual(pe.paid_to, cash)
+
+		rows = [i for i in list_invoices(company=self.company, project=self.project) if i["name"] == name]
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["status"], "Partly Paid")
+		self.assertAlmostEqual(rows[0]["outstanding"], 60000, places=2)
+		self.assertEqual(len(list_receipts(name)), 1)
+
+	def test_draft_has_no_gl_until_submit(self):
+		from buildsuite_core.api.invoice import save_invoice
+
+		cust = self._customer()
+		res = save_invoice(
+			json.dumps({"customer": cust, "project": self.project, "date": "2026-07-20", "items": [{"description": "x", "qty": 2, "rate": 500}]})
+		)
+		si = frappe.get_doc("Sales Invoice", res["name"])
+		self.assertEqual(si.docstatus, 0)
+		self.assertEqual(flt(si.grand_total), 1000)
+		self.assertFalse(frappe.get_all("GL Entry", filters={"voucher_no": si.name}))

--- a/frontend/src/data/invoiceApi.js
+++ b/frontend/src/data/invoiceApi.js
@@ -19,6 +19,8 @@ export const cancelInvoice = (name) => call("cancel_invoice", { name });
 export const deleteInvoice = (name) => call("delete_invoice", { name });
 export const recordInvoiceReceipt = (args) => call("record_receipt", args);
 export const listInvoiceReceipts = (name) => call("list_receipts", { name });
+export const recordCustomerAdvance = (args) => call("record_advance", args);
+export const invoiceAdvancesSummary = () => call("advances_summary", {});
 export const listDepositAccounts = () => call("list_deposit_accounts", {});
 export const listInvoiceTaxTemplates = () => call("list_tax_templates", {});
 export const listInvoicePaymentModes = () => call("list_payment_modes", {});

--- a/frontend/src/data/invoiceApi.js
+++ b/frontend/src/data/invoiceApi.js
@@ -1,0 +1,24 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Live Project Finance › Invoices endpoints (buildsuite_core.api.invoice.*). An invoice IS an
+// ERPNext Sales Invoice; these create drafts, list them, submit/cancel, and receive payments.
+async function call(method, args) {
+	try {
+		return await frappeRequest({ url: `buildsuite_core.api.invoice.${method}`, params: args || {} });
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const listInvoices = (args = {}) => call("list_invoices", args);
+export const getInvoice = (name) => call("get_invoice", { name });
+export const saveInvoice = (payload) => call("save_invoice", { payload: JSON.stringify(payload) });
+export const submitInvoice = (name) => call("submit_invoice", { name });
+export const cancelInvoice = (name) => call("cancel_invoice", { name });
+export const deleteInvoice = (name) => call("delete_invoice", { name });
+export const recordInvoiceReceipt = (args) => call("record_receipt", args);
+export const listInvoiceReceipts = (name) => call("list_receipts", { name });
+export const listDepositAccounts = () => call("list_deposit_accounts", {});
+export const listInvoiceTaxTemplates = () => call("list_tax_templates", {});
+export const listInvoicePaymentModes = () => call("list_payment_modes", {});

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -477,6 +477,12 @@ const routes = [
 				component: () => import("@/views/finance/FinancePettyCashPanel.vue"),
 			},
 			{
+				path: "project-finance/invoices/:id",
+				name: "finance-invoice",
+				component: () => import("@/views/finance/FinanceInvoiceDetailView.vue"),
+				props: true,
+			},
+			{
 				path: "project-finance/report/:slug",
 				name: "finance-report",
 				component: () => import("@/views/finance/FinanceReportPageView.vue"),

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -477,6 +477,17 @@ const routes = [
 				component: () => import("@/views/finance/FinancePettyCashPanel.vue"),
 			},
 			{
+				path: "project-finance/invoices/new",
+				name: "finance-invoice-new",
+				component: () => import("@/views/finance/FinanceInvoiceFormView.vue"),
+			},
+			{
+				path: "project-finance/invoices/:id/edit",
+				name: "finance-invoice-edit",
+				component: () => import("@/views/finance/FinanceInvoiceFormView.vue"),
+				props: true,
+			},
+			{
 				path: "project-finance/invoices/:id",
 				name: "finance-invoice",
 				component: () => import("@/views/finance/FinanceInvoiceDetailView.vue"),

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -147,6 +147,7 @@ async function saveReceive() {
 		<template v-if="inv" #actions>
 			<div class="flex items-center gap-2">
 				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md" :disabled="busy" @click="onDelete">Delete</button>
+				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="router.push(`/project-finance/invoices/${inv.name}/edit`)">Edit</button>
 				<button v-if="isDraft" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="onSubmit">Submit</button>
 				<button v-if="isSubmitted && payment.outstanding > 0.01" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="openReceive">Receive payment</button>
 				<button v-if="isSubmitted" type="button" class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md" :disabled="busy" @click="onCancel">Cancel</button>

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -1,0 +1,241 @@
+<script setup>
+// Project Finance › Invoice detail — a full page over one ERPNext Sales Invoice. Summary
+// strip, item lines, taxes, receipts, and the docstatus lifecycle: Submit/Delete (Draft),
+// Receive/Cancel (Submitted). Payment is a real Payment Entry into a Bank/Cash account.
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import {
+	getInvoice,
+	submitInvoice,
+	cancelInvoice,
+	deleteInvoice,
+	recordInvoiceReceipt,
+	listInvoiceReceipts,
+	listDepositAccounts,
+	listInvoicePaymentModes,
+} from "@/data/invoiceApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const props = defineProps({ id: { type: String, required: true } });
+const router = useRouter();
+const confirmDialog = useConfirm();
+
+const inv = ref(null);
+const receipts = ref([]);
+const loading = ref(true);
+async function load() {
+	loading.value = true;
+	try {
+		inv.value = await getInvoice(props.id);
+		receipts.value = inv.value.docstatus === 1 ? await listInvoiceReceipts(props.id) : [];
+	} catch (err) {
+		showToast(err.message || "Failed to load invoice", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
+
+const isDraft = computed(() => inv.value?.docstatus === 0);
+const isSubmitted = computed(() => inv.value?.docstatus === 1);
+const payment = computed(() => inv.value?.payment || { invoiced: 0, received: 0, outstanding: 0, status: "Draft" });
+const statusPills = computed(() => {
+	if (!inv.value) return [];
+	const doc = inv.value.docstatus === 2 ? "Cancelled" : inv.value.docstatus === 1 ? "Submitted" : "Draft";
+	return isSubmitted.value ? [doc, payment.value.status] : [doc];
+});
+
+const breadcrumbs = [
+	{ label: "Project Finance", to: "/project-finance" },
+	{ label: "Invoices", to: "/project-finance/invoices" },
+	{ label: props.id },
+];
+
+// --- lifecycle ---
+const busy = ref(false);
+async function onSubmit() {
+	const ok = await confirmDialog({ title: "Submit invoice?", message: `Submit ${inv.value.name} (${fmtINR(payment.value.invoiced || inv.value.grand_total)})? It posts the receivable and counts as income.`, confirmLabel: "Submit" });
+	if (!ok) return;
+	busy.value = true;
+	try {
+		await submitInvoice(inv.value.name);
+		await load();
+		showToast("Submitted.");
+	} catch (err) {
+		showToast(err.message || "Submit failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onCancel() {
+	const ok = await confirmDialog({ title: "Cancel invoice?", message: `Cancel ${inv.value.name}? Its receivable and any allocations are reversed.`, confirmLabel: "Cancel invoice", cancelLabel: "Keep", destructive: true });
+	if (!ok) return;
+	busy.value = true;
+	try {
+		await cancelInvoice(inv.value.name);
+		await load();
+		showToast("Cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onDelete() {
+	const ok = await confirmDialog({ title: "Delete draft?", message: `Permanently delete ${inv.value.name}?`, confirmLabel: "Delete", destructive: true });
+	if (!ok) return;
+	try {
+		await deleteInvoice(inv.value.name);
+		showToast("Deleted.");
+		router.push("/project-finance/invoices");
+	} catch (err) {
+		showToast(err.message || "Delete failed", "error");
+	}
+}
+
+// --- receive ---
+const rec = ref({ open: false, amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const depositAccounts = ref([]);
+const payModes = ref([]);
+async function openReceive() {
+	if (!depositAccounts.value.length) {
+		try {
+			[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
+		} catch {
+			/* fall through */
+		}
+	}
+	rec.value = {
+		open: true,
+		amount: Number(payment.value.outstanding) || null,
+		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		date: new Date().toISOString().slice(0, 10),
+		mode_of_payment: payModes.value[0] || "",
+		reference_no: "",
+		saving: false,
+	};
+}
+async function saveReceive() {
+	const amt = Number(rec.value.amount) || 0;
+	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
+	if (amt > Number(payment.value.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`, "error");
+	if (!rec.value.deposit_to) return showToast("Pick the account to deposit into.", "error");
+	rec.value.saving = true;
+	try {
+		await recordInvoiceReceipt({ name: inv.value.name, amount: amt, date: rec.value.date, mode_of_payment: rec.value.mode_of_payment || undefined, deposit_to: rec.value.deposit_to, reference_no: rec.value.reference_no || undefined });
+		rec.value.open = false;
+		await load();
+		showToast("Payment received.");
+	} catch (err) {
+		showToast(err.message || "Receipt failed", "error");
+	} finally {
+		rec.value.saving = false;
+	}
+}
+</script>
+
+<template>
+	<DeskPage :title="inv ? inv.name : id" :breadcrumbs="breadcrumbs">
+		<template v-if="inv" #actions>
+			<div class="flex items-center gap-2">
+				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md" :disabled="busy" @click="onDelete">Delete</button>
+				<button v-if="isDraft" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="onSubmit">Submit</button>
+				<button v-if="isSubmitted && payment.outstanding > 0.01" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="openReceive">Receive payment</button>
+				<button v-if="isSubmitted" type="button" class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md" :disabled="busy" @click="onCancel">Cancel</button>
+			</div>
+		</template>
+
+		<div v-if="!inv" class="py-16 text-center text-sm text-ink-400">{{ loading ? "Loading…" : "Invoice not found." }}</div>
+		<div v-else class="space-y-4">
+			<div class="flex items-center gap-2">
+				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
+			</div>
+
+			<!-- header facts -->
+			<div class="grid grid-cols-2 md:grid-cols-4 gap-2">
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Customer</div><div class="text-sm text-ink-900 mt-0.5">{{ inv.customer_name }}</div></div>
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Project</div><div class="text-sm text-ink-900 mt-0.5">{{ inv.project_name || "—" }}</div></div>
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Date</div><div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(inv.date) }}</div></div>
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Due</div><div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(inv.due_date) }}</div></div>
+			</div>
+
+			<!-- money strip (submitted) -->
+			<div v-if="isSubmitted" class="grid grid-cols-2 md:grid-cols-3 gap-2">
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Invoiced</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.invoiced) }}</div></div>
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Received</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.received) }}</div></div>
+				<div class="border px-3 py-2 rounded-md" :class="payment.outstanding > 0.01 ? 'bg-warning-50 border-warning-200' : 'bg-success-50 border-success-200'"><div class="text-[10px] uppercase tracking-wider font-medium" :class="payment.outstanding > 0.01 ? 'text-warning-700' : 'text-success-700'">Outstanding</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.outstanding) }}</div></div>
+			</div>
+
+			<!-- line items -->
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Items</h3></div>
+				<table class="w-full text-xs">
+					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-4 py-2">Description</th><th class="text-right px-4 py-2">Qty</th><th class="text-right px-4 py-2">Rate</th><th class="text-right px-4 py-2">Amount</th></tr></thead>
+					<tbody>
+						<tr v-for="(l, idx) in inv.items" :key="idx" class="border-t border-ink-100">
+							<td class="px-4 py-2 text-ink-900">{{ l.description }}</td>
+							<td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ l.qty }}</td>
+							<td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ fmtINR(l.rate) }}</td>
+							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(l.amount) }}</td>
+						</tr>
+					</tbody>
+					<tfoot class="border-t border-ink-200">
+						<tr><td colspan="3" class="px-4 py-1.5 text-right text-ink-500">Net total</td><td class="px-4 py-1.5 text-right tabular-nums text-ink-700">{{ fmtINR(inv.net_total) }}</td></tr>
+						<tr v-for="(t, idx) in inv.taxes" :key="'t' + idx"><td colspan="3" class="px-4 py-1.5 text-right text-ink-500">{{ t.description }} ({{ t.rate }}%)</td><td class="px-4 py-1.5 text-right tabular-nums text-ink-700">{{ fmtINR(t.tax_amount) }}</td></tr>
+						<tr class="border-t border-ink-200 font-semibold"><td colspan="3" class="px-4 py-2 text-right text-ink-900">Grand total</td><td class="px-4 py-2 text-right tabular-nums text-ink-900">{{ fmtINR(inv.grand_total) }}</td></tr>
+					</tfoot>
+				</table>
+			</section>
+
+			<!-- receipts -->
+			<section v-if="receipts.length" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Receipts</h3></div>
+				<table class="w-full text-xs">
+					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Mode</th><th class="text-left px-4 py-2">Reference</th><th class="text-left px-4 py-2">Entry</th><th class="text-right px-4 py-2">Amount</th></tr></thead>
+					<tbody>
+						<tr v-for="p in receipts" :key="p.payment_entry" class="border-t border-ink-100">
+							<td class="px-4 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(p.date) }}</td>
+							<td class="px-4 py-2 text-ink-700">{{ p.mode_of_payment || "—" }}</td>
+							<td class="px-4 py-2 text-ink-600">{{ p.reference_no || "—" }}</td>
+							<td class="px-4 py-2"><DeskLink :to="`/app/payment-entry/${p.payment_entry}`" class="font-mono text-ink-700">{{ p.payment_entry }}</DeskLink></td>
+							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(p.amount) }}</td>
+						</tr>
+					</tbody>
+				</table>
+			</section>
+		</div>
+
+		<!-- Receive payment modal -->
+		<div v-if="rec.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="rec.open = false">
+			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
+				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Receive payment</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="rec.open = false">✕</button></header>
+				<div class="px-4 py-4 space-y-3">
+					<div class="text-sm text-ink-700">From <span class="font-medium">{{ inv.customer_name }}</span> against <span class="font-mono text-xs">{{ inv.name }}</span>. Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(payment.outstanding) }}</span>.</div>
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Amount" required><DeskInput v-model.number="rec.amount" type="number" min="0" /></DeskField>
+						<DeskField label="Date"><DeskInput v-model="rec.date" type="date" /></DeskField>
+					</div>
+					<DeskField label="Deposit into" required>
+						<DeskSelect v-model="rec.deposit_to"><option value="" disabled>Bank / Cash account…</option><option v-for="a in depositAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+					</DeskField>
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Mode of payment"><DeskSelect v-model="rec.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
+						<DeskField label="Reference no."><DeskInput v-model="rec.reference_no" placeholder="UTR / cheque no." /></DeskField>
+					</div>
+				</div>
+				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
+					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="rec.open = false">Cancel</button>
+					<button type="button" class="text-xs desk-save-btn" :disabled="rec.saving" @click="saveReceive">{{ rec.saving ? "Receiving…" : "Record receipt" }}</button>
+				</footer>
+			</div>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceInvoiceFormView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceFormView.vue
@@ -1,0 +1,146 @@
+<script setup>
+// Project Finance › Invoice form — a full PAGE (not a modal), for create
+// (/project-finance/invoices/new) and edit of a Draft (/project-finance/invoices/:id/edit;
+// a non-Draft bounces to the detail page). Saves a draft Sales Invoice via api.invoice.
+import { computed, reactive, ref } from "vue";
+import { useRouter } from "vue-router";
+import { showToast } from "@/utils/appToast";
+import { getInvoice, saveInvoice, listInvoiceTaxTemplates } from "@/data/invoiceApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { activeCompanyFilter } from "@/composables/useActiveCompany";
+import { fmtINR } from "@/utils/format";
+
+const props = defineProps({ id: { type: String, default: "" } });
+const router = useRouter();
+const companyFilter = activeCompanyFilter();
+const isEdit = computed(() => !!props.id);
+
+function newLine() {
+	return { description: "", qty: 1, rate: null };
+}
+const form = reactive({
+	customer: "",
+	project: "",
+	date: new Date().toISOString().slice(0, 10),
+	due_date: new Date(Date.now() + 30 * 86400000).toISOString().slice(0, 10),
+	taxes_and_charges: "",
+	lines: [newLine()],
+	saving: false,
+});
+const taxTemplates = ref([]);
+const loading = ref(isEdit.value);
+
+listInvoiceTaxTemplates()
+	.then((r) => (taxTemplates.value = r || []))
+	.catch(() => {});
+
+if (isEdit.value) {
+	getInvoice(props.id)
+		.then((inv) => {
+			if (inv.docstatus !== 0) {
+				router.replace(`/project-finance/invoices/${props.id}`);
+				return;
+			}
+			Object.assign(form, {
+				customer: inv.customer,
+				project: inv.project || "",
+				date: inv.date,
+				due_date: inv.due_date || "",
+				taxes_and_charges: inv.taxes_and_charges || "",
+				lines: (inv.items || []).map((l) => ({ description: l.description, qty: l.qty ?? 1, rate: l.rate })),
+			});
+			if (!form.lines.length) form.lines = [newLine()];
+		})
+		.catch((err) => showToast(err.message || "Failed to load invoice", "error"))
+		.finally(() => (loading.value = false));
+}
+
+const subtotal = computed(() => form.lines.reduce((a, l) => a + (Number(l.qty) || 0) * (Number(l.rate) || 0), 0));
+
+const breadcrumbs = computed(() => [
+	{ label: "Project Finance", to: "/project-finance" },
+	{ label: "Invoices", to: "/project-finance/invoices" },
+	{ label: isEdit.value ? `Edit ${props.id}` : "New" },
+]);
+
+function goBack() {
+	router.push(isEdit.value ? `/project-finance/invoices/${props.id}` : "/project-finance/invoices");
+}
+async function save() {
+	if (!form.customer) return showToast("Pick a customer.", "error");
+	const lines = form.lines.filter((l) => Number(l.rate) > 0);
+	if (!lines.length) return showToast("Add at least one line with an amount.", "error");
+	form.saving = true;
+	try {
+		const res = await saveInvoice({
+			name: isEdit.value ? props.id : undefined,
+			customer: form.customer,
+			project: form.project || undefined,
+			date: form.date,
+			due_date: form.due_date || undefined,
+			taxes_and_charges: form.taxes_and_charges || undefined,
+			items: lines.map((l) => ({ description: l.description, qty: Number(l.qty) || 1, rate: Number(l.rate) })),
+		});
+		showToast(isEdit.value ? "Invoice updated." : "Invoice saved as draft.");
+		router.push(`/project-finance/invoices/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Failed to save", "error");
+	} finally {
+		form.saving = false;
+	}
+}
+</script>
+
+<template>
+	<DeskPage :title="isEdit ? `Edit ${id}` : 'New invoice'" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<div class="flex items-center gap-2">
+				<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="goBack">Cancel</button>
+				<button type="button" class="text-xs desk-save-btn" :disabled="form.saving || loading" @click="save">{{ form.saving ? "Saving…" : isEdit ? "Save" : "Save as draft" }}</button>
+			</div>
+		</template>
+
+		<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Loading…</div>
+		<div v-else class="max-w-3xl space-y-4">
+			<section class="bg-white border border-ink-200 rounded-lg p-4 space-y-3">
+				<div class="grid grid-cols-2 gap-3">
+					<DeskField label="Customer" required><DeskLinkPicker v-model="form.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" /></DeskField>
+					<DeskField label="Project"><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Optional…" /></DeskField>
+				</div>
+				<div class="grid grid-cols-3 gap-3">
+					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
+					<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
+					<DeskField label="Tax"><DeskSelect v-model="form.taxes_and_charges"><option value="">No tax</option><option v-for="t in taxTemplates" :key="t.name" :value="t.name">{{ t.title || t.name }}</option></DeskSelect></DeskField>
+				</div>
+			</section>
+
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Items</h3></div>
+				<table class="w-full text-xs">
+					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-16">Qty</th><th class="text-right px-3 py-2 w-28">Rate</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
+					<tbody>
+						<tr v-for="(l, idx) in form.lines" :key="idx" class="border-t border-ink-100">
+							<td class="px-2 py-1"><input v-model="l.description" type="text" placeholder="What is billed?" class="w-full px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none" /></td>
+							<td class="px-2 py-1"><input v-model.number="l.qty" type="number" min="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
+							<td class="px-2 py-1"><input v-model.number="l.rate" type="number" min="0" placeholder="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
+							<td class="px-3 py-1 text-right tabular-nums text-ink-700">{{ fmtINR((Number(l.qty) || 0) * (Number(l.rate) || 0)) }}</td>
+							<td class="px-2 py-1 text-center"><button v-if="form.lines.length > 1" type="button" class="text-ink-400 hover:text-danger-600" @click="form.lines.splice(idx, 1)">✕</button></td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr class="border-t border-ink-200 bg-ink-50/40">
+							<td colspan="3" class="px-3 py-2"><button type="button" class="text-[11px] text-brand-700 hover:underline" @click="form.lines.push(newLine())">+ Add line</button></td>
+							<td class="px-3 py-2 text-right tabular-nums font-semibold text-ink-900">{{ fmtINR(subtotal) }}</td>
+							<td></td>
+						</tr>
+					</tfoot>
+				</table>
+			</section>
+			<p class="text-[11px] text-ink-400">Any tax is applied on save; the subtotal above is before tax.</p>
+		</div>
+	</DeskPage>
+</template>

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -9,7 +9,6 @@ import {
 	listInvoices,
 	saveInvoice,
 	submitInvoice,
-	cancelInvoice,
 	deleteInvoice,
 	recordInvoiceReceipt,
 	listDepositAccounts,
@@ -146,23 +145,6 @@ async function onSubmit(inv) {
 		showToast(err.message || "Submit failed", "error");
 	}
 }
-async function onCancel(inv) {
-	const ok = await confirmDialog({
-		title: "Cancel invoice?",
-		message: `Cancel ${inv.name}? Its receivable and any allocations are reversed.`,
-		confirmLabel: "Cancel invoice",
-		cancelLabel: "Keep",
-		destructive: true,
-	});
-	if (!ok) return;
-	try {
-		await cancelInvoice(inv.name);
-		await load();
-		showToast("Cancelled.");
-	} catch (err) {
-		showToast(err.message || "Cancel failed", "error");
-	}
-}
 async function onDelete(inv) {
 	const ok = await confirmDialog({ title: "Delete draft?", message: `Permanently delete ${inv.name}?`, confirmLabel: "Delete", destructive: true });
 	if (!ok) return;
@@ -271,7 +253,6 @@ async function saveReceive() {
 								<button v-if="i.docstatus === 0" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onSubmit(i)">Submit</button>
 								<button v-if="i.docstatus === 0" type="button" class="text-[11px] px-2 py-0.5 ml-1 text-danger-600 hover:underline" @click="onDelete(i)">Delete</button>
 								<button v-if="i.docstatus === 1 && i.outstanding > 0.01" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openReceive(i)">Receive</button>
-								<button v-if="i.docstatus === 1" type="button" class="text-[11px] px-2 py-0.5 ml-1 border border-warning-300 bg-warning-50 text-warning-700 rounded" @click="onCancel(i)">Cancel</button>
 							</td>
 						</tr>
 					</tbody>

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -7,12 +7,10 @@ import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import {
 	listInvoices,
-	saveInvoice,
 	recordInvoiceReceipt,
 	recordCustomerAdvance,
 	invoiceAdvancesSummary,
 	listDepositAccounts,
-	listInvoiceTaxTemplates,
 	listInvoicePaymentModes,
 } from "@/data/invoiceApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -21,12 +19,10 @@ import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
-import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
 const router = useRouter();
-const companyFilter = activeCompanyFilter();
 
 const invoices = ref([]);
 const advancesTotal = ref(0);
@@ -84,55 +80,9 @@ const rows = computed(() => {
 	);
 });
 
-// --- create form ---
-const modalOpen = ref(false);
-const taxTemplates = ref([]);
-const form = reactive({ customer: "", project: "", date: "", due_date: "", taxes_and_charges: "", lines: [], saving: false });
-function newLine() {
-	return { description: "", qty: 1, rate: null };
-}
-async function openNew() {
-	Object.assign(form, {
-		customer: "",
-		project: "",
-		date: new Date().toISOString().slice(0, 10),
-		due_date: "",
-		taxes_and_charges: "",
-		lines: [newLine()],
-		saving: false,
-	});
-	modalOpen.value = true;
-	if (!taxTemplates.value.length) {
-		try {
-			taxTemplates.value = await listInvoiceTaxTemplates();
-		} catch {
-			/* optional */
-		}
-	}
-}
-const formSubtotal = computed(() => form.lines.reduce((a, l) => a + (Number(l.qty) || 0) * (Number(l.rate) || 0), 0));
-async function save() {
-	if (!form.customer) return showToast("Pick a customer.", "error");
-	const lines = form.lines.filter((l) => Number(l.rate) > 0);
-	if (!lines.length) return showToast("Add at least one line with an amount.", "error");
-	form.saving = true;
-	try {
-		await saveInvoice({
-			customer: form.customer,
-			project: form.project || undefined,
-			date: form.date,
-			due_date: form.due_date || undefined,
-			taxes_and_charges: form.taxes_and_charges || undefined,
-			items: lines.map((l) => ({ description: l.description, qty: Number(l.qty) || 1, rate: Number(l.rate) })),
-		});
-		modalOpen.value = false;
-		await load();
-		showToast("Invoice saved as draft.");
-	} catch (err) {
-		showToast(err.message || "Failed to save", "error");
-	} finally {
-		form.saving = false;
-	}
+// --- create: full-page form ---
+function openNew() {
+	router.push("/project-finance/invoices/new");
 }
 
 // --- record customer advance (on-account receipt) ---
@@ -282,51 +232,6 @@ async function saveReceive() {
 				</table>
 				<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "No invoices yet." }}</div>
 			</section>
-		</div>
-
-		<!-- New invoice modal -->
-		<div v-if="modalOpen" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="modalOpen = false">
-			<div class="bg-white border border-ink-200 w-full max-w-2xl shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">New invoice</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="modalOpen = false">✕</button></header>
-				<div class="px-4 py-4 space-y-3">
-					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Customer" required><DeskLinkPicker v-model="form.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" /></DeskField>
-						<DeskField label="Project"><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Optional…" /></DeskField>
-					</div>
-					<div class="grid grid-cols-3 gap-3">
-						<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
-						<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
-						<DeskField label="Tax"><DeskSelect v-model="form.taxes_and_charges"><option value="">No tax</option><option v-for="t in taxTemplates" :key="t.name" :value="t.name">{{ t.title || t.name }}</option></DeskSelect></DeskField>
-					</div>
-
-					<div class="border border-ink-200 rounded-lg overflow-hidden">
-						<table class="w-full text-xs">
-							<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-16">Qty</th><th class="text-right px-3 py-2 w-28">Rate</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
-							<tbody>
-								<tr v-for="(l, idx) in form.lines" :key="idx" class="border-t border-ink-100">
-									<td class="px-2 py-1"><input v-model="l.description" type="text" placeholder="What is billed?" class="w-full px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none" /></td>
-									<td class="px-2 py-1"><input v-model.number="l.qty" type="number" min="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
-									<td class="px-2 py-1"><input v-model.number="l.rate" type="number" min="0" placeholder="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
-									<td class="px-3 py-1 text-right tabular-nums text-ink-700">{{ fmtINR((Number(l.qty) || 0) * (Number(l.rate) || 0)) }}</td>
-									<td class="px-2 py-1 text-center"><button v-if="form.lines.length > 1" type="button" class="text-ink-400 hover:text-danger-600" @click="form.lines.splice(idx, 1)">✕</button></td>
-								</tr>
-							</tbody>
-							<tfoot>
-								<tr class="border-t border-ink-200 bg-ink-50/40">
-									<td colspan="3" class="px-3 py-2"><button type="button" class="text-[11px] text-brand-700 hover:underline" @click="form.lines.push(newLine())">+ Add line</button></td>
-									<td class="px-3 py-2 text-right tabular-nums font-semibold text-ink-900">{{ fmtINR(formSubtotal) }}</td>
-									<td></td>
-								</tr>
-							</tfoot>
-						</table>
-					</div>
-					<p class="text-[11px] text-ink-400">Any tax is applied on save; the subtotal above is before tax.</p>
-				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="modalOpen = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="form.saving" @click="save">{{ form.saving ? "Saving…" : "Save as draft" }}</button>
-				</footer>
-			</div>
 		</div>
 
 		<!-- Receive payment modal -->

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -1,81 +1,352 @@
 <script setup>
+// Project Finance › Invoices — LIVE over ERPNext Sales Invoice (money in). An invoice IS a
+// Sales Invoice: create a draft, submit (posts the receivable), and receive payments (a real
+// Payment Entry into a Bank/Cash account). docstatus lifecycle: Draft → Submitted → Cancelled.
 import { computed, reactive, ref } from "vue";
-import { useFinanceMock } from "@/data/financeMock";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import {
+	listInvoices,
+	saveInvoice,
+	submitInvoice,
+	cancelInvoice,
+	deleteInvoice,
+	recordInvoiceReceipt,
+	listDepositAccounts,
+	listInvoiceTaxTemplates,
+	listInvoicePaymentModes,
+} from "@/data/invoiceApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
-const fin = useFinanceMock();
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
-const rows = computed(() => fin.invoices);
+const confirmDialog = useConfirm();
+const companyFilter = activeCompanyFilter();
 
-const form = reactive({ open: false, customer: "", project: "", date: new Date().toISOString().slice(0, 10), due_date: "", gst_rate: 18, description: "", amount: 0 });
-function createInvoice() {
-	if (!form.customer || !(Number(form.amount) > 0)) return;
-	fin.addInvoice({ customer: form.customer, project: form.project, date: form.date, due_date: form.due_date, gst_rate: Number(form.gst_rate), lines: [{ id: "l", description: form.description, amount: Number(form.amount) }] });
-	form.open = false;
+const invoices = ref([]);
+const loading = ref(true);
+async function load() {
+	loading.value = true;
+	try {
+		invoices.value = await listInvoices();
+	} catch (err) {
+		showToast(err.message || "Failed to load invoices", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+load();
+
+const totalOutstanding = computed(() => invoices.value.reduce((a, i) => a + (Number(i.outstanding) || 0), 0));
+
+// --- aging (submitted + still owed) ---
+function daysOverdue(due) {
+	if (!due) return 0;
+	return Math.floor((Date.now() - new Date(due).getTime()) / 86400000);
+}
+function aging(inv) {
+	if (inv.docstatus !== 1 || !(Number(inv.outstanding) > 0.01)) return null;
+	const d = daysOverdue(inv.due_date);
+	if (d <= 0) return { label: "Not due", cls: "bg-ink-100 text-ink-500" };
+	const bucket = d <= 30 ? "0–30" : d <= 60 ? "31–60" : d <= 90 ? "61–90" : "90+";
+	const cls = d <= 30 ? "bg-warning-50 text-warning-700" : "bg-danger-50 text-danger-700";
+	return { label: `${bucket} d`, cls };
 }
 
-const pay = reactive({ open: false, inv: null, amount: 0, account: "" });
-function openReceive(inv) { Object.assign(pay, { open: true, inv, amount: fin.invoiceOutstanding(inv), account: fin.financeAccounts[0]?.id || "" }); }
-function receive() {
-	if (!(Number(pay.amount) > 0) || !pay.account) return;
-	fin.addInvoiceReceipt(pay.inv.id, pay.amount, pay.account);
-	pay.open = false;
+// --- filters ---
+const search = ref("");
+const statusFilter = ref("");
+const hasFilters = computed(() => search.value || statusFilter.value);
+function clearFilters() {
+	search.value = "";
+	statusFilter.value = "";
+}
+const rows = computed(() => {
+	const term = search.value.trim().toLowerCase();
+	return invoices.value.filter(
+		(i) =>
+			(!statusFilter.value || i.status === statusFilter.value) &&
+			(!term ||
+				i.name.toLowerCase().includes(term) ||
+				(i.customer_name || "").toLowerCase().includes(term) ||
+				(i.project_name || "").toLowerCase().includes(term)),
+	);
+});
+
+// --- create form ---
+const modalOpen = ref(false);
+const taxTemplates = ref([]);
+const form = reactive({ customer: "", project: "", date: "", due_date: "", taxes_and_charges: "", lines: [], saving: false });
+function newLine() {
+	return { description: "", qty: 1, rate: null };
+}
+async function openNew() {
+	Object.assign(form, {
+		customer: "",
+		project: "",
+		date: new Date().toISOString().slice(0, 10),
+		due_date: "",
+		taxes_and_charges: "",
+		lines: [newLine()],
+		saving: false,
+	});
+	modalOpen.value = true;
+	if (!taxTemplates.value.length) {
+		try {
+			taxTemplates.value = await listInvoiceTaxTemplates();
+		} catch {
+			/* optional */
+		}
+	}
+}
+const formSubtotal = computed(() => form.lines.reduce((a, l) => a + (Number(l.qty) || 0) * (Number(l.rate) || 0), 0));
+async function save() {
+	if (!form.customer) return showToast("Pick a customer.", "error");
+	const lines = form.lines.filter((l) => Number(l.rate) > 0);
+	if (!lines.length) return showToast("Add at least one line with an amount.", "error");
+	form.saving = true;
+	try {
+		await saveInvoice({
+			customer: form.customer,
+			project: form.project || undefined,
+			date: form.date,
+			due_date: form.due_date || undefined,
+			taxes_and_charges: form.taxes_and_charges || undefined,
+			items: lines.map((l) => ({ description: l.description, qty: Number(l.qty) || 1, rate: Number(l.rate) })),
+		});
+		modalOpen.value = false;
+		await load();
+		showToast("Invoice saved as draft.");
+	} catch (err) {
+		showToast(err.message || "Failed to save", "error");
+	} finally {
+		form.saving = false;
+	}
+}
+
+// --- docstatus actions ---
+async function onSubmit(inv) {
+	const ok = await confirmDialog({
+		title: "Submit invoice?",
+		message: `Submit ${inv.name} (${fmtINR(inv.total)})? It posts the receivable and can then be paid.`,
+		confirmLabel: "Submit",
+	});
+	if (!ok) return;
+	try {
+		await submitInvoice(inv.name);
+		await load();
+		showToast("Submitted.");
+	} catch (err) {
+		showToast(err.message || "Submit failed", "error");
+	}
+}
+async function onCancel(inv) {
+	const ok = await confirmDialog({
+		title: "Cancel invoice?",
+		message: `Cancel ${inv.name}? Its receivable and any allocations are reversed.`,
+		confirmLabel: "Cancel invoice",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await cancelInvoice(inv.name);
+		await load();
+		showToast("Cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	}
+}
+async function onDelete(inv) {
+	const ok = await confirmDialog({ title: "Delete draft?", message: `Permanently delete ${inv.name}?`, confirmLabel: "Delete", destructive: true });
+	if (!ok) return;
+	try {
+		await deleteInvoice(inv.name);
+		await load();
+		showToast("Deleted.");
+	} catch (err) {
+		showToast(err.message || "Delete failed", "error");
+	}
+}
+
+// --- receive payment ---
+const rec = reactive({ open: false, inv: null, amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const depositAccounts = ref([]);
+const payModes = ref([]);
+async function openReceive(inv) {
+	if (!depositAccounts.value.length) {
+		try {
+			[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
+		} catch {
+			/* fall through */
+		}
+	}
+	Object.assign(rec, {
+		open: true,
+		inv,
+		amount: Number(inv.outstanding) || null,
+		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		date: new Date().toISOString().slice(0, 10),
+		mode_of_payment: payModes.value[0] || "",
+		reference_no: "",
+		saving: false,
+	});
+}
+async function saveReceive() {
+	const amt = Number(rec.amount) || 0;
+	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
+	if (amt > Number(rec.inv.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(rec.inv.outstanding)}.`, "error");
+	if (!rec.deposit_to) return showToast("Pick the account to deposit into.", "error");
+	rec.saving = true;
+	try {
+		await recordInvoiceReceipt({
+			name: rec.inv.name,
+			amount: amt,
+			date: rec.date,
+			mode_of_payment: rec.mode_of_payment || undefined,
+			deposit_to: rec.deposit_to,
+			reference_no: rec.reference_no || undefined,
+		});
+		rec.open = false;
+		await load();
+		showToast("Payment received.");
+	} catch (err) {
+		showToast(err.message || "Receipt failed", "error");
+	} finally {
+		rec.saving = false;
+	}
 }
 </script>
 
 <template>
 	<DeskPage title="Invoices" :breadcrumbs="breadcrumbs">
-		<template #actions><button class="desk-save-btn" @click="form.open = true">+ New Invoice</button></template>
-		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
-			<table class="w-full text-xs" style="min-width: 720px">
-				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
-					<tr><th class="text-left px-3 py-2">Invoice</th><th class="text-left px-3 py-2">Customer</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-left px-3 py-2">Status</th><th></th></tr>
-				</thead>
-				<tbody>
-					<tr v-for="i in rows" :key="i.id" class="border-t border-ink-100">
-						<td class="px-3 py-2 font-mono text-[11px]">{{ i.id }}</td>
-						<td class="px-3 py-2 text-ink-900">{{ fin.customerById(i.customer)?.name || i.customer }}</td>
-						<td class="px-3 py-2 text-ink-500">{{ fin.projectName(i.project) }}</td>
-						<td class="px-3 py-2 text-ink-500">{{ fmtDate(i.due_date) }}</td>
-						<td class="px-3 py-2 text-ink-600">{{ fin.agingBucket(i.due_date) }}</td>
-						<td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(i.total) }}</td>
-						<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(fin.invoiceOutstanding(i)) }}</td>
-						<td class="px-3 py-2"><StatusBadge :status="i.workflow_state" /></td>
-						<td class="px-3 py-2 text-right"><button v-if="fin.invoiceOutstanding(i) > 0.5" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openReceive(i)">Receive</button></td>
-					</tr>
-				</tbody>
-			</table>
+		<template #actions><button type="button" class="desk-save-btn" @click="openNew">+ New invoice</button></template>
+
+		<div class="space-y-4">
+			<div class="flex items-center gap-4 text-sm">
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Outstanding receivable</div>
+					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(totalOutstanding) }}</div>
+				</div>
+			</div>
+
+			<!-- filters -->
+			<div class="flex items-center gap-2 flex-wrap">
+				<input v-model="search" type="text" placeholder="Search invoice, customer, project…" class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-72 max-w-full" />
+				<select v-model="statusFilter" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+					<option value="">All statuses</option>
+					<option value="Draft">Draft</option>
+					<option value="Unpaid">Unpaid</option>
+					<option value="Partly Paid">Partly Paid</option>
+					<option value="Paid">Paid</option>
+					<option value="Cancelled">Cancelled</option>
+				</select>
+				<button v-if="hasFilters" type="button" class="text-[11px] text-danger-600 hover:underline" @click="clearFilters">Clear filters</button>
+				<span class="text-[11px] text-ink-400 ml-auto">{{ rows.length }} invoice{{ rows.length === 1 ? "" : "s" }}</span>
+			</div>
+
+			<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+				<table v-if="rows.length" class="w-full text-xs" style="min-width: 760px">
+					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200">
+						<tr><th class="text-left px-3 py-2">Invoice</th><th class="text-left px-3 py-2">Customer</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-left px-3 py-2">Status</th><th class="px-3 py-2"></th></tr>
+					</thead>
+					<tbody>
+						<tr v-for="i in rows" :key="i.name" class="border-t border-ink-100 hover:bg-brand-50/30">
+							<td class="px-3 py-2 font-mono text-[11px] text-ink-500">{{ i.name }}</td>
+							<td class="px-3 py-2 text-ink-900">{{ i.customer_name }}</td>
+							<td class="px-3 py-2 text-ink-500">{{ i.project_name || "—" }}</td>
+							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(i.date) }}</td>
+							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(i.due_date) }}</td>
+							<td class="px-3 py-2"><span v-if="aging(i)" class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="aging(i).cls">{{ aging(i).label }}</span><span v-else class="text-ink-300">—</span></td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900">{{ fmtINR(i.total) }}</td>
+							<td class="px-3 py-2 text-right tabular-nums font-medium" :class="i.outstanding > 0.01 ? 'text-ink-900' : 'text-ink-400'">{{ fmtINR(i.outstanding) }}</td>
+							<td class="px-3 py-2"><StatusBadge :status="i.status" size="xs" /></td>
+							<td class="px-3 py-2 text-right whitespace-nowrap">
+								<button v-if="i.docstatus === 0" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onSubmit(i)">Submit</button>
+								<button v-if="i.docstatus === 0" type="button" class="text-[11px] px-2 py-0.5 ml-1 text-danger-600 hover:underline" @click="onDelete(i)">Delete</button>
+								<button v-if="i.docstatus === 1 && i.outstanding > 0.01" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openReceive(i)">Receive</button>
+								<button v-if="i.docstatus === 1" type="button" class="text-[11px] px-2 py-0.5 ml-1 border border-warning-300 bg-warning-50 text-warning-700 rounded" @click="onCancel(i)">Cancel</button>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "No invoices yet." }}</div>
+			</section>
 		</div>
 
-		<div v-if="form.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="form.open = false">
-			<div class="bg-white rounded-lg shadow-xl w-full max-w-lg p-5">
-				<h3 class="text-sm font-semibold text-ink-900 mb-4">New invoice</h3>
-				<div class="grid grid-cols-2 gap-3">
-					<DeskField label="Customer" required><DeskSelect v-model="form.customer"><option value="">—</option><option v-for="c in fin.customers" :key="c.id" :value="c.id">{{ c.name }}</option></DeskSelect></DeskField>
-					<DeskField label="Project"><DeskSelect v-model="form.project"><option value="">—</option><option v-for="p in fin.projects" :key="p.id" :value="p.id">{{ p.name }}</option></DeskSelect></DeskField>
-					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
-					<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
-					<DeskField label="GST %"><DeskInput v-model.number="form.gst_rate" type="number" /></DeskField>
-					<DeskField label="Amount" required><DeskInput v-model.number="form.amount" type="number" /></DeskField>
-					<DeskField label="Description" class="col-span-2"><DeskInput v-model="form.description" /></DeskField>
+		<!-- New invoice modal -->
+		<div v-if="modalOpen" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="modalOpen = false">
+			<div class="bg-white border border-ink-200 w-full max-w-2xl shadow-xl rounded-xl" @click.stop>
+				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">New invoice</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="modalOpen = false">✕</button></header>
+				<div class="px-4 py-4 space-y-3">
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Customer" required><DeskLinkPicker v-model="form.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" /></DeskField>
+						<DeskField label="Project"><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Optional…" /></DeskField>
+					</div>
+					<div class="grid grid-cols-3 gap-3">
+						<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
+						<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
+						<DeskField label="Tax"><DeskSelect v-model="form.taxes_and_charges"><option value="">No tax</option><option v-for="t in taxTemplates" :key="t.name" :value="t.name">{{ t.title || t.name }}</option></DeskSelect></DeskField>
+					</div>
+
+					<div class="border border-ink-200 rounded-lg overflow-hidden">
+						<table class="w-full text-xs">
+							<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-16">Qty</th><th class="text-right px-3 py-2 w-28">Rate</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
+							<tbody>
+								<tr v-for="(l, idx) in form.lines" :key="idx" class="border-t border-ink-100">
+									<td class="px-2 py-1"><input v-model="l.description" type="text" placeholder="What is billed?" class="w-full px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none" /></td>
+									<td class="px-2 py-1"><input v-model.number="l.qty" type="number" min="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
+									<td class="px-2 py-1"><input v-model.number="l.rate" type="number" min="0" placeholder="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
+									<td class="px-3 py-1 text-right tabular-nums text-ink-700">{{ fmtINR((Number(l.qty) || 0) * (Number(l.rate) || 0)) }}</td>
+									<td class="px-2 py-1 text-center"><button v-if="form.lines.length > 1" type="button" class="text-ink-400 hover:text-danger-600" @click="form.lines.splice(idx, 1)">✕</button></td>
+								</tr>
+							</tbody>
+							<tfoot>
+								<tr class="border-t border-ink-200 bg-ink-50/40">
+									<td colspan="3" class="px-3 py-2"><button type="button" class="text-[11px] text-brand-700 hover:underline" @click="form.lines.push(newLine())">+ Add line</button></td>
+									<td class="px-3 py-2 text-right tabular-nums font-semibold text-ink-900">{{ fmtINR(formSubtotal) }}</td>
+									<td></td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+					<p class="text-[11px] text-ink-400">Any tax is applied on save; the subtotal above is before tax.</p>
 				</div>
-				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="form.open = false">Cancel</button><button class="desk-save-btn" @click="createInvoice">Create</button></div>
+				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
+					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="modalOpen = false">Cancel</button>
+					<button type="button" class="text-xs desk-save-btn" :disabled="form.saving" @click="save">{{ form.saving ? "Saving…" : "Save as draft" }}</button>
+				</footer>
 			</div>
 		</div>
 
-		<div v-if="pay.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="pay.open = false">
-			<div class="bg-white rounded-lg shadow-xl w-full max-w-sm p-5">
-				<h3 class="text-sm font-semibold text-ink-900 mb-4">Receive payment</h3>
-				<div class="space-y-3">
-					<DeskField label="Amount"><DeskInput v-model.number="pay.amount" type="number" /></DeskField>
-					<DeskField label="Into account"><DeskSelect v-model="pay.account"><option v-for="a in fin.financeAccounts" :key="a.id" :value="a.id">{{ a.name }}</option></DeskSelect></DeskField>
+		<!-- Receive payment modal -->
+		<div v-if="rec.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="rec.open = false">
+			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
+				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Receive payment</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="rec.open = false">✕</button></header>
+				<div class="px-4 py-4 space-y-3">
+					<div class="text-sm text-ink-700">From <span class="font-medium">{{ rec.inv?.customer_name }}</span> against <span class="font-mono text-xs">{{ rec.inv?.name }}</span>. Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(rec.inv?.outstanding) }}</span>.</div>
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Amount" required><DeskInput v-model.number="rec.amount" type="number" min="0" /></DeskField>
+						<DeskField label="Date"><DeskInput v-model="rec.date" type="date" /></DeskField>
+					</div>
+					<DeskField label="Deposit into" required>
+						<DeskSelect v-model="rec.deposit_to"><option value="" disabled>Bank / Cash account…</option><option v-for="a in depositAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+					</DeskField>
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Mode of payment"><DeskSelect v-model="rec.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
+						<DeskField label="Reference no."><DeskInput v-model="rec.reference_no" placeholder="UTR / cheque no." /></DeskField>
+					</div>
 				</div>
-				<div class="flex justify-end gap-2 mt-5"><button class="desk-btn" @click="pay.open = false">Cancel</button><button class="desk-save-btn" @click="receive">Receive</button></div>
+				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
+					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="rec.open = false">Cancel</button>
+					<button type="button" class="text-xs desk-save-btn" :disabled="rec.saving" @click="saveReceive">{{ rec.saving ? "Receiving…" : "Record receipt" }}</button>
+				</footer>
 			</div>
 		</div>
 	</DeskPage>

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -3,14 +3,14 @@
 // Sales Invoice: create a draft, submit (posts the receivable), and receive payments (a real
 // Payment Entry into a Bank/Cash account). docstatus lifecycle: Draft → Submitted → Cancelled.
 import { computed, reactive, ref } from "vue";
-import { useConfirm } from "@/composables/useConfirm";
+import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import {
 	listInvoices,
 	saveInvoice,
-	submitInvoice,
-	deleteInvoice,
 	recordInvoiceReceipt,
+	recordCustomerAdvance,
+	invoiceAdvancesSummary,
 	listDepositAccounts,
 	listInvoiceTaxTemplates,
 	listInvoicePaymentModes,
@@ -25,15 +25,17 @@ import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
-const confirmDialog = useConfirm();
+const router = useRouter();
 const companyFilter = activeCompanyFilter();
 
 const invoices = ref([]);
+const advancesTotal = ref(0);
 const loading = ref(true);
 async function load() {
 	loading.value = true;
 	try {
 		invoices.value = await listInvoices();
+		invoiceAdvancesSummary().then((r) => (advancesTotal.value = Number(r?.total) || 0)).catch(() => {});
 	} catch (err) {
 		showToast(err.message || "Failed to load invoices", "error");
 	} finally {
@@ -41,6 +43,10 @@ async function load() {
 	}
 }
 load();
+
+function openDetail(inv) {
+	router.push(`/project-finance/invoices/${inv.name}`);
+}
 
 const totalOutstanding = computed(() => invoices.value.reduce((a, i) => a + (Number(i.outstanding) || 0), 0));
 
@@ -129,31 +135,41 @@ async function save() {
 	}
 }
 
-// --- docstatus actions ---
-async function onSubmit(inv) {
-	const ok = await confirmDialog({
-		title: "Submit invoice?",
-		message: `Submit ${inv.name} (${fmtINR(inv.total)})? It posts the receivable and can then be paid.`,
-		confirmLabel: "Submit",
-	});
-	if (!ok) return;
-	try {
-		await submitInvoice(inv.name);
-		await load();
-		showToast("Submitted.");
-	} catch (err) {
-		showToast(err.message || "Submit failed", "error");
+// --- record customer advance (on-account receipt) ---
+const adv = reactive({ open: false, customer: "", amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+async function openAdvance() {
+	if (!depositAccounts.value.length) {
+		try {
+			[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
+		} catch {
+			/* fall through */
+		}
 	}
+	Object.assign(adv, {
+		open: true,
+		customer: "",
+		amount: null,
+		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		date: new Date().toISOString().slice(0, 10),
+		mode_of_payment: payModes.value[0] || "",
+		reference_no: "",
+		saving: false,
+	});
 }
-async function onDelete(inv) {
-	const ok = await confirmDialog({ title: "Delete draft?", message: `Permanently delete ${inv.name}?`, confirmLabel: "Delete", destructive: true });
-	if (!ok) return;
+async function saveAdvance() {
+	if (!adv.customer) return showToast("Pick a customer.", "error");
+	if (!(Number(adv.amount) > 0)) return showToast("Enter an amount greater than zero.", "error");
+	if (!adv.deposit_to) return showToast("Pick the account to deposit into.", "error");
+	adv.saving = true;
 	try {
-		await deleteInvoice(inv.name);
+		await recordCustomerAdvance({ customer: adv.customer, amount: Number(adv.amount), date: adv.date, deposit_to: adv.deposit_to, mode_of_payment: adv.mode_of_payment || undefined, reference_no: adv.reference_no || undefined });
+		adv.open = false;
 		await load();
-		showToast("Deleted.");
+		showToast("Advance recorded.");
 	} catch (err) {
-		showToast(err.message || "Delete failed", "error");
+		showToast(err.message || "Failed to record advance", "error");
+	} finally {
+		adv.saving = false;
 	}
 }
 
@@ -208,13 +224,22 @@ async function saveReceive() {
 
 <template>
 	<DeskPage title="Invoices" :breadcrumbs="breadcrumbs">
-		<template #actions><button type="button" class="desk-save-btn" @click="openNew">+ New invoice</button></template>
+		<template #actions>
+			<div class="flex items-center gap-2">
+				<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="openAdvance">Record advance</button>
+				<button type="button" class="desk-save-btn" @click="openNew">+ New invoice</button>
+			</div>
+		</template>
 
 		<div class="space-y-4">
 			<div class="flex items-center gap-4 text-sm">
 				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
 					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Outstanding receivable</div>
 					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(totalOutstanding) }}</div>
+				</div>
+				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Customer advances</div>
+					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(advancesTotal) }}</div>
 				</div>
 			</div>
 
@@ -239,7 +264,7 @@ async function saveReceive() {
 						<tr><th class="text-left px-3 py-2">Invoice</th><th class="text-left px-3 py-2">Customer</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-left px-3 py-2">Status</th><th class="px-3 py-2"></th></tr>
 					</thead>
 					<tbody>
-						<tr v-for="i in rows" :key="i.name" class="border-t border-ink-100 hover:bg-brand-50/30">
+						<tr v-for="i in rows" :key="i.name" class="border-t border-ink-100 hover:bg-brand-50/40 cursor-pointer" @click="openDetail(i)">
 							<td class="px-3 py-2 font-mono text-[11px] text-ink-500">{{ i.name }}</td>
 							<td class="px-3 py-2 text-ink-900">{{ i.customer_name }}</td>
 							<td class="px-3 py-2 text-ink-500">{{ i.project_name || "—" }}</td>
@@ -250,9 +275,7 @@ async function saveReceive() {
 							<td class="px-3 py-2 text-right tabular-nums font-medium" :class="i.outstanding > 0.01 ? 'text-ink-900' : 'text-ink-400'">{{ fmtINR(i.outstanding) }}</td>
 							<td class="px-3 py-2"><StatusBadge :status="i.status" size="xs" /></td>
 							<td class="px-3 py-2 text-right whitespace-nowrap">
-								<button v-if="i.docstatus === 0" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="onSubmit(i)">Submit</button>
-								<button v-if="i.docstatus === 0" type="button" class="text-[11px] px-2 py-0.5 ml-1 text-danger-600 hover:underline" @click="onDelete(i)">Delete</button>
-								<button v-if="i.docstatus === 1 && i.outstanding > 0.01" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click="openReceive(i)">Receive</button>
+								<button v-if="i.docstatus === 1 && i.outstanding > 0.01" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click.stop="openReceive(i)">Receive</button>
 							</td>
 						</tr>
 					</tbody>
@@ -327,6 +350,32 @@ async function saveReceive() {
 				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
 					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="rec.open = false">Cancel</button>
 					<button type="button" class="text-xs desk-save-btn" :disabled="rec.saving" @click="saveReceive">{{ rec.saving ? "Receiving…" : "Record receipt" }}</button>
+				</footer>
+			</div>
+		</div>
+
+		<!-- Record customer advance modal -->
+		<div v-if="adv.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="adv.open = false">
+			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
+				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Record customer advance</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="adv.open = false">✕</button></header>
+				<div class="px-4 py-4 space-y-3">
+					<p class="text-[11px] text-ink-500">Money received before (or without) an invoice — it stays on the customer's account until a later invoice draws it down.</p>
+					<DeskField label="Customer" required><DeskLinkPicker v-model="adv.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" /></DeskField>
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Amount" required><DeskInput v-model.number="adv.amount" type="number" min="0" placeholder="0" /></DeskField>
+						<DeskField label="Date"><DeskInput v-model="adv.date" type="date" /></DeskField>
+					</div>
+					<DeskField label="Deposit into" required>
+						<DeskSelect v-model="adv.deposit_to"><option value="" disabled>Bank / Cash account…</option><option v-for="a in depositAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+					</DeskField>
+					<div class="grid grid-cols-2 gap-3">
+						<DeskField label="Mode of payment"><DeskSelect v-model="adv.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
+						<DeskField label="Reference no."><DeskInput v-model="adv.reference_no" placeholder="UTR / cheque no." /></DeskField>
+					</div>
+				</div>
+				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
+					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="adv.open = false">Cancel</button>
+					<button type="button" class="text-xs desk-save-btn" :disabled="adv.saving" @click="saveAdvance">{{ adv.saving ? "Recording…" : "Record advance" }}</button>
 				</footer>
 			</div>
 		</div>


### PR DESCRIPTION
Makes **Project Finance › Invoices** live (it was mock). An invoice **is** an ERPNext Sales Invoice — no wrapper doctype — so the endpoints drive Sales Invoice directly (the analog of how Subcontractor Bill relates to Purchase Invoice, but simpler).

Functional-first pass, as agreed — end-to-end usable. Full detail page + customer advances come next.

## Backend — `api/invoice.py`
- `list_invoices` — company-scoped list with aging inputs (due date, outstanding) + pay status (Draft/Unpaid/Partly Paid/Paid/Cancelled).
- `save_invoice` — create/edit a **draft** SI: customer, project, dates, line items (qty×rate), optional **Sales Taxes and Charges Template**. Company is the project's, else the default (single-company seam); lines use a generic non-stock service item + the company income account.
- `submit_invoice` / `cancel_invoice` / `delete_invoice`.
- `record_receipt` — a real **Payment Entry** receiving into a **Bank/Cash** account (`deposit_to`), guarded to the invoice's company; `list_receipts`.
- Pickers: `list_deposit_accounts` (Bank/Cash, default company), `list_tax_templates` (Sales), `list_payment_modes`.

## Frontend
- `FinanceInvoicesPanel` wired live: list with **aging buckets** + status + outstanding, filters (search/status), a **create form** (customer, project, dates, tax, add/remove line items with running subtotal), Submit/Cancel/Delete, and an inline **Receive Payment** modal (amount, Bank/Cash deposit, date, mode, reference).
- `invoiceApi.js` wrappers.

## Verification
- `test_invoice` (2) green — create → submit → partial receipt (asserts received/outstanding + the Payment Entry deposits to the chosen account), and draft-has-no-GL-until-submit.
- Frontend builds clean.

## Deferred (next pass)
- Full-page invoice **detail** view + payments history table.
- **Customer advances** capture.
- Richer multi-tax / discount waterfall (currently one Sales tax template).