### PR TITLE
feat: invoice form matches the prototype (full page + taxes/discount/terms)

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -92,6 +92,11 @@ def _serialize(doc):
 		"date": str(doc.posting_date) if doc.posting_date else None,
 		"due_date": str(doc.due_date) if doc.due_date else None,
 		"taxes_and_charges": doc.taxes_and_charges,
+		"additional_discount_on": doc.apply_discount_on or "Net Total",
+		"additional_discount_percentage": doc.additional_discount_percentage,
+		"discount_amount": doc.discount_amount,
+		"terms": doc.terms,
+		"tc_name": doc.tc_name,
 		"docstatus": doc.docstatus,
 		"net_total": doc.net_total,
 		"total_taxes_and_charges": doc.total_taxes_and_charges,
@@ -101,7 +106,7 @@ def _serialize(doc):
 			for r in doc.items
 		],
 		"taxes": [
-			{"description": t.description, "rate": t.rate, "tax_amount": t.tax_amount, "account_head": t.account_head}
+			{"charge_type": t.charge_type, "account_head": t.account_head, "description": t.description, "rate": t.rate, "tax_amount": t.tax_amount}
 			for t in doc.taxes
 		],
 		"payment": _payment_summary(doc.name),
@@ -180,7 +185,9 @@ def get_invoice(name):
 @frappe.whitelist()
 def save_invoice(payload):
 	"""Create or edit a DRAFT Sales Invoice. payload: {name?, customer, project?, date,
-	due_date?, taxes_and_charges?, items:[{description, qty, rate}]}."""
+	due_date?, items:[{description, qty, rate}], taxes_and_charges?, taxes:[{charge_type,
+	account_head, rate, description}], additional_discount_on?, additional_discount_percentage?,
+	discount_amount?, terms?, tc_name?}. Taxes/discount follow the Subcontractor Bill pattern."""
 	data = frappe.parse_json(payload)
 
 	customer = data.get("customer")
@@ -230,19 +237,32 @@ def save_invoice(payload):
 			},
 		)
 
-	template = data.get("taxes_and_charges")
-	if template:
-		si.taxes_and_charges = template
-		for t in frappe.get_doc("Sales Taxes and Charges Template", template).taxes:
-			si.append(
-				"taxes",
-				{
-					"charge_type": t.charge_type or "On Net Total",
-					"account_head": t.account_head,
-					"description": t.description or t.account_head,
-					"rate": flt(t.rate),
-				},
-			)
+	# Taxes: the edited rows if the UI sent any, else expand the chosen template (Bill pattern).
+	si.taxes_and_charges = data.get("taxes_and_charges") or None
+	rows = data.get("taxes")
+	if rows is None and si.taxes_and_charges:
+		rows = get_tax_template_rows(si.taxes_and_charges)
+	for t in rows or []:
+		if not t.get("account_head"):
+			continue
+		si.append(
+			"taxes",
+			{
+				"charge_type": t.get("charge_type") or "On Net Total",
+				"account_head": t.get("account_head"),
+				"description": t.get("description") or t.get("account_head"),
+				"rate": flt(t.get("rate")),
+			},
+		)
+
+	# Discount → native SI fields (percentage OR amount, on Net/Grand Total).
+	si.apply_discount_on = data.get("additional_discount_on") or "Net Total"
+	si.additional_discount_percentage = flt(data.get("additional_discount_percentage"))
+	si.discount_amount = flt(data.get("discount_amount"))
+
+	# Terms & conditions.
+	si.tc_name = data.get("tc_name") or None
+	si.terms = data.get("terms") or None
 
 	si.flags.ignore_permissions = True
 	si.set_missing_values()
@@ -427,6 +447,27 @@ def list_tax_templates(company=None):
 	return frappe.get_all(
 		"Sales Taxes and Charges Template", filters=filters, fields=["name", "title"], order_by="title asc"
 	)
+
+
+@frappe.whitelist()
+def get_tax_template_rows(template):
+	"""Resolve a Sales tax template's rows into the invoice's tax-table shape (Bill pattern)."""
+	doc = frappe.get_doc("Sales Taxes and Charges Template", template)
+	return [
+		{
+			"charge_type": t.charge_type,
+			"account_head": t.account_head,
+			"description": t.description or t.account_head,
+			"rate": t.rate,
+		}
+		for t in doc.taxes
+	]
+
+
+@frappe.whitelist()
+def get_terms(name):
+	"""The body text of a Terms and Conditions template (imported into the invoice terms box)."""
+	return {"terms": frappe.db.get_value("Terms and Conditions", name, "terms") or ""}
 
 
 @frappe.whitelist()

--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -470,10 +470,27 @@ def get_tax_template_rows(template):
 	]
 
 
+def _html_to_text(html):
+	"""Render a Terms & Conditions body (a Text Editor / HTML field) as friendly plain text
+	for the invoice's terms box — block tags become line breaks, remaining tags are stripped.
+	Plain text (no markup) is returned unchanged."""
+	if not html or "<" not in html:
+		return html or ""
+	import html as _html
+	import re
+
+	text = re.sub(r"</(p|div|li|h[1-6]|tr)>", "\n", html, flags=re.I)
+	text = re.sub(r"<br\s*/?>", "\n", text, flags=re.I)
+	text = re.sub(r"<li[^>]*>", "• ", text, flags=re.I)
+	text = re.sub(r"<[^>]+>", "", text)
+	return re.sub(r"\n{3,}", "\n\n", _html.unescape(text)).strip()
+
+
 @frappe.whitelist()
 def get_terms(name):
-	"""The body text of a Terms and Conditions template (imported into the invoice terms box)."""
-	return {"terms": frappe.db.get_value("Terms and Conditions", name, "terms") or ""}
+	"""The body of a Terms and Conditions template as plain text (imported into the invoice
+	terms box). ERPNext stores it as HTML, which is unfriendly to edit — so convert it."""
+	return {"terms": _html_to_text(frappe.db.get_value("Terms and Conditions", name, "terms"))}
 
 
 @frappe.whitelist()

--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -264,6 +264,12 @@ def save_invoice(payload):
 	si.tc_name = data.get("tc_name") or None
 	si.terms = data.get("terms") or None
 
+	# Single-company guard: every tax account must belong to this invoice's company (else the
+	# Sales Invoice rejects it with a cryptic row error).
+	for t in si.taxes:
+		if t.account_head and frappe.db.get_value("Account", t.account_head, "company") != company:
+			frappe.throw(_("Tax account {0} does not belong to company {1}.").format(t.account_head, company))
+
 	si.flags.ignore_permissions = True
 	si.set_missing_values()
 	si.save()

--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -414,6 +414,25 @@ def record_advance(customer, amount, date=None, deposit_to=None, mode_of_payment
 
 
 @frappe.whitelist()
+def receivables_summary(company=None):
+	"""Header totals for the Invoices panel — total outstanding receivable (submitted, unpaid
+	Sales Invoices) and total unallocated customer advances — for the active company."""
+	company = company or default_company()
+	outstanding = frappe.db.sql(
+		"""
+		SELECT COALESCE(SUM(outstanding_amount), 0)
+		FROM `tabSales Invoice`
+		WHERE docstatus = 1 AND company = %(company)s AND outstanding_amount > 0
+		""",
+		{"company": company},
+	)
+	return {
+		"outstanding": flt(outstanding[0][0]) if outstanding else 0,
+		"advances": advances_summary(company)["total"],
+	}
+
+
+@frappe.whitelist()
 def advances_summary(company=None):
 	"""Total unallocated customer advances held for the active (default) company."""
 	company = company or default_company()

--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -111,6 +111,45 @@ def seed_master_data():
 	seed_subcontract_masters()
 
 	seed_employee_accounting_dimension()
+	seed_invoice_terms()
+
+
+# Sales-invoice Terms & Conditions boilerplate (plain text — kept human-friendly, no HTML).
+INVOICE_TERMS = [
+	(
+		"Standard Sales Invoice",
+		"1. Payment: Payment is due by the due date stated on this invoice. Interest may be charged on overdue amounts as per the contract.\n"
+		"2. Taxes: Amounts are exclusive of taxes unless stated; GST is charged as itemised on this invoice.\n"
+		"3. Disputes: Any discrepancy must be notified in writing within 7 days of receipt of this invoice.\n"
+		"4. Remittance: Payment by account-payee instrument or bank transfer to the account communicated separately, quoting this invoice number.",
+	),
+	(
+		"RA / Milestone Billing",
+		"1. Basis: This invoice is raised against the certified work-done / milestone stated in the line items, as per the contract billing schedule.\n"
+		"2. Certification: Quantities and values are as certified by the client's engineer; recovery of advances and retention (if applicable) is as per contract.\n"
+		"3. Payment: Due by the stated due date. Delays beyond the credit period attract interest as per contract.\n"
+		"4. Taxes: GST as itemised. TDS, if deducted, must be deposited and certificates furnished within statutory timelines.\n"
+		"5. Disputes: Discrepancies must be raised in writing within 7 days; undisputed amounts shall not be withheld.",
+	),
+	(
+		"Advance-adjusted Invoice",
+		"1. Adjustment: This invoice is net of advances received and adjusted as itemised/communicated.\n"
+		"2. Payment: Balance due by the stated due date to the designated bank account, quoting this invoice number.\n"
+		"3. Taxes: GST as itemised on this invoice.\n"
+		"4. Disputes: Any discrepancy must be notified in writing within 7 days of receipt.",
+	),
+]
+
+
+def seed_invoice_terms():
+	"""Seed the standard sales-invoice Terms & Conditions templates (idempotent). Stored as
+	plain text so the invoice's terms box shows friendly text, not raw HTML."""
+	for title, terms in INVOICE_TERMS:
+		if frappe.db.exists("Terms and Conditions", title):
+			continue
+		frappe.get_doc(
+			{"doctype": "Terms and Conditions", "title": title, "selling": 1, "terms": terms}
+		).insert(ignore_permissions=True)
 
 
 def seed_employee_accounting_dimension():

