### PR TITLE
feat: seed per-company finance accounts + configurable Petty Cash Account

### DIFF
--- a/buildsuite_core/api/core_settings.py
+++ b/buildsuite_core/api/core_settings.py
@@ -32,14 +32,57 @@ def _project_series_options():
 	return []
 
 
+def _petty_cash_options(company):
+	"""Cash / Bank ledger accounts of the default company — the candidates the admin can choose
+	as the petty-cash float that petty cash and expenses post to/from."""
+	if not company:
+		return []
+	return frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "account_type": ["in", ["Cash", "Bank"]]},
+		fields=["name", "account_type"],
+		order_by="account_type, name",
+	)
+
+
 @frappe.whitelist()
 def get_core_settings():
 	"""The org-wide settings for the admin Settings screen."""
 	_require_admin()
+	from buildsuite_core.utils.project import default_company
+
+	settings = frappe.get_single(SETTINGS)
+	company = default_company()
 	return {
 		"project_naming": project_naming_mode(),
 		"project_naming_modes": NAMING_MODES,
+		"petty_cash_account": settings.default_petty_cash_account,
+		"petty_cash_options": _petty_cash_options(company),
 	}
+
+
+@frappe.whitelist()
+def set_petty_cash_account(account: str | None = None):
+	"""Set the configurable Petty Cash Account — the Cash/Bank float petty cash and expenses
+	post to/from. Must be a ledger Cash/Bank account of the default company."""
+	_require_admin()
+	from buildsuite_core.utils.project import default_company
+
+	account = (account or "").strip() or None
+	if account:
+		acc = frappe.db.get_value("Account", account, ["is_group", "company", "account_type"], as_dict=True)
+		if not acc or acc.is_group:
+			frappe.throw(_("Choose a ledger (non-group) account."))
+		company = default_company()
+		if company and acc.company != company:
+			frappe.throw(_("The petty cash account must belong to {0}.").format(company))
+		if acc.account_type not in ("Cash", "Bank"):
+			frappe.throw(_("The petty cash account must be a Cash or Bank account."))
+	doc = frappe.get_single(SETTINGS)
+	doc.default_petty_cash_account = account
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return {"petty_cash_account": doc.default_petty_cash_account}
 
 
 @frappe.whitelist()

--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -60,7 +60,9 @@ def backfill_work_order_company():
 def backfill_bill_company():
 	"""Re-anchor DRAFT Subcontractor Bills whose company drifted from their project's — so the
 	Vue tax/account pickers filter to the right company and the PI can post."""
-	_backfill_project_company("Subcontractor Bill", extra_where="and d.docstatus = 0 and d.project is not null")
+	_backfill_project_company(
+		"Subcontractor Bill", extra_where="and d.docstatus = 0 and d.project is not null"
+	)
 
 
 def drop_legacy_task_type_field():
@@ -112,6 +114,7 @@ def seed_master_data():
 
 	seed_employee_accounting_dimension()
 	seed_invoice_terms()
+	seed_finance_accounts()
 
 
 # Sales-invoice Terms & Conditions boilerplate (plain text — kept human-friendly, no HTML).
@@ -152,6 +155,68 @@ def seed_invoice_terms():
 		).insert(ignore_permissions=True)
 
 
