### PR TITLE
feat: View Ledger button on the Petty Cash Request form

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.js
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.js
@@ -146,9 +146,10 @@ function update_child_readonly(frm) {
 // ---------------------------------------------------------------------
 
 function add_ledger_button(frm) {
-	if (!frm.doc.journal_entry) return;
+	// Only once the expense is submitted and has posted its Journal Entry.
+	if (frm.doc.docstatus !== 1 || !frm.doc.journal_entry) return;
 
-	frm.add_custom_button(__("View Ledger"), () => {
+	frm.add_custom_button(__("Ledger"), () => {
 		frappe.set_route("query-report", "General Ledger", {
 			company: frm.doc.company,
 			voucher_no: frm.doc.journal_entry,
@@ -156,7 +157,7 @@ function add_ledger_button(frm) {
 			to_date: frm.doc.date,
 			group_by: "Group by Voucher (Consolidated)",
 		});
-	});
+	}, __("View"));
 
 	frm.add_custom_button(__("Journal Entry"), () => {
 		frappe.set_route("Form", "Journal Entry", frm.doc.journal_entry);

--- a/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.js
+++ b/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+// For license information, please see license.txt
+
+// A disbursed petty cash request has posted a Journal Entry — surface a "View Ledger"
+// button (General Ledger filtered to that voucher) and a quick jump to the JE, mirroring
+// the Expense Entry form.
+frappe.ui.form.on("Petty Cash Request", {
+	refresh(frm) {
+		if (!frm.doc.journal_entry) return;
+
+		frm.add_custom_button(__("View Ledger"), () => {
+			frappe.set_route("query-report", "General Ledger", {
+				company: frm.doc.company,
+				voucher_no: frm.doc.journal_entry,
+				from_date: frm.doc.request_date,
+				to_date: frm.doc.request_date,
+				group_by: "Group by Voucher (Consolidated)",
+			});
+		});
+
+		frm.add_custom_button(
+			__("Journal Entry"),
+			() => frappe.set_route("Form", "Journal Entry", frm.doc.journal_entry),
+			__("View"),
+		);
+	},
+});

--- a/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.js
+++ b/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.js
@@ -1,22 +1,25 @@
 // Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 // For license information, please see license.txt
 
-// A disbursed petty cash request has posted a Journal Entry — surface a "View Ledger"
-// button (General Ledger filtered to that voucher) and a quick jump to the JE, mirroring
-// the Expense Entry form.
+// A disbursed petty cash request has posted a Journal Entry — surface a "View" action group
+// (Ledger + Journal Entry) for it, mirroring the Expense Entry form. Only shown once the
+// request is Disbursed (has a posted JE).
 frappe.ui.form.on("Petty Cash Request", {
 	refresh(frm) {
-		if (!frm.doc.journal_entry) return;
+		if (frm.doc.status !== "Disbursed" || !frm.doc.journal_entry) return;
 
-		frm.add_custom_button(__("View Ledger"), () => {
-			frappe.set_route("query-report", "General Ledger", {
-				company: frm.doc.company,
-				voucher_no: frm.doc.journal_entry,
-				from_date: frm.doc.request_date,
-				to_date: frm.doc.request_date,
-				group_by: "Group by Voucher (Consolidated)",
-			});
-		});
+		frm.add_custom_button(
+			__("Ledger"),
+			() =>
+				frappe.set_route("query-report", "General Ledger", {
+					company: frm.doc.company,
+					voucher_no: frm.doc.journal_entry,
+					from_date: frm.doc.request_date,
+					to_date: frm.doc.request_date,
+					group_by: "Group by Voucher (Consolidated)",
+				}),
+			__("View"),
+		);
 
 		frm.add_custom_button(
 			__("Journal Entry"),


### PR DESCRIPTION
Mirrors the **Expense Entry** form's "View Ledger" action for **Petty Cash Request**.

A disbursed request (one with a posted Journal Entry) now shows:
- **View Ledger** — opens the General Ledger report filtered to that voucher (company + posting date + group by voucher), same as Expense Entry.
- **View → Journal Entry** — a quick jump to the disbursement JE.

## Why this shape
It's a **doctype-level form script** (`doctype/petty_cash_request/petty_cash_request.js`), exactly like `doctype/expense_entry/expense_entry.js` — auto-loaded by Frappe on the form. That makes it **independent of the disburse-button work** (PRs #117/#119, which add a separate `public/js/petty_cash_request.js` via the doctype_js hook); both coexist, and this merges cleanly regardless of which disburse approach you pick.

Needs `bench build` on deploy (new form script).