### PR TITLE
fix: drop Machinery code field (auto-name) and default company on new…

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/machinery/machinery.json
+++ b/buildsuite_core/buildsuite_core/doctype/machinery/machinery.json
@@ -2,12 +2,10 @@
  "actions": [],
  "allow_bulk_edit": 1,
  "allow_rename": 1,
- "autoname": "field:machinery_code",
  "creation": "2026-07-26 12:31:17.175094",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
-  "machinery_code",
   "section_break_iczz",
   "machinery_name",
   "rate",
@@ -22,13 +20,6 @@
   "company"
  ],
  "fields": [
-  {
-   "fieldname": "machinery_code",
-   "fieldtype": "Data",
-   "label": "Machinery Code",
-   "reqd": 1,
-   "unique": 1
-  },
   {
    "fieldname": "machinery_name",
    "fieldtype": "Data",
@@ -101,11 +92,10 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-26 22:22:36.482000",
+ "modified": "2026-07-30 19:51:17.006494",
  "modified_by": "Administrator",
  "module": "BuildSuite Core",
  "name": "Machinery",
- "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {

--- a/buildsuite_core/buildsuite_core/doctype/machinery/machinery.py
+++ b/buildsuite_core/buildsuite_core/doctype/machinery/machinery.py
@@ -16,7 +16,6 @@ class Machinery(Document):
 
 		asset: DF.Link | None
 		company: DF.Link
-		machinery_code: DF.Data
 		machinery_name: DF.Data
 		machinery_type: DF.Link
 		owner_vendor: DF.Data | None

--- a/frontend/src/data/companyApi.js
+++ b/frontend/src/data/companyApi.js
@@ -1,0 +1,15 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+async function call(method) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.company.${method}`,
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+// The logged-in user's default company (User → user default → site default).
+export const getActiveCompany = () => call("active_company");

--- a/frontend/src/views/MachineryDetailView.vue
+++ b/frontend/src/views/MachineryDetailView.vue
@@ -24,7 +24,6 @@ const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
 const { errors, applyServerErrors, setErrors } = useFormErrors({
-	machinery_code: "machinery_code",
 	machinery_name: "machinery_name",
 	machinery_type: "machinery_type",
 	company: "company",
@@ -41,7 +40,6 @@ function snapshot() {
 	const d = doc.value;
 	if (!d) return {};
 	return {
-		machinery_code: d.machinery_code || "",
 		machinery_name: d.machinery_name || "",
 		machinery_type: d.machinery_type || "",
 		ownership: d.ownership || "Owned",
@@ -195,9 +193,6 @@ const breadcrumbs = computed(() => [
 		<!-- View mode -->
 		<div v-if="!editing">
 			<DeskSection title="Machinery" :cols="3">
-				<DeskField label="Code"
-					><div class="text-sm font-mono text-ink-900">{{ doc.machinery_code }}</div></DeskField
-				>
 				<DeskField label="Type"
 					><div class="text-sm text-ink-700">{{ doc.machinery_type || "—" }}</div></DeskField
 				>
@@ -258,9 +253,6 @@ const breadcrumbs = computed(() => [
 		<!-- Edit mode -->
 		<div v-else>
 			<DeskSection title="Machinery" :cols="3">
-				<DeskField label="Code" hint="Record ID — cannot be changed">
-					<div class="text-sm font-mono text-ink-500">{{ doc.machinery_code }}</div>
-				</DeskField>
 				<DeskField label="Name" required :error="errors.machinery_name"
 					><DeskInput v-model="form.machinery_name"
 				/></DeskField>

--- a/frontend/src/views/MachineryListView.vue
+++ b/frontend/src/views/MachineryListView.vue
@@ -15,7 +15,6 @@ const router = useRouter();
 const machRes = useDocTypeList("Machinery", {
 	fields: [
 		"name",
-		"machinery_code",
 		"machinery_name",
 		"machinery_type",
 		"ownership",
@@ -37,7 +36,6 @@ const rows = computed(() => {
 	if (q)
 		data = data.filter(
 			(m) =>
-				(m.machinery_code || "").toLowerCase().includes(q) ||
 				(m.machinery_name || "").toLowerCase().includes(q) ||
 				(m.machinery_type || "").toLowerCase().includes(q),
 		);
@@ -45,7 +43,6 @@ const rows = computed(() => {
 });
 
 const columns = [
-	{ key: "machinery_code", label: "Code" },
 	{ key: "machinery_name", label: "Name" },
 	{ key: "machinery_type", label: "Type" },
 	{ key: "ownership", label: "Ownership" },
@@ -76,16 +73,13 @@ function onRowClick(row) {
 			:rows="rows"
 			:columns="columns"
 			row-key="id"
-			search-placeholder="Search code, name, type…"
+			search-placeholder="Search name, type…"
 			@row-click="onRowClick"
 		>
-			<template #cell-machinery_code="{ row }">
-				<DeskLink :to="`/machinery/${row.id}`" class="font-mono text-xs" @click.stop
-					>{{ row.machinery_code }}</DeskLink
-				>
-			</template>
 			<template #cell-machinery_name="{ row }">
-				<span class="text-ink-900 font-medium">{{ row.machinery_name }}</span>
+				<DeskLink :to="`/machinery/${row.id}`" class="font-medium" @click.stop
+					>{{ row.machinery_name }}</DeskLink
+				>
 			</template>
 			<template #cell-machinery_type="{ row }">
 				<span

--- a/frontend/src/views/NewMachineryView.vue
+++ b/frontend/src/views/NewMachineryView.vue
@@ -7,6 +7,7 @@ import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { createDataAdapter } from "@/data/adapters";
+import { getActiveCompany } from "@/data/companyApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
 import DeskActionBar from "@/components/desk/DeskActionBar.vue";
@@ -20,7 +21,6 @@ const router = useRouter();
 const adapter = createDataAdapter(useDataStore());
 
 const form = reactive({
-	machinery_code: "",
 	machinery_name: "",
 	machinery_type: "",
 	ownership: "Owned",
@@ -32,16 +32,21 @@ const form = reactive({
 	company: "",
 });
 const { errors, applyServerErrors, setErrors } = useFormErrors({
-	machinery_code: "machinery_code",
 	machinery_name: "machinery_name",
 	machinery_type: "machinery_type",
 	company: "company",
 });
 const saving = ref(false);
 
+// Prefill the user's default company (editable).
+getActiveCompany()
+	.then((c) => {
+		if (c && !form.company) form.company = c;
+	})
+	.catch(() => {});
+
 function validate() {
 	const e = {};
-	if (!form.machinery_code.trim()) e.machinery_code = "Code is required.";
 	if (!form.machinery_name.trim()) e.machinery_name = "Name is required.";
 	if (!form.machinery_type) e.machinery_type = "Type is required.";
 	if (!form.company) e.company = "Company is required.";
@@ -58,7 +63,6 @@ async function onSave() {
 	saving.value = true;
 	try {
 		const res = await adapter.create("Machinery", {
-			machinery_code: form.machinery_code.trim(),
 			machinery_name: form.machinery_name.trim(),
 			machinery_type: form.machinery_type,
 			ownership: form.ownership,
@@ -98,13 +102,6 @@ const breadcrumbs = [
 			</template>
 
 			<DeskSection title="Machinery" :cols="3">
-				<!-- Code on its own first line -->
-				<div class="md:col-span-2 lg:col-span-3">
-					<DeskField label="Code" required :error="errors.machinery_code">
-						<DeskInput v-model="form.machinery_code" />
-					</DeskField>
-				</div>
-
 				<DeskField label="Name" required :error="errors.machinery_name">
 					<DeskInput v-model="form.machinery_name" />
 				</DeskField>


### PR DESCRIPTION

- Machinery now auto-names (hash) instead of a manual code field
- Removed Code from the register list, detail and new forms
- New Machinery prefills the user's default company via companyApi (frappe-ui)