### PR TITLE
feat: advance payment linking across invoices and bills

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -14,6 +14,7 @@ from frappe.utils import flt, nowdate
 from buildsuite_core.utils.project import default_company
 
 SI = "Sales Invoice"
+PE = "Payment Entry"
 SERVICE_ITEM = "Professional Services"
 SERVICE_ITEM_GROUP = "Services"
 
@@ -81,11 +82,77 @@ def _payment_summary(name):
 	return {"invoiced": invoiced, "received": received, "outstanding": outstanding, "status": status}
 
 
+def _ref_is_advance(pe_type, paid_amount, unallocated, allocated):
+	"""True when a Payment Entry linked to an invoice is a customer ADVANCE (on-account money
+	adjusted against the invoice) rather than a plain receipt raised for that one invoice. A
+	receipt (via record_receipt) is a Receive fully consumed 1:1 by the invoice; an advance
+	still carries unallocated money or funds more than this allocation."""
+	if pe_type != "Receive":
+		return False
+	return flt(unallocated) > 0.01 or flt(paid_amount) - flt(allocated) > 0.01
+
+
+def _linked_advances(doc):
+	"""Advances adjusted against this invoice, one entry per Payment Entry with its TOTAL applied.
+
+	Draft → the native `advances` table. Submitted → the advance's Payment Entry references to
+	this invoice, SUMMED per Payment Entry (a partial advance may be reconciled in several steps,
+	each adding its own reference row). A Payment Entry counts as an advance when it was set on
+	the invoice before submit (its advances-table row is retained after submit) or when it is an
+	on-account receipt reconciled after submit — a plain cash receipt is neither."""
+	if doc.docstatus == 0:
+		return [
+			{"payment_entry": a.reference_name, "allocated": flt(a.allocated_amount)}
+			for a in doc.advances
+			if a.reference_type == PE and flt(a.allocated_amount) > 0
+		]
+
+	refs = frappe.get_all(
+		"Payment Entry Reference",
+		filters={"reference_doctype": SI, "reference_name": doc.name, "docstatus": 1},
+		fields=["parent", "allocated_amount"],
+		order_by="creation asc",
+	)
+	totals, order = {}, []
+	for r in refs:
+		if r.parent not in totals:
+			totals[r.parent] = 0
+			order.append(r.parent)
+		totals[r.parent] += flt(r.allocated_amount)
+
+	table_pes = {
+		a.reference_name for a in doc.advances if a.reference_type == PE and flt(a.allocated_amount) > 0
+	}
+	out = []
+	for pe_name in order:
+		total = totals[pe_name]
+		is_advance = pe_name in table_pes
+		if not is_advance:
+			pe = frappe.db.get_value(
+				PE, pe_name, ["payment_type", "paid_amount", "unallocated_amount"], as_dict=True
+			)
+			is_advance = bool(pe) and _ref_is_advance(
+				pe.payment_type, pe.paid_amount, pe.unallocated_amount, total
+			)
+		if is_advance:
+			out.append({"payment_entry": pe_name, "allocated": total})
+	return out
+
+
 def _serialize(doc):
+	advances = _linked_advances(doc)
+	adjusted = sum(a["allocated"] for a in advances)
+	pay = _payment_summary(doc.name)
+	# Advance adjustment settles the receivable but is not a cash receipt — split it out of
+	# "Received" so the totals read the way the prototype shows them.
+	pay["advance_adjusted"] = adjusted
+	if doc.docstatus == 1:
+		pay["received"] = max(flt(pay["received"]) - adjusted, 0)
 	return {
 		"name": doc.name,
 		"customer": doc.customer,
 		"customer_name": doc.customer_name,
+		"customer_gstin": frappe.db.get_value("Customer", doc.customer, "tax_id") if doc.customer else None,
 		"project": doc.project,
 		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
 		"company": doc.company,
@@ -101,15 +168,24 @@ def _serialize(doc):
 		"net_total": doc.net_total,
 		"total_taxes_and_charges": doc.total_taxes_and_charges,
 		"grand_total": doc.grand_total,
+		"total_advance": flt(doc.get("total_advance")),
+		"advance_adjusted": adjusted,
+		"advances": advances,
 		"items": [
 			{"description": r.description, "qty": r.qty, "rate": r.rate, "amount": r.amount}
 			for r in doc.items
 		],
 		"taxes": [
-			{"charge_type": t.charge_type, "account_head": t.account_head, "description": t.description, "rate": t.rate, "tax_amount": t.tax_amount}
+			{
+				"charge_type": t.charge_type,
+				"account_head": t.account_head,
+				"description": t.description,
+				"rate": t.rate,
+				"tax_amount": t.tax_amount,
+			}
 			for t in doc.taxes
 		],
-		"payment": _payment_summary(doc.name),
+		"payment": pay,
 	}
 
 
@@ -128,15 +204,28 @@ def list_invoices(project=None, company=None):
 		SI,
 		filters=filters,
 		fields=[
-			"name", "customer", "customer_name", "project", "posting_date", "due_date",
-			"grand_total", "outstanding_amount", "status", "docstatus",
+			"name",
+			"customer",
+			"customer_name",
+			"project",
+			"posting_date",
+			"due_date",
+			"grand_total",
+			"outstanding_amount",
+			"status",
+			"docstatus",
 		],
 		order_by="posting_date desc, creation desc",
 		limit_page_length=0,
 	)
 	pids = list({r.project for r in rows if r.project})
 	pnames = (
-		{p.name: p.project_name for p in frappe.get_all("Project", filters={"name": ["in", pids]}, fields=["name", "project_name"])}
+		{
+			p.name: p.project_name
+			for p in frappe.get_all(
+				"Project", filters={"name": ["in", pids]}, fields=["name", "project_name"]
+			)
+		}
 		if pids
 		else {}
 	)
@@ -343,7 +432,10 @@ def record_receipt(name, amount=None, date=None, mode_of_payment=None, deposit_t
 
 @frappe.whitelist()
 def list_receipts(name):
-	"""Payment Entries allocated to this invoice."""
+	"""Cash receipts allocated to this invoice — plain Payment Entries only. Adjusted customer
+	advances are excluded here; they show under the invoice's Advance Payments instead."""
+	doc = frappe.get_doc(SI, name)
+	advance_pes = {a["payment_entry"] for a in _linked_advances(doc)}
 	refs = frappe.get_all(
 		"Payment Entry Reference",
 		filters={"reference_doctype": SI, "reference_name": name, "docstatus": 1},
@@ -351,9 +443,13 @@ def list_receipts(name):
 	)
 	out = []
 	for r in refs:
+		if r.parent in advance_pes:
+			continue
 		pe = frappe.db.get_value(
-			"Payment Entry", r.parent, ["posting_date", "mode_of_payment", "reference_no"], as_dict=True
+			PE, r.parent, ["posting_date", "mode_of_payment", "reference_no"], as_dict=True
 		)
+		if not pe:
+			continue
 		out.append(
 			{
 				"payment_entry": r.parent,
@@ -411,6 +507,198 @@ def record_advance(customer, amount, date=None, deposit_to=None, mode_of_payment
 	pe.insert()
 	pe.submit()
 	return {"payment_entry": pe.name}
+
+
+# --------------------------------------------------------------------------- #
+# Adjust a customer advance against an invoice (ERPNext-native)
+#   Draft     → the Sales Invoice `advances` child table (reconciles on submit).
+#   Submitted → Payment Reconciliation (link) / Unreconcile Payment (unlink).
+# --------------------------------------------------------------------------- #
+def _receivable_for(customer, company):
+	from erpnext.accounts.party import get_party_account
+
+	return get_party_account("Customer", customer, company)
+
+
+def _draft_committed(pe_names):
+	"""How much of each Payment Entry is already earmarked on DRAFT invoices' advances tables.
+	A draft advance does not reduce the Payment Entry's `unallocated_amount` (nothing hits the
+	ledger until submit), so we net it off ourselves — otherwise an advance already adjusted on
+	a draft keeps showing as fully available and can be linked again and again."""
+	if not pe_names:
+		return {}
+	rows = frappe.get_all(
+		"Sales Invoice Advance",
+		filters={"reference_type": PE, "reference_name": ["in", list(pe_names)], "docstatus": 0},
+		fields=["reference_name", "allocated_amount"],
+	)
+	out = {}
+	for r in rows:
+		out[r.reference_name] = out.get(r.reference_name, 0) + flt(r.allocated_amount)
+	return out
+
+
+@frappe.whitelist()
+def available_advances(name):
+	"""The invoice customer's on-account advances that can still be adjusted against this
+	invoice, oldest first — the Payment Entry's unallocated balance net of anything already
+	earmarked on any draft invoice (including this one)."""
+	si = frappe.get_doc(SI, name)
+	si.check_permission("read")
+	rows = frappe.get_all(
+		PE,
+		filters={
+			"docstatus": 1,
+			"payment_type": "Receive",
+			"party_type": "Customer",
+			"party": si.customer,
+			"company": si.company,
+			"unallocated_amount": [">", 0.01],
+		},
+		fields=["name", "posting_date", "unallocated_amount", "mode_of_payment", "reference_no", "paid_to"],
+		order_by="posting_date asc, creation asc",
+	)
+	committed = _draft_committed([r.name for r in rows])
+	out = []
+	for r in rows:
+		remaining = flt(r.unallocated_amount) - flt(committed.get(r.name, 0))
+		if remaining <= 0.01:
+			continue
+		out.append(
+			{
+				"payment_entry": r.name,
+				"date": str(r.posting_date) if r.posting_date else None,
+				"unallocated": remaining,
+				"mode_of_payment": r.mode_of_payment,
+				"reference_no": r.reference_no,
+				"deposit_to": r.paid_to,
+			}
+		)
+	return out
+
+
+def _reconcile_advance(si, pe, amount):
+	"""Allocate `amount` of an unallocated advance Payment Entry against a submitted invoice via
+	the native Payment Reconciliation tool (honours a partial allocation)."""
+	pr = frappe.new_doc("Payment Reconciliation")
+	pr.company = si.company
+	pr.party_type = "Customer"
+	pr.party = si.customer
+	pr.receivable_payable_account = _receivable_for(si.customer, si.company)
+	pr.get_unreconciled_entries()
+	inv_d = [i.as_dict() for i in pr.invoices if i.invoice_number == si.name]
+	pay_d = [p.as_dict() for p in pr.payments if p.reference_name == pe.name]
+	if not inv_d or not pay_d:
+		frappe.throw(_("Could not find the advance or the invoice among unreconciled entries."))
+	pr.allocate_entries({"invoices": inv_d, "payments": pay_d})
+	# allocate_entries auto-fills full amounts; trim to the requested partial while leaving
+	# unreconciled_amount untouched (the modified-check validates it against the ledger).
+	matched = False
+	for a in pr.allocation:
+		if a.reference_name == pe.name and a.invoice_number == si.name:
+			a.allocated_amount = amount
+			matched = True
+		else:
+			a.allocated_amount = 0
+	pr.set("allocation", [a for a in pr.allocation if flt(a.allocated_amount) > 0])
+	if not matched or not pr.allocation:
+		frappe.throw(_("Allocation could not be prepared."))
+	pr.reconcile()
+
+
+@frappe.whitelist()
+def link_advance(name, payment_entry, amount):
+	"""Adjust `amount` of a customer advance against this invoice, reducing its outstanding."""
+	si = frappe.get_doc(SI, name)
+	si.check_permission("write")
+	amount = flt(amount)
+	if amount <= 0:
+		frappe.throw(_("Enter an allocation greater than zero."))
+
+	pe = frappe.get_doc(PE, payment_entry)
+	if pe.docstatus != 1 or pe.payment_type != "Receive" or pe.party != si.customer:
+		frappe.throw(_("{0} is not an advance from this customer.").format(payment_entry))
+	available = flt(pe.unallocated_amount)
+	if amount > available + 0.01:
+		frappe.throw(_("Only {0} is unadjusted on {1}.").format(available, payment_entry))
+
+	if si.docstatus == 0:
+		existing = next(
+			(a for a in si.advances if a.reference_type == PE and a.reference_name == payment_entry), None
+		)
+		prior = flt(existing.allocated_amount) if existing else 0
+		other_rows = sum(flt(a.allocated_amount) for a in si.advances if a is not existing)
+		# The advance can back at most its own unadjusted balance (net of what it already backs
+		# on OTHER drafts), and never more than the invoice's own total.
+		committed_elsewhere = flt(_draft_committed([payment_entry]).get(payment_entry, 0)) - prior
+		pe_room = available - committed_elsewhere - prior
+		invoice_room = flt(si.grand_total) - other_rows - prior
+		room = min(pe_room, invoice_room)
+		if room <= 0.01:
+			frappe.throw(_("This advance is already fully adjusted against the invoice."))
+		if amount > room + 0.01:
+			frappe.throw(
+				_("At most {0} more of {1} can be adjusted against this invoice.").format(room, payment_entry)
+			)
+		if existing:
+			existing.advance_amount = available
+			existing.allocated_amount = prior + amount
+		else:
+			si.append(
+				"advances",
+				{
+					"reference_type": PE,
+					"reference_name": payment_entry,
+					"advance_amount": available,
+					"allocated_amount": amount,
+					"remarks": pe.remarks,
+				},
+			)
+		si.flags.ignore_permissions = True
+		si.save()
+	elif si.docstatus == 1:
+		if flt(si.outstanding_amount) <= 0.01:
+			frappe.throw(_("This invoice is already settled."))
+		_reconcile_advance(si, pe, min(amount, flt(si.outstanding_amount)))
+	else:
+		frappe.throw(_("A cancelled invoice cannot take advances."))
+	return {"payment": _payment_summary(name)}
+
+
+@frappe.whitelist()
+def unlink_advance(name, payment_entry):
+	"""Reverse an advance adjustment — remove the draft `advances` row, or unreconcile the
+	Payment Entry from a submitted invoice (native Unreconcile Payment)."""
+	si = frappe.get_doc(SI, name)
+	si.check_permission("write")
+	if si.docstatus == 0:
+		si.set(
+			"advances",
+			[a for a in si.advances if not (a.reference_type == PE and a.reference_name == payment_entry)],
+		)
+		si.flags.ignore_permissions = True
+		si.save()
+	elif si.docstatus == 1:
+		from erpnext.accounts.doctype.unreconcile_payment.unreconcile_payment import (
+			create_unreconcile_doc_for_selection,
+		)
+
+		create_unreconcile_doc_for_selection(
+			frappe.as_json(
+				[
+					{
+						"company": si.company,
+						"voucher_type": PE,
+						"voucher_no": payment_entry,
+						"against_voucher_type": SI,
+						"against_voucher_no": si.name,
+					}
+				]
+			)
+		)
+	else:
+		frappe.throw(_("Nothing to unlink on a cancelled invoice."))
+	return {"payment": _payment_summary(name)}
 
 
 @frappe.whitelist()

--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -28,10 +28,30 @@ def _effective_company(doc):
 	return doc.company
 
 
+def _linked_advances_for_bill(doc):
+	"""Advances adjusted against this bill — read through its generated Purchase Invoice, reusing
+	the supplier-bill logic (the subcontractor is the PI's supplier)."""
+	from buildsuite_core.api import supplier_bill as _sb
+
+	if not doc.purchase_invoice or not frappe.db.exists("Purchase Invoice", doc.purchase_invoice):
+		return []
+	pi = frappe.get_doc("Purchase Invoice", doc.purchase_invoice)
+	return _sb._linked_advances(pi)
+
+
 def _serialize(doc):
+	advances = _linked_advances_for_bill(doc)
+	adjusted = sum(a["allocated"] for a in advances)
+	pay = _payment_summary(doc)
+	# Advance adjustment settles the payable but is not a cash payment — split it out of "Paid".
+	pay["advance_adjusted"] = adjusted
+	if doc.docstatus == 1:
+		pay["paid"] = max(flt(pay["paid"]) - adjusted, 0)
 	return {
 		"name": doc.name,
 		"is_direct": doc.is_direct,
+		"advance_adjusted": adjusted,
+		"advances": advances,
 		"work_order": doc.work_order,
 		"ra_no": doc.ra_no,
 		"subcontractor": doc.subcontractor,
@@ -94,7 +114,7 @@ def _serialize(doc):
 			}
 			for t in doc.taxes
 		],
-		"payment": _payment_summary(doc),
+		"payment": pay,
 		"actions": _available_actions(doc),
 	}
 
@@ -116,7 +136,10 @@ def _payment_summary(doc):
 	if not doc.purchase_invoice or not frappe.db.exists("Purchase Invoice", doc.purchase_invoice):
 		return {"invoiced": 0, "paid": 0, "outstanding": 0, "status": "Unpaid"}
 	pi = frappe.db.get_value(
-		"Purchase Invoice", doc.purchase_invoice, ["grand_total", "outstanding_amount", "status"], as_dict=True
+		"Purchase Invoice",
+		doc.purchase_invoice,
+		["grand_total", "outstanding_amount", "status"],
+		as_dict=True,
 	)
 	invoiced = flt(pi.grand_total)
 	outstanding = flt(pi.outstanding_amount)
@@ -172,9 +195,7 @@ def get_wo_bill_context(work_order: str):
 				"this_period_amount": tpq * flt(row.rate),
 			}
 		)