+# Ledger accounts every BuildSuite finance posting depends on. Users never configure these —
+# the generated documents (petty cash, expense reimbursements, subcontractor retention, plant
+# recovery) post to/from them. Seeded per company; "Petty Cash" is handled separately because it
+# is the imprest float the petty-cash setting points at. (name, root_type, account_type, parent).
+# Retention/Reimbursements/Advances carry a BLANK account_type on purpose: the ERPNext "Payable"
+# type forces a party subledger on every line, but these are held against the company, not a
+# party. Plant Recovery is a contra-expense (credited when internal plant is recovered).
+FINANCE_ACCOUNTS = [
+	("Petty Cash Advances", "Asset", "", "Current Assets"),
+	("Reimbursements Payable", "Liability", "", "Current Liabilities"),
+	("Retention Payable", "Liability", "", "Current Liabilities"),
+	("Plant Recovery", "Expense", "", "Expenses"),
+	("Cash", "Asset", "Cash", "Cash In Hand"),
+	("Bank", "Asset", "Bank", "Bank Accounts"),
+]
+
+
+def seed_company_accounts(company):
+	"""Create the BuildSuite ledger accounts a finance posting depends on, for ONE company.
+	Idempotent — reuses accounts a prior pass (or ERPNext's default CoA) already created."""
+	from buildsuite_core.utils.petty_cash import resolve_petty_cash_account
+	from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+	resolve_petty_cash_account(company)  # the "Petty Cash" imprest float (Cash In Hand)
+	for account_name, root_type, account_type, parent_hint in FINANCE_ACCOUNTS:
+		_ensure_account(company, account_name, root_type, account_type, parent_hint)
+
+
+def seed_finance_accounts():
+	"""Seed the finance ledger accounts for EVERY company, then point the petty-cash setting at
+	the default company's Petty Cash float. Idempotent; a company that can't be seeded (e.g. a
+	part-configured Chart of Accounts) is logged and skipped so it never breaks migrate."""
+	for company in frappe.get_all("Company", pluck="name"):
+		try:
+			seed_company_accounts(company)
+		except Exception:
+			frappe.log_error(
+				title=f"BuildSuite: could not seed finance accounts for {company}"[:140],
+				message=frappe.get_traceback(),
+			)
+	_seed_default_petty_cash_account()
+
+
+def _seed_default_petty_cash_account():
+	"""Default the configurable Petty Cash Account (BuildSuite Core Settings) to the default
+	company's seeded 'Petty Cash' ledger — so petty cash and expenses have a float to post
+	to/from out of the box. Respects an account an admin has already chosen."""
+	from buildsuite_core.utils.petty_cash import resolve_petty_cash_account
+	from buildsuite_core.utils.project import default_company
+
+	company = default_company()
+	if not company:
+		return
+	settings = frappe.get_single("BuildSuite Core Settings")
+	current = settings.default_petty_cash_account
+	if current and frappe.db.exists("Account", current):
+		return
+	settings.default_petty_cash_account = resolve_petty_cash_account(company)
+	settings.flags.ignore_permissions = True
+	settings.save()
+
+
 def seed_employee_accounting_dimension():
 	"""Register an 'Employee' Accounting Dimension.
 
@@ -176,6 +241,7 @@ def create_item_group():
 	if frappe.db.get_value("Item Group", "Asset"):
 		frappe.rename_doc("Item Group", "Asset", "Assets", force=1, merge=0)
 	frappe.db.commit()
+
 
 def before_migrate():
 	delete_custom_fields(CUSTOM_FIELD)

--- a/buildsuite_core/tests/test_seed_finance_accounts.py
+++ b/buildsuite_core/tests/test_seed_finance_accounts.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Per-company finance account seeding + the configurable Petty Cash Account setting.
+
+Every BuildSuite finance posting (petty cash, expense reimbursements, subcontractor retention,
+plant recovery) depends on these ledgers existing — users never configure them, so they are
+seeded on install/migrate. The petty-cash float is configurable via BuildSuite Core Settings."""
+
+import frappe
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestSeedFinanceAccounts(BuildSuiteTestCase):
+	def test_seed_company_accounts_creates_ledgers(self):
+		from buildsuite_core.install import seed_company_accounts
+
+		seed_company_accounts(self.company)
+		expected = {
+			"Petty Cash": ("Asset", "Cash"),
+			"Petty Cash Advances": ("Asset", ""),
+			"Reimbursements Payable": ("Liability", ""),
+			"Retention Payable": ("Liability", ""),
+			"Plant Recovery": ("Expense", ""),  # contra-expense
+			"Cash": ("Asset", "Cash"),
+			"Bank": ("Asset", "Bank"),
+		}
+		for name, (root_type, account_type) in expected.items():
+			acc = frappe.db.get_value(
+				"Account",
+				{"account_name": name, "company": self.company, "is_group": 0},
+				["root_type", "account_type"],
+				as_dict=True,
+			)
+			self.assertIsNotNone(acc, f"{name} was not seeded")
+			self.assertEqual(acc.root_type, root_type, name)
+			self.assertEqual(acc.account_type or "", account_type, name)
+
+	def test_seeding_is_idempotent(self):
+		from buildsuite_core.install import seed_company_accounts
+
+		seed_company_accounts(self.company)
+		seed_company_accounts(self.company)  # a second pass must not duplicate
+		for name in ("Retention Payable", "Plant Recovery", "Petty Cash"):
+			rows = frappe.get_all(
+				"Account", filters={"account_name": name, "company": self.company, "is_group": 0}
+			)
+			self.assertEqual(len(rows), 1, f"{name} duplicated")
+
+	def test_default_petty_cash_account_is_seeded(self):
+		from buildsuite_core.install import seed_finance_accounts
+
+		frappe.db.set_single_value("BuildSuite Core Settings", "default_petty_cash_account", None)
+		seed_finance_accounts()
+		value = frappe.db.get_single_value("BuildSuite Core Settings", "default_petty_cash_account")
+		self.assertTrue(value)
+		self.assertEqual(frappe.db.get_value("Account", value, "account_name"), "Petty Cash")
+
+	def test_petty_cash_account_setting_round_trip(self):
+		# The setting keys off the BuildSuite default company, so seed + assert against it.
+		from buildsuite_core.api.core_settings import get_core_settings, set_petty_cash_account
+		from buildsuite_core.install import seed_company_accounts
+		from buildsuite_core.utils.project import default_company
+
+		company = default_company()
+		seed_company_accounts(company)
+		cash = frappe.db.get_value(
+			"Account", {"account_name": "Cash", "company": company, "is_group": 0}, "name"
+		)
+		set_petty_cash_account(cash)
+		settings = get_core_settings()
+		self.assertEqual(settings["petty_cash_account"], cash)
+		self.assertIn(cash, [o["name"] for o in settings["petty_cash_options"]])
+
+	def test_petty_cash_account_rejects_non_cash_account(self):
+		from buildsuite_core.api.core_settings import set_petty_cash_account
+		from buildsuite_core.install import seed_company_accounts
+		from buildsuite_core.utils.project import default_company
+
+		company = default_company()
+		seed_company_accounts(company)
+		expense = frappe.db.get_value(
+			"Account", {"account_name": "Plant Recovery", "company": company, "is_group": 0}, "name"
+		)
+		self.assertRaises(frappe.ValidationError, set_petty_cash_account, expense)