--- a/buildsuite_core/tests/test_invoice.py
+++ b/buildsuite_core/tests/test_invoice.py
@@ -127,6 +127,30 @@ class TestInvoice(BuildSuiteTestCase):
 		self.assertEqual(data["terms"], "Payment within 30 days.")
 		self.assertEqual(len(data["taxes"]), 1)
 
+	def test_cross_company_tax_account_rejected(self):
+		from buildsuite_core.api.invoice import save_invoice
+
+		other = frappe.db.get_value("Company", {"name": ["!=", self.company]}, "name")
+		if not other:
+			self.skipTest("needs a second company")
+		other_acc = frappe.db.get_value("Account", {"company": other, "is_group": 0, "root_type": "Liability"}, "name")
+		if not other_acc:
+			self.skipTest("no cross-company account")
+		cust = self._customer()
+		self.assertRaises(
+			frappe.ValidationError,
+			save_invoice,
+			json.dumps(
+				{
+					"customer": cust,
+					"project": self.project,
+					"date": "2026-07-20",
+					"items": [{"description": "x", "qty": 1, "rate": 1000}],
+					"taxes": [{"charge_type": "On Net Total", "account_head": other_acc, "rate": 5}],
+				}
+			),
+		)
+
 	def test_draft_has_no_gl_until_submit(self):
 		from buildsuite_core.api.invoice import save_invoice
 

--- a/buildsuite_core/tests/test_invoice.py
+++ b/buildsuite_core/tests/test_invoice.py
@@ -94,6 +94,39 @@ class TestInvoice(BuildSuiteTestCase):
 		self.assertAlmostEqual(flt(pe.unallocated_amount), 15000, places=2)
 		self.assertAlmostEqual(advances_summary(company=self.company)["total"] - before, 15000, places=2)
 
+	def test_taxes_and_discount(self):
+		from buildsuite_core.api.invoice import get_invoice, save_invoice
+
+		cust = self._customer()
+		income_tax = frappe.db.get_value("Account", {"company": self.company, "account_type": "Tax", "is_group": 0}, "name")
+		if not income_tax:
+			from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+			income_tax = _ensure_account(self.company, "Output Tax", "Liability", "Tax", "Duties and Taxes")
+		res = save_invoice(
+			json.dumps(
+				{
+					"customer": cust,
+					"project": self.project,
+					"date": "2026-07-20",
+					"items": [{"description": "Work", "qty": 1, "rate": 100000}],
+					"taxes": [{"charge_type": "On Net Total", "account_head": income_tax, "rate": 10}],
+					"additional_discount_on": "Net Total",
+					"additional_discount_percentage": 5,
+					"terms": "Payment within 30 days.",
+				}
+			)
+		)
+		si = frappe.get_doc("Sales Invoice", res["name"])
+		# 100000 − 5% = 95000 net; +10% tax = 9500 → 104500.
+		self.assertAlmostEqual(flt(si.grand_total), 104500, places=2)
+		self.assertEqual(len(si.taxes), 1)
+		self.assertEqual(si.apply_discount_on, "Net Total")
+		data = get_invoice(res["name"])
+		self.assertEqual(data["additional_discount_percentage"], 5)
+		self.assertEqual(data["terms"], "Payment within 30 days.")
+		self.assertEqual(len(data["taxes"]), 1)
+
 	def test_draft_has_no_gl_until_submit(self):
 		from buildsuite_core.api.invoice import save_invoice
 

--- a/buildsuite_core/tests/test_invoice.py
+++ b/buildsuite_core/tests/test_invoice.py
@@ -151,6 +151,16 @@ class TestInvoice(BuildSuiteTestCase):
 			),
 		)
 