-	existing = frappe.get_all(
-		BILL, filters={"work_order": work_order, "docstatus": ["<", 2]}, pluck="ra_no"
-	)
+	existing = frappe.get_all(BILL, filters={"work_order": work_order, "docstatus": ["<", 2]}, pluck="ra_no")
 	return {
 		"work_order": wo.name,
 		"subcontractor": wo.subcontractor,
@@ -252,7 +273,9 @@ def save_bill(payload):
 		doc.retention_percent = flt(data.get("retention_percent"))
 		doc.set("lines", [])
 		for row in data.get("lines") or []:
-			amount = flt(row.get("amount") if row.get("amount") is not None else row.get("this_period_amount"))
+			amount = flt(
+				row.get("amount") if row.get("amount") is not None else row.get("this_period_amount")
+			)
 			if not (row.get("scope") or "").strip() and amount <= 0:
 				continue
 			doc.append(
@@ -410,27 +433,54 @@ def list_payment_modes():
 
 @frappe.whitelist()
 def list_payments(name: str):
-	"""Payment Entries allocated to this bill's PI."""
-	bill = frappe.db.get_value(BILL, name, "purchase_invoice")
-	if not bill:
+	"""Cash payments allocated to this bill's PI — advances are excluded (they show under the
+	bill's Advance Payments instead), reusing the supplier-bill logic."""
+	from buildsuite_core.api import supplier_bill as _sb
+
+	pi = frappe.db.get_value(BILL, name, "purchase_invoice")
+	if not pi:
 		return []
-	refs = frappe.get_all(
-		"Payment Entry Reference",
-		filters={"reference_doctype": "Purchase Invoice", "reference_name": bill, "docstatus": 1},
-		fields=["parent", "allocated_amount"],
-	)
-	out = []
-	for r in refs:
-		pe = frappe.db.get_value(
-			"Payment Entry", r.parent, ["posting_date", "mode_of_payment", "reference_no"], as_dict=True
-		)
-		out.append(
-			{
-				"payment_entry": r.parent,
-				"date": str(pe.posting_date) if pe.posting_date else None,
-				"mode_of_payment": pe.mode_of_payment,
-				"reference_no": pe.reference_no,
-				"amount": flt(r.allocated_amount),
-			}
-		)
-	return out
+	return _sb.list_payments(pi)
+
+
+# --------------------------------------------------------------------------- #
+# Adjust a subcontractor advance against the bill — reconciled against the bill's generated
+# Purchase Invoice (the subcontractor is the PI's supplier). Available only after submit, when
+# the PI exists; delegates to the supplier-bill advance logic.
+# --------------------------------------------------------------------------- #
+@frappe.whitelist()
+def available_advances(name: str):
+	"""On-account advances paid to this subcontractor that can be adjusted against the bill."""
+	from buildsuite_core.api import supplier_bill as _sb
+
+	bill = frappe.get_doc(BILL, name)
+	bill.check_permission("read")
+	if not bill.purchase_invoice or not frappe.db.exists("Purchase Invoice", bill.purchase_invoice):
+		return []
+	return _sb.available_advances(bill.purchase_invoice)
+
+
+@frappe.whitelist()
+def link_advance(name: str, payment_entry: str, amount):
+	"""Adjust `amount` of a subcontractor advance against this bill, reducing its outstanding."""
+	from buildsuite_core.api import supplier_bill as _sb
+
+	bill = frappe.get_doc(BILL, name)
+	bill.check_permission("write")
+	if not bill.purchase_invoice:
+		frappe.throw(_("Submit the bill first — advances link to its Purchase Invoice."))
+	_sb.link_advance(bill.purchase_invoice, payment_entry, amount)
+	return {"payment": _serialize(frappe.get_doc(BILL, name))["payment"]}
+
+
+@frappe.whitelist()
+def unlink_advance(name: str, payment_entry: str):
+	"""Reverse an advance adjustment on this bill (native Unreconcile Payment)."""
+	from buildsuite_core.api import supplier_bill as _sb
+
+	bill = frappe.get_doc(BILL, name)
+	bill.check_permission("write")
+	if not bill.purchase_invoice:
+		frappe.throw(_("This bill has no Purchase Invoice."))
+	_sb.unlink_advance(bill.purchase_invoice, payment_entry)
+	return {"payment": _serialize(frappe.get_doc(BILL, name))["payment"]}

--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -14,6 +14,7 @@ from frappe.utils import flt, nowdate
 from buildsuite_core.utils.project import default_company
 
 PI = "Purchase Invoice"
+PE = "Payment Entry"
 SERVICE_ITEM = "Supplier Charges"
 SERVICE_ITEM_GROUP = "Services"
 
@@ -81,12 +82,78 @@ def _payment_summary(name):
 	return {"invoiced": invoiced, "paid": paid, "outstanding": outstanding, "status": status}
 
 
+def _ref_is_advance(pe_type, paid_amount, unallocated, allocated):
+	"""True when a Payment Entry linked to a bill is a supplier ADVANCE (on-account money adjusted
+	against the bill) rather than a plain payment raised for that one bill. A payment (via
+	record_payment) is a Pay fully consumed 1:1 by the bill; an advance still carries unallocated
+	money or funds more than this allocation."""
+	if pe_type != "Pay":
+		return False
+	return flt(unallocated) > 0.01 or flt(paid_amount) - flt(allocated) > 0.01
+
+
+def _linked_advances(doc):
+	"""Advances adjusted against this bill, one entry per Payment Entry with its TOTAL applied.
+
+	Draft → the native `advances` table. Submitted → the advance Payment Entry's references to
+	this bill, SUMMED per Payment Entry (a partial advance may be reconciled in several steps).
+	A Payment Entry counts as an advance when it was set on the bill before submit (its
+	advances-table row is retained after submit) or when it is an on-account payment reconciled
+	after submit — a plain cash payment is neither."""
+	if doc.docstatus == 0:
+		return [
+			{"payment_entry": a.reference_name, "allocated": flt(a.allocated_amount)}
+			for a in doc.advances
+			if a.reference_type == PE and flt(a.allocated_amount) > 0
+		]
+
+	refs = frappe.get_all(
+		"Payment Entry Reference",
+		filters={"reference_doctype": PI, "reference_name": doc.name, "docstatus": 1},
+		fields=["parent", "allocated_amount"],
+		order_by="creation asc",
+	)
+	totals, order = {}, []
+	for r in refs:
+		if r.parent not in totals:
+			totals[r.parent] = 0
+			order.append(r.parent)
+		totals[r.parent] += flt(r.allocated_amount)
+
+	table_pes = {
+		a.reference_name for a in doc.advances if a.reference_type == PE and flt(a.allocated_amount) > 0
+	}
+	out = []
+	for pe_name in order:
+		total = totals[pe_name]
+		is_advance = pe_name in table_pes
+		if not is_advance:
+			pe = frappe.db.get_value(
+				PE, pe_name, ["payment_type", "paid_amount", "unallocated_amount"], as_dict=True
+			)
+			is_advance = bool(pe) and _ref_is_advance(
+				pe.payment_type, pe.paid_amount, pe.unallocated_amount, total
+			)
+		if is_advance:
+			out.append({"payment_entry": pe_name, "allocated": total})
+	return out
+
+
 def _serialize(doc):
+	advances = _linked_advances(doc)
+	adjusted = sum(a["allocated"] for a in advances)
+	pay = _payment_summary(doc.name)
+	# Advance adjustment settles the payable but is not a cash payment — split it out of "Paid"
+	# so the totals read the way the prototype shows them.
+	pay["advance_adjusted"] = adjusted
+	if doc.docstatus == 1:
+		pay["paid"] = max(flt(pay["paid"]) - adjusted, 0)
 	return {
 		"name": doc.name,
 		"kind": "supplier",
 		"supplier": doc.supplier,
 		"supplier_name": doc.supplier_name,
+		"supplier_gstin": frappe.db.get_value("Supplier", doc.supplier, "tax_id") if doc.supplier else None,
 		"project": doc.project,
 		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
 		"company": doc.company,
@@ -104,15 +171,23 @@ def _serialize(doc):
 		"net_total": doc.net_total,
 		"total_taxes_and_charges": doc.total_taxes_and_charges,
 		"grand_total": doc.grand_total,
+		"advance_adjusted": adjusted,
+		"advances": advances,
 		"items": [
 			{"description": r.description, "qty": r.qty, "rate": r.rate, "amount": r.amount}
 			for r in doc.items
 		],
 		"taxes": [
-			{"charge_type": t.charge_type, "account_head": t.account_head, "description": t.description, "rate": t.rate, "tax_amount": t.tax_amount}
+			{
+				"charge_type": t.charge_type,
+				"account_head": t.account_head,
+				"description": t.description,
+				"rate": t.rate,
+				"tax_amount": t.tax_amount,
+			}
 			for t in doc.taxes
 		],
-		"payment": _payment_summary(doc.name),
+		"payment": pay,
 	}
 
 
@@ -142,7 +217,18 @@ def list_payables(company=None):
 	for pi in frappe.get_all(
 		PI,
 		filters=pi_filters,
-		fields=["name", "supplier", "supplier_name", "project", "posting_date", "due_date", "grand_total", "outstanding_amount", "status", "docstatus"],
+		fields=[
+			"name",
+			"supplier",
+			"supplier_name",
+			"project",
+			"posting_date",
+			"due_date",
+			"grand_total",
+			"outstanding_amount",
+			"status",
+			"docstatus",
+		],
 		order_by="posting_date desc, creation desc",
 	):
 		rows.append(
@@ -170,7 +256,9 @@ def list_payables(company=None):
 		grand = flt(sb.net_payable)
 		outstanding = grand
 		if sb.purchase_invoice and frappe.db.exists(PI, sb.purchase_invoice):
-			pi = frappe.db.get_value(PI, sb.purchase_invoice, ["grand_total", "outstanding_amount"], as_dict=True)
+			pi = frappe.db.get_value(
+				PI, sb.purchase_invoice, ["grand_total", "outstanding_amount"], as_dict=True
+			)
 			grand = flt(pi.grand_total)
 			outstanding = flt(pi.outstanding_amount)
 		rows.append(
@@ -395,6 +483,10 @@ def record_payment(name, amount=None, date=None, mode_of_payment=None, pay_from=
 
 @frappe.whitelist()
 def list_payments(name):
+	"""Cash payments allocated to this bill — plain Payment Entries only. Adjusted supplier
+	advances are excluded here; they show under the bill's Advance Payments instead."""
+	doc = frappe.get_doc(PI, name)
+	advance_pes = {a["payment_entry"] for a in _linked_advances(doc)}
 	refs = frappe.get_all(
 		"Payment Entry Reference",
 		filters={"reference_doctype": PI, "reference_name": name, "docstatus": 1},
@@ -402,9 +494,13 @@ def list_payments(name):
 	)
 	out = []
 	for r in refs:
+		if r.parent in advance_pes:
+			continue
 		pe = frappe.db.get_value(
-			"Payment Entry", r.parent, ["posting_date", "mode_of_payment", "reference_no"], as_dict=True
+			PE, r.parent, ["posting_date", "mode_of_payment", "reference_no"], as_dict=True
 		)
+		if not pe:
+			continue
 		out.append(
 			{
 				"payment_entry": r.parent,
@@ -462,6 +558,194 @@ def record_advance(supplier, amount, date=None, pay_from=None, mode_of_payment=N
 
 
 # --------------------------------------------------------------------------- #
+# Adjust a supplier advance against a bill (ERPNext-native)
+#   Draft     → the Purchase Invoice `advances` child table (reconciles on submit).
+#   Submitted → Payment Reconciliation (link) / Unreconcile Payment (unlink).
+# --------------------------------------------------------------------------- #
+def _payable_for(supplier, company):
+	from erpnext.accounts.party import get_party_account
+
+	return get_party_account("Supplier", supplier, company)
+
+
+def _draft_committed(pe_names):
+	"""How much of each Payment Entry is already earmarked on DRAFT bills' advances tables. A
+	draft advance does not reduce the Payment Entry's `unallocated_amount`, so we net it off
+	ourselves — otherwise an advance already linked on a draft keeps showing as fully available
+	and can be linked again and again."""
+	if not pe_names:
+		return {}
+	rows = frappe.get_all(
+		"Purchase Invoice Advance",
+		filters={"reference_type": PE, "reference_name": ["in", list(pe_names)], "docstatus": 0},
+		fields=["reference_name", "allocated_amount"],
+	)
+	out = {}
+	for r in rows:
+		out[r.reference_name] = out.get(r.reference_name, 0) + flt(r.allocated_amount)
+	return out
+
+
+@frappe.whitelist()
+def available_advances(name):
+	"""The bill supplier's on-account advances that can still be adjusted against this bill,
+	oldest first — the Payment Entry's unallocated balance net of anything already earmarked on
+	any draft bill (including this one)."""
+	pi = frappe.get_doc(PI, name)
+	pi.check_permission("read")
+	rows = frappe.get_all(
+		PE,
+		filters={
+			"docstatus": 1,
+			"payment_type": "Pay",
+			"party_type": "Supplier",
+			"party": pi.supplier,
+			"company": pi.company,
+			"unallocated_amount": [">", 0.01],
+		},
+		fields=["name", "posting_date", "unallocated_amount", "mode_of_payment", "reference_no", "paid_from"],
+		order_by="posting_date asc, creation asc",
+	)
+	committed = _draft_committed([r.name for r in rows])
+	out = []
+	for r in rows:
+		remaining = flt(r.unallocated_amount) - flt(committed.get(r.name, 0))
+		if remaining <= 0.01:
+			continue
+		out.append(
+			{
+				"payment_entry": r.name,
+				"date": str(r.posting_date) if r.posting_date else None,
+				"unallocated": remaining,
+				"mode_of_payment": r.mode_of_payment,
+				"reference_no": r.reference_no,
+				"pay_from": r.paid_from,
+			}
+		)
+	return out
+
+
+def _reconcile_advance(pi, pe, amount):
+	"""Allocate `amount` of an unallocated advance Payment Entry against a submitted bill via the
+	native Payment Reconciliation tool (honours a partial allocation)."""
+	pr = frappe.new_doc("Payment Reconciliation")
+	pr.company = pi.company
+	pr.party_type = "Supplier"
+	pr.party = pi.supplier
+	pr.receivable_payable_account = _payable_for(pi.supplier, pi.company)
+	pr.get_unreconciled_entries()
+	inv_d = [i.as_dict() for i in pr.invoices if i.invoice_number == pi.name]
+	pay_d = [p.as_dict() for p in pr.payments if p.reference_name == pe.name]
+	if not inv_d or not pay_d:
+		frappe.throw(_("Could not find the advance or the bill among unreconciled entries."))
+	pr.allocate_entries({"invoices": inv_d, "payments": pay_d})
+	matched = False
+	for a in pr.allocation:
+		if a.reference_name == pe.name and a.invoice_number == pi.name:
+			a.allocated_amount = amount
+			matched = True
+		else:
+			a.allocated_amount = 0
+	pr.set("allocation", [a for a in pr.allocation if flt(a.allocated_amount) > 0])
+	if not matched or not pr.allocation:
+		frappe.throw(_("Allocation could not be prepared."))
+	pr.reconcile()
+
+
+@frappe.whitelist()
+def link_advance(name, payment_entry, amount):
+	"""Adjust `amount` of a supplier advance against this bill, reducing its outstanding."""
+	pi = frappe.get_doc(PI, name)
+	pi.check_permission("write")
+	amount = flt(amount)
+	if amount <= 0:
+		frappe.throw(_("Enter an allocation greater than zero."))
+
+	pe = frappe.get_doc(PE, payment_entry)
+	if pe.docstatus != 1 or pe.payment_type != "Pay" or pe.party != pi.supplier:
+		frappe.throw(_("{0} is not an advance to this supplier.").format(payment_entry))
+	available = flt(pe.unallocated_amount)
+	if amount > available + 0.01:
+		frappe.throw(_("Only {0} is unadjusted on {1}.").format(available, payment_entry))
+
+	if pi.docstatus == 0:
+		existing = next(
+			(a for a in pi.advances if a.reference_type == PE and a.reference_name == payment_entry), None
+		)
+		prior = flt(existing.allocated_amount) if existing else 0
+		other_rows = sum(flt(a.allocated_amount) for a in pi.advances if a is not existing)
+		committed_elsewhere = flt(_draft_committed([payment_entry]).get(payment_entry, 0)) - prior
+		pe_room = available - committed_elsewhere - prior
+		bill_room = flt(pi.grand_total) - other_rows - prior
+		room = min(pe_room, bill_room)
+		if room <= 0.01:
+			frappe.throw(_("This advance is already fully adjusted against the bill."))
+		if amount > room + 0.01:
+			frappe.throw(
+				_("At most {0} more of {1} can be adjusted against this bill.").format(room, payment_entry)
+			)
+		if existing:
+			existing.advance_amount = available
+			existing.allocated_amount = prior + amount
+		else:
+			pi.append(
+				"advances",
+				{
+					"reference_type": PE,
+					"reference_name": payment_entry,
+					"advance_amount": available,
+					"allocated_amount": amount,
+					"remarks": pe.remarks,
+				},
+			)
+		pi.flags.ignore_permissions = True
+		pi.save()
+	elif pi.docstatus == 1:
+		if flt(pi.outstanding_amount) <= 0.01:
+			frappe.throw(_("This bill is already settled."))
+		_reconcile_advance(pi, pe, min(amount, flt(pi.outstanding_amount)))
+	else:
+		frappe.throw(_("A cancelled bill cannot take advances."))
+	return {"payment": _payment_summary(name)}
+
+
+@frappe.whitelist()
+def unlink_advance(name, payment_entry):
+	"""Reverse an advance adjustment — remove the draft `advances` row, or unreconcile the
+	Payment Entry from a submitted bill (native Unreconcile Payment)."""
+	pi = frappe.get_doc(PI, name)
+	pi.check_permission("write")
+	if pi.docstatus == 0:
+		pi.set(
+			"advances",
+			[a for a in pi.advances if not (a.reference_type == PE and a.reference_name == payment_entry)],
+		)
+		pi.flags.ignore_permissions = True
+		pi.save()
+	elif pi.docstatus == 1:
+		from erpnext.accounts.doctype.unreconcile_payment.unreconcile_payment import (
+			create_unreconcile_doc_for_selection,
+		)
+
+		create_unreconcile_doc_for_selection(
+			frappe.as_json(
+				[
+					{
+						"company": pi.company,
+						"voucher_type": PE,
+						"voucher_no": payment_entry,
+						"against_voucher_type": PI,
+						"against_voucher_no": pi.name,
+					}
+				]
+			)
+		)
+	else:
+		frappe.throw(_("Nothing to unlink on a cancelled bill."))
+	return {"payment": _payment_summary(name)}
+
+
+# --------------------------------------------------------------------------- #
 # Pickers
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
@@ -490,7 +774,12 @@ def list_tax_templates(company=None):
 def get_tax_template_rows(template):
 	doc = frappe.get_doc("Purchase Taxes and Charges Template", template)
 	return [
-		{"charge_type": t.charge_type, "account_head": t.account_head, "description": t.description or t.account_head, "rate": t.rate}
+		{
+			"charge_type": t.charge_type,
+			"account_head": t.account_head,
+			"description": t.description or t.account_head,
+			"rate": t.rate,
+		}
 		for t in doc.taxes
 	]
 

--- a/buildsuite_core/tests/test_invoice.py
+++ b/buildsuite_core/tests/test_invoice.py
@@ -24,8 +24,10 @@ class TestInvoice(BuildSuiteTestCase):
 				{
 					"doctype": "Customer",
 					"customer_name": f"Cust {self._n}",
-					"customer_group": frappe.db.get_value("Customer Group", {"is_group": 0}, "name") or "All Customer Groups",
-					"territory": frappe.db.get_value("Territory", {"is_group": 0}, "name") or "All Territories",
+					"customer_group": frappe.db.get_value("Customer Group", {"is_group": 0}, "name")
+					or "All Customer Groups",
+					"territory": frappe.db.get_value("Territory", {"is_group": 0}, "name")
+					or "All Territories",
 				}
 			)
 			.insert(ignore_permissions=True)
@@ -98,7 +100,9 @@ class TestInvoice(BuildSuiteTestCase):
 		from buildsuite_core.api.invoice import get_invoice, save_invoice
 
 		cust = self._customer()
-		income_tax = frappe.db.get_value("Account", {"company": self.company, "account_type": "Tax", "is_group": 0}, "name")
+		income_tax = frappe.db.get_value(
+			"Account", {"company": self.company, "account_type": "Tax", "is_group": 0}, "name"
+		)
 		if not income_tax:
 			from buildsuite_core.utils.subcontract_billing import _ensure_account
 
@@ -133,7 +137,9 @@ class TestInvoice(BuildSuiteTestCase):
 		other = frappe.db.get_value("Company", {"name": ["!=", self.company]}, "name")
 		if not other:
 			self.skipTest("needs a second company")
-		other_acc = frappe.db.get_value("Account", {"company": other, "is_group": 0, "root_type": "Liability"}, "name")
+		other_acc = frappe.db.get_value(
+			"Account", {"company": other, "is_group": 0, "root_type": "Liability"}, "name"
+		)
 		if not other_acc:
 			self.skipTest("no cross-company account")
 		cust = self._customer()
@@ -161,12 +167,188 @@ class TestInvoice(BuildSuiteTestCase):
 		self.assertEqual(_html_to_text("<p>A</p><p>B</p>"), "A\nB")
 		self.assertEqual(_html_to_text("1. Plain\n2. Text"), "1. Plain\n2. Text")
 
+	def _draft_invoice(self, cust, rate=50000):
+		from buildsuite_core.api.invoice import save_invoice
+
+		return save_invoice(
+			json.dumps(
+				{
+					"customer": cust,
+					"project": self.project,
+					"date": "2026-07-20",
+					"due_date": "2026-08-20",
+					"items": [{"description": "Work", "qty": 1, "rate": rate}],
+				}
+			)
+		)["name"]
+
+	def test_link_advance_on_draft(self):
+		"""A customer advance adjusted against a DRAFT invoice lands in the native `advances`
+		table, reduces outstanding, and unlinks cleanly."""
+		from buildsuite_core.api.invoice import (
+			available_advances,
+			get_invoice,
+			link_advance,
+			record_advance,
+			unlink_advance,
+		)
+
+		cust = self._customer()
+		cash = self._deposit_account()
+		pe = record_advance(cust, amount=30000, date="2026-07-20", deposit_to=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		name = self._draft_invoice(cust, rate=50000)
+
+		avail = [a for a in available_advances(name) if a["payment_entry"] == pe]
+		self.assertEqual(len(avail), 1)
+		self.assertAlmostEqual(avail[0]["unallocated"], 30000, places=2)
+
+		link_advance(name, pe, 20000)
+		data = get_invoice(name)
+		self.assertEqual(len(data["advances"]), 1)
+		self.assertEqual(data["advances"][0]["payment_entry"], pe)
+		self.assertAlmostEqual(data["advance_adjusted"], 20000, places=2)
+		# The advance settles part of the receivable even before submit.
+		si = frappe.get_doc("Sales Invoice", name)
+		self.assertAlmostEqual(flt(si.outstanding_amount), 30000, places=2)
+
+		unlink_advance(name, pe)
+		self.assertEqual(len(get_invoice(name)["advances"]), 0)
+		self.assertAlmostEqual(
+			flt(frappe.db.get_value("Payment Entry", pe, "unallocated_amount")), 30000, places=2
+		)
+
+	def test_draft_advance_caps_and_submits(self):
+		"""An advance adjusted on a draft drops out of 'available' once fully used, cannot be
+		re-linked past its balance, and the draft then submits cleanly (regression: a re-linked
+		advance used to pile up allocated_amount beyond the Payment Entry and block submit)."""
+		from buildsuite_core.api.invoice import (
+			available_advances,
+			get_invoice,
+			link_advance,
+			list_receipts,
+			record_advance,
+			submit_invoice,
+		)
+
+		cust = self._customer()
+		cash = self._deposit_account()
+		pe = record_advance(cust, amount=40000, date="2026-07-20", deposit_to=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		name = self._draft_invoice(cust, rate=200000)
+
+		link_advance(name, pe, 40000)
+		# Fully adjusted → no longer offered as available, and a re-link is rejected.
+		self.assertEqual([a for a in available_advances(name) if a["payment_entry"] == pe], [])
+		self.assertRaises(frappe.ValidationError, link_advance, name, pe, 10000)
+
+		si = frappe.get_doc("Sales Invoice", name)
+		self.assertAlmostEqual(flt(si.advances[0].allocated_amount), 40000, places=2)
+		self.assertLessEqual(flt(si.advances[0].allocated_amount), flt(si.advances[0].advance_amount) + 0.01)
+		submit_invoice(name)  # must not raise "Allocated amount cannot be greater than unadjusted amount"
+		si.reload()
+		self.assertEqual(si.docstatus, 1)
+		self.assertAlmostEqual(flt(si.outstanding_amount), 160000, places=2)
+		# Post-submit the advance is RETAINED as an advance (not reclassified as a cash receipt),
+		# even though it is fully consumed — so the waterfall keeps showing "Advance adjusted".
+		data = get_invoice(name)
+		self.assertAlmostEqual(data["advance_adjusted"], 40000, places=2)
+		self.assertEqual(len(data["advances"]), 1)
+		self.assertAlmostEqual(data["payment"]["received"], 0, places=2)
+		self.assertEqual(len(list_receipts(name)), 0)
+
+	def test_link_advance_on_submitted(self):
+		"""A partial advance adjusted against a SUBMITTED invoice reconciles natively (PE
+		reference), reduces outstanding, is excluded from receipts, and unlinks (unreconcile)."""
+		from buildsuite_core.api.invoice import (
+			get_invoice,
+			link_advance,
+			list_receipts,
+			record_advance,
+			submit_invoice,
+			unlink_advance,
+		)
+
+		cust = self._customer()
+		cash = self._deposit_account()
+		pe = record_advance(cust, amount=100000, date="2026-07-20", deposit_to=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		name = self._draft_invoice(cust, rate=60000)
+		submit_invoice(name)
+
+		link_advance(name, pe, 40000)
+		si = frappe.get_doc("Sales Invoice", name)
+		self.assertAlmostEqual(flt(si.outstanding_amount), 20000, places=2)
+		self.assertAlmostEqual(
+			flt(frappe.db.get_value("Payment Entry", pe, "unallocated_amount")), 60000, places=2
+		)
+
+		data = get_invoice(name)
+		self.assertEqual(len(data["advances"]), 1)
+		self.assertAlmostEqual(data["advance_adjusted"], 40000, places=2)
+		self.assertAlmostEqual(data["payment"]["received"], 0, places=2)
+		# The reconciled advance is not counted as a cash receipt.
+		self.assertEqual(len(list_receipts(name)), 0)
+
+		unlink_advance(name, pe)
+		si.reload()
+		self.assertAlmostEqual(flt(si.outstanding_amount), 60000, places=2)
+		self.assertAlmostEqual(
+			flt(frappe.db.get_value("Payment Entry", pe, "unallocated_amount")), 100000, places=2
+		)
+		self.assertEqual(len(get_invoice(name)["advances"]), 0)
+
+	def test_same_advance_reconciled_in_multiple_steps(self):
+		"""Adjusting the SAME advance against a submitted invoice several times sums into ONE
+		Advance Payments line (regression: only the first reconciliation used to count; the rest
+		leaked into 'Received')."""
+		from buildsuite_core.api.invoice import (
+			get_invoice,
+			link_advance,
+			list_receipts,
+			record_advance,
+			submit_invoice,
+		)
+
+		cust = self._customer()
+		cash = self._deposit_account()
+		pe = record_advance(cust, amount=70000, date="2026-07-20", deposit_to=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		name = self._draft_invoice(cust, rate=100000)
+		submit_invoice(name)
+
+		link_advance(name, pe, 10000)
+		link_advance(name, pe, 15000)
+		link_advance(name, pe, 6000)  # same advance, three steps → 31000 total
+
+		data = get_invoice(name)
+		adv_rows = [a for a in data["advances"] if a["payment_entry"] == pe]
+		self.assertEqual(len(adv_rows), 1)
+		self.assertAlmostEqual(adv_rows[0]["allocated"], 31000, places=2)
+		self.assertAlmostEqual(data["advance_adjusted"], 31000, places=2)
+		self.assertAlmostEqual(data["payment"]["received"], 0, places=2)
+		self.assertEqual(len(list_receipts(name)), 0)
+		self.assertAlmostEqual(
+			flt(frappe.db.get_value("Payment Entry", pe, "unallocated_amount")), 39000, places=2
+		)
+
 	def test_draft_has_no_gl_until_submit(self):
 		from buildsuite_core.api.invoice import save_invoice
 
 		cust = self._customer()
 		res = save_invoice(
-			json.dumps({"customer": cust, "project": self.project, "date": "2026-07-20", "items": [{"description": "x", "qty": 2, "rate": 500}]})
+			json.dumps(
+				{
+					"customer": cust,
+					"project": self.project,
+					"date": "2026-07-20",
+					"items": [{"description": "x", "qty": 2, "rate": 500}],
+				}
+			)
 		)
 		si = frappe.get_doc("Sales Invoice", res["name"])
 		self.assertEqual(si.docstatus, 0)

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -58,7 +58,12 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 				"project": self.project,
 				"date": "2026-07-05",
 				"entries": [
-					{"description": "Tiling work", "work_order_line": line, "quantity": qty, "is_deduction": 0}
+					{
+						"description": "Tiling work",
+						"work_order_line": line,
+						"quantity": qty,
+						"is_deduction": 0,
+					}
 				],
 			}
 		).insert(ignore_permissions=True)
@@ -226,9 +231,7 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		wo = self._work_order(sub, qty=100, rate=85)
 		self._certified_mb(wo, qty=40)
 
-		bill = frappe.get_doc(
-			{"doctype": "Subcontractor Bill", "work_order": wo.name, "date": "2026-07-20"}
-		)
+		bill = frappe.get_doc({"doctype": "Subcontractor Bill", "work_order": wo.name, "date": "2026-07-20"})
 		bill.fetch_lines()
 		bill.insert(ignore_permissions=True)
 		# 40 measured × 85 = 3400 gross; retention 5% = 170.
@@ -263,6 +266,58 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		self.assertAlmostEqual(res["payment"]["paid"], 50000, places=2)
 		self.assertAlmostEqual(res["payment"]["outstanding"], 40000, places=2)
 
+	def test_advance_adjusted_against_bill_pi(self):
+		"""A subcontractor advance links to the bill's generated PI, settles the payable, is
+		excluded from cash payments, and unlinks cleanly."""
+		from buildsuite_core.api import subcontractor_bill as SC
+		from buildsuite_core.api.supplier_bill import record_advance
+		from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+		sub = self._subcontractor()
+		cash = _ensure_account(self.company, "Cash", "Asset", "Cash", "Current Assets")
+		bill = self._direct_bill(sub, amount=100000, retention=10)  # net payable 90000
+		bill.submit()
+		bill.reload()
+
+		pe = record_advance(sub.name, amount=40000, date="2026-07-21", pay_from=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		self.assertEqual(len([a for a in SC.available_advances(bill.name) if a["payment_entry"] == pe]), 1)
+
+		SC.link_advance(bill.name, pe, 30000)
+		data = SC.get_bill(bill.name)
+		self.assertEqual(len(data["advances"]), 1)
+		self.assertAlmostEqual(data["advance_adjusted"], 30000, places=2)
+		self.assertAlmostEqual(data["payment"]["paid"], 0, places=2)  # advance is not a cash payment
+		self.assertEqual(len(SC.list_payments(bill.name)), 0)
+		self.assertAlmostEqual(
+			flt(frappe.get_doc("Purchase Invoice", bill.purchase_invoice).outstanding_amount), 60000, places=2
+		)
+
+		SC.unlink_advance(bill.name, pe)
+		self.assertAlmostEqual(
+			flt(frappe.get_doc("Purchase Invoice", bill.purchase_invoice).outstanding_amount), 90000, places=2
+		)
+		self.assertAlmostEqual(
+			flt(frappe.db.get_value("Payment Entry", pe, "unallocated_amount")), 40000, places=2
+		)
+		self.assertEqual(len(SC.get_bill(bill.name)["advances"]), 0)
+
+	def test_advance_linking_needs_a_submitted_bill(self):
+		"""A draft bill has no Purchase Invoice, so it offers no advances and rejects a link."""
+		from buildsuite_core.api import subcontractor_bill as SC
+		from buildsuite_core.api.supplier_bill import record_advance
+		from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+		sub = self._subcontractor()
+		cash = _ensure_account(self.company, "Cash", "Asset", "Cash", "Current Assets")
+		bill = self._direct_bill(sub, amount=50000, retention=0)  # draft — no PI yet
+		pe = record_advance(sub.name, amount=10000, date="2026-07-21", pay_from=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		self.assertEqual(SC.available_advances(bill.name), [])
+		self.assertRaises(frappe.ValidationError, SC.link_advance, bill.name, pe, 5000)
+
 	def test_record_payment_uses_paid_from_account(self):
 		from buildsuite_core.api.subcontractor_bill import list_pay_accounts, record_payment
 		from buildsuite_core.utils.subcontract_billing import _ensure_account
@@ -276,6 +331,8 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		bill = self._direct_bill(self._subcontractor(), amount=100000, retention=10)
 		bill.submit()
 		bill.reload()
-		res = record_payment(bill.name, amount=25000, date="2026-07-21", mode_of_payment="Cash", paid_from=cash)
+		res = record_payment(
+			bill.name, amount=25000, date="2026-07-21", mode_of_payment="Cash", paid_from=cash
+		)
 		pe = frappe.get_doc("Payment Entry", res["payment_entry"])
 		self.assertEqual(pe.paid_from, cash)

--- a/buildsuite_core/tests/test_supplier_bill.py
+++ b/buildsuite_core/tests/test_supplier_bill.py
@@ -24,7 +24,8 @@ class TestSupplierBill(BuildSuiteTestCase):
 				{
 					"doctype": "Supplier",
 					"supplier_name": f"Supp {self._n}",
-					"supplier_group": frappe.db.get_value("Supplier Group", {"is_group": 0}, "name") or "All Supplier Groups",
+					"supplier_group": frappe.db.get_value("Supplier Group", {"is_group": 0}, "name")
+					or "All Supplier Groups",
 				}
 			)
 			.insert(ignore_permissions=True)
@@ -90,3 +91,109 @@ class TestSupplierBill(BuildSuiteTestCase):
 		self.assertEqual(pe.party, supp)
 		self.assertAlmostEqual(flt(pe.unallocated_amount), 20000, places=2)
 		self.assertAlmostEqual(payables_summary(company=self.company)["advances"] - before, 20000, places=2)
+
+	def _draft_bill(self, supp, rate=50000):
+		from buildsuite_core.api.supplier_bill import save_bill
+
+		return save_bill(
+			json.dumps(
+				{
+					"supplier": supp,
+					"project": self.project,
+					"date": "2026-07-20",
+					"due_date": "2026-08-20",
+					"items": [{"description": "Material", "qty": 1, "rate": rate}],
+				}
+			)
+		)["name"]
+
+	def test_link_advance_on_draft_bill(self):
+		"""A supplier advance adjusted against a DRAFT bill lands in the native `advances` table,
+		reduces outstanding, drops out of 'available' once used, and cannot be over-linked."""
+		from buildsuite_core.api.supplier_bill import (
+			available_advances,
+			get_bill,
+			link_advance,
+			record_advance,
+			submit_bill,
+			unlink_advance,
+		)
+
+		supp = self._supplier()
+		cash = self._cash()
+		pe = record_advance(supp, amount=30000, date="2026-07-20", pay_from=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		name = self._draft_bill(supp, rate=50000)
+
+		self.assertAlmostEqual(
+			[a for a in available_advances(name) if a["payment_entry"] == pe][0]["unallocated"],
+			30000,
+			places=2,
+		)
+		link_advance(name, pe, 20000)
+		data = get_bill(name)
+		self.assertEqual(len(data["advances"]), 1)
+		self.assertAlmostEqual(data["advance_adjusted"], 20000, places=2)
+		self.assertAlmostEqual(
+			flt(frappe.get_doc("Purchase Invoice", name).outstanding_amount), 30000, places=2
+		)
+		# 10000 left, not the full 30000
+		self.assertAlmostEqual(
+			[a for a in available_advances(name) if a["payment_entry"] == pe][0]["unallocated"],
+			10000,
+			places=2,
+		)
+
+		unlink_advance(name, pe)
+		self.assertEqual(len(get_bill(name)["advances"]), 0)
+
+		# Re-link and submit — must not raise "Allocated amount cannot be greater than unadjusted".
+		link_advance(name, pe, 20000)
+		submit_bill(name)
+		pi = frappe.get_doc("Purchase Invoice", name)
+		self.assertEqual(pi.docstatus, 1)
+		self.assertAlmostEqual(flt(pi.outstanding_amount), 30000, places=2)
+		self.assertAlmostEqual(get_bill(name)["advance_adjusted"], 20000, places=2)
+
+	def test_supplier_advance_multi_step_on_submitted(self):
+		"""Adjusting the SAME advance against a submitted bill in several steps sums into ONE
+		Advance Payments line, excluded from cash payments; unlink reverts everything."""
+		from buildsuite_core.api.supplier_bill import (
+			get_bill,
+			link_advance,
+			list_payments,
+			record_advance,
+			submit_bill,
+			unlink_advance,
+		)
+
+		supp = self._supplier()
+		cash = self._cash()
+		pe = record_advance(supp, amount=70000, date="2026-07-20", pay_from=cash, mode_of_payment="Cash")[
+			"payment_entry"
+		]
+		name = self._draft_bill(supp, rate=60000)
+		submit_bill(name)
+
+		link_advance(name, pe, 10000)
+		link_advance(name, pe, 15000)  # same advance, two steps → 25000 total
+		data = get_bill(name)
+		adv_rows = [a for a in data["advances"] if a["payment_entry"] == pe]
+		self.assertEqual(len(adv_rows), 1)
+		self.assertAlmostEqual(adv_rows[0]["allocated"], 25000, places=2)
+		self.assertAlmostEqual(data["advance_adjusted"], 25000, places=2)
+		self.assertAlmostEqual(data["payment"]["paid"], 0, places=2)
+		self.assertEqual(len(list_payments(name)), 0)
+		self.assertAlmostEqual(
+			flt(frappe.get_doc("Purchase Invoice", name).outstanding_amount), 35000, places=2
+		)
+
+		unlink_advance(name, pe)
+		self.assertAlmostEqual(
+			flt(frappe.get_doc("Purchase Invoice", name).outstanding_amount), 60000, places=2
+		)
+		self.assertAlmostEqual(
+			flt(frappe.db.get_value("Payment Entry", pe, "unallocated_amount")), 70000, places=2
+		)
+		self.assertEqual(len(get_bill(name)["advances"]), 0)

--- a/frontend/src/data/invoiceApi.js
+++ b/frontend/src/data/invoiceApi.js
@@ -5,7 +5,10 @@ import { parseFrappeError } from "@/utils/frappeError";
 // ERPNext Sales Invoice; these create drafts, list them, submit/cancel, and receive payments.
 async function call(method, args) {
 	try {
-		return await frappeRequest({ url: `buildsuite_core.api.invoice.${method}`, params: args || {} });
+		return await frappeRequest({
+			url: `buildsuite_core.api.invoice.${method}`,
+			params: args || {},
+		});
 	} catch (err) {
 		throw new Error(parseFrappeError(err).summary || "Request failed.");
 	}
@@ -21,6 +24,9 @@ export const recordInvoiceReceipt = (args) => call("record_receipt", args);
 export const listInvoiceReceipts = (name) => call("list_receipts", { name });
 export const recordCustomerAdvance = (args) => call("record_advance", args);
 export const invoiceAdvancesSummary = () => call("advances_summary", {});
+export const availableInvoiceAdvances = (name) => call("available_advances", { name });
+export const linkInvoiceAdvance = (args) => call("link_advance", args);
+export const unlinkInvoiceAdvance = (args) => call("unlink_advance", args);
 export const invoiceReceivablesSummary = () => call("receivables_summary", {});
 export const listDepositAccounts = () => call("list_deposit_accounts", {});
 export const listInvoiceTaxTemplates = () => call("list_tax_templates", {});

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -53,7 +53,8 @@ async function billCall(method, args) {
 }
 
 export const getBill = (name) => billCall("get_bill", { name });
-export const getWoBillContext = (workOrder) => billCall("get_wo_bill_context", { work_order: workOrder });
+export const getWoBillContext = (workOrder) =>
+	billCall("get_wo_bill_context", { work_order: workOrder });
 export const saveBill = (payload) => billCall("save_bill", { payload: JSON.stringify(payload) });
 export const submitBill = (name) => billCall("submit_bill", { name });
 export const cancelBill = (name) => billCall("cancel_bill", { name });
@@ -67,3 +68,6 @@ export const makeBillPaymentEntry = (name) => billCall("make_payment_entry", { n
 // Bank/Cash accounts a bill is paid FROM (default company); Modes of Payment for the modal.
 export const listBillPayAccounts = () => billCall("list_pay_accounts", {});
 export const listPaymentModes = () => billCall("list_payment_modes", {});
+export const availableBillAdvances = (name) => billCall("available_advances", { name });
+export const linkBillAdvance = (args) => billCall("link_advance", args);
+export const unlinkBillAdvance = (args) => billCall("unlink_advance", args);

--- a/frontend/src/data/supplierBillApi.js
+++ b/frontend/src/data/supplierBillApi.js
@@ -5,7 +5,10 @@ import { parseFrappeError } from "@/utils/frappeError";
 // A supplier bill IS an ERPNext Purchase Invoice; subcontractor bills use their own module.
 async function call(method, args) {
 	try {
-		return await frappeRequest({ url: `buildsuite_core.api.supplier_bill.${method}`, params: args || {} });
+		return await frappeRequest({
+			url: `buildsuite_core.api.supplier_bill.${method}`,
+			params: args || {},
+		});
 	} catch (err) {
 		throw new Error(parseFrappeError(err).summary || "Request failed.");
 	}
@@ -14,13 +17,17 @@ async function call(method, args) {
 export const listPayables = (args = {}) => call("list_payables", args);
 export const payablesSummary = () => call("payables_summary", {});
 export const getSupplierBill = (name) => call("get_bill", { name });
-export const saveSupplierBill = (payload) => call("save_bill", { payload: JSON.stringify(payload) });
+export const saveSupplierBill = (payload) =>
+	call("save_bill", { payload: JSON.stringify(payload) });
 export const submitSupplierBill = (name) => call("submit_bill", { name });
 export const cancelSupplierBill = (name) => call("cancel_bill", { name });
 export const deleteSupplierBill = (name) => call("delete_bill", { name });
 export const recordSupplierBillPayment = (args) => call("record_payment", args);
 export const listSupplierBillPayments = (name) => call("list_payments", { name });
 export const recordSupplierAdvance = (args) => call("record_advance", args);
+export const availableSupplierBillAdvances = (name) => call("available_advances", { name });
+export const linkSupplierBillAdvance = (args) => call("link_advance", args);
+export const unlinkSupplierBillAdvance = (args) => call("unlink_advance", args);
 export const listBillPayAccounts = () => call("list_pay_accounts", {});
 export const getSupplierBillTaxRows = (template) => call("get_tax_template_rows", { template });
 export const getSupplierBillTerms = (name) => call("get_terms", { name });

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -4,7 +4,7 @@
 // Attachments. Real data throughout — company-scoped tax-template / account / expense pickers,
 // a generated Purchase Invoice, and (on submit) a Desk Payment Entry link-out. Draft-editable.
 
-import { computed, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
@@ -23,6 +23,9 @@ import {
 	listBillPayments,
 	listBillPayAccounts,
 	listPaymentModes,
+	availableBillAdvances,
+	linkBillAdvance,
+	unlinkBillAdvance,
 } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -63,9 +66,13 @@ watch(() => props.id, load, { immediate: true });
 const isDraft = computed(() => bill.value?.docstatus === 0);
 const isSubmitted = computed(() => bill.value?.docstatus === 1);
 const editable = computed(() => isDraft.value);
-const payment = computed(() => bill.value?.payment || { paid: 0, outstanding: 0, invoiced: 0, status: "Unpaid" });
+const payment = computed(
+	() => bill.value?.payment || { paid: 0, outstanding: 0, invoiced: 0, status: "Unpaid" }
+);
 const retPct = computed(() => Number(bill.value?.retention_percent) || 0);
-const taxRatePct = computed(() => (bill.value?.taxes || []).reduce((a, t) => a + (Number(t.rate) || 0), 0));
+const taxRatePct = computed(() =>
+	(bill.value?.taxes || []).reduce((a, t) => a + (Number(t.rate) || 0), 0)
+);
 
 const statusPills = computed(() => {
 	if (!bill.value) return [];
@@ -78,10 +85,18 @@ const wf = computed(() => {
 	if (!b) return {};
 	const gross = (b.lines || []).reduce((a, l) => a + (Number(l.this_period_amount) || 0), 0);
 	const discBase = (base) =>
-		Math.min(discType.value === "%" ? (base * (Number(discValue.value) || 0)) / 100 : Number(discValue.value) || 0, base);
+		Math.min(
+			discType.value === "%"
+				? (base * (Number(discValue.value) || 0)) / 100
+				: Number(discValue.value) || 0,
+			base
+		);
 	const netDiscount = b.additional_discount_on === "Net Total" ? discBase(gross) : 0;
 	const taxable = Math.max(0, gross - netDiscount);
-	const taxRows = (b.taxes || []).map((t) => ({ ...t, amount: (taxable * (Number(t.rate) || 0)) / 100 }));
+	const taxRows = (b.taxes || []).map((t) => ({
+		...t,
+		amount: (taxable * (Number(t.rate) || 0)) / 100,
+	}));
 	const tax = taxRows.reduce((a, t) => a + t.amount, 0);
 	const grandTotal = taxable + tax;
 	const grandDiscount = b.additional_discount_on === "Grand Total" ? discBase(grandTotal) : 0;
@@ -90,7 +105,20 @@ const wf = computed(() => {
 	const retention = (taxable * (Number(b.retention_percent) || 0)) / 100;
 	const advance = Number(b.advance_recovery) || 0;
 	const netPayable = Math.max(0, invoiceValue - tds - retention - advance);
-	return { gross, netDiscount, grandDiscount, taxable, taxRows, tax, grandTotal, invoiceValue, tds, retention, advance, netPayable };
+	return {
+		gross,
+		netDiscount,
+		grandDiscount,
+		taxable,
+		taxRows,
+		tax,
+		grandTotal,
+		invoiceValue,
+		tds,
+		retention,
+		advance,
+		netPayable,
+	};
 });
 
 // --- taxes editor ---
@@ -170,7 +198,9 @@ async function onSubmit() {
 	}
 	const ok = await confirmDialog({
 		title: `Submit Bill ${bill.value.ra_no}?`,
-		message: `This posts the bill and generates the Purchase Invoice for ${fmtINR(wf.value.netPayable)} net payable. A submitted bill is read-only.`,
+		message: `This posts the bill and generates the Purchase Invoice for ${fmtINR(
+			wf.value.netPayable
+		)} net payable. A submitted bill is read-only.`,
 		confirmLabel: "Submit",
 	});
 	if (!ok) return;
@@ -203,11 +233,22 @@ async function loadPayments() {
 }
 watch(isSubmitted, loadPayments, { immediate: true });
 
-const pay = ref({ open: false, amount: null, account: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const pay = ref({
+	open: false,
+	amount: null,
+	account: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 async function onMakePayment() {
 	if (!payAccounts.value.length) {
 		try {
-			[payAccounts.value, payModes.value] = await Promise.all([listBillPayAccounts(), listPaymentModes()]);
+			[payAccounts.value, payModes.value] = await Promise.all([
+				listBillPayAccounts(),
+				listPaymentModes(),
+			]);
 		} catch {
 			/* fall back to the built-in modes; accounts stay empty and the field warns */
 		}
@@ -216,7 +257,10 @@ async function onMakePayment() {
 	pay.value = {
 		open: true,
 		amount: Number(payment.value.outstanding) || null,
-		account: payAccounts.value.find((a) => a.account_type === "Bank")?.name || payAccounts.value[0]?.name || "",
+		account:
+			payAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			payAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -226,7 +270,11 @@ async function onMakePayment() {
 async function savePayment() {
 	const amt = Number(pay.value.amount) || 0;
 	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
-	if (amt > Number(payment.value.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`, "error");
+	if (amt > Number(payment.value.outstanding) + 0.01)
+		return showToast(
+			`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`,
+			"error"
+		);
 	if (!pay.value.account) return showToast("Pick the account to pay from.", "error");
 	pay.value.saving = true;
 	try {
@@ -246,6 +294,95 @@ async function savePayment() {
 		showToast(err.message || "Payment failed", "error");
 	} finally {
 		pay.value.saving = false;
+	}
+}
+
+// --- advance payments: adjust the subcontractor's on-account advances against this bill.
+// The bill has no Purchase Invoice until submit, so advance linking is submitted-only. ---
+const availableAdvances = ref([]);
+const linkedAdvances = computed(() => bill.value?.advances || []);
+const advanceAdjusted = computed(() => Number(bill.value?.advance_adjusted) || 0);
+const unlinkedTotal = computed(() =>
+	availableAdvances.value.reduce((a, x) => a + Number(x.unallocated || 0), 0)
+);
+const canLinkAdv = computed(() => isSubmitted.value);
+const advAlloc = reactive({});
+const adv = ref({ open: false, msg: "", error: "", saving: "" });
+async function loadAdvances() {
+	if (!isSubmitted.value) {
+		availableAdvances.value = [];
+		return;
+	}
+	try {
+		availableAdvances.value = await availableBillAdvances(bill.value.name);
+	} catch {
+		availableAdvances.value = [];
+	}
+}
+watch(isSubmitted, loadAdvances, { immediate: true });
+function suggestAllocations() {
+	for (const a of availableAdvances.value)
+		advAlloc[a.payment_entry] = Math.min(
+			Number(a.unallocated),
+			Number(payment.value.outstanding) || 0
+		);
+}
+function openLinkAdvance() {
+	adv.value.error = "";
+	adv.value.msg = "";
+	suggestAllocations();
+	adv.value.open = true;
+}
+async function doLink(a) {
+	const amt = Number(advAlloc[a.payment_entry]) || 0;
+	if (amt <= 0) {
+		adv.value.error = "Enter an amount greater than zero.";
+		return;
+	}
+	if (amt > Number(a.unallocated) + 0.01) {
+		adv.value.error = `Only ${fmtINR(a.unallocated)} is unadjusted on ${a.payment_entry}.`;
+		return;
+	}
+	adv.value.saving = a.payment_entry;
+	adv.value.error = "";
+	try {
+		await linkBillAdvance({
+			name: bill.value.name,
+			payment_entry: a.payment_entry,
+			amount: amt,
+		});
+		adv.value.open = false;
+		await load();
+		await loadPayments();
+		await loadAdvances();
+		adv.value.msg = `Linked ${fmtINR(amt)} from ${
+			a.payment_entry
+		} — outstanding is now ${fmtINR(payment.value.outstanding)}.`;
+		showToast("Advance linked.");
+	} catch (err) {
+		adv.value.error = err.message || "Could not link the advance.";
+	} finally {
+		adv.value.saving = "";
+	}
+}
+async function unlinkAdvance(row) {
+	const ok = await confirmDialog({
+		title: "Unlink advance?",
+		message: `Return ${fmtINR(row.allocated)} to ${
+			row.payment_entry
+		}'s unallocated balance? The net payable goes back up.`,
+		confirmLabel: "Unlink",
+	});
+	if (!ok) return;
+	adv.value.msg = "";
+	try {
+		await unlinkBillAdvance({ name: bill.value.name, payment_entry: row.payment_entry });
+		await load();
+		await loadPayments();
+		await loadAdvances();
+		showToast("Advance unlinked.");
+	} catch (err) {
+		showToast(err.message || "Unlink failed", "error");
 	}
 }
 async function onCancel() {
@@ -302,7 +439,11 @@ async function onFilesPicked(e) {
 	uploading.value += files.length;
 	for (const f of files) {
 		try {
-			await new FileUploadHandler().upload(f, { doctype: "Subcontractor Bill", docname: props.id, private: false });
+			await new FileUploadHandler().upload(f, {
+				doctype: "Subcontractor Bill",
+				docname: props.id,
+				private: false,
+			});
 		} catch (err) {
 			showToast(`Failed to upload ${f.name}`, "error");
 		} finally {
@@ -355,14 +496,23 @@ const breadcrumbs = computed(() => [
 	{ label: "Subcontractor Bills", to: "/subcontractor-bills" },
 	{ label: bill.value?.name || props.id },
 ]);
-const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 0], ["company", "=", bill.value.company]] : [["is_group", "=", 0]]));
+const accountFilters = computed(() =>
+	bill.value?.company
+		? [
+				["is_group", "=", 0],
+				["company", "=", bill.value.company],
+		  ]
+		: [["is_group", "=", 0]]
+);
 </script>
 
 <template>
 	<DeskPage
 		v-if="bill"
 		:title="`Subcontractor Bill ${bill.ra_no}`"
-		:subtitle="`${bill.name} · ${bill.subcontractor_name || bill.subcontractor} · ${bill.project_name || bill.project}`"
+		:subtitle="`${bill.name} · ${bill.subcontractor_name || bill.subcontractor} · ${
+			bill.project_name || bill.project
+		}`"
 		:breadcrumbs="breadcrumbs"
 		:status="statusPills"
 	>
@@ -377,87 +527,294 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 			>
 				Open in Accounting →
 			</button>
-			<button v-if="isDraft" type="button" class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700" style="border-radius: 6px" :disabled="busy" @click="onEdit">Edit</button>
-			<button v-if="isDraft" type="button" class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium" style="border-radius: 6px" :disabled="busy" @click="onSubmit">Submit</button>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onEdit"
+			>
+				Edit
+			</button>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onSubmit"
+			>
+				Submit
+			</button>
 			<template v-if="isSubmitted">
-				<button v-if="payment.status !== 'Paid'" type="button" class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium" style="border-radius: 6px" @click="onMakePayment">Make Payment</button>
-				<button type="button" class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium" style="border-radius: 6px" :disabled="busy" @click="onCancel">Cancel</button>
+				<button
+					v-if="payment.status !== 'Paid'"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+					style="border-radius: 6px"
+					@click="onMakePayment"
+				>
+					Make Payment
+				</button>
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+					style="border-radius: 6px"
+					:disabled="busy"
+					@click="onCancel"
+				>
+					Cancel
+				</button>
 			</template>
-			<button v-if="isDraft" type="button" class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700" style="border-radius: 6px" :disabled="busy" @click="onDelete">Delete</button>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onDelete"
+			>
+				Delete
+			</button>
 		</template>
 
 		<!-- Submit success + PI reference -->
-		<div v-if="submitMsg" class="mb-4 px-4 py-2.5 bg-success-50 border border-success-200 rounded-md text-xs text-success-700 flex items-center gap-2">
+		<div
+			v-if="submitMsg"
+			class="mb-4 px-4 py-2.5 bg-success-50 border border-success-200 rounded-md text-xs text-success-700 flex items-center gap-2"
+		>
 			<span class="text-sm">✓</span><span class="font-medium">{{ submitMsg }}</span>
 		</div>
 		<div v-else-if="bill.purchase_invoice" class="mb-4 text-xs text-ink-600">
 			Purchase Invoice
-			<DeskLink :to="`/app/purchase-invoice/${bill.purchase_invoice}`" class="font-mono font-medium text-ink-900">{{ bill.purchase_invoice }}</DeskLink>
+			<DeskLink
+				:to="`/app/purchase-invoice/${bill.purchase_invoice}`"
+				class="font-mono font-medium text-ink-900"
+				>{{ bill.purchase_invoice }}</DeskLink
+			>
 		</div>
 		<div v-if="isSubmitted && payment.status !== 'Paid'" class="mb-4 text-xs text-ink-600">
-			Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(payment.outstanding) }}</span>
-			<span v-if="payment.paid > 0"> · paid {{ fmtINR(payment.paid) }} of {{ fmtINR(payment.invoiced) }}</span>
+			Outstanding
+			<span class="font-semibold text-ink-900 tabular-nums">{{
+				fmtINR(payment.outstanding)
+			}}</span>
+			<span v-if="payment.paid > 0">
+				· paid {{ fmtINR(payment.paid) }} of {{ fmtINR(payment.invoiced) }}</span
+			>
 		</div>
-		<div v-else-if="isSubmitted && payment.status === 'Paid'" class="mb-4 text-xs text-success-700">
+		<div
+			v-else-if="isSubmitted && payment.status === 'Paid'"
+			class="mb-4 text-xs text-success-700"
+		>
 			Fully paid — {{ fmtINR(payment.paid) }} of {{ fmtINR(payment.invoiced) }}
 		</div>
 
+		<!-- advance linked confirmation -->
+		<div
+			v-if="adv.msg"
+			class="mb-4 px-4 py-2.5 bg-success-50 border border-success-200 rounded-md text-xs text-success-700 flex items-center gap-2"
+		>
+			<span class="text-sm">✓</span><span class="font-medium">{{ adv.msg }}</span>
+		</div>
+		<!-- unlinked-advance suggestion (submitted — the bill's PI exists) -->
+		<div
+			v-if="canLinkAdv && availableAdvances.length && payment.outstanding > 0.01"
+			class="mb-4 px-4 py-2.5 bg-info-50 border border-info-200 rounded-md text-xs text-ink-700 flex items-center justify-between gap-3 flex-wrap"
+		>
+			<span>
+				<span class="font-medium text-ink-900"
+					>{{ bill.subcontractor_name }} has {{ fmtINR(unlinkedTotal) }} in unlinked
+					advance payment{{ availableAdvances.length === 1 ? "" : "s" }}</span
+				>
+				— link {{ availableAdvances.length === 1 ? "it" : "them" }} to this bill to settle
+				the payable.
+			</span>
+			<button
+				type="button"
+				class="text-xs px-2.5 py-1 border border-info-200 bg-white hover:bg-info-50 text-info-700 font-medium flex-shrink-0 rounded-md"
+				@click="openLinkAdvance"
+			>
+				Link advance →
+			</button>
+		</div>
+
 		<!-- Payments made against this bill -->
-		<div v-if="isSubmitted && payments.length" class="mb-4 bg-white border border-ink-200 rounded-lg overflow-hidden">
-			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Payments</h3></div>
+		<div
+			v-if="isSubmitted && payments.length"
+			class="mb-4 bg-white border border-ink-200 rounded-lg overflow-hidden"
+		>
+			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+				<h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">
+					Payments
+				</h3>
+			</div>
 			<table class="w-full text-xs">
 				<thead class="text-ink-500 uppercase tracking-wider text-[10px]">
-					<tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Mode</th><th class="text-left px-4 py-2">Reference</th><th class="text-left px-4 py-2">Entry</th><th class="text-right px-4 py-2">Amount</th></tr>
+					<tr>
+						<th class="text-left px-4 py-2">Date</th>
+						<th class="text-left px-4 py-2">Mode</th>
+						<th class="text-left px-4 py-2">Reference</th>
+						<th class="text-left px-4 py-2">Entry</th>
+						<th class="text-right px-4 py-2">Amount</th>
+					</tr>
 				</thead>
 				<tbody>
-					<tr v-for="p in payments" :key="p.payment_entry" class="border-t border-ink-100">
-						<td class="px-4 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(p.date) }}</td>
+					<tr
+						v-for="p in payments"
+						:key="p.payment_entry"
+						class="border-t border-ink-100"
+					>
+						<td class="px-4 py-2 text-ink-500 whitespace-nowrap">
+							{{ fmtDate(p.date) }}
+						</td>
 						<td class="px-4 py-2 text-ink-700">{{ p.mode_of_payment || "—" }}</td>
 						<td class="px-4 py-2 text-ink-600">{{ p.reference_no || "—" }}</td>
-						<td class="px-4 py-2"><DeskLink :to="`/app/payment-entry/${p.payment_entry}`" class="font-mono text-ink-700">{{ p.payment_entry }}</DeskLink></td>
-						<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(p.amount) }}</td>
+						<td class="px-4 py-2">
+							<DeskLink
+								:to="`/app/payment-entry/${p.payment_entry}`"
+								class="font-mono text-ink-700"
+								>{{ p.payment_entry }}</DeskLink
+							>
+						</td>
+						<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">
+							{{ fmtINR(p.amount) }}
+						</td>
 					</tr>
 				</tbody>
 			</table>
 		</div>
 
+		<!-- Advance Payments (subcontractor advances adjusted against the bill's PI) -->
+		<div
+			v-if="isSubmitted && (linkedAdvances.length || availableAdvances.length)"
+			class="mb-4 bg-white border border-ink-200 rounded-lg overflow-hidden"
+		>
+			<div
+				class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3"
+			>
+				<h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">
+					Advance Payments
+				</h3>
+				<button
+					v-if="availableAdvances.length"
+					type="button"
+					class="text-xs text-brand-700 hover:underline"
+					@click="openLinkAdvance"
+				>
+					+ Link advance
+				</button>
+			</div>
+			<template v-if="linkedAdvances.length">
+				<div
+					v-for="row in linkedAdvances"
+					:key="row.payment_entry"
+					class="flex items-center justify-between px-4 py-2.5 border-t border-ink-100 text-sm gap-2"
+				>
+					<DeskLink
+						:to="`/app/payment-entry/${row.payment_entry}`"
+						class="font-mono text-xs text-ink-900 min-w-0 truncate"
+						>{{ row.payment_entry }}</DeskLink
+					>
+					<span class="flex items-center gap-2 flex-shrink-0">
+						<span class="tabular-nums text-info-700 font-medium">{{
+							fmtINR(row.allocated)
+						}}</span>
+						<button
+							type="button"
+							class="text-ink-400 hover:text-danger-600 text-xs"
+							:title="`Unlink ${row.payment_entry}`"
+							@click="unlinkAdvance(row)"
+						>
+							✕
+						</button>
+					</span>
+				</div>
+				<div
+					class="px-4 py-2 border-t border-ink-100 flex items-center justify-between text-[11px]"
+				>
+					<span class="uppercase tracking-wider text-ink-500 font-medium"
+						>Total advance adjusted</span
+					>
+					<span class="tabular-nums font-semibold text-ink-900">{{
+						fmtINR(advanceAdjusted)
+					}}</span>
+				</div>
+			</template>
+			<div v-else class="px-4 py-3 text-xs text-ink-400 italic border-t border-ink-100">
+				No advances linked yet — {{ bill.subcontractor_name }} has
+				{{ fmtINR(unlinkedTotal) }} unallocated.
+			</div>
+		</div>
+
 		<!-- Summary strip -->
 		<div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
-				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">{{ bill.is_direct ? "Subcontractor" : "Work Order" }}</div>
-				<DeskLink v-if="!bill.is_direct" :to="`/subcontractor-work-orders/${bill.work_order}`" class="text-sm mt-0.5 block">{{ bill.work_order }}</DeskLink>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					{{ bill.is_direct ? "Subcontractor" : "Work Order" }}
+				</div>
+				<DeskLink
+					v-if="!bill.is_direct"
+					:to="`/subcontractor-work-orders/${bill.work_order}`"
+					class="text-sm mt-0.5 block"
+					>{{ bill.work_order }}</DeskLink
+				>
 				<div v-else class="text-sm text-ink-900 mt-0.5">{{ bill.subcontractor_name }}</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
-				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Date</div>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Date
+				</div>
 				<div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(bill.date) }}</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
-				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Gross this period</div>
-				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(wf.gross) }}</div>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Gross this period
+				</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ fmtINR(wf.gross) }}
+				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
-				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Retention</div>
-				<div class="text-base font-semibold text-warning-700 tabular-nums mt-0.5">{{ fmtINR(wf.retention) }}</div>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Retention
+				</div>
+				<div class="text-base font-semibold text-warning-700 tabular-nums mt-0.5">
+					{{ fmtINR(wf.retention) }}
+				</div>
 				<div class="text-[10px] text-ink-500">{{ retPct }}% withheld</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
-				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Net payable</div>
-				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(wf.netPayable) }}</div>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Net payable
+				</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ fmtINR(wf.netPayable) }}
+				</div>
 			</div>
 		</div>
 
 		<!-- Bill lines -->
 		<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
 			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
-				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Lines — claimed against schedule of values</h3>
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+					Lines — claimed against schedule of values
+				</h3>
 			</div>
-			<div v-if="!bill.is_direct" class="px-4 py-2 bg-info-50 border-b border-info-200 text-[11px] text-ink-700">
+			<div
+				v-if="!bill.is_direct"
+				class="px-4 py-2 bg-info-50 border-b border-info-200 text-[11px] text-ink-700"
+			>
 				<span class="font-medium text-ink-900">How qty is computed:</span>
-				This period qty = (Measured to date from Certified MBs) − (Previously billed qty). Read-only on this bill.
+				This period qty = (Measured to date from Certified MBs) − (Previously billed qty).
+				Read-only on this bill.
 			</div>
-			<div v-else class="px-4 py-2 bg-info-50 border-b border-info-200 text-[11px] text-ink-700">
-				<span class="font-medium text-ink-900">Direct bill</span> — manual charge lines, not tied to a Work Order.
+			<div
+				v-else
+				class="px-4 py-2 bg-info-50 border-b border-info-200 text-[11px] text-ink-700"
+			>
+				<span class="font-medium text-ink-900">Direct bill</span> — manual charge lines,
+				not tied to a Work Order.
 			</div>
 			<div class="overflow-x-auto">
 				<table class="w-full text-xs" style="min-width: 640px">
@@ -473,23 +830,64 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="(l, i) in bill.lines" :key="i" class="border-t border-ink-100 align-top">
+						<tr
+							v-for="(l, i) in bill.lines"
+							:key="i"
+							class="border-t border-ink-100 align-top"
+						>
 							<td class="px-3 py-2 text-ink-900">{{ l.scope || "—" }}</td>
 							<td class="px-3 py-2">
-								<span v-if="l.cost_code_label" class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-info-50 text-info-700">{{ l.cost_code_label }}</span>
+								<span
+									v-if="l.cost_code_label"
+									class="text-[10px] font-mono px-1.5 py-0.5 rounded bg-info-50 text-info-700"
+									>{{ l.cost_code_label }}</span
+								>
 								<span v-else class="text-ink-300">—</span>
 							</td>
-							<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ l.rate ? fmtINR(l.rate) + "/" + (l.uom || "") : "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums text-info-700 font-medium">{{ l.measured_qty_to_date != null ? Number(l.measured_qty_to_date).toLocaleString("en-IN") : "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums text-ink-500">{{ l.previous_qty != null ? Number(l.previous_qty).toLocaleString("en-IN") : "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">{{ l.this_period_qty != null ? Number(l.this_period_qty).toLocaleString("en-IN") : "—" }}</td>
-							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">{{ fmtINR(l.this_period_amount) }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+								{{ l.rate ? fmtINR(l.rate) + "/" + (l.uom || "") : "—" }}
+							</td>
+							<td
+								class="px-3 py-2 text-right tabular-nums text-info-700 font-medium"
+							>
+								{{
+									l.measured_qty_to_date != null
+										? Number(l.measured_qty_to_date).toLocaleString("en-IN")
+										: "—"
+								}}
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-500">
+								{{
+									l.previous_qty != null
+										? Number(l.previous_qty).toLocaleString("en-IN")
+										: "—"
+								}}
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+								{{
+									l.this_period_qty != null
+										? Number(l.this_period_qty).toLocaleString("en-IN")
+										: "—"
+								}}
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+								{{ fmtINR(l.this_period_amount) }}
+							</td>
 						</tr>
 					</tbody>
 					<tfoot>
 						<tr class="border-t-2 border-ink-200 bg-ink-50">
-							<td colspan="6" class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider">Gross bill value</td>
-							<td class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900">{{ fmtINR(wf.gross) }}</td>
+							<td
+								colspan="6"
+								class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider"
+							>
+								Gross bill value
+							</td>
+							<td
+								class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+							>
+								{{ fmtINR(wf.gross) }}
+							</td>
 						</tr>
 					</tfoot>
 				</table>
@@ -498,10 +896,16 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 
 		<!-- Taxes and Charges -->
 		<section class="mt-6 bg-white border border-ink-200 rounded-lg overflow-hidden">
-			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3">
-				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Taxes and Charges</h3>
+			<div
+				class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3"
+			>
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+					Taxes and Charges
+				</h3>
 				<div v-if="editable" class="flex items-center gap-2">
-					<label class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Template</label>
+					<label class="text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+						>Template</label
+					>
 					<div class="w-48">
 						<DeskLinkPicker
 							:model-value="bill.taxes_and_charges"
@@ -514,7 +918,9 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 						/>
 					</div>
 				</div>
-				<span v-else class="text-[11px] text-ink-500">{{ bill.taxes_and_charges || "No tax" }}</span>
+				<span v-else class="text-[11px] text-ink-500">{{
+					bill.taxes_and_charges || "No tax"
+				}}</span>
 			</div>
 			<div class="overflow-x-auto">
 				<table class="w-full text-xs" style="min-width: 480px">
@@ -540,62 +946,167 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 									:filters="accountFilters"
 									placeholder="Account…"
 								/>
-								<span v-else class="text-ink-900">{{ t.account_head || "—" }}</span>
+								<span v-else class="text-ink-900">{{
+									t.account_head || "—"
+								}}</span>
 							</td>
 							<td class="px-3 py-1.5 text-right">
-								<input v-if="editable" v-model.number="bill.taxes[i].rate" type="number" min="0" step="0.5" class="w-full bg-transparent text-right tabular-nums focus:outline-none py-1" />
+								<input
+									v-if="editable"
+									v-model.number="bill.taxes[i].rate"
+									type="number"
+									min="0"
+									step="0.5"
+									class="w-full bg-transparent text-right tabular-nums focus:outline-none py-1"
+								/>
 								<span v-else class="tabular-nums text-ink-700">{{ t.rate }}</span>
 							</td>
-							<td class="px-3 py-1.5 text-right tabular-nums text-ink-900 font-medium">{{ fmtINR(t.amount) }}</td>
-							<td v-if="editable" class="px-2 py-1.5 text-center"><button type="button" class="text-ink-400 hover:text-danger-600" @click="removeTaxRow(i)">✕</button></td>
+							<td
+								class="px-3 py-1.5 text-right tabular-nums text-ink-900 font-medium"
+							>
+								{{ fmtINR(t.amount) }}
+							</td>
+							<td v-if="editable" class="px-2 py-1.5 text-center">
+								<button
+									type="button"
+									class="text-ink-400 hover:text-danger-600"
+									@click="removeTaxRow(i)"
+								>
+									✕
+								</button>
+							</td>
 						</tr>
-						<tr v-if="!wf.taxRows.length"><td :colspan="editable ? 5 : 4" class="px-3 py-3 text-center text-ink-400 italic">No tax. Pick a template or add a row.</td></tr>
+						<tr v-if="!wf.taxRows.length">
+							<td
+								:colspan="editable ? 5 : 4"
+								class="px-3 py-3 text-center text-ink-400 italic"
+							>
+								No tax. Pick a template or add a row.
+							</td>
+						</tr>
 					</tbody>
 					<tfoot v-if="wf.taxRows.length">
-						<tr class="border-t border-ink-200 bg-ink-50"><td colspan="3" class="px-3 py-2 text-right text-[11px] font-semibold uppercase tracking-wider text-ink-700">Total taxes</td><td class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900">{{ fmtINR(wf.tax) }}</td><td v-if="editable"></td></tr>
+						<tr class="border-t border-ink-200 bg-ink-50">
+							<td
+								colspan="3"
+								class="px-3 py-2 text-right text-[11px] font-semibold uppercase tracking-wider text-ink-700"
+							>
+								Total taxes
+							</td>
+							<td
+								class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+							>
+								{{ fmtINR(wf.tax) }}
+							</td>
+							<td v-if="editable"></td>
+						</tr>
 					</tfoot>
 				</table>
 			</div>
-			<div v-if="editable" class="px-3 py-2 border-t border-ink-100"><button type="button" class="text-xs text-brand-700 hover:underline" @click="addTaxRow">+ Add row</button></div>
+			<div v-if="editable" class="px-3 py-2 border-t border-ink-100">
+				<button
+					type="button"
+					class="text-xs text-brand-700 hover:underline"
+					@click="addTaxRow"
+				>
+					+ Add row
+				</button>
+			</div>
 		</section>
 
 		<!-- Retention/TDS/discount + waterfall -->
 		<section class="mt-4 grid grid-cols-1 lg:grid-cols-2 gap-4">
 			<div class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Retention, TDS &amp; discount</h3></div>
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+					<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+						Retention, TDS &amp; discount
+					</h3>
+				</div>
 				<div class="p-4 space-y-3 text-xs">
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Retention %</label>
-							<input v-model.number="bill.retention_percent" :readonly="!editable" type="number" min="0" max="20" step="0.5" class="desk-input" />
+							<label
+								class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Retention %</label
+							>
+							<input
+								v-model.number="bill.retention_percent"
+								:readonly="!editable"
+								type="number"
+								min="0"
+								max="20"
+								step="0.5"
+								class="desk-input"
+							/>
 						</div>
 						<div>
-							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Advance recovery (₹)</label>
-							<input v-model.number="bill.advance_recovery" :readonly="!editable" type="number" min="0" step="0.01" class="desk-input" />
+							<label
+								class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Advance recovery (₹)</label
+							>
+							<input
+								v-model.number="bill.advance_recovery"
+								:readonly="!editable"
+								type="number"
+								min="0"
+								step="0.01"
+								class="desk-input"
+							/>
 						</div>
 					</div>
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Bill type</label>
-							<select v-model="bill.bill_type" :disabled="!editable" class="desk-input"><option value="Normal">Normal</option><option value="Final">Final (release retention)</option></select>
+							<label
+								class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Bill type</label
+							>
+							<select
+								v-model="bill.bill_type"
+								:disabled="!editable"
+								class="desk-input"
+							>
+								<option value="Normal">Normal</option>
+								<option value="Final">Final (release retention)</option>
+							</select>
 						</div>
 						<div>
-							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Expense account</label>
+							<label
+								class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Expense account</label
+							>
 							<DeskLinkPicker
 								v-model="bill.expense_account"
 								doctype="Account"
 								label-field="name"
 								value-field="name"
-								:filters="bill.company ? [['root_type', '=', 'Expense'], ['is_group', '=', 0], ['company', '=', bill.company]] : []"
+								:filters="
+									bill.company
+										? [
+												['root_type', '=', 'Expense'],
+												['is_group', '=', 0],
+												['company', '=', bill.company],
+										  ]
+										: []
+								"
 								placeholder="Default (Subcontractor Charges)"
 								:disabled="!editable"
 							/>
 						</div>
 					</div>
 					<div>
-						<label class="flex items-center gap-2 py-0.5"><input type="checkbox" v-model="bill.apply_tds" :disabled="!editable" class="accent-brand-600" /><span class="text-ink-800">Apply TDS (withholding)</span></label>
+						<label class="flex items-center gap-2 py-0.5"
+							><input
+								type="checkbox"
+								v-model="bill.apply_tds"
+								:disabled="!editable"
+								class="accent-brand-600"
+							/><span class="text-ink-800">Apply TDS (withholding)</span></label
+						>
 						<div v-if="bill.apply_tds" class="mt-1.5">
-							<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Withholding category</label>
+							<label
+								class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Withholding category</label
+							>
 							<DeskLinkPicker
 								v-model="bill.tax_withholding_category"
 								doctype="Tax Withholding Category"
@@ -607,44 +1118,186 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 						</div>
 					</div>
 					<div>
-						<label class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1">Additional Discount</label>
+						<label
+							class="block text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+							>Additional Discount</label
+						>
 						<div class="flex items-center gap-2">
-							<select v-model="bill.additional_discount_on" :disabled="!editable" class="desk-input !w-32"><option>Net Total</option><option>Grand Total</option></select>
-							<input v-model.number="discValue" :readonly="!editable" type="number" min="0" step="0.01" class="desk-input flex-1" />
+							<select
+								v-model="bill.additional_discount_on"
+								:disabled="!editable"
+								class="desk-input !w-32"
+							>
+								<option>Net Total</option>
+								<option>Grand Total</option>
+							</select>
+							<input
+								v-model.number="discValue"
+								:readonly="!editable"
+								type="number"
+								min="0"
+								step="0.01"
+								class="desk-input flex-1"
+							/>
 							<div class="flex border border-ink-200 rounded-md overflow-hidden">
-								<button type="button" :disabled="!editable" class="px-2.5 py-1" :class="discType === '%' ? 'bg-brand-50 text-brand-700 font-medium' : 'bg-white text-ink-600'" @click="discType = '%'">%</button>
-								<button type="button" :disabled="!editable" class="px-2.5 py-1 border-l border-ink-200" :class="discType === '₹' ? 'bg-brand-50 text-brand-700 font-medium' : 'bg-white text-ink-600'" @click="discType = '₹'">₹</button>
+								<button
+									type="button"
+									:disabled="!editable"
+									class="px-2.5 py-1"
+									:class="
+										discType === '%'
+											? 'bg-brand-50 text-brand-700 font-medium'
+											: 'bg-white text-ink-600'
+									"
+									@click="discType = '%'"
+								>
+									%
+								</button>
+								<button
+									type="button"
+									:disabled="!editable"
+									class="px-2.5 py-1 border-l border-ink-200"
+									:class="
+										discType === '₹'
+											? 'bg-brand-50 text-brand-700 font-medium'
+											: 'bg-white text-ink-600'
+									"
+									@click="discType = '₹'"
+								>
+									₹
+								</button>
 							</div>
 						</div>
-						<p class="text-[10px] text-ink-400 mt-1">Apply on <span class="font-medium">Net Total</span> (before tax) or <span class="font-medium">Grand Total</span> (after tax).</p>
+						<p class="text-[10px] text-ink-400 mt-1">
+							Apply on <span class="font-medium">Net Total</span> (before tax) or
+							<span class="font-medium">Grand Total</span> (after tax).
+						</p>
 					</div>
-					<button v-if="editable" class="desk-save-btn w-full" :disabled="savingBilling" @click="saveBilling">{{ savingBilling ? "Saving…" : "Save billing" }}</button>
+					<button
+						v-if="editable"
+						class="desk-save-btn w-full"
+						:disabled="savingBilling"
+						@click="saveBilling"
+					>
+						{{ savingBilling ? "Saving…" : "Save billing" }}
+					</button>
 				</div>
 			</div>
 
 			<div class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Net payable</h3></div>
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+					<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+						Net payable
+					</h3>
+				</div>
 				<div class="p-4 text-xs">
-					<div class="flex justify-between py-1"><span class="text-ink-600">Gross bill value</span><span class="tabular-nums font-medium">{{ fmtINR(wf.gross) }}</span></div>
-					<div v-if="bill.additional_discount_on === 'Net Total' && wf.netDiscount" class="flex justify-between py-1"><span class="text-ink-500">Less: Discount (on Net Total)</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.netDiscount) }})</span></div>
-					<div class="flex justify-between py-1 border-t border-ink-100"><span class="text-ink-700 font-medium">Taxable value</span><span class="tabular-nums font-medium">{{ fmtINR(wf.taxable) }}</span></div>
-					<div class="flex justify-between py-1"><span class="text-ink-500">Add: Taxes<span v-if="taxRatePct"> (@ {{ taxRatePct }}%)</span></span><span class="tabular-nums text-ink-700">+ {{ fmtINR(wf.tax) }}</span></div>
-					<div class="flex justify-between py-1 border-t border-ink-100"><span class="text-ink-700 font-medium">{{ bill.additional_discount_on === 'Grand Total' ? 'Grand total' : 'Invoice value' }}</span><span class="tabular-nums font-medium">{{ fmtINR(wf.grandTotal) }}</span></div>
-					<template v-if="bill.additional_discount_on === 'Grand Total' && wf.grandDiscount">
-						<div class="flex justify-between py-1"><span class="text-ink-500">Less: Discount (on Grand Total)</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.grandDiscount) }})</span></div>
-						<div class="flex justify-between py-1 border-t border-ink-100"><span class="text-ink-700 font-medium">Invoice value</span><span class="tabular-nums font-medium">{{ fmtINR(wf.invoiceValue) }}</span></div>
-					</template>
-					<div v-if="wf.tds" class="flex justify-between py-1"><span class="text-ink-500">Less: TDS withheld @ {{ bill.tds_rate }}%</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.tds) }})</span></div>
 					<div class="flex justify-between py-1">
-						<span class="text-ink-500">Less: Retention held @ {{ bill.retention_percent }}%</span>
-						<span class="tabular-nums text-warning-700">({{ fmtINR(wf.retention) }})</span>
+						<span class="text-ink-600">Gross bill value</span
+						><span class="tabular-nums font-medium">{{ fmtINR(wf.gross) }}</span>
 					</div>
-					<div class="text-[10px] text-ink-400 -mt-0.5 mb-0.5">Held on your books, released on the final bill.</div>
-					<div v-if="wf.advance" class="flex justify-between py-1"><span class="text-ink-500">Less: Advance recovery</span><span class="tabular-nums text-ink-600">({{ fmtINR(wf.advance) }})</span></div>
+					<div
+						v-if="bill.additional_discount_on === 'Net Total' && wf.netDiscount"
+						class="flex justify-between py-1"
+					>
+						<span class="text-ink-500">Less: Discount (on Net Total)</span
+						><span class="tabular-nums text-ink-600"
+							>({{ fmtINR(wf.netDiscount) }})</span
+						>
+					</div>
+					<div class="flex justify-between py-1 border-t border-ink-100">
+						<span class="text-ink-700 font-medium">Taxable value</span
+						><span class="tabular-nums font-medium">{{ fmtINR(wf.taxable) }}</span>
+					</div>
+					<div class="flex justify-between py-1">
+						<span class="text-ink-500"
+							>Add: Taxes<span v-if="taxRatePct"> (@ {{ taxRatePct }}%)</span></span
+						><span class="tabular-nums text-ink-700">+ {{ fmtINR(wf.tax) }}</span>
+					</div>
+					<div class="flex justify-between py-1 border-t border-ink-100">
+						<span class="text-ink-700 font-medium">{{
+							bill.additional_discount_on === "Grand Total"
+								? "Grand total"
+								: "Invoice value"
+						}}</span
+						><span class="tabular-nums font-medium">{{ fmtINR(wf.grandTotal) }}</span>
+					</div>
+					<template
+						v-if="bill.additional_discount_on === 'Grand Total' && wf.grandDiscount"
+					>
+						<div class="flex justify-between py-1">
+							<span class="text-ink-500">Less: Discount (on Grand Total)</span
+							><span class="tabular-nums text-ink-600"
+								>({{ fmtINR(wf.grandDiscount) }})</span
+							>
+						</div>
+						<div class="flex justify-between py-1 border-t border-ink-100">
+							<span class="text-ink-700 font-medium">Invoice value</span
+							><span class="tabular-nums font-medium">{{
+								fmtINR(wf.invoiceValue)
+							}}</span>
+						</div>
+					</template>
+					<div v-if="wf.tds" class="flex justify-between py-1">
+						<span class="text-ink-500">Less: TDS withheld @ {{ bill.tds_rate }}%</span
+						><span class="tabular-nums text-ink-600">({{ fmtINR(wf.tds) }})</span>
+					</div>
+					<div class="flex justify-between py-1">
+						<span class="text-ink-500"
+							>Less: Retention held @ {{ bill.retention_percent }}%</span
+						>
+						<span class="tabular-nums text-warning-700"
+							>({{ fmtINR(wf.retention) }})</span
+						>
+					</div>
+					<div class="text-[10px] text-ink-400 -mt-0.5 mb-0.5">
+						Held on your books, released on the final bill.
+					</div>
+					<div v-if="wf.advance" class="flex justify-between py-1">
+						<span class="text-ink-500">Less: Advance recovery</span
+						><span class="tabular-nums text-ink-600">({{ fmtINR(wf.advance) }})</span>
+					</div>
 					<div class="flex justify-between py-2 border-t-2 border-ink-200 mt-1">
-						<span class="font-semibold text-ink-900">Net payable to subcontractor</span>
-						<span class="tabular-nums font-bold text-base text-brand-700">{{ fmtINR(wf.netPayable) }}</span>
+						<span class="font-semibold text-ink-900"
+							>Net payable to subcontractor</span
+						>
+						<span class="tabular-nums font-bold text-base text-brand-700">{{
+							fmtINR(wf.netPayable)
+						}}</span>
 					</div>
+					<!-- advances settle the payable (like payments), shown below the total -->
+					<div v-if="advanceAdjusted > 0" class="flex justify-between py-1">
+						<span class="text-ink-500">Advance adjusted</span
+						><span class="tabular-nums text-info-700"
+							>− {{ fmtINR(advanceAdjusted) }}</span
+						>
+					</div>
+					<template v-if="isSubmitted && advanceAdjusted > 0">
+						<div class="flex justify-between py-1">
+							<span class="text-ink-500">Paid</span
+							><span class="tabular-nums text-ink-600">{{
+								fmtINR(payment.paid)
+							}}</span>
+						</div>
+						<div class="flex justify-between py-1">
+							<span
+								class="font-medium"
+								:class="
+									payment.outstanding > 0.01
+										? 'text-danger-700'
+										: 'text-success-700'
+								"
+								>Outstanding</span
+							><span
+								class="tabular-nums font-medium"
+								:class="
+									payment.outstanding > 0.01
+										? 'text-danger-700'
+										: 'text-success-700'
+								"
+								>{{ fmtINR(payment.outstanding) }}</span
+							>
+						</div>
+					</template>
 				</div>
 			</div>
 		</section>
@@ -654,13 +1307,24 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 			<input ref="fileInput" type="file" multiple class="hidden" @change="onFilesPicked" />
 			<div class="flex items-center justify-between mb-2 gap-3">
 				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
-					Attachments <span v-if="attachments.length" class="text-ink-400 font-normal">({{ attachments.length }})</span>
+					Attachments
+					<span v-if="attachments.length" class="text-ink-400 font-normal"
+						>({{ attachments.length }})</span
+					>
 				</h3>
-				<button type="button" class="desk-save-btn !text-xs" :disabled="uploading > 0" @click="fileInput?.click()">
+				<button
+					type="button"
+					class="desk-save-btn !text-xs"
+					:disabled="uploading > 0"
+					@click="fileInput?.click()"
+				>
 					{{ uploading > 0 ? `Uploading… (${uploading})` : "+ Upload" }}
 				</button>
 			</div>
-			<div v-if="attachments.length" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+			<div
+				v-if="attachments.length"
+				class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+			>
 				<table class="w-full text-xs">
 					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
 						<tr>
@@ -673,17 +1337,43 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="att in attachments" :key="att.name" class="border-t border-ink-100 hover:bg-brand-50/40">
-							<td class="px-2 py-2 text-base text-center">{{ fileIcon(att.file_url || att.file_name) }}</td>
+						<tr
+							v-for="att in attachments"
+							:key="att.name"
+							class="border-t border-ink-100 hover:bg-brand-50/40"
+						>
+							<td class="px-2 py-2 text-base text-center">
+								{{ fileIcon(att.file_url || att.file_name) }}
+							</td>
 							<td class="px-3 py-2">
-								<a v-if="att.file_url" :href="att.file_url" target="_blank" rel="noopener" class="text-brand-700 hover:underline truncate block max-w-xs" :title="att.file_name">{{ att.file_name }}</a>
+								<a
+									v-if="att.file_url"
+									:href="att.file_url"
+									target="_blank"
+									rel="noopener"
+									class="text-brand-700 hover:underline truncate block max-w-xs"
+									:title="att.file_name"
+									>{{ att.file_name }}</a
+								>
 								<span v-else class="text-ink-700">{{ att.file_name }}</span>
 							</td>
-							<td class="px-3 py-2 text-right text-ink-600 tabular-nums">{{ formatFileSize(att.file_size) }}</td>
+							<td class="px-3 py-2 text-right text-ink-600 tabular-nums">
+								{{ formatFileSize(att.file_size) }}
+							</td>
 							<td class="px-3 py-2 text-ink-600">{{ fmtDate(att.creation) }}</td>
-							<td class="px-3 py-2"><FrappeUserBadge :user-id="att.owner" size="xs" /></td>
+							<td class="px-3 py-2">
+								<FrappeUserBadge :user-id="att.owner" size="xs" />
+							</td>
 							<td class="px-1 py-2 text-center">
-								<button type="button" class="text-xs px-1.5 py-0.5 border border-ink-200 bg-white hover:bg-danger-50 text-danger-700" style="border-radius: 4px" :title="`Delete ${att.file_name}`" @click="onDeleteFile(att)">✕</button>
+								<button
+									type="button"
+									class="text-xs px-1.5 py-0.5 border border-ink-200 bg-white hover:bg-danger-50 text-danger-700"
+									style="border-radius: 4px"
+									:title="`Delete ${att.file_name}`"
+									@click="onDeleteFile(att)"
+								>
+									✕
+								</button>
 							</td>
 						</tr>
 					</tbody>
@@ -691,56 +1381,219 @@ const accountFilters = computed(() => (bill.value?.company ? [["is_group", "=", 
 			</div>
 			<div v-else class="py-6 text-center border border-dashed border-ink-200 rounded-lg">
 				<div class="text-sm text-ink-500 mb-1">No attachments yet.</div>
-				<div class="text-xs text-ink-400 italic">Invoices, measurement sheets, and site photos go here.</div>
+				<div class="text-xs text-ink-400 italic">
+					Invoices, measurement sheets, and site photos go here.
+				</div>
 			</div>
 		</section>
 
 		<!-- Make Payment modal (inline — posts a Payment Entry, no Desk redirect) -->
-		<div v-if="pay.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="pay.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between">
+		<div
+			v-if="pay.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="pay.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
 					<h2 class="text-sm font-semibold text-ink-900">Make payment</h2>
-					<button type="button" class="text-ink-400 hover:text-ink-900" @click="pay.open = false">✕</button>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="pay.open = false"
+					>
+						✕
+					</button>
 				</header>
 				<div class="px-4 py-4 space-y-3">
 					<div class="text-sm text-ink-700">
-						Pay <span class="font-medium">{{ bill.subcontractor_name }}</span> against <span class="font-mono text-xs">{{ bill.ra_no || bill.name }}</span>.
-						Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(payment.outstanding) }}</span>.
+						Pay <span class="font-medium">{{ bill.subcontractor_name }}</span> against
+						<span class="font-mono text-xs">{{ bill.ra_no || bill.name }}</span
+						>. Outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(payment.outstanding)
+						}}</span
+						>.
 					</div>
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1">Amount <span class="text-danger-600">*</span></label>
-							<input v-model.number="pay.amount" type="number" min="0" class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400" />
+							<label
+								class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Amount <span class="text-danger-600">*</span></label
+							>
+							<input
+								v-model.number="pay.amount"
+								type="number"
+								min="0"
+								class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+							/>
 						</div>
 						<div>
-							<label class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1">Date</label>
-							<input v-model="pay.date" type="date" class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400" />
+							<label
+								class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Date</label
+							>
+							<input
+								v-model="pay.date"
+								type="date"
+								class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+							/>
 						</div>
 					</div>
 					<div>
-						<label class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1">Paid from account <span class="text-danger-600">*</span></label>
-						<select v-model="pay.account" class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400">
+						<label
+							class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+							>Paid from account <span class="text-danger-600">*</span></label
+						>
+						<select
+							v-model="pay.account"
+							class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+						>
 							<option value="" disabled>Bank / Cash account…</option>
-							<option v-for="a in payAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option>
+							<option v-for="a in payAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option>
 						</select>
 					</div>
 					<div class="grid grid-cols-2 gap-3">
 						<div>
-							<label class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1">Mode of payment</label>
-							<select v-model="pay.mode_of_payment" class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400">
+							<label
+								class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Mode of payment</label
+							>
+							<select
+								v-model="pay.mode_of_payment"
+								class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+							>
 								<option v-for="m in payModes" :key="m" :value="m">{{ m }}</option>
 							</select>
 						</div>
 						<div>
-							<label class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1">Reference no. <span class="text-ink-400 normal-case">(optional)</span></label>
-							<input v-model="pay.reference_no" type="text" placeholder="UTR / cheque no." class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400" />
+							<label
+								class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Reference no.
+								<span class="text-ink-400 normal-case">(optional)</span></label
+							>
+							<input
+								v-model="pay.reference_no"
+								type="text"
+								placeholder="UTR / cheque no."
+								class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+							/>
 						</div>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="pay.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="pay.saving" @click="savePayment">{{ pay.saving ? "Recording…" : "Record payment" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="pay.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="pay.saving"
+						@click="savePayment"
+					>
+						{{ pay.saving ? "Recording…" : "Record payment" }}
+					</button>
 				</footer>
+			</div>
+		</div>
+
+		<!-- Link advance modal -->
+		<div
+			v-if="adv.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="adv.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-lg shadow-xl rounded-xl flex flex-col max-h-[85vh]"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Link advance payment</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="adv.open = false"
+					>
+						✕
+					</button>
+				</header>
+				<div class="px-4 py-4 overflow-y-auto flex-1 space-y-3">
+					<div class="text-xs text-ink-600">
+						Unlinked advances paid to
+						<span class="font-medium text-ink-900">{{ bill.subcontractor_name }}</span
+						>. Current outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(payment.outstanding)
+						}}</span>
+						— the suggested allocation settles as much of it as each advance allows.
+					</div>
+					<div v-if="availableAdvances.length" class="space-y-2">
+						<div
+							v-for="a in availableAdvances"
+							:key="a.payment_entry"
+							class="border border-ink-200 rounded-lg px-3 py-2.5"
+						>
+							<div class="flex items-center justify-between gap-2">
+								<div class="min-w-0">
+									<div class="font-mono text-xs text-ink-900 truncate">
+										{{ a.payment_entry }}
+									</div>
+									<div class="text-[11px] text-ink-500">
+										{{ fmtDate(a.date)
+										}}<span v-if="a.mode_of_payment">
+											· {{ a.mode_of_payment }}</span
+										>
+									</div>
+								</div>
+								<div class="text-right flex-shrink-0">
+									<div class="text-xs text-ink-500">Unallocated</div>
+									<div class="text-sm font-semibold text-ink-900 tabular-nums">
+										{{ fmtINR(a.unallocated) }}
+									</div>
+								</div>
+							</div>
+							<div class="flex items-center gap-2 mt-2">
+								<label
+									class="text-[10px] uppercase tracking-wider text-ink-500 font-medium flex-shrink-0"
+									>Adjust</label
+								>
+								<input
+									v-model.number="advAlloc[a.payment_entry]"
+									type="number"
+									min="0"
+									:max="a.unallocated"
+									class="flex-1 text-sm px-2.5 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+								/>
+								<button
+									type="button"
+									class="text-xs px-3 py-1.5 bg-brand-600 hover:bg-brand-700 text-white font-medium rounded-md flex-shrink-0 disabled:opacity-60"
+									:disabled="adv.saving === a.payment_entry"
+									@click="doLink(a)"
+								>
+									{{ adv.saving === a.payment_entry ? "Linking…" : "Link" }}
+								</button>
+							</div>
+						</div>
+					</div>
+					<div v-else class="text-xs text-ink-400 italic py-2">
+						No unlinked advances left for this subcontractor.
+					</div>
+					<div v-if="adv.error" class="text-[11px] text-danger-600">{{ adv.error }}</div>
+				</div>
 			</div>
 		</div>
 	</DeskPage>

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -2,7 +2,7 @@
 // Project Finance › Invoice detail — a full page over one ERPNext Sales Invoice. Summary
 // strip, item lines, taxes, receipts, and the docstatus lifecycle: Submit/Delete (Draft),
 // Receive/Cancel (Submitted). Payment is a real Payment Entry into a Bank/Cash account.
-import { computed, ref, watch } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
@@ -15,6 +15,9 @@ import {
 	listInvoiceReceipts,
 	listDepositAccounts,
 	listInvoicePaymentModes,
+	availableInvoiceAdvances,
+	linkInvoiceAdvance,
+	unlinkInvoiceAdvance,
 } from "@/data/invoiceApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
@@ -30,12 +33,16 @@ const confirmDialog = useConfirm();
 
 const inv = ref(null);
 const receipts = ref([]);
+const availableAdvances = ref([]);
 const loading = ref(true);
 async function load() {
 	loading.value = true;
 	try {
 		inv.value = await getInvoice(props.id);
 		receipts.value = inv.value.docstatus === 1 ? await listInvoiceReceipts(props.id) : [];
+		// On-account advances from this customer that can still be adjusted (draft or submitted).
+		availableAdvances.value =
+			inv.value.docstatus === 2 ? [] : await availableInvoiceAdvances(props.id);
 	} catch (err) {
 		showToast(err.message || "Failed to load invoice", "error");
 	} finally {
@@ -46,11 +53,18 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => inv.value?.docstatus === 0);
 const isSubmitted = computed(() => inv.value?.docstatus === 1);
-const payment = computed(() => inv.value?.payment || { invoiced: 0, received: 0, outstanding: 0, status: "Draft" });
+const state = computed(() => {
+	if (!inv.value) return "";
+	if (inv.value.docstatus === 2) return "Cancelled";
+	if (inv.value.docstatus === 1) return "Submitted";
+	return "Draft";
+});
+const payment = computed(
+	() => inv.value?.payment || { invoiced: 0, received: 0, outstanding: 0, status: "Draft" }
+);
 const statusPills = computed(() => {
 	if (!inv.value) return [];
-	const doc = inv.value.docstatus === 2 ? "Cancelled" : inv.value.docstatus === 1 ? "Submitted" : "Draft";
-	return isSubmitted.value ? [doc, payment.value.status] : [doc];
+	return isSubmitted.value ? [state.value, payment.value.status] : [state.value];
 });
 
 const breadcrumbs = [
@@ -62,7 +76,13 @@ const breadcrumbs = [
 // --- lifecycle ---
 const busy = ref(false);
 async function onSubmit() {
-	const ok = await confirmDialog({ title: "Submit invoice?", message: `Submit ${inv.value.name} (${fmtINR(payment.value.invoiced || inv.value.grand_total)})? It posts the receivable and counts as income.`, confirmLabel: "Submit" });
+	const ok = await confirmDialog({
+		title: "Submit invoice?",
+		message: `Submit ${inv.value.name} (${fmtINR(
+			payment.value.invoiced || inv.value.grand_total
+		)})? It posts the receivable and counts as income.`,
+		confirmLabel: "Submit",
+	});
 	if (!ok) return;
 	busy.value = true;
 	try {
@@ -76,7 +96,13 @@ async function onSubmit() {
 	}
 }
 async function onCancel() {
-	const ok = await confirmDialog({ title: "Cancel invoice?", message: `Cancel ${inv.value.name}? Its receivable and any allocations are reversed.`, confirmLabel: "Cancel invoice", cancelLabel: "Keep", destructive: true });
+	const ok = await confirmDialog({
+		title: "Cancel invoice?",
+		message: `Cancel ${inv.value.name}? Its receivable and any allocations are reversed.`,
+		confirmLabel: "Cancel invoice",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
 	if (!ok) return;
 	busy.value = true;
 	try {
@@ -90,7 +116,12 @@ async function onCancel() {
 	}
 }
 async function onDelete() {
-	const ok = await confirmDialog({ title: "Delete draft?", message: `Permanently delete ${inv.value.name}?`, confirmLabel: "Delete", destructive: true });
+	const ok = await confirmDialog({
+		title: "Delete draft?",
+		message: `Permanently delete ${inv.value.name}?`,
+		confirmLabel: "Delete",
+		destructive: true,
+	});
 	if (!ok) return;
 	try {
 		await deleteInvoice(inv.value.name);
@@ -100,15 +131,35 @@ async function onDelete() {
 		showToast(err.message || "Delete failed", "error");
 	}
 }
+function onPrint() {
+	// Opens ERPNext's native Sales Invoice print view in a new tab.
+	window.open(
+		`/printview?doctype=Sales%20Invoice&name=${encodeURIComponent(
+			inv.value.name
+		)}&trigger_print=1`,
+		"_blank"
+	);
+}
 
 // --- receive ---
-const rec = ref({ open: false, amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const rec = ref({
+	open: false,
+	amount: null,
+	deposit_to: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 const depositAccounts = ref([]);
 const payModes = ref([]);
 async function openReceive() {
 	if (!depositAccounts.value.length) {
 		try {
-			[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
+			[depositAccounts.value, payModes.value] = await Promise.all([
+				listDepositAccounts(),
+				listInvoicePaymentModes(),
+			]);
 		} catch {
 			/* fall through */
 		}
@@ -116,7 +167,10 @@ async function openReceive() {
 	rec.value = {
 		open: true,
 		amount: Number(payment.value.outstanding) || null,
-		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		deposit_to:
+			depositAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			depositAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -126,11 +180,22 @@ async function openReceive() {
 async function saveReceive() {
 	const amt = Number(rec.value.amount) || 0;
 	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
-	if (amt > Number(payment.value.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`, "error");
+	if (amt > Number(payment.value.outstanding) + 0.01)
+		return showToast(
+			`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`,
+			"error"
+		);
 	if (!rec.value.deposit_to) return showToast("Pick the account to deposit into.", "error");
 	rec.value.saving = true;
 	try {
-		await recordInvoiceReceipt({ name: inv.value.name, amount: amt, date: rec.value.date, mode_of_payment: rec.value.mode_of_payment || undefined, deposit_to: rec.value.deposit_to, reference_no: rec.value.reference_no || undefined });
+		await recordInvoiceReceipt({
+			name: inv.value.name,
+			amount: amt,
+			date: rec.value.date,
+			mode_of_payment: rec.value.mode_of_payment || undefined,
+			deposit_to: rec.value.deposit_to,
+			reference_no: rec.value.reference_no || undefined,
+		});
 		rec.value.open = false;
 		await load();
 		showToast("Payment received.");
@@ -140,102 +205,612 @@ async function saveReceive() {
 		rec.value.saving = false;
 	}
 }
+
+// --- advance payments (ERPNext-native adjustment) ---
+// Draft adjusts via the Sales Invoice `advances` table; Submitted via Payment Reconciliation.
+const linkedAdvances = computed(() => inv.value?.advances || []);
+const advanceAdjusted = computed(() => Number(inv.value?.advance_adjusted) || 0);
+const unlinkedTotal = computed(() =>
+	availableAdvances.value.reduce((a, x) => a + Number(x.unallocated || 0), 0)
+);
+const canLink = computed(() => inv.value && inv.value.docstatus !== 2);
+// Amount still owed the advance can settle: outstanding (submitted) or grand − advances (draft).
+const remainingOutstanding = computed(() => {
+	if (!inv.value) return 0;
+	if (isSubmitted.value) return Number(payment.value.outstanding) || 0;
+	return Math.max(Number(inv.value.grand_total) - advanceAdjusted.value, 0);
+});
+
+const adv = ref({ open: false, msg: "", error: "", saving: "" });
+const advAlloc = reactive({});
+function suggestAllocations() {
+	for (const a of availableAdvances.value)
+		advAlloc[a.payment_entry] = Math.min(Number(a.unallocated), remainingOutstanding.value);
+}
+function openLinkAdvance() {
+	adv.value.error = "";
+	adv.value.msg = "";
+	suggestAllocations();
+	adv.value.open = true;
+}
+async function doLink(a) {
+	const amt = Number(advAlloc[a.payment_entry]) || 0;
+	if (amt <= 0) {
+		adv.value.error = "Enter an amount greater than zero.";
+		return;
+	}
+	if (amt > Number(a.unallocated) + 0.01) {
+		adv.value.error = `Only ${fmtINR(a.unallocated)} is unadjusted on ${a.payment_entry}.`;
+		return;
+	}
+	adv.value.saving = a.payment_entry;
+	adv.value.error = "";
+	try {
+		await linkInvoiceAdvance({
+			name: inv.value.name,
+			payment_entry: a.payment_entry,
+			amount: amt,
+		});
+		adv.value.open = false;
+		await load();
+		adv.value.msg = `Adjusted ${fmtINR(amt)} from ${
+			a.payment_entry
+		} — outstanding is now ${fmtINR(remainingOutstanding.value)}.`;
+		showToast("Advance adjusted.");
+	} catch (err) {
+		adv.value.error = err.message || "Could not link the advance.";
+	} finally {
+		adv.value.saving = "";
+	}
+}
+async function unlinkAdvance(row) {
+	const ok = await confirmDialog({
+		title: "Unlink advance?",
+		message: `Return ${fmtINR(row.allocated)} to ${
+			row.payment_entry
+		}'s unallocated balance? The invoice's outstanding goes back up.`,
+		confirmLabel: "Unlink",
+	});
+	if (!ok) return;
+	adv.value.msg = "";
+	try {
+		await unlinkInvoiceAdvance({ name: inv.value.name, payment_entry: row.payment_entry });
+		await load();
+		showToast("Advance unlinked.");
+	} catch (err) {
+		showToast(err.message || "Unlink failed", "error");
+	}
+}
 </script>
 
 <template>
-	<DeskPage :title="inv ? inv.name : id" :breadcrumbs="breadcrumbs">
+	<DeskPage
+		:title="inv ? inv.name : id"
+		:subtitle="inv ? `Invoiced ${fmtDate(inv.date)} · due ${fmtDate(inv.due_date)}` : ''"
+		:breadcrumbs="breadcrumbs"
+	>
 		<template v-if="inv" #actions>
 			<div class="flex items-center gap-2">
-				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md" :disabled="busy" @click="onDelete">Delete</button>
-				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="router.push(`/project-finance/invoices/${inv.name}/edit`)">Edit</button>
-				<button v-if="isDraft" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="onSubmit">Submit</button>
-				<button v-if="isSubmitted && payment.outstanding > 0.01" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="openReceive">Receive payment</button>
-				<button v-if="isSubmitted" type="button" class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md" :disabled="busy" @click="onCancel">Cancel</button>
+				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5"
+					@click="onPrint"
+				>
+					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.75"
+							d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+						/>
+					</svg>
+					Print / PDF
+				</button>
+				<button
+					v-if="isDraft"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md"
+					:disabled="busy"
+					@click="onDelete"
+				>
+					Delete
+				</button>
+				<button
+					v-if="isDraft"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+					@click="router.push(`/project-finance/invoices/${inv.name}/edit`)"
+				>
+					Edit
+				</button>
+				<button
+					v-if="isDraft"
+					type="button"
+					class="text-xs desk-save-btn"
+					:disabled="busy"
+					@click="onSubmit"
+				>
+					Submit
+				</button>
+				<button
+					v-if="isSubmitted && payment.outstanding > 0.01"
+					type="button"
+					class="text-xs desk-save-btn"
+					:disabled="busy"
+					@click="openReceive"
+				>
+					Receive payment
+				</button>
+				<button
+					v-if="isSubmitted"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md"
+					:disabled="busy"
+					@click="onCancel"
+				>
+					Cancel
+				</button>
 			</div>
 		</template>
 
-		<div v-if="!inv" class="py-16 text-center text-sm text-ink-400">{{ loading ? "Loading…" : "Invoice not found." }}</div>
+		<div v-if="!inv" class="py-16 text-center text-sm text-ink-400">
+			{{ loading ? "Loading…" : "Invoice not found." }}
+		</div>
 		<div v-else class="space-y-4">
-			<div class="flex items-center gap-2">
-				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
+			<!-- draft / cancelled notice -->
+			<div
+				v-if="state === 'Draft'"
+				class="px-4 py-2.5 bg-warning-50 border border-warning-200 rounded-lg text-sm text-warning-700"
+			>
+				Draft — not posted yet. Submit it to make it a receivable and enable payment
+				receipt.
+			</div>
+			<div
+				v-if="state === 'Cancelled'"
+				class="px-4 py-2.5 bg-danger-50 border border-danger-200 rounded-lg text-sm text-danger-700"
+			>
+				Cancelled — no longer a receivable and excluded from income.
 			</div>
 
-			<!-- header facts -->
-			<div class="grid grid-cols-2 md:grid-cols-4 gap-2">
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Customer</div><div class="text-sm text-ink-900 mt-0.5">{{ inv.customer_name }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Project</div><div class="text-sm text-ink-900 mt-0.5">{{ inv.project_name || "—" }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Date</div><div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(inv.date) }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Due</div><div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(inv.due_date) }}</div></div>
+			<!-- advance adjusted confirmation -->
+			<div
+				v-if="adv.msg"
+				class="px-4 py-2.5 bg-success-50 border border-success-200 rounded-md text-xs text-success-700 flex items-center gap-2"
+			>
+				<span class="text-sm">✓</span><span class="font-medium">{{ adv.msg }}</span>
 			</div>
 
-			<!-- money strip (submitted) -->
-			<div v-if="isSubmitted" class="grid grid-cols-2 md:grid-cols-3 gap-2">
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Invoiced</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.invoiced) }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Received</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.received) }}</div></div>
-				<div class="border px-3 py-2 rounded-md" :class="payment.outstanding > 0.01 ? 'bg-warning-50 border-warning-200' : 'bg-success-50 border-success-200'"><div class="text-[10px] uppercase tracking-wider font-medium" :class="payment.outstanding > 0.01 ? 'text-warning-700' : 'text-success-700'">Outstanding</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.outstanding) }}</div></div>
+			<!-- unlinked-advance suggestion -->
+			<div
+				v-if="canLink && availableAdvances.length && remainingOutstanding > 0.01"
+				class="px-4 py-2.5 bg-info-50 border border-info-200 rounded-md text-xs text-ink-700 flex items-center justify-between gap-3 flex-wrap"
+			>
+				<span>
+					<span class="font-medium text-ink-900"
+						>{{ inv.customer_name }} has {{ fmtINR(unlinkedTotal) }} in unadjusted
+						advance payment{{ availableAdvances.length === 1 ? "" : "s" }}</span
+					>
+					— adjust {{ availableAdvances.length === 1 ? "it" : "them" }} against this
+					invoice to reduce the outstanding.
+				</span>
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1 border border-info-200 bg-white hover:bg-info-50 text-info-700 font-medium flex-shrink-0 rounded-md"
+					@click="openLinkAdvance"
+				>
+					Link advance →
+				</button>
+			</div>
+
+			<!-- summary strip -->
+			<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Customer</div>
+					<div class="text-sm font-medium text-ink-900 mt-0.5">
+						{{ inv.customer_name }}
+					</div>
+					<div
+						v-if="inv.customer_gstin"
+						class="text-[10px] font-mono text-ink-400 mt-0.5"
+					>
+						{{ inv.customer_gstin }}
+					</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Project</div>
+					<DeskLink
+						v-if="inv.project"
+						:to="`/projects/${inv.project}`"
+						class="text-sm"
+						>{{ inv.project_name || inv.project }}</DeskLink
+					>
+					<div v-else class="text-sm text-ink-500 mt-0.5">—</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">
+						Invoice total
+					</div>
+					<div class="text-sm font-semibold text-ink-900 tabular-nums mt-0.5">
+						{{ fmtINR(inv.grand_total) }}
+					</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">
+						{{ isSubmitted ? "Outstanding" : "Status" }}
+					</div>
+					<div
+						v-if="isSubmitted"
+						class="text-sm font-semibold tabular-nums mt-0.5"
+						:class="
+							payment.outstanding > 0.01 ? 'text-danger-700' : 'text-success-700'
+						"
+					>
+						{{ fmtINR(payment.outstanding) }}
+					</div>
+					<div v-else class="text-sm text-ink-700 mt-0.5">{{ state }}</div>
+				</div>
 			</div>
 
 			<!-- line items -->
 			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Items</h3></div>
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+					<h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">
+						Items
+					</h3>
+				</div>
 				<table class="w-full text-xs">
-					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-4 py-2">Description</th><th class="text-right px-4 py-2">Qty</th><th class="text-right px-4 py-2">Rate</th><th class="text-right px-4 py-2">Amount</th></tr></thead>
+					<thead class="text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="text-left px-4 py-2">Description</th>
+							<th class="text-right px-4 py-2">Qty</th>
+							<th class="text-right px-4 py-2">Rate</th>
+							<th class="text-right px-4 py-2">Amount</th>
+						</tr>
+					</thead>
 					<tbody>
-						<tr v-for="(l, idx) in inv.items" :key="idx" class="border-t border-ink-100">
+						<tr
+							v-for="(l, idx) in inv.items"
+							:key="idx"
+							class="border-t border-ink-100"
+						>
 							<td class="px-4 py-2 text-ink-900">{{ l.description }}</td>
-							<td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ l.qty }}</td>
-							<td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ fmtINR(l.rate) }}</td>
-							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(l.amount) }}</td>
+							<td class="px-4 py-2 text-right tabular-nums text-ink-600">
+								{{ l.qty }}
+							</td>
+							<td class="px-4 py-2 text-right tabular-nums text-ink-600">
+								{{ fmtINR(l.rate) }}
+							</td>
+							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">
+								{{ fmtINR(l.amount) }}
+							</td>
 						</tr>
 					</tbody>
-					<tfoot class="border-t border-ink-200">
-						<tr><td colspan="3" class="px-4 py-1.5 text-right text-ink-500">Net total</td><td class="px-4 py-1.5 text-right tabular-nums text-ink-700">{{ fmtINR(inv.net_total) }}</td></tr>
-						<tr v-for="(t, idx) in inv.taxes" :key="'t' + idx"><td colspan="3" class="px-4 py-1.5 text-right text-ink-500">{{ t.description }} ({{ t.rate }}%)</td><td class="px-4 py-1.5 text-right tabular-nums text-ink-700">{{ fmtINR(t.tax_amount) }}</td></tr>
-						<tr class="border-t border-ink-200 font-semibold"><td colspan="3" class="px-4 py-2 text-right text-ink-900">Grand total</td><td class="px-4 py-2 text-right tabular-nums text-ink-900">{{ fmtINR(inv.grand_total) }}</td></tr>
-					</tfoot>
 				</table>
 			</section>
 
-			<!-- receipts -->
-			<section v-if="receipts.length" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Receipts</h3></div>
-				<table class="w-full text-xs">
-					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Mode</th><th class="text-left px-4 py-2">Reference</th><th class="text-left px-4 py-2">Entry</th><th class="text-right px-4 py-2">Amount</th></tr></thead>
-					<tbody>
-						<tr v-for="p in receipts" :key="p.payment_entry" class="border-t border-ink-100">
-							<td class="px-4 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(p.date) }}</td>
-							<td class="px-4 py-2 text-ink-700">{{ p.mode_of_payment || "—" }}</td>
-							<td class="px-4 py-2 text-ink-600">{{ p.reference_no || "—" }}</td>
-							<td class="px-4 py-2"><DeskLink :to="`/app/payment-entry/${p.payment_entry}`" class="font-mono text-ink-700">{{ p.payment_entry }}</DeskLink></td>
-							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(p.amount) }}</td>
-						</tr>
-					</tbody>
-				</table>
-			</section>
+			<!-- receipts + advances (left) · totals waterfall (right) -->
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+				<section class="space-y-4">
+					<!-- receipts -->
+					<div
+						v-if="receipts.length"
+						class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+					>
+						<div
+							class="bg-ink-50 px-4 py-2 border-b border-ink-200 text-[11px] uppercase tracking-wider font-semibold text-ink-700"
+						>
+							Receipts ({{ receipts.length }})
+						</div>
+						<div
+							v-for="p in receipts"
+							:key="p.payment_entry"
+							class="flex items-center justify-between px-4 py-2.5 border-t border-ink-100 text-sm gap-2"
+						>
+							<span class="text-ink-600 min-w-0 truncate"
+								>{{ fmtDate(p.date)
+								}}<span v-if="p.mode_of_payment">
+									· {{ p.mode_of_payment }}</span
+								></span
+							>
+							<span class="flex items-center gap-2 flex-shrink-0">
+								<DeskLink
+									:to="`/app/payment-entry/${p.payment_entry}`"
+									class="font-mono text-[11px] text-ink-500"
+									>{{ p.payment_entry }}</DeskLink
+								>
+								<span class="tabular-nums text-success-700 font-medium">{{
+									fmtINR(p.amount)
+								}}</span>
+							</span>
+						</div>
+					</div>
+
+					<!-- Advance Payments (ERPNext SI "Advance Payments") -->
+					<div
+						v-if="linkedAdvances.length || (canLink && availableAdvances.length)"
+						class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+					>
+						<div
+							class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3"
+						>
+							<span
+								class="text-[11px] uppercase tracking-wider font-semibold text-ink-700"
+								>Advance Payments</span
+							>
+							<button
+								v-if="canLink && availableAdvances.length"
+								type="button"
+								class="text-xs text-brand-700 hover:underline"
+								@click="openLinkAdvance"
+							>
+								+ Link advance
+							</button>
+						</div>
+						<template v-if="linkedAdvances.length">
+							<div
+								v-for="row in linkedAdvances"
+								:key="row.payment_entry"
+								class="flex items-center justify-between px-4 py-2.5 border-t border-ink-100 text-sm gap-2"
+							>
+								<DeskLink
+									:to="`/app/payment-entry/${row.payment_entry}`"
+									class="font-mono text-xs text-ink-900 min-w-0 truncate"
+									>{{ row.payment_entry }}</DeskLink
+								>
+								<span class="flex items-center gap-2 flex-shrink-0">
+									<span class="tabular-nums text-info-700 font-medium">{{
+										fmtINR(row.allocated)
+									}}</span>
+									<button
+										v-if="canLink"
+										type="button"
+										class="text-ink-400 hover:text-danger-600 text-xs"
+										:title="`Unlink ${row.payment_entry}`"
+										@click="unlinkAdvance(row)"
+									>
+										✕
+									</button>
+								</span>
+							</div>
+							<div
+								class="px-4 py-2 border-t border-ink-100 flex items-center justify-between text-[11px]"
+							>
+								<span class="uppercase tracking-wider text-ink-500 font-medium"
+									>Total advance adjusted</span
+								>
+								<span class="tabular-nums font-semibold text-ink-900">{{
+									fmtINR(advanceAdjusted)
+								}}</span>
+							</div>
+						</template>
+						<div
+							v-else
+							class="px-4 py-3 text-xs text-ink-400 italic border-t border-ink-100"
+						>
+							No advances adjusted yet — {{ inv.customer_name }} has
+							{{ fmtINR(unlinkedTotal) }} unallocated.
+						</div>
+					</div>
+				</section>
+
+				<!-- totals waterfall -->
+				<section class="bg-ink-50 rounded-lg px-4 py-3 text-sm space-y-1 self-start">
+					<div class="flex justify-between text-ink-600">
+						<span>Net total</span
+						><span class="tabular-nums">{{ fmtINR(inv.net_total) }}</span>
+					</div>
+					<div
+						v-for="(t, idx) in inv.taxes"
+						:key="'t' + idx"
+						class="flex justify-between text-ink-600"
+					>
+						<span>{{ t.description }} ({{ t.rate }}%)</span
+						><span class="tabular-nums">{{ fmtINR(t.tax_amount) }}</span>
+					</div>
+					<div
+						class="flex justify-between font-semibold text-ink-900 border-t border-ink-200 pt-1.5"
+					>
+						<span>Invoice total</span
+						><span class="tabular-nums">{{ fmtINR(inv.grand_total) }}</span>
+					</div>
+					<div v-if="advanceAdjusted > 0" class="flex justify-between text-ink-600">
+						<span>Advance adjusted</span
+						><span class="tabular-nums text-info-700"
+							>− {{ fmtINR(advanceAdjusted) }}</span
+						>
+					</div>
+					<template v-if="isSubmitted">
+						<div class="flex justify-between text-ink-600">
+							<span>Received</span
+							><span class="tabular-nums">{{ fmtINR(payment.received) }}</span>
+						</div>
+						<div
+							class="flex justify-between font-semibold"
+							:class="
+								payment.outstanding > 0.01 ? 'text-danger-700' : 'text-success-700'
+							"
+						>
+							<span>Outstanding</span
+							><span class="tabular-nums">{{ fmtINR(payment.outstanding) }}</span>
+						</div>
+					</template>
+					<div v-else-if="advanceAdjusted > 0" class="text-[10px] text-ink-400">
+						Settles against the receivable when the invoice is submitted.
+					</div>
+				</section>
+			</div>
 		</div>
 
 		<!-- Receive payment modal -->
-		<div v-if="rec.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="rec.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Receive payment</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="rec.open = false">✕</button></header>
+		<div
+			v-if="rec.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="rec.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Receive payment</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="rec.open = false"
+					>
+						✕
+					</button>
+				</header>
 				<div class="px-4 py-4 space-y-3">
-					<div class="text-sm text-ink-700">From <span class="font-medium">{{ inv.customer_name }}</span> against <span class="font-mono text-xs">{{ inv.name }}</span>. Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(payment.outstanding) }}</span>.</div>
+					<div class="text-sm text-ink-700">
+						From <span class="font-medium">{{ inv.customer_name }}</span> against
+						<span class="font-mono text-xs">{{ inv.name }}</span
+						>. Outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(payment.outstanding)
+						}}</span
+						>.
+					</div>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Amount" required><DeskInput v-model.number="rec.amount" type="number" min="0" /></DeskField>
-						<DeskField label="Date"><DeskInput v-model="rec.date" type="date" /></DeskField>
+						<DeskField label="Amount" required
+							><DeskInput v-model.number="rec.amount" type="number" min="0"
+						/></DeskField>
+						<DeskField label="Date"
+							><DeskInput v-model="rec.date" type="date"
+						/></DeskField>
 					</div>
 					<DeskField label="Deposit into" required>
-						<DeskSelect v-model="rec.deposit_to"><option value="" disabled>Bank / Cash account…</option><option v-for="a in depositAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+						<DeskSelect v-model="rec.deposit_to"
+							><option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in depositAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option></DeskSelect
+						>
 					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Mode of payment"><DeskSelect v-model="rec.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
-						<DeskField label="Reference no."><DeskInput v-model="rec.reference_no" placeholder="UTR / cheque no." /></DeskField>
+						<DeskField label="Mode of payment"
+							><DeskSelect v-model="rec.mode_of_payment"
+								><option value="">—</option>
+								<option v-for="m in payModes" :key="m" :value="m">
+									{{ m }}
+								</option></DeskSelect
+							></DeskField
+						>
+						<DeskField label="Reference no."
+							><DeskInput v-model="rec.reference_no" placeholder="UTR / cheque no."
+						/></DeskField>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="rec.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="rec.saving" @click="saveReceive">{{ rec.saving ? "Receiving…" : "Record receipt" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="rec.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="rec.saving"
+						@click="saveReceive"
+					>
+						{{ rec.saving ? "Receiving…" : "Record receipt" }}
+					</button>
 				</footer>
+			</div>
+		</div>
+
+		<!-- Link advance modal -->
+		<div
+			v-if="adv.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="adv.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-lg shadow-xl rounded-xl flex flex-col max-h-[85vh]"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Link advance payment</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="adv.open = false"
+					>
+						✕
+					</button>
+				</header>
+				<div class="px-4 py-4 overflow-y-auto flex-1 space-y-3">
+					<div class="text-xs text-ink-600">
+						Unadjusted advances received from
+						<span class="font-medium text-ink-900">{{ inv.customer_name }}</span
+						>. Current outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(remainingOutstanding)
+						}}</span>
+						— the suggested allocation settles as much of it as each advance allows.
+					</div>
+					<div v-if="availableAdvances.length" class="space-y-2">
+						<div
+							v-for="a in availableAdvances"
+							:key="a.payment_entry"
+							class="border border-ink-200 rounded-lg px-3 py-2.5"
+						>
+							<div class="flex items-center justify-between gap-2">
+								<div class="min-w-0">
+									<div class="font-mono text-xs text-ink-900 truncate">
+										{{ a.payment_entry }}
+									</div>
+									<div class="text-[11px] text-ink-500">
+										{{ fmtDate(a.date)
+										}}<span v-if="a.mode_of_payment">
+											· {{ a.mode_of_payment }}</span
+										>
+									</div>
+								</div>
+								<div class="text-right flex-shrink-0">
+									<div class="text-xs text-ink-500">Unallocated</div>
+									<div class="text-sm font-semibold text-ink-900 tabular-nums">
+										{{ fmtINR(a.unallocated) }}
+									</div>
+								</div>
+							</div>
+							<div class="flex items-center gap-2 mt-2">
+								<label
+									class="text-[10px] uppercase tracking-wider text-ink-500 font-medium flex-shrink-0"
+									>Adjust</label
+								>
+								<input
+									v-model.number="advAlloc[a.payment_entry]"
+									type="number"
+									min="0"
+									:max="a.unallocated"
+									class="flex-1 text-sm px-2.5 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+								/>
+								<button
+									type="button"
+									class="text-xs px-3 py-1.5 bg-brand-600 hover:bg-brand-700 text-white font-medium rounded-md flex-shrink-0 disabled:opacity-60"
+									:disabled="adv.saving === a.payment_entry"
+									@click="doLink(a)"
+								>
+									{{ adv.saving === a.payment_entry ? "Linking…" : "Link" }}
+								</button>
+							</div>
+						</div>
+					</div>
+					<div v-else class="text-xs text-ink-400 italic py-2">
+						No unadjusted advances left for this customer.
+					</div>
+					<div v-if="adv.error" class="text-[11px] text-danger-600">{{ adv.error }}</div>
+				</div>
 			</div>
 		</div>
 	</DeskPage>

--- a/frontend/src/views/finance/FinanceSupplierBillDetailView.vue
+++ b/frontend/src/views/finance/FinanceSupplierBillDetailView.vue
@@ -1,9 +1,9 @@
 <script setup>
 // Project Finance › Bills › Supplier bill detail — a full page over one ERPNext Purchase
-// Invoice. Summary strip, item lines, taxes, payments, and the docstatus lifecycle:
-// Submit/Delete/Edit (Draft), Pay/Cancel (Submitted). Pay = a real Payment Entry from a
-// Bank/Cash account. Mirrors the customer-invoice detail.
-import { computed, ref, watch } from "vue";
+// Invoice. Summary strip, item lines, payments, supplier-advance adjustment, and the docstatus
+// lifecycle: Submit/Delete/Edit (Draft), Pay/Cancel (Submitted). Pay = a real Payment Entry
+// from a Bank/Cash account. Mirrors the customer-invoice detail (payable side).
+import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
@@ -16,6 +16,9 @@ import {
 	listSupplierBillPayments,
 	listBillPayAccounts,
 	listSupplierBillPaymentModes,
+	availableSupplierBillAdvances,
+	linkSupplierBillAdvance,
+	unlinkSupplierBillAdvance,
 } from "@/data/supplierBillApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
@@ -31,12 +34,17 @@ const confirmDialog = useConfirm();
 
 const bill = ref(null);
 const payments = ref([]);
+const availableAdvances = ref([]);
 const loading = ref(true);
 async function load() {
 	loading.value = true;
 	try {
 		bill.value = await getSupplierBill(props.id);
-		payments.value = bill.value.docstatus === 1 ? await listSupplierBillPayments(props.id) : [];
+		payments.value =
+			bill.value.docstatus === 1 ? await listSupplierBillPayments(props.id) : [];
+		// On-account advances to this supplier that can still be adjusted (draft or submitted).
+		availableAdvances.value =
+			bill.value.docstatus === 2 ? [] : await availableSupplierBillAdvances(props.id);
 	} catch (err) {
 		showToast(err.message || "Failed to load bill", "error");
 	} finally {
@@ -47,11 +55,18 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => bill.value?.docstatus === 0);
 const isSubmitted = computed(() => bill.value?.docstatus === 1);
-const payment = computed(() => bill.value?.payment || { invoiced: 0, paid: 0, outstanding: 0, status: "Draft" });
+const state = computed(() => {
+	if (!bill.value) return "";
+	if (bill.value.docstatus === 2) return "Cancelled";
+	if (bill.value.docstatus === 1) return "Submitted";
+	return "Draft";
+});
+const payment = computed(
+	() => bill.value?.payment || { invoiced: 0, paid: 0, outstanding: 0, status: "Draft" }
+);
 const statusPills = computed(() => {
 	if (!bill.value) return [];
-	const doc = bill.value.docstatus === 2 ? "Cancelled" : bill.value.docstatus === 1 ? "Submitted" : "Draft";
-	return isSubmitted.value ? [doc, payment.value.status] : [doc];
+	return isSubmitted.value ? [state.value, payment.value.status] : [state.value];
 });
 
 const breadcrumbs = [
@@ -60,9 +75,16 @@ const breadcrumbs = [
 	{ label: props.id },
 ];
 
+// --- lifecycle ---
 const busy = ref(false);
 async function onSubmit() {
-	const ok = await confirmDialog({ title: "Submit bill?", message: `Submit ${bill.value.name} (${fmtINR(bill.value.grand_total)})? It posts the payable and can then be paid.`, confirmLabel: "Submit" });
+	const ok = await confirmDialog({
+		title: "Submit bill?",
+		message: `Submit ${bill.value.name} (${fmtINR(
+			bill.value.grand_total
+		)})? It posts the payable and can then be paid.`,
+		confirmLabel: "Submit",
+	});
 	if (!ok) return;
 	busy.value = true;
 	try {
@@ -76,7 +98,13 @@ async function onSubmit() {
 	}
 }
 async function onCancel() {
-	const ok = await confirmDialog({ title: "Cancel bill?", message: `Cancel ${bill.value.name}? Its payable and any allocations are reversed.`, confirmLabel: "Cancel bill", cancelLabel: "Keep", destructive: true });
+	const ok = await confirmDialog({
+		title: "Cancel bill?",
+		message: `Cancel ${bill.value.name}? Its payable and any allocations are reversed.`,
+		confirmLabel: "Cancel bill",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
 	if (!ok) return;
 	busy.value = true;
 	try {
@@ -90,7 +118,12 @@ async function onCancel() {
 	}
 }
 async function onDelete() {
-	const ok = await confirmDialog({ title: "Delete draft?", message: `Permanently delete ${bill.value.name}?`, confirmLabel: "Delete", destructive: true });
+	const ok = await confirmDialog({
+		title: "Delete draft?",
+		message: `Permanently delete ${bill.value.name}?`,
+		confirmLabel: "Delete",
+		destructive: true,
+	});
 	if (!ok) return;
 	try {
 		await deleteSupplierBill(bill.value.name);
@@ -100,15 +133,35 @@ async function onDelete() {
 		showToast(err.message || "Delete failed", "error");
 	}
 }
+function onPrint() {
+	// Opens ERPNext's native Purchase Invoice print view in a new tab.
+	window.open(
+		`/printview?doctype=Purchase%20Invoice&name=${encodeURIComponent(
+			bill.value.name
+		)}&trigger_print=1`,
+		"_blank"
+	);
+}
 
 // --- pay ---
-const pay = ref({ open: false, amount: null, pay_from: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const pay = ref({
+	open: false,
+	amount: null,
+	pay_from: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 const payAccounts = ref([]);
 const payModes = ref([]);
 async function openPay() {
 	if (!payAccounts.value.length) {
 		try {
-			[payAccounts.value, payModes.value] = await Promise.all([listBillPayAccounts(), listSupplierBillPaymentModes()]);
+			[payAccounts.value, payModes.value] = await Promise.all([
+				listBillPayAccounts(),
+				listSupplierBillPaymentModes(),
+			]);
 		} catch {
 			/* fall through */
 		}
@@ -116,7 +169,10 @@ async function openPay() {
 	pay.value = {
 		open: true,
 		amount: Number(payment.value.outstanding) || null,
-		pay_from: payAccounts.value.find((a) => a.account_type === "Bank")?.name || payAccounts.value[0]?.name || "",
+		pay_from:
+			payAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			payAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -126,11 +182,22 @@ async function openPay() {
 async function savePay() {
 	const amt = Number(pay.value.amount) || 0;
 	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
-	if (amt > Number(payment.value.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`, "error");
+	if (amt > Number(payment.value.outstanding) + 0.01)
+		return showToast(
+			`Can't exceed the outstanding ${fmtINR(payment.value.outstanding)}.`,
+			"error"
+		);
 	if (!pay.value.pay_from) return showToast("Pick the account to pay from.", "error");
 	pay.value.saving = true;
 	try {
-		await recordSupplierBillPayment({ name: bill.value.name, amount: amt, date: pay.value.date, mode_of_payment: pay.value.mode_of_payment || undefined, pay_from: pay.value.pay_from, reference_no: pay.value.reference_no || undefined });
+		await recordSupplierBillPayment({
+			name: bill.value.name,
+			amount: amt,
+			date: pay.value.date,
+			mode_of_payment: pay.value.mode_of_payment || undefined,
+			pay_from: pay.value.pay_from,
+			reference_no: pay.value.reference_no || undefined,
+		});
 		pay.value.open = false;
 		await load();
 		showToast("Payment made.");
@@ -140,99 +207,616 @@ async function savePay() {
 		pay.value.saving = false;
 	}
 }
+
+// --- advance payments (ERPNext-native adjustment) ---
+// Draft adjusts via the Purchase Invoice `advances` table; Submitted via Payment Reconciliation.
+const linkedAdvances = computed(() => bill.value?.advances || []);
+const advanceAdjusted = computed(() => Number(bill.value?.advance_adjusted) || 0);
+const unlinkedTotal = computed(() =>
+	availableAdvances.value.reduce((a, x) => a + Number(x.unallocated || 0), 0)
+);
+const canLink = computed(() => bill.value && bill.value.docstatus !== 2);
+// Amount still owed the advance can settle: outstanding (submitted) or grand − advances (draft).
+const remainingOutstanding = computed(() => {
+	if (!bill.value) return 0;
+	if (isSubmitted.value) return Number(payment.value.outstanding) || 0;
+	return Math.max(Number(bill.value.grand_total) - advanceAdjusted.value, 0);
+});
+
+const adv = ref({ open: false, msg: "", error: "", saving: "" });
+const advAlloc = reactive({});
+function suggestAllocations() {
+	for (const a of availableAdvances.value)
+		advAlloc[a.payment_entry] = Math.min(Number(a.unallocated), remainingOutstanding.value);
+}
+function openLinkAdvance() {
+	adv.value.error = "";
+	adv.value.msg = "";
+	suggestAllocations();
+	adv.value.open = true;
+}
+async function doLink(a) {
+	const amt = Number(advAlloc[a.payment_entry]) || 0;
+	if (amt <= 0) {
+		adv.value.error = "Enter an amount greater than zero.";
+		return;
+	}
+	if (amt > Number(a.unallocated) + 0.01) {
+		adv.value.error = `Only ${fmtINR(a.unallocated)} is unadjusted on ${a.payment_entry}.`;
+		return;
+	}
+	adv.value.saving = a.payment_entry;
+	adv.value.error = "";
+	try {
+		await linkSupplierBillAdvance({
+			name: bill.value.name,
+			payment_entry: a.payment_entry,
+			amount: amt,
+		});
+		adv.value.open = false;
+		await load();
+		adv.value.msg = `Linked ${fmtINR(amt)} from ${
+			a.payment_entry
+		} — outstanding is now ${fmtINR(remainingOutstanding.value)}.`;
+		showToast("Advance linked.");
+	} catch (err) {
+		adv.value.error = err.message || "Could not link the advance.";
+	} finally {
+		adv.value.saving = "";
+	}
+}
+async function unlinkAdvance(row) {
+	const ok = await confirmDialog({
+		title: "Unlink advance?",
+		message: `Return ${fmtINR(row.allocated)} to ${
+			row.payment_entry
+		}'s unallocated balance? The net payable goes back up.`,
+		confirmLabel: "Unlink",
+	});
+	if (!ok) return;
+	adv.value.msg = "";
+	try {
+		await unlinkSupplierBillAdvance({
+			name: bill.value.name,
+			payment_entry: row.payment_entry,
+		});
+		await load();
+		showToast("Advance unlinked.");
+	} catch (err) {
+		showToast(err.message || "Unlink failed", "error");
+	}
+}
 </script>
 
 <template>
-	<DeskPage :title="bill ? bill.name : id" :breadcrumbs="breadcrumbs">
+	<DeskPage
+		:title="bill ? bill.name : id"
+		:subtitle="bill ? `Billed ${fmtDate(bill.date)} · due ${fmtDate(bill.due_date)}` : ''"
+		:breadcrumbs="breadcrumbs"
+	>
 		<template v-if="bill" #actions>
 			<div class="flex items-center gap-2">
-				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md" :disabled="busy" @click="onDelete">Delete</button>
-				<button v-if="isDraft" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="router.push(`/project-finance/supplier-bills/${bill.name}/edit`)">Edit</button>
-				<button v-if="isDraft" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="onSubmit">Submit</button>
-				<button v-if="isSubmitted && payment.outstanding > 0.01" type="button" class="text-xs desk-save-btn" :disabled="busy" @click="openPay">Pay</button>
-				<button v-if="isSubmitted" type="button" class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md" :disabled="busy" @click="onCancel">Cancel</button>
+				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5"
+					@click="onPrint"
+				>
+					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="1.75"
+							d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+						/>
+					</svg>
+					Print / PDF
+				</button>
+				<button
+					v-if="isDraft"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md"
+					:disabled="busy"
+					@click="onDelete"
+				>
+					Delete
+				</button>
+				<button
+					v-if="isDraft"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+					@click="router.push(`/project-finance/supplier-bills/${bill.name}/edit`)"
+				>
+					Edit
+				</button>
+				<button
+					v-if="isDraft"
+					type="button"
+					class="text-xs desk-save-btn"
+					:disabled="busy"
+					@click="onSubmit"
+				>
+					Submit
+				</button>
+				<button
+					v-if="isSubmitted && payment.outstanding > 0.01"
+					type="button"
+					class="text-xs desk-save-btn"
+					:disabled="busy"
+					@click="openPay"
+				>
+					Pay
+				</button>
+				<button
+					v-if="isSubmitted"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md"
+					:disabled="busy"
+					@click="onCancel"
+				>
+					Cancel
+				</button>
 			</div>
 		</template>
 
-		<div v-if="!bill" class="py-16 text-center text-sm text-ink-400">{{ loading ? "Loading…" : "Bill not found." }}</div>
+		<div v-if="!bill" class="py-16 text-center text-sm text-ink-400">
+			{{ loading ? "Loading…" : "Bill not found." }}
+		</div>
 		<div v-else class="space-y-4">
-			<div class="flex items-center gap-2">
-				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
+			<!-- draft / cancelled notice -->
+			<div
+				v-if="state === 'Draft'"
+				class="px-4 py-2.5 bg-warning-50 border border-warning-200 rounded-lg text-sm text-warning-700"
+			>
+				Draft — not posted yet. Submit it to make it a payable and enable payment.
+			</div>
+			<div
+				v-if="state === 'Cancelled'"
+				class="px-4 py-2.5 bg-danger-50 border border-danger-200 rounded-lg text-sm text-danger-700"
+			>
+				Cancelled — no longer a payable and excluded from costs.
 			</div>
 
-			<div class="grid grid-cols-2 md:grid-cols-4 gap-2">
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Supplier</div><div class="text-sm text-ink-900 mt-0.5">{{ bill.supplier_name }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Project</div><div class="text-sm text-ink-900 mt-0.5">{{ bill.project_name || "—" }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Bill date</div><div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(bill.date) }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Due</div><div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(bill.due_date) }}</div></div>
-			</div>
-			<div v-if="bill.bill_no" class="text-xs text-ink-500">Supplier invoice <span class="font-medium text-ink-700">{{ bill.bill_no }}</span><span v-if="bill.bill_date"> · {{ fmtDate(bill.bill_date) }}</span></div>
-
-			<div v-if="isSubmitted" class="grid grid-cols-2 md:grid-cols-3 gap-2">
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Billed</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.invoiced) }}</div></div>
-				<div class="bg-white border border-ink-200 px-3 py-2 rounded-md"><div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">Paid</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.paid) }}</div></div>
-				<div class="border px-3 py-2 rounded-md" :class="payment.outstanding > 0.01 ? 'bg-warning-50 border-warning-200' : 'bg-success-50 border-success-200'"><div class="text-[10px] uppercase tracking-wider font-medium" :class="payment.outstanding > 0.01 ? 'text-warning-700' : 'text-success-700'">Outstanding</div><div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">{{ fmtINR(payment.outstanding) }}</div></div>
+			<!-- advance linked confirmation -->
+			<div
+				v-if="adv.msg"
+				class="px-4 py-2.5 bg-success-50 border border-success-200 rounded-md text-xs text-success-700 flex items-center gap-2"
+			>
+				<span class="text-sm">✓</span><span class="font-medium">{{ adv.msg }}</span>
 			</div>
 
+			<!-- unlinked-advance suggestion -->
+			<div
+				v-if="canLink && availableAdvances.length && remainingOutstanding > 0.01"
+				class="px-4 py-2.5 bg-info-50 border border-info-200 rounded-md text-xs text-ink-700 flex items-center justify-between gap-3 flex-wrap"
+			>
+				<span>
+					<span class="font-medium text-ink-900"
+						>{{ bill.supplier_name }} has {{ fmtINR(unlinkedTotal) }} in unlinked
+						advance payment{{ availableAdvances.length === 1 ? "" : "s" }}</span
+					>
+					— link {{ availableAdvances.length === 1 ? "it" : "them" }} to this bill to
+					settle the payable.
+				</span>
+				<button
+					type="button"
+					class="text-xs px-2.5 py-1 border border-info-200 bg-white hover:bg-info-50 text-info-700 font-medium flex-shrink-0 rounded-md"
+					@click="openLinkAdvance"
+				>
+					Link advance →
+				</button>
+			</div>
+
+			<!-- summary strip -->
+			<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Supplier</div>
+					<div class="text-sm font-medium text-ink-900 mt-0.5">
+						{{ bill.supplier_name }}
+					</div>
+					<div
+						v-if="bill.supplier_gstin"
+						class="text-[10px] font-mono text-ink-400 mt-0.5"
+					>
+						{{ bill.supplier_gstin }}
+					</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Project</div>
+					<DeskLink
+						v-if="bill.project"
+						:to="`/projects/${bill.project}`"
+						class="text-sm"
+						>{{ bill.project_name || bill.project }}</DeskLink
+					>
+					<div v-else class="text-sm text-ink-500 mt-0.5">—</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Bill total</div>
+					<div class="text-sm font-semibold text-ink-900 tabular-nums mt-0.5">
+						{{ fmtINR(bill.grand_total) }}
+					</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-3">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">
+						{{ isSubmitted ? "Outstanding" : "Status" }}
+					</div>
+					<div
+						v-if="isSubmitted"
+						class="text-sm font-semibold tabular-nums mt-0.5"
+						:class="
+							payment.outstanding > 0.01 ? 'text-danger-700' : 'text-success-700'
+						"
+					>
+						{{ fmtINR(payment.outstanding) }}
+					</div>
+					<div v-else class="text-sm text-ink-700 mt-0.5">{{ state }}</div>
+				</div>
+			</div>
+			<div v-if="bill.bill_no" class="text-xs text-ink-500">
+				Supplier invoice <span class="font-medium text-ink-700">{{ bill.bill_no }}</span
+				><span v-if="bill.bill_date"> · {{ fmtDate(bill.bill_date) }}</span>
+			</div>
+
+			<!-- line items -->
 			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Items</h3></div>
+				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+					<h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">
+						Items
+					</h3>
+				</div>
 				<table class="w-full text-xs">
-					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-4 py-2">Description</th><th class="text-right px-4 py-2">Qty</th><th class="text-right px-4 py-2">Rate</th><th class="text-right px-4 py-2">Amount</th></tr></thead>
+					<thead class="text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="text-left px-4 py-2">Description</th>
+							<th class="text-right px-4 py-2">Qty</th>
+							<th class="text-right px-4 py-2">Rate</th>
+							<th class="text-right px-4 py-2">Amount</th>
+						</tr>
+					</thead>
 					<tbody>
-						<tr v-for="(l, idx) in bill.items" :key="idx" class="border-t border-ink-100">
+						<tr
+							v-for="(l, idx) in bill.items"
+							:key="idx"
+							class="border-t border-ink-100"
+						>
 							<td class="px-4 py-2 text-ink-900">{{ l.description }}</td>
-							<td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ l.qty }}</td>
-							<td class="px-4 py-2 text-right tabular-nums text-ink-600">{{ fmtINR(l.rate) }}</td>
-							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(l.amount) }}</td>
+							<td class="px-4 py-2 text-right tabular-nums text-ink-600">
+								{{ l.qty }}
+							</td>
+							<td class="px-4 py-2 text-right tabular-nums text-ink-600">
+								{{ fmtINR(l.rate) }}
+							</td>
+							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">
+								{{ fmtINR(l.amount) }}
+							</td>
 						</tr>
 					</tbody>
-					<tfoot class="border-t border-ink-200">
-						<tr><td colspan="3" class="px-4 py-1.5 text-right text-ink-500">Net total</td><td class="px-4 py-1.5 text-right tabular-nums text-ink-700">{{ fmtINR(bill.net_total) }}</td></tr>
-						<tr v-for="(t, idx) in bill.taxes" :key="'t' + idx"><td colspan="3" class="px-4 py-1.5 text-right text-ink-500">{{ t.description }} ({{ t.rate }}%)</td><td class="px-4 py-1.5 text-right tabular-nums text-ink-700">{{ fmtINR(t.tax_amount) }}</td></tr>
-						<tr class="border-t border-ink-200 font-semibold"><td colspan="3" class="px-4 py-2 text-right text-ink-900">Grand total</td><td class="px-4 py-2 text-right tabular-nums text-ink-900">{{ fmtINR(bill.grand_total) }}</td></tr>
-					</tfoot>
 				</table>
 			</section>
 
-			<section v-if="payments.length" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">Payments</h3></div>
-				<table class="w-full text-xs">
-					<thead class="text-ink-500 uppercase tracking-wider text-[10px]"><tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Mode</th><th class="text-left px-4 py-2">Reference</th><th class="text-left px-4 py-2">Entry</th><th class="text-right px-4 py-2">Amount</th></tr></thead>
-					<tbody>
-						<tr v-for="p in payments" :key="p.payment_entry" class="border-t border-ink-100">
-							<td class="px-4 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(p.date) }}</td>
-							<td class="px-4 py-2 text-ink-700">{{ p.mode_of_payment || "—" }}</td>
-							<td class="px-4 py-2 text-ink-600">{{ p.reference_no || "—" }}</td>
-							<td class="px-4 py-2"><DeskLink :to="`/app/payment-entry/${p.payment_entry}`" class="font-mono text-ink-700">{{ p.payment_entry }}</DeskLink></td>
-							<td class="px-4 py-2 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(p.amount) }}</td>
-						</tr>
-					</tbody>
-				</table>
-			</section>
+			<!-- payments + advances (left) · totals waterfall (right) -->
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+				<section class="space-y-4">
+					<!-- payments -->
+					<div
+						v-if="payments.length"
+						class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+					>
+						<div
+							class="bg-ink-50 px-4 py-2 border-b border-ink-200 text-[11px] uppercase tracking-wider font-semibold text-ink-700"
+						>
+							Payments ({{ payments.length }})
+						</div>
+						<div
+							v-for="p in payments"
+							:key="p.payment_entry"
+							class="flex items-center justify-between px-4 py-2.5 border-t border-ink-100 text-sm gap-2"
+						>
+							<span class="text-ink-600 min-w-0 truncate"
+								>{{ fmtDate(p.date)
+								}}<span v-if="p.mode_of_payment">
+									· {{ p.mode_of_payment }}</span
+								></span
+							>
+							<span class="flex items-center gap-2 flex-shrink-0">
+								<DeskLink
+									:to="`/app/payment-entry/${p.payment_entry}`"
+									class="font-mono text-[11px] text-ink-500"
+									>{{ p.payment_entry }}</DeskLink
+								>
+								<span class="tabular-nums text-success-700 font-medium">{{
+									fmtINR(p.amount)
+								}}</span>
+							</span>
+						</div>
+					</div>
+
+					<!-- Advance Payments (ERPNext PI "Advance Payments") -->
+					<div
+						v-if="linkedAdvances.length || (canLink && availableAdvances.length)"
+						class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+					>
+						<div
+							class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3"
+						>
+							<span
+								class="text-[11px] uppercase tracking-wider font-semibold text-ink-700"
+								>Advance Payments</span
+							>
+							<button
+								v-if="canLink && availableAdvances.length"
+								type="button"
+								class="text-xs text-brand-700 hover:underline"
+								@click="openLinkAdvance"
+							>
+								+ Link advance
+							</button>
+						</div>
+						<template v-if="linkedAdvances.length">
+							<div
+								v-for="row in linkedAdvances"
+								:key="row.payment_entry"
+								class="flex items-center justify-between px-4 py-2.5 border-t border-ink-100 text-sm gap-2"
+							>
+								<DeskLink
+									:to="`/app/payment-entry/${row.payment_entry}`"
+									class="font-mono text-xs text-ink-900 min-w-0 truncate"
+									>{{ row.payment_entry }}</DeskLink
+								>
+								<span class="flex items-center gap-2 flex-shrink-0">
+									<span class="tabular-nums text-info-700 font-medium">{{
+										fmtINR(row.allocated)
+									}}</span>
+									<button
+										v-if="canLink"
+										type="button"
+										class="text-ink-400 hover:text-danger-600 text-xs"
+										:title="`Unlink ${row.payment_entry}`"
+										@click="unlinkAdvance(row)"
+									>
+										✕
+									</button>
+								</span>
+							</div>
+							<div
+								class="px-4 py-2 border-t border-ink-100 flex items-center justify-between text-[11px]"
+							>
+								<span class="uppercase tracking-wider text-ink-500 font-medium"
+									>Total advance adjusted</span
+								>
+								<span class="tabular-nums font-semibold text-ink-900">{{
+									fmtINR(advanceAdjusted)
+								}}</span>
+							</div>
+						</template>
+						<div
+							v-else
+							class="px-4 py-3 text-xs text-ink-400 italic border-t border-ink-100"
+						>
+							No advances linked yet — {{ bill.supplier_name }} has
+							{{ fmtINR(unlinkedTotal) }} unallocated.
+						</div>
+					</div>
+				</section>
+
+				<!-- totals waterfall -->
+				<section class="bg-ink-50 rounded-lg px-4 py-3 text-sm space-y-1 self-start">
+					<div class="flex justify-between text-ink-600">
+						<span>Net total</span
+						><span class="tabular-nums">{{ fmtINR(bill.net_total) }}</span>
+					</div>
+					<div
+						v-for="(t, idx) in bill.taxes"
+						:key="'t' + idx"
+						class="flex justify-between text-ink-600"
+					>
+						<span>{{ t.description }} ({{ t.rate }}%)</span
+						><span class="tabular-nums">{{ fmtINR(t.tax_amount) }}</span>
+					</div>
+					<div
+						class="flex justify-between font-semibold text-ink-900 border-t border-ink-200 pt-1.5"
+					>
+						<span>Bill total</span
+						><span class="tabular-nums">{{ fmtINR(bill.grand_total) }}</span>
+					</div>
+					<div v-if="advanceAdjusted > 0" class="flex justify-between text-ink-600">
+						<span>Advance adjusted</span
+						><span class="tabular-nums text-info-700"
+							>− {{ fmtINR(advanceAdjusted) }}</span
+						>
+					</div>
+					<template v-if="isSubmitted">
+						<div class="flex justify-between text-ink-600">
+							<span>Paid</span
+							><span class="tabular-nums">{{ fmtINR(payment.paid) }}</span>
+						</div>
+						<div
+							class="flex justify-between font-semibold"
+							:class="
+								payment.outstanding > 0.01 ? 'text-danger-700' : 'text-success-700'
+							"
+						>
+							<span>Outstanding</span
+							><span class="tabular-nums">{{ fmtINR(payment.outstanding) }}</span>
+						</div>
+					</template>
+					<div v-else-if="advanceAdjusted > 0" class="text-[10px] text-ink-400">
+						Settles the payable when the bill is submitted.
+					</div>
+				</section>
+			</div>
 		</div>
 
 		<!-- Pay modal -->
-		<div v-if="pay.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="pay.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Pay bill</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="pay.open = false">✕</button></header>
+		<div
+			v-if="pay.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="pay.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Pay bill</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="pay.open = false"
+					>
+						✕
+					</button>
+				</header>
 				<div class="px-4 py-4 space-y-3">
-					<div class="text-sm text-ink-700">Pay <span class="font-medium">{{ bill.supplier_name }}</span> against <span class="font-mono text-xs">{{ bill.name }}</span>. Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(payment.outstanding) }}</span>.</div>
+					<div class="text-sm text-ink-700">
+						Pay <span class="font-medium">{{ bill.supplier_name }}</span> against
+						<span class="font-mono text-xs">{{ bill.name }}</span
+						>. Outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(payment.outstanding)
+						}}</span
+						>.
+					</div>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Amount" required><DeskInput v-model.number="pay.amount" type="number" min="0" /></DeskField>
-						<DeskField label="Date"><DeskInput v-model="pay.date" type="date" /></DeskField>
+						<DeskField label="Amount" required
+							><DeskInput v-model.number="pay.amount" type="number" min="0"
+						/></DeskField>
+						<DeskField label="Date"
+							><DeskInput v-model="pay.date" type="date"
+						/></DeskField>
 					</div>
 					<DeskField label="Pay from" required>
-						<DeskSelect v-model="pay.pay_from"><option value="" disabled>Bank / Cash account…</option><option v-for="a in payAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+						<DeskSelect v-model="pay.pay_from"
+							><option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in payAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option></DeskSelect
+						>
 					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Mode of payment"><DeskSelect v-model="pay.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
-						<DeskField label="Reference no."><DeskInput v-model="pay.reference_no" placeholder="UTR / cheque no." /></DeskField>
+						<DeskField label="Mode of payment"
+							><DeskSelect v-model="pay.mode_of_payment"
+								><option value="">—</option>
+								<option v-for="m in payModes" :key="m" :value="m">
+									{{ m }}
+								</option></DeskSelect
+							></DeskField
+						>
+						<DeskField label="Reference no."
+							><DeskInput v-model="pay.reference_no" placeholder="UTR / cheque no."
+						/></DeskField>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="pay.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="pay.saving" @click="savePay">{{ pay.saving ? "Paying…" : "Record payment" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="pay.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="pay.saving"
+						@click="savePay"
+					>
+						{{ pay.saving ? "Paying…" : "Record payment" }}
+					</button>
 				</footer>
+			</div>
+		</div>
+
+		<!-- Link advance modal -->
+		<div
+			v-if="adv.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="adv.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-lg shadow-xl rounded-xl flex flex-col max-h-[85vh]"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between flex-shrink-0"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Link advance payment</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="adv.open = false"
+					>
+						✕
+					</button>
+				</header>
+				<div class="px-4 py-4 overflow-y-auto flex-1 space-y-3">
+					<div class="text-xs text-ink-600">
+						Unlinked advances paid to
+						<span class="font-medium text-ink-900">{{ bill.supplier_name }}</span
+						>. Current outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(remainingOutstanding)
+						}}</span>
+						— the suggested allocation settles as much of it as each advance allows.
+					</div>
+					<div v-if="availableAdvances.length" class="space-y-2">
+						<div
+							v-for="a in availableAdvances"
+							:key="a.payment_entry"
+							class="border border-ink-200 rounded-lg px-3 py-2.5"
+						>
+							<div class="flex items-center justify-between gap-2">
+								<div class="min-w-0">
+									<div class="font-mono text-xs text-ink-900 truncate">
+										{{ a.payment_entry }}
+									</div>
+									<div class="text-[11px] text-ink-500">
+										{{ fmtDate(a.date)
+										}}<span v-if="a.mode_of_payment">
+											· {{ a.mode_of_payment }}</span
+										>
+									</div>
+								</div>
+								<div class="text-right flex-shrink-0">
+									<div class="text-xs text-ink-500">Unallocated</div>
+									<div class="text-sm font-semibold text-ink-900 tabular-nums">
+										{{ fmtINR(a.unallocated) }}
+									</div>
+								</div>
+							</div>
+							<div class="flex items-center gap-2 mt-2">
+								<label
+									class="text-[10px] uppercase tracking-wider text-ink-500 font-medium flex-shrink-0"
+									>Adjust</label
+								>
+								<input
+									v-model.number="advAlloc[a.payment_entry]"
+									type="number"
+									min="0"
+									:max="a.unallocated"
+									class="flex-1 text-sm px-2.5 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+								/>
+								<button
+									type="button"
+									class="text-xs px-3 py-1.5 bg-brand-600 hover:bg-brand-700 text-white font-medium rounded-md flex-shrink-0 disabled:opacity-60"
+									:disabled="adv.saving === a.payment_entry"
+									@click="doLink(a)"
+								>
+									{{ adv.saving === a.payment_entry ? "Linking…" : "Link" }}
+								</button>
+							</div>
+						</div>
+					</div>
+					<div v-else class="text-xs text-ink-400 italic py-2">
+						No unlinked advances left for this supplier.
+					</div>
+					<div v-if="adv.error" class="text-[11px] text-danger-600">{{ adv.error }}</div>
+				</div>
 			</div>
 		</div>
 	</DeskPage>


### PR DESCRIPTION
## Summary

Adds ERPNext-native **advance payment linking** so a party's on-account advances can be adjusted against invoices and bills, settling the receivable/payable. The same settlement model is applied across all three instruments, in three self-contained commits:

1. **Invoices** — customer advances → Sales Invoice
2. **Supplier bills** — supplier advances → Purchase Invoice
3. **Subcontractor bills** — subcontractor advances → the bill's generated Purchase Invoice

## How it works (native ERPNext, no custom fields)

- **Draft** invoice / supplier bill: the advance is written to the document's native `advances` child table and auto-reconciles on submit.
- **Submitted** document: the advance is reconciled via **Payment Reconciliation**; unlink via **Unreconcile Payment**.
- Reads sum a Payment Entry's references (an advance applied in several steps shows as one line with its total), split the advance out of Received/Paid, and exclude it from the receipts/payments list.
- Allocation is capped to the advance's unadjusted balance, and `available_advances` nets off amounts already earmarked on other drafts — so an advance can't be over-allocated.
- Subcontractor bills settle through their generated PI (the subcontractor is the PI's supplier), so their advance logic **delegates** to the supplier-bill logic on that PI. **Submitted-only** — the PI exists only after submit.

## UI

Each detail view gains: a "{party} has ₹X in unlinked advances — link them to settle" banner, an **Advance Payments** section (link / unlink ✕ + total adjusted), a link modal with suggested allocations, a "✓ Linked/Adjusted…" confirmation, and an "Advance adjusted" line in the totals waterfall. The invoice and supplier-bill detail pages were also aligned to the prototype (page subtitle, summary strip with a colour-coded Outstanding card + GSTIN, Print/PDF, and the two-column payments+advances / waterfall layout).

## Tests

- `test_invoice`: draft + submitted (partial, multi-step) link/unlink — **10 pass**.
- `test_supplier_bill`: draft + submitted + multi-step — **4 pass**.
- `test_subcontractor_bill`: advance adjusted against the PI + submitted-only guard — **new tests pass**.

## Notes

- Two **pre-existing** subcontractor-bill test failures (`test_make_payment_entry_creates_draft_against_pi`, `test_record_payment_reduces_outstanding`) also fail on `develop` — a dev-site default-account *"Reference No … mandatory for Bank transaction"* quirk, unrelated to this change (verified by stashing these changes and re-running).
- Subcontractor advances are submitted-only by design (the PI is the accounting instrument and only exists after submit); supplier bills can additionally stage advances on the draft's `advances` table.