--- a/frontend/src/data/coreSettingsApi.js
+++ b/frontend/src/data/coreSettingsApi.js
@@ -16,6 +16,8 @@ async function call(method, args) {
 }
 
 export const getCoreSettings = () => call("get_core_settings");
+// Petty Cash Account — the configurable Cash/Bank float petty cash and expenses post to/from.
+export const setPettyCashAccount = (account) => call("set_petty_cash_account", { account });
 export const setProjectNaming = (projectNaming) =>
 	call("set_project_naming", { project_naming: projectNaming });
 // Naming mode + series options for the New Project form (available to any user).

--- a/frontend/src/views/settings/CoreSettingsView.vue
+++ b/frontend/src/views/settings/CoreSettingsView.vue
@@ -9,7 +9,7 @@
 import { ref, watch, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
-import { getCoreSettings, setProjectNaming } from "@/data/coreSettingsApi";
+import { getCoreSettings, setProjectNaming, setPettyCashAccount } from "@/data/coreSettingsApi";
 import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -32,11 +32,18 @@ const PROJECT_ID_MODE = "Project ID";
 const projectNaming = ref(PROJECT_ID_MODE);
 const namingModes = ref([PROJECT_ID_MODE, "Name Series"]);
 
+// Petty Cash Account — the configurable Cash/Bank float that petty cash and expenses post
+// to/from (server-persisted on BuildSuite Core Settings). Loaded like project naming.
+const pettyCashAccount = ref("");
+const pettyCashOptions = ref([]);
+
 onMounted(async () => {
 	try {
 		const res = await getCoreSettings();
 		projectNaming.value = res.project_naming || PROJECT_ID_MODE;
 		namingModes.value = res.project_naming_modes || namingModes.value;
+		pettyCashAccount.value = res.petty_cash_account || "";
+		pettyCashOptions.value = res.petty_cash_options || [];
 	} catch {
 		/* leave defaults; non-admins can't read it */
 	}
@@ -47,13 +54,14 @@ watch(
 	(s) => {
 		if (s) form.value = JSON.parse(JSON.stringify(s));
 	},
-	{ immediate: true, deep: true },
+	{ immediate: true, deep: true }
 );
 
 function startEdit() {
 	form.value = {
 		...JSON.parse(JSON.stringify(store.coreSettings)),
 		naming_mode: projectNaming.value,
+		petty_cash_account: pettyCashAccount.value,
 	};
 	editing.value = true;
 }
@@ -69,6 +77,10 @@ async function saveEdit() {
 		if (form.value.naming_mode && form.value.naming_mode !== projectNaming.value) {
 			await setProjectNaming(form.value.naming_mode);
 			projectNaming.value = form.value.naming_mode;
+		}
+		if (form.value.petty_cash_account !== pettyCashAccount.value) {
+			const res = await setPettyCashAccount(form.value.petty_cash_account || "");
+			pettyCashAccount.value = res.petty_cash_account || "";
 		}
 		editing.value = false;
 	} catch (err) {
@@ -178,6 +190,23 @@ const PROJECT_TYPES = ["Commercial", "Residential", "Infrastructure", "Industria
 						</div>
 						<DeskSelect v-else v-model="form.naming_mode">
 							<option v-for="m in namingModes" :key="m" :value="m">{{ m }}</option>
+						</DeskSelect>
+					</DeskField>
+				</DeskSection>
+
+				<DeskSection title="Accounting">
+					<DeskField
+						label="Petty Cash Account"
+						hint="The Cash / Bank ledger that petty cash is disbursed into and expenses are paid from. Defaults to the seeded 'Petty Cash' account; change it to post to a different float."
+					>
+						<div v-if="!editing" class="text-sm text-ink-900 py-1">
+							{{ pettyCashAccount || "—" }}
+						</div>
+						<DeskSelect v-else v-model="form.petty_cash_account">
+							<option value="">— None —</option>
+							<option v-for="a in pettyCashOptions" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option>
 						</DeskSelect>
 					</DeskField>
 				</DeskSection>


### PR DESCRIPTION
## Summary

Seeds the ledger accounts every BuildSuite finance posting depends on, and makes the petty-cash float a configurable setting instead of a hardcoded "Petty Cash" account.

## Per-company account seeding — `install.py`

`seed_finance_accounts()` runs on **install and every migrate** (via `seed_master_data`), creating these ledgers for **every company** — idempotent, and a part-configured company (e.g. an incomplete Chart of Accounts) is logged and skipped so it never breaks migrate:

| Account | Root | Type |
|---|---|---|
| Petty Cash | Asset | Cash |
| Petty Cash Advances | Asset | — |
| Reimbursements Payable | Liability | — |
| Retention Payable | Liability | — |
| Plant Recovery | Expense | — *(contra)* |
| Cash | Asset | Cash |
| Bank | Asset | Bank |

Retention / Reimbursements / Advances carry a **blank** `account_type` on purpose — the ERPNext "Payable" type forces a party subledger on every line, but these are held against the company, not a party. Users never configure these; the generated documents (petty cash, expense reimbursements, subcontractor retention, plant recovery) post to/from them. (No GST templates — India Compliance provides those.)

## Configurable Petty Cash Account

The float petty cash and expenses post to/from is no longer hardcoded:

- **Seeded** on install to the default company's `Petty Cash` (`BuildSuite Core Settings.default_petty_cash_account`), only if unset — so an admin's later choice is respected.
- **API** (`core_settings.py`): `get_core_settings` returns the current account + the Cash/Bank candidates; `set_petty_cash_account` validates it's a ledger Cash/Bank account of the default company.
- **UI**: a new **Accounting → Petty Cash Account** picker in `CoreSettingsView.vue` (Settings → BuildSuite Core Settings).

## Tests

`test_seed_finance_accounts` (5, all green): account seeding (root/type + idempotency), default-account seeding, settings round-trip, and non-Cash/Bank rejection.