+	def test_seed_invoice_terms_and_plain_text(self):
+		from buildsuite_core.api.invoice import _html_to_text
+		from buildsuite_core.install import seed_invoice_terms
+
+		seed_invoice_terms()  # idempotent
+		self.assertTrue(frappe.db.exists("Terms and Conditions", "Standard Sales Invoice"))
+		# HTML terms render as friendly plain text (block tags → newlines, tags stripped).
+		self.assertEqual(_html_to_text("<p>A</p><p>B</p>"), "A\nB")
+		self.assertEqual(_html_to_text("1. Plain\n2. Text"), "1. Plain\n2. Text")
+
 	def test_draft_has_no_gl_until_submit(self):
 		from buildsuite_core.api.invoice import save_invoice
 

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -30,6 +30,12 @@ const classes = computed(() => {
 		Delayed: "bg-danger-50 text-danger-700",
 		Open: "bg-ink-100 text-ink-600",
 		Draft: "bg-ink-100 text-ink-600",
+		// Sales Invoice submission + payment statuses.
+		Submitted: "bg-info-50 text-info-700",
+		Unpaid: "bg-warning-50 text-warning-700",
+		"Partly Paid": "bg-warning-100 text-warning-700",
+		Paid: "bg-success-50 text-success-700",
+		Overdue: "bg-danger-50 text-danger-700",
 		"Pending Approval": "bg-warning-50 text-warning-700",
 		Approved: "bg-success-50 text-success-700",
 		Rejected: "bg-danger-50 text-danger-700",

--- a/frontend/src/data/invoiceApi.js
+++ b/frontend/src/data/invoiceApi.js
@@ -21,6 +21,7 @@ export const recordInvoiceReceipt = (args) => call("record_receipt", args);
 export const listInvoiceReceipts = (name) => call("list_receipts", { name });
 export const recordCustomerAdvance = (args) => call("record_advance", args);
 export const invoiceAdvancesSummary = () => call("advances_summary", {});
+export const invoiceReceivablesSummary = () => call("receivables_summary", {});
 export const listDepositAccounts = () => call("list_deposit_accounts", {});
 export const listInvoiceTaxTemplates = () => call("list_tax_templates", {});
 export const getInvoiceTaxTemplateRows = (template) => call("get_tax_template_rows", { template });

--- a/frontend/src/data/invoiceApi.js
+++ b/frontend/src/data/invoiceApi.js
@@ -23,4 +23,6 @@ export const recordCustomerAdvance = (args) => call("record_advance", args);
 export const invoiceAdvancesSummary = () => call("advances_summary", {});
 export const listDepositAccounts = () => call("list_deposit_accounts", {});
 export const listInvoiceTaxTemplates = () => call("list_tax_templates", {});
+export const getInvoiceTaxTemplateRows = (template) => call("get_tax_template_rows", { template });
+export const getInvoiceTerms = (name) => call("get_terms", { name });
 export const listInvoicePaymentModes = () => call("list_payment_modes", {});

--- a/frontend/src/views/finance/FinanceInvoiceFormView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceFormView.vue
@@ -1,15 +1,19 @@
 <script setup>
 // Project Finance › Invoice form — a full PAGE (not a modal), for create
 // (/project-finance/invoices/new) and edit of a Draft (/project-finance/invoices/:id/edit;
-// a non-Draft bounces to the detail page). Saves a draft Sales Invoice via api.invoice.
+// a non-Draft bounces to the detail page). Item lines (qty × rate), then taxes & discount
+// via templates + a live waterfall — the same pattern as the Subcontractor Bill. Saves a
+// draft Sales Invoice via api.invoice.
 import { computed, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
-import { getInvoice, saveInvoice, listInvoiceTaxTemplates } from "@/data/invoiceApi";
+import { getInvoice, saveInvoice, getInvoiceTaxTemplateRows, getInvoiceTerms } from "@/data/invoiceApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
-import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { fmtINR } from "@/utils/format";
@@ -19,7 +23,7 @@ const router = useRouter();
 const companyFilter = activeCompanyFilter();
 const isEdit = computed(() => !!props.id);
 
-function newLine() {
+function blankLine() {
 	return { description: "", qty: 1, rate: null };
 }
 const form = reactive({
@@ -27,16 +31,19 @@ const form = reactive({
 	project: "",
 	date: new Date().toISOString().slice(0, 10),
 	due_date: new Date(Date.now() + 30 * 86400000).toISOString().slice(0, 10),
+	lines: [blankLine()],
 	taxes_and_charges: "",
-	lines: [newLine()],
-	saving: false,
+	taxes: [],
+	discount_on: "Net Total",
+	discount_type: "%", // "%" | "₹"
+	discount_value: 0,
+	tc_name: "",
+	terms: "",
 });
-const taxTemplates = ref([]);
+const termsOpen = ref(false);
+const errors = reactive({ customer: "", lines: "" });
+const saving = ref(false);
 const loading = ref(isEdit.value);
-
-listInvoiceTaxTemplates()
-	.then((r) => (taxTemplates.value = r || []))
-	.catch(() => {});
 
 if (isEdit.value) {
 	getInvoice(props.id)
@@ -50,16 +57,78 @@ if (isEdit.value) {
 				project: inv.project || "",
 				date: inv.date,
 				due_date: inv.due_date || "",
-				taxes_and_charges: inv.taxes_and_charges || "",
 				lines: (inv.items || []).map((l) => ({ description: l.description, qty: l.qty ?? 1, rate: l.rate })),
+				taxes_and_charges: inv.taxes_and_charges || "",
+				taxes: (inv.taxes || []).map((t) => ({ charge_type: t.charge_type, account_head: t.account_head, description: t.description, rate: t.rate })),
+				discount_on: inv.additional_discount_on || "Net Total",
+				discount_type: Number(inv.discount_amount) > 0 ? "₹" : "%",
+				discount_value: Number(inv.discount_amount) > 0 ? Number(inv.discount_amount) : Number(inv.additional_discount_percentage) || 0,
+				tc_name: inv.tc_name || "",
+				terms: inv.terms || "",
 			});
-			if (!form.lines.length) form.lines = [newLine()];
+			if (!form.lines.length) form.lines = [blankLine()];
+			termsOpen.value = !!inv.terms;
 		})
 		.catch((err) => showToast(err.message || "Failed to load invoice", "error"))
 		.finally(() => (loading.value = false));
 }
 
-const subtotal = computed(() => form.lines.reduce((a, l) => a + (Number(l.qty) || 0) * (Number(l.rate) || 0), 0));
+// --- items ---
+function lineAmount(l) {
+	return (Number(l.qty) || 0) * (Number(l.rate) || 0);
+}
+function addLine() {
+	form.lines.push(blankLine());
+}
+function removeLine(idx) {
+	form.lines.splice(idx, 1);
+	if (!form.lines.length) form.lines.push(blankLine());
+}
+
+// --- taxes (template → rows, editable; Bill pattern) ---
+async function applyTemplate(tpl) {
+	form.taxes_and_charges = tpl || "";
+	if (!tpl) return;
+	try {
+		form.taxes = await getInvoiceTaxTemplateRows(tpl);
+	} catch (err) {
+		showToast(err.message || "Failed to load tax template", "error");
+	}
+}
+function addTaxRow() {
+	form.taxes.push({ charge_type: "On Net Total", account_head: "", rate: 0 });
+	form.taxes_and_charges = "";
+}
+function removeTaxRow(idx) {
+	form.taxes.splice(idx, 1);
+	form.taxes_and_charges = "";
+}
+
+// --- terms ---
+async function onPickTerms(name) {
+	form.tc_name = name || "";
+	if (!name) return;
+	try {
+		form.terms = (await getInvoiceTerms(name)).terms || "";
+		termsOpen.value = true;
+	} catch {
+		/* ignore */
+	}
+}
+
+// --- live waterfall ---
+const wf = computed(() => {
+	const net = form.lines.reduce((a, l) => a + lineAmount(l), 0);
+	const discBase = (base) => (form.discount_type === "%" ? (base * (Number(form.discount_value) || 0)) / 100 : Number(form.discount_value) || 0);
+	const netDiscount = form.discount_on === "Net Total" ? discBase(net) : 0;
+	const taxable = Math.max(0, net - netDiscount);
+	const taxRows = form.taxes.map((t) => ({ ...t, amount: (taxable * (Number(t.rate) || 0)) / 100 }));
+	const tax = taxRows.reduce((a, r) => a + r.amount, 0);
+	const grandTotal = taxable + tax;
+	const grandDiscount = form.discount_on === "Grand Total" ? discBase(grandTotal) : 0;
+	const invoiceTotal = Math.max(0, grandTotal - grandDiscount);
+	return { net, netDiscount, taxable, taxRows, tax, grandTotal, grandDiscount, invoiceTotal };
+});
 
 const breadcrumbs = computed(() => [
 	{ label: "Project Finance", to: "/project-finance" },
@@ -67,14 +136,15 @@ const breadcrumbs = computed(() => [
 	{ label: isEdit.value ? `Edit ${props.id}` : "New" },
 ]);
 
-function goBack() {
-	router.push(isEdit.value ? `/project-finance/invoices/${props.id}` : "/project-finance/invoices");
-}
 async function save() {
-	if (!form.customer) return showToast("Pick a customer.", "error");
-	const lines = form.lines.filter((l) => Number(l.rate) > 0);
-	if (!lines.length) return showToast("Add at least one line with an amount.", "error");
-	form.saving = true;
+	errors.customer = "";
+	errors.lines = "";
+	if (!form.customer) errors.customer = "Customer is required.";
+	const lines = form.lines.filter((l) => (l.description || "").trim() && lineAmount(l) > 0);
+	if (!lines.length) errors.lines = "Add at least one item with a quantity and rate.";
+	if (errors.customer || errors.lines) return;
+
+	saving.value = true;
 	try {
 		const res = await saveInvoice({
 			name: isEdit.value ? props.id : undefined,
@@ -82,65 +152,125 @@ async function save() {
 			project: form.project || undefined,
 			date: form.date,
 			due_date: form.due_date || undefined,
+			items: lines.map((l) => ({ description: l.description.trim(), qty: Number(l.qty) || 1, rate: Number(l.rate) })),
 			taxes_and_charges: form.taxes_and_charges || undefined,
-			items: lines.map((l) => ({ description: l.description, qty: Number(l.qty) || 1, rate: Number(l.rate) })),
+			taxes: form.taxes.filter((t) => t.account_head).map((t) => ({ charge_type: t.charge_type, account_head: t.account_head, description: t.description, rate: Number(t.rate) || 0 })),
+			additional_discount_on: form.discount_on,
+			additional_discount_percentage: form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
+			discount_amount: form.discount_type === "₹" ? Number(form.discount_value) || 0 : 0,
+			tc_name: form.tc_name || undefined,
+			terms: form.terms || undefined,
 		});
 		showToast(isEdit.value ? "Invoice updated." : "Invoice saved as draft.");
 		router.push(`/project-finance/invoices/${res.name}`);
 	} catch (err) {
 		showToast(err.message || "Failed to save", "error");
 	} finally {
-		form.saving = false;
+		saving.value = false;
 	}
 }
 </script>
 
 <template>
-	<DeskPage :title="isEdit ? `Edit ${id}` : 'New invoice'" :breadcrumbs="breadcrumbs">
-		<template #actions>
-			<div class="flex items-center gap-2">
-				<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="goBack">Cancel</button>
-				<button type="button" class="text-xs desk-save-btn" :disabled="form.saving || loading" @click="save">{{ form.saving ? "Saving…" : isEdit ? "Save" : "Save as draft" }}</button>
-			</div>
-		</template>
+	<DeskPage :title="isEdit ? `Edit ${id}` : 'New Invoice'" :breadcrumbs="breadcrumbs" subtitle="Bills the customer — Submit posts it as a receivable.">
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar :save-label="isEdit ? 'Save invoice' : 'Create invoice'" :saving="saving" @save="save" @cancel="router.back()" />
+			</template>
 
-		<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Loading…</div>
-		<div v-else class="max-w-3xl space-y-4">
-			<section class="bg-white border border-ink-200 rounded-lg p-4 space-y-3">
-				<div class="grid grid-cols-2 gap-3">
-					<DeskField label="Customer" required><DeskLinkPicker v-model="form.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" /></DeskField>
-					<DeskField label="Project"><DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="Optional…" /></DeskField>
-				</div>
-				<div class="grid grid-cols-3 gap-3">
-					<DeskField label="Date"><DeskInput v-model="form.date" type="date" /></DeskField>
+			<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Loading…</div>
+			<template v-else>
+				<DeskSection title="Invoice details" :cols="4">
+					<DeskField label="Customer" required :error="errors.customer">
+						<DeskLinkPicker v-model="form.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" />
+					</DeskField>
+					<DeskField label="Project" hint="Optional — tags the income to a project.">
+						<DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="None" />
+					</DeskField>
+					<DeskField label="Invoice date"><DeskInput v-model="form.date" type="date" /></DeskField>
 					<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
-					<DeskField label="Tax"><DeskSelect v-model="form.taxes_and_charges"><option value="">No tax</option><option v-for="t in taxTemplates" :key="t.name" :value="t.name">{{ t.title || t.name }}</option></DeskSelect></DeskField>
-				</div>
-			</section>
+				</DeskSection>
 
-			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Items</h3></div>
-				<table class="w-full text-xs">
-					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-3 py-2">Description</th><th class="text-right px-3 py-2 w-16">Qty</th><th class="text-right px-3 py-2 w-28">Rate</th><th class="text-right px-3 py-2 w-28">Amount</th><th class="w-8"></th></tr></thead>
-					<tbody>
-						<tr v-for="(l, idx) in form.lines" :key="idx" class="border-t border-ink-100">
-							<td class="px-2 py-1"><input v-model="l.description" type="text" placeholder="What is billed?" class="w-full px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none" /></td>
-							<td class="px-2 py-1"><input v-model.number="l.qty" type="number" min="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
-							<td class="px-2 py-1"><input v-model.number="l.rate" type="number" min="0" placeholder="0" class="w-full text-right px-1.5 py-1 border border-transparent hover:border-ink-200 focus:border-brand-400 rounded focus:outline-none tabular-nums" /></td>
-							<td class="px-3 py-1 text-right tabular-nums text-ink-700">{{ fmtINR((Number(l.qty) || 0) * (Number(l.rate) || 0)) }}</td>
-							<td class="px-2 py-1 text-center"><button v-if="form.lines.length > 1" type="button" class="text-ink-400 hover:text-danger-600" @click="form.lines.splice(idx, 1)">✕</button></td>
-						</tr>
-					</tbody>
-					<tfoot>
-						<tr class="border-t border-ink-200 bg-ink-50/40">
-							<td colspan="3" class="px-3 py-2"><button type="button" class="text-[11px] text-brand-700 hover:underline" @click="form.lines.push(newLine())">+ Add line</button></td>
-							<td class="px-3 py-2 text-right tabular-nums font-semibold text-ink-900">{{ fmtINR(subtotal) }}</td>
-							<td></td>
-						</tr>
-					</tfoot>
-				</table>
-			</section>
-			<p class="text-[11px] text-ink-400">Any tax is applied on save; the subtotal above is before tax.</p>
-		</div>
+				<DeskSection title="Items" :cols="1">
+					<div>
+						<div class="hidden md:grid grid-cols-[1fr_110px_140px_140px_36px] gap-2 text-[10px] uppercase tracking-wider text-ink-500 font-medium px-1 mb-1">
+							<span>Description</span><span class="text-right">Qty</span><span class="text-right">Rate</span><span class="text-right">Amount</span><span></span>
+						</div>
+						<div v-for="(l, idx) in form.lines" :key="idx" class="grid grid-cols-2 md:grid-cols-[1fr_110px_140px_140px_36px] gap-2 items-center mb-2">
+							<DeskInput v-model="l.description" placeholder="e.g. Block A — RA-4 milestone" class="col-span-2 md:col-span-1" />
+							<DeskInput v-model.number="l.qty" type="number" min="0" placeholder="Qty" class="text-right" />
+							<DeskInput v-model.number="l.rate" type="number" min="0" placeholder="Rate" class="text-right" />
+							<div class="text-xs tabular-nums text-ink-700 text-right">{{ fmtINR(lineAmount(l)) }}</div>
+							<button type="button" class="text-ink-400 hover:text-danger-600 text-sm" aria-label="Remove line" @click="removeLine(idx)">✕</button>
+						</div>
+						<p v-if="errors.lines" class="text-[11px] text-danger-600 mb-2">{{ errors.lines }}</p>
+						<button type="button" class="text-xs text-brand-700 hover:underline" @click="addLine">+ Add item</button>
+					</div>
+				</DeskSection>
+
+				<!-- taxes + collapsible terms on the left, live totals pinned on the right -->
+				<div class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_340px] gap-6 mb-6">
+					<div class="space-y-5 min-w-0">
+						<!-- taxes & discount (template-driven, Bill pattern) -->
+						<div>
+							<h3 class="desk-section-title">Taxes &amp; discount</h3>
+							<hr class="desk-divider" />
+							<div class="flex items-center gap-2 mb-2 mt-2">
+								<div class="w-64">
+									<DeskLinkPicker :model-value="form.taxes_and_charges" doctype="Sales Taxes and Charges Template" label-field="title" value-field="name" placeholder="Tax template…" @update:model-value="applyTemplate" />
+								</div>
+								<button type="button" class="text-[11px] text-brand-700 hover:underline whitespace-nowrap" @click="addTaxRow">+ Add row</button>
+							</div>
+							<div v-if="form.taxes.length" class="space-y-1.5">
+								<div v-for="(row, idx) in form.taxes" :key="idx" class="flex items-center gap-2">
+									<input v-model="row.account_head" type="text" placeholder="Tax account head" class="w-56 text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200" />
+									<input v-model.number="row.rate" type="number" min="0" step="0.5" class="w-16 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200" />
+									<span class="text-[10px] text-ink-400">%</span>
+									<button type="button" class="text-ink-400 hover:text-danger-600 text-xs" @click="removeTaxRow(idx)">✕</button>
+								</div>
+							</div>
+							<div class="flex items-center gap-2 flex-wrap mt-3">
+								<span class="text-xs text-ink-500">Discount</span>
+								<select v-model="form.discount_on" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+									<option value="Net Total">On Net Total</option>
+									<option value="Grand Total">On Grand Total</option>
+								</select>
+								<input v-model.number="form.discount_value" type="number" min="0" class="w-24 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200" />
+								<div class="flex rounded-md border border-ink-200 overflow-hidden text-[11px]">
+									<button type="button" class="px-2 py-1" :class="form.discount_type === '₹' ? 'bg-ink-900 text-white' : 'text-ink-600'" @click="form.discount_type = '₹'">₹</button>
+									<button type="button" class="px-2 py-1" :class="form.discount_type === '%' ? 'bg-ink-900 text-white' : 'text-ink-600'" @click="form.discount_type = '%'">%</button>
+								</div>
+							</div>
+						</div>
+
+						<!-- collapsible terms -->
+						<div>
+							<button type="button" class="w-full flex items-center gap-2 text-left" @click="termsOpen = !termsOpen">
+								<h3 class="desk-section-title">Terms &amp; conditions</h3>
+								<span v-if="form.terms && !termsOpen" class="text-[10px] px-1.5 py-0.5 bg-brand-50 text-brand-700 rounded-full">set</span>
+								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-ink-400 transition-transform" :class="termsOpen ? 'rotate-90' : ''"><path d="M9 18l6-6-6-6" /></svg>
+							</button>
+							<hr class="desk-divider" />
+							<div v-if="termsOpen" class="mt-2">
+								<div class="w-64 mb-2">
+									<DeskLinkPicker :model-value="form.tc_name" doctype="Terms and Conditions" label-field="name" value-field="name" placeholder="Import from template…" @update:model-value="onPickTerms" />
+								</div>
+								<textarea v-model="form.terms" rows="5" placeholder="Terms printed on the invoice — import a template above or write your own." class="w-full text-xs px-3 py-2 border border-ink-200 rounded-md leading-relaxed focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"></textarea>
+							</div>
+						</div>
+					</div>
+
+					<!-- live totals waterfall -->
+					<div class="bg-ink-50 rounded-lg px-4 py-3 text-sm space-y-1 self-start">
+						<div class="flex justify-between text-ink-600"><span>Net total</span><span class="tabular-nums">{{ fmtINR(wf.net) }}</span></div>
+						<div v-if="wf.netDiscount > 0" class="flex justify-between text-ink-600"><span>Discount (on net)</span><span class="tabular-nums text-danger-700">− {{ fmtINR(wf.netDiscount) }}</span></div>
+						<div v-if="wf.taxable !== wf.net" class="flex justify-between text-ink-600"><span>Taxable value</span><span class="tabular-nums">{{ fmtINR(wf.taxable) }}</span></div>
+						<div v-for="(row, idx) in wf.taxRows" :key="idx" class="flex justify-between text-ink-600"><span>{{ row.account_head || "Tax" }} ({{ row.rate }}%)</span><span class="tabular-nums">{{ fmtINR(row.amount) }}</span></div>
+						<div v-if="wf.grandDiscount > 0" class="flex justify-between text-ink-600"><span>Discount (on grand total)</span><span class="tabular-nums text-danger-700">− {{ fmtINR(wf.grandDiscount) }}</span></div>
+						<div class="flex justify-between font-semibold text-ink-900 border-t border-ink-200 pt-1.5"><span>Invoice total</span><span class="tabular-nums">{{ fmtINR(wf.invoiceTotal) }}</span></div>
+					</div>
+				</div>
+			</template>
+		</DeskForm>
 	</DeskPage>
 </template>

--- a/frontend/src/views/finance/FinanceInvoiceFormView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceFormView.vue
@@ -21,6 +21,9 @@ import { fmtINR } from "@/utils/format";
 const props = defineProps({ id: { type: String, default: "" } });
 const router = useRouter();
 const companyFilter = activeCompanyFilter();
+// Tax account heads: non-group accounts in the active (default) company only — so a tax
+// template / row can't pull an account from another company (which the Sales Invoice rejects).
+const accountFilters = computed(() => [["is_group", "=", 0], ...companyFilter.value]);
 const isEdit = computed(() => !!props.id);
 
 function blankLine() {
@@ -217,13 +220,13 @@ async function save() {
 							<hr class="desk-divider" />
 							<div class="flex items-center gap-2 mb-2 mt-2">
 								<div class="w-64">
-									<DeskLinkPicker :model-value="form.taxes_and_charges" doctype="Sales Taxes and Charges Template" label-field="title" value-field="name" placeholder="Tax template…" @update:model-value="applyTemplate" />
+									<DeskLinkPicker :model-value="form.taxes_and_charges" doctype="Sales Taxes and Charges Template" label-field="title" value-field="name" :filters="companyFilter" placeholder="Tax template…" @update:model-value="applyTemplate" />
 								</div>
 								<button type="button" class="text-[11px] text-brand-700 hover:underline whitespace-nowrap" @click="addTaxRow">+ Add row</button>
 							</div>
 							<div v-if="form.taxes.length" class="space-y-1.5">
 								<div v-for="(row, idx) in form.taxes" :key="idx" class="flex items-center gap-2">
-									<input v-model="row.account_head" type="text" placeholder="Tax account head" class="w-56 text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200" />
+									<div class="w-56"><DeskLinkPicker v-model="row.account_head" doctype="Account" label-field="name" value-field="name" :filters="accountFilters" placeholder="Tax account…" /></div>
 									<input v-model.number="row.rate" type="number" min="0" step="0.5" class="w-16 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200" />
 									<span class="text-[10px] text-ink-400">%</span>
 									<button type="button" class="text-ink-400 hover:text-danger-600 text-xs" @click="removeTaxRow(idx)">✕</button>

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -169,14 +169,8 @@ async function saveAdvance() {
 
 		<div class="space-y-4">
 			<div class="flex items-center gap-4 text-sm">
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
-					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Outstanding receivable</div>
-					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(summary.outstanding) }}</div>
-				</div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
-					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Customer advances</div>
-					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(summary.advances) }}</div>
-				</div>
+				<div><span class="text-ink-500">Outstanding</span> <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(summary.outstanding) }}</span></div>
+				<div v-if="summary.advances > 0"><span class="text-ink-500">Advances held</span> <span class="font-semibold text-info-700 tabular-nums">{{ fmtINR(summary.advances) }}</span></div>
 			</div>
 
 			<DocTypeListView

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -1,15 +1,15 @@
 <script setup>
-// Project Finance › Invoices — LIVE over ERPNext Sales Invoice (money in). An invoice IS a
-// Sales Invoice: create a draft, submit (posts the receivable), and receive payments (a real
-// Payment Entry into a Bank/Cash account). docstatus lifecycle: Draft → Submitted → Cancelled.
+// Project Finance › Invoices — LIVE over ERPNext Sales Invoice (money in). The list is the
+// standard DocTypeListView (pagination / sort / filter / search for free); an invoice IS a
+// Sales Invoice. Rows show two status badges — submission (Draft/Submitted/Cancelled) and, for
+// submitted invoices, the payment status (Unpaid/Overdue/Partly Paid/Paid) — both colour-coded.
 import { computed, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import {
-	listInvoices,
 	recordInvoiceReceipt,
 	recordCustomerAdvance,
-	invoiceAdvancesSummary,
+	invoiceReceivablesSummary,
 	listDepositAccounts,
 	listInvoicePaymentModes,
 } from "@/data/invoiceApi";
@@ -18,83 +18,117 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
 const router = useRouter();
+const activeCompany = useActiveCompany();
+const baseFilters = computed(() => (activeCompany.value ? [["company", "=", activeCompany.value]] : []));
 
-const invoices = ref([]);
-const advancesTotal = ref(0);
-const loading = ref(true);
-async function load() {
-	loading.value = true;
+// The list is a doctype resource; bump this to force a refresh after receive/advance.
+const listKey = ref(0);
+function refreshList() {
+	listKey.value += 1;
+	loadSummary();
+}
+
+// --- header summary (across all invoices, not just the page) ---
+const summary = reactive({ outstanding: 0, advances: 0 });
+async function loadSummary() {
 	try {
-		invoices.value = await listInvoices();
-		invoiceAdvancesSummary().then((r) => (advancesTotal.value = Number(r?.total) || 0)).catch(() => {});
-	} catch (err) {
-		showToast(err.message || "Failed to load invoices", "error");
-	} finally {
-		loading.value = false;
+		const r = await invoiceReceivablesSummary();
+		summary.outstanding = Number(r?.outstanding) || 0;
+		summary.advances = Number(r?.advances) || 0;
+	} catch {
+		/* ignore */
 	}
 }
-load();
+loadSummary();
 
-function openDetail(inv) {
-	router.push(`/project-finance/invoices/${inv.name}`);
+// --- status derivation from the native Sales Invoice `status` ---
+function submissionOf(s) {
+	if (s === "Draft") return "Draft";
+	if (s === "Cancelled") return "Cancelled";
+	return "Submitted";
 }
-
-const totalOutstanding = computed(() => invoices.value.reduce((a, i) => a + (Number(i.outstanding) || 0), 0));
+function paymentOf(s) {
+	return s === "Draft" || s === "Cancelled" ? null : s; // Unpaid / Overdue / Partly Paid / Paid
+}
+function canReceive(row) {
+	return submissionOf(row.status) === "Submitted" && Number(row.outstanding_amount) > 0.01;
+}
 
 // --- aging (submitted + still owed) ---
-function daysOverdue(due) {
-	if (!due) return 0;
-	return Math.floor((Date.now() - new Date(due).getTime()) / 86400000);
-}
-function aging(inv) {
-	if (inv.docstatus !== 1 || !(Number(inv.outstanding) > 0.01)) return null;
-	const d = daysOverdue(inv.due_date);
+function aging(row) {
+	if (submissionOf(row.status) !== "Submitted" || !(Number(row.outstanding_amount) > 0.01)) return null;
+	if (!row.due_date) return null;
+	const d = Math.floor((Date.now() - new Date(row.due_date).getTime()) / 86400000);
 	if (d <= 0) return { label: "Not due", cls: "bg-ink-100 text-ink-500" };
 	const bucket = d <= 30 ? "0–30" : d <= 60 ? "31–60" : d <= 90 ? "61–90" : "90+";
 	const cls = d <= 30 ? "bg-warning-50 text-warning-700" : "bg-danger-50 text-danger-700";
 	return { label: `${bucket} d`, cls };
 }
 
-// --- filters ---
-const search = ref("");
 const statusFilter = ref("");
-const hasFilters = computed(() => search.value || statusFilter.value);
-function clearFilters() {
-	search.value = "";
-	statusFilter.value = "";
-}
-const rows = computed(() => {
-	const term = search.value.trim().toLowerCase();
-	return invoices.value.filter(
-		(i) =>
-			(!statusFilter.value || i.status === statusFilter.value) &&
-			(!term ||
-				i.name.toLowerCase().includes(term) ||
-				(i.customer_name || "").toLowerCase().includes(term) ||
-				(i.project_name || "").toLowerCase().includes(term)),
-	);
-});
+const filterValues = computed(() => ({ status: statusFilter.value }));
 
-// --- create: full-page form ---
+function openDetail(row) {
+	router.push(`/project-finance/invoices/${row.name}`);
+}
 function openNew() {
 	router.push("/project-finance/invoices/new");
+}
+
+// --- receive payment ---
+const depositAccounts = ref([]);
+const payModes = ref([]);
+async function ensurePayRefs() {
+	if (depositAccounts.value.length) return;
+	try {
+		[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
+	} catch {
+		/* fall through */
+	}
+}
+const rec = reactive({ open: false, inv: null, amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+async function openReceive(row) {
+	await ensurePayRefs();
+	Object.assign(rec, {
+		open: true,
+		inv: { name: row.name, customer_name: row.customer_name, outstanding: Number(row.outstanding_amount) || 0 },
+		amount: Number(row.outstanding_amount) || null,
+		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		date: new Date().toISOString().slice(0, 10),
+		mode_of_payment: payModes.value[0] || "",
+		reference_no: "",
+		saving: false,
+	});
+}
+async function saveReceive() {
+	const amt = Number(rec.amount) || 0;
+	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
+	if (amt > Number(rec.inv.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(rec.inv.outstanding)}.`, "error");
+	if (!rec.deposit_to) return showToast("Pick the account to deposit into.", "error");
+	rec.saving = true;
+	try {
+		await recordInvoiceReceipt({ name: rec.inv.name, amount: amt, date: rec.date, mode_of_payment: rec.mode_of_payment || undefined, deposit_to: rec.deposit_to, reference_no: rec.reference_no || undefined });
+		rec.open = false;
+		refreshList();
+		showToast("Payment received.");
+	} catch (err) {
+		showToast(err.message || "Receipt failed", "error");
+	} finally {
+		rec.saving = false;
+	}
 }
 
 // --- record customer advance (on-account receipt) ---
 const adv = reactive({ open: false, customer: "", amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
 async function openAdvance() {
-	if (!depositAccounts.value.length) {
-		try {
-			[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
-		} catch {
-			/* fall through */
-		}
-	}
+	await ensurePayRefs();
 	Object.assign(adv, {
 		open: true,
 		customer: "",
@@ -114,60 +148,12 @@ async function saveAdvance() {
 	try {
 		await recordCustomerAdvance({ customer: adv.customer, amount: Number(adv.amount), date: adv.date, deposit_to: adv.deposit_to, mode_of_payment: adv.mode_of_payment || undefined, reference_no: adv.reference_no || undefined });
 		adv.open = false;
-		await load();
+		refreshList();
 		showToast("Advance recorded.");
 	} catch (err) {
 		showToast(err.message || "Failed to record advance", "error");
 	} finally {
 		adv.saving = false;
-	}
-}
-
-// --- receive payment ---
-const rec = reactive({ open: false, inv: null, amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
-const depositAccounts = ref([]);
-const payModes = ref([]);
-async function openReceive(inv) {
-	if (!depositAccounts.value.length) {
-		try {
-			[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
-		} catch {
-			/* fall through */
-		}
-	}
-	Object.assign(rec, {
-		open: true,
-		inv,
-		amount: Number(inv.outstanding) || null,
-		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
-		date: new Date().toISOString().slice(0, 10),
-		mode_of_payment: payModes.value[0] || "",
-		reference_no: "",
-		saving: false,
-	});
-}
-async function saveReceive() {
-	const amt = Number(rec.amount) || 0;
-	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
-	if (amt > Number(rec.inv.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(rec.inv.outstanding)}.`, "error");
-	if (!rec.deposit_to) return showToast("Pick the account to deposit into.", "error");
-	rec.saving = true;
-	try {
-		await recordInvoiceReceipt({
-			name: rec.inv.name,
-			amount: amt,
-			date: rec.date,
-			mode_of_payment: rec.mode_of_payment || undefined,
-			deposit_to: rec.deposit_to,
-			reference_no: rec.reference_no || undefined,
-		});
-		rec.open = false;
-		await load();
-		showToast("Payment received.");
-	} catch (err) {
-		showToast(err.message || "Receipt failed", "error");
-	} finally {
-		rec.saving = false;
 	}
 }
 </script>
@@ -185,53 +171,75 @@ async function saveReceive() {
 			<div class="flex items-center gap-4 text-sm">
 				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
 					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Outstanding receivable</div>
-					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(totalOutstanding) }}</div>
+					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(summary.outstanding) }}</div>
 				</div>
 				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md">
 					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Customer advances</div>
-					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(advancesTotal) }}</div>
+					<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(summary.advances) }}</div>
 				</div>
 			</div>
 
-			<!-- filters -->
-			<div class="flex items-center gap-2 flex-wrap">
-				<input v-model="search" type="text" placeholder="Search invoice, customer, project…" class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-72 max-w-full" />
-				<select v-model="statusFilter" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
-					<option value="">All statuses</option>
-					<option value="Draft">Draft</option>
-					<option value="Unpaid">Unpaid</option>
-					<option value="Partly Paid">Partly Paid</option>
-					<option value="Paid">Paid</option>
-					<option value="Cancelled">Cancelled</option>
-				</select>
-				<button v-if="hasFilters" type="button" class="text-[11px] text-danger-600 hover:underline" @click="clearFilters">Clear filters</button>
-				<span class="text-[11px] text-ink-400 ml-auto">{{ rows.length }} invoice{{ rows.length === 1 ? "" : "s" }}</span>
-			</div>
+			<DocTypeListView
+				v-if="activeCompany"
+				:key="listKey"
+				doctype="Sales Invoice"
+				:field-order="['customer_name', 'project', 'posting_date', 'due_date', 'grand_total', 'outstanding_amount', 'status']"
+				:columns="[
+					{ key: 'name', label: 'Invoice' },
+					{ key: 'customer_name', label: 'Customer' },
+					{ key: 'project', label: 'Project' },
+					{ key: 'posting_date', label: 'Date' },
+					{ key: 'due_date', label: 'Due' },
+					{ key: 'aging', label: 'Aging', fields: ['due_date', 'outstanding_amount', 'status'] },
+					{ key: 'grand_total', label: 'Total', align: 'right' },
+					{ key: 'outstanding_amount', label: 'Outstanding', align: 'right' },
+					{ key: 'status', label: 'Status', fields: ['status', 'outstanding_amount'] },
+					{ key: 'actions', label: '', align: 'right' },
+				]"
+				:search-fields="['name', 'customer_name']"
+				:base-filters="baseFilters"
+				:filter-values="filterValues"
+				:filter-field-map="{ status: 'status' }"
+				cache-key="buildsuite-invoice-list"
+				row-key="name"
+				initial-order-by="posting_date desc"
+				search-placeholder="Search invoice, customer…"
+				empty-message="No invoices yet."
+				@row-click="openDetail"
+			>
+				<template #filter-chips>
+					<DeskSelect v-model="statusFilter" class="!w-40">
+						<option value="">Status: Any</option>
+						<option>Draft</option>
+						<option>Unpaid</option>
+						<option>Overdue</option>
+						<option>Partly Paid</option>
+						<option>Paid</option>
+						<option>Cancelled</option>
+					</DeskSelect>
+				</template>
 
-			<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
-				<table v-if="rows.length" class="w-full text-xs" style="min-width: 760px">
-					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200">
-						<tr><th class="text-left px-3 py-2">Invoice</th><th class="text-left px-3 py-2">Customer</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-left px-3 py-2">Status</th><th class="px-3 py-2"></th></tr>
-					</thead>
-					<tbody>
-						<tr v-for="i in rows" :key="i.name" class="border-t border-ink-100 hover:bg-brand-50/40 cursor-pointer" @click="openDetail(i)">
-							<td class="px-3 py-2 font-mono text-[11px] text-ink-500">{{ i.name }}</td>
-							<td class="px-3 py-2 text-ink-900">{{ i.customer_name }}</td>
-							<td class="px-3 py-2 text-ink-500">{{ i.project_name || "—" }}</td>
-							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(i.date) }}</td>
-							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(i.due_date) }}</td>
-							<td class="px-3 py-2"><span v-if="aging(i)" class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="aging(i).cls">{{ aging(i).label }}</span><span v-else class="text-ink-300">—</span></td>
-							<td class="px-3 py-2 text-right tabular-nums text-ink-900">{{ fmtINR(i.total) }}</td>
-							<td class="px-3 py-2 text-right tabular-nums font-medium" :class="i.outstanding > 0.01 ? 'text-ink-900' : 'text-ink-400'">{{ fmtINR(i.outstanding) }}</td>
-							<td class="px-3 py-2"><StatusBadge :status="i.status" size="xs" /></td>
-							<td class="px-3 py-2 text-right whitespace-nowrap">
-								<button v-if="i.docstatus === 1 && i.outstanding > 0.01" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click.stop="openReceive(i)">Receive</button>
-							</td>
-						</tr>
-					</tbody>
-				</table>
-				<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "No invoices yet." }}</div>
-			</section>
+				<template #cell-name="{ row }"><span class="font-mono text-[11px] text-ink-500">{{ row.name }}</span></template>
+				<template #cell-customer_name="{ row }"><span class="text-ink-900">{{ row.customer_name }}</span></template>
+				<template #cell-project="{ row }"><span class="text-ink-500">{{ row.project || "—" }}</span></template>
+				<template #cell-posting_date="{ row }"><span class="text-ink-500 whitespace-nowrap">{{ fmtDate(row.posting_date) }}</span></template>
+				<template #cell-due_date="{ row }"><span class="text-ink-500 whitespace-nowrap">{{ fmtDate(row.due_date) }}</span></template>
+				<template #cell-aging="{ row }">
+					<span v-if="aging(row)" class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="aging(row).cls">{{ aging(row).label }}</span>
+					<span v-else class="text-ink-300">—</span>
+				</template>
+				<template #cell-grand_total="{ row }"><span class="tabular-nums text-ink-900">{{ fmtINR(row.grand_total) }}</span></template>
+				<template #cell-outstanding_amount="{ row }"><span class="tabular-nums font-medium" :class="Number(row.outstanding_amount) > 0.01 ? 'text-ink-900' : 'text-ink-400'">{{ fmtINR(row.outstanding_amount) }}</span></template>
+				<template #cell-status="{ row }">
+					<div class="flex items-center gap-1.5">
+						<StatusBadge :status="submissionOf(row.status)" size="xs" />
+						<StatusBadge v-if="paymentOf(row.status)" :status="paymentOf(row.status)" size="xs" />
+					</div>
+				</template>
+				<template #cell-actions="{ row }">
+					<button v-if="canReceive(row)" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click.stop="openReceive(row)">Receive</button>
+				</template>
+			</DocTypeListView>
 		</div>
 
 		<!-- Receive payment modal -->


### PR DESCRIPTION
Rebuilds the New/Edit invoice form to faithfully match the prototype's `InvoiceFormView`, and makes taxes & discount work **exactly like the Subcontractor Bill** (as requested) rather than the earlier simplified modal.

## Layout (prototype parity)
Full-page **DeskForm** with a sticky **action bar**, then:
- **Invoice details** section (4-col): Customer, Project, Invoice date, Due date.
- **Items** section: the description / qty / rate / amount grid with add & remove.
- A bottom row: **Taxes & discount** + **collapsible Terms & conditions** on the left, a **live totals waterfall** pinned on the right.

## Taxes & discount — Subcontractor Bill pattern
- A **Sales Taxes and Charges Template** picker expands into an **editable tax table** (account head + rate, add/remove rows) — same flow as the bill.
- **Discount** on **Net Total / Grand Total**, as **% or amount** (₹/% toggle).
- The waterfall (net → discount → taxable → taxes → invoice total) computes live and persists to the Sales Invoice's native fields (`apply_discount_on`, `discount_amount`, `additional_discount_percentage`).

## Terms
Import from a **Terms and Conditions** template into an editable box (persisted as `terms` + `tc_name`).

## Backend (`api/invoice.py`)
- `save_invoice` now accepts `taxes` rows (or expands the template), the discount fields, and `terms`/`tc_name`.
- `get_invoice` returns them for edit; adds `get_tax_template_rows` (Sales) and `get_terms`.

## Verification
- `test_invoice` (4) green — new taxes+discount test: 100000 −5% net, +10% tax = **104500**, round-tripped through `get_invoice`.
- Frontend builds clean.

Follow-up to the merged invoices PR (#120).