### PR TITLE
feat: Subcontractor module — prototype alignment (phased)

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -245,6 +245,34 @@ def committed_by_cost_code(project: str):
 
 
 @frappe.whitelist()
+def subcontract_actual_by_cost_code(project: str):
+	"""Sum of SUBMITTED Subcontractor Bill line `this_period_amount` for a project, grouped by
+	cost-code group. Feeds the BOQ 'Actual' — the subcontracted spend billed so far. It is ADDED
+	to (never replaces) the task-progress actuals. Only submitted (docstatus 1) bills count."""
+	if not project:
+		return {}
+	bills = frappe.get_all(
+		"Subcontractor Bill",
+		filters={"project": project, "docstatus": 1},
+		pluck="name",
+	)
+	if not bills:
+		return {}
+	rows = frappe.get_all(
+		"Subcontractor Bill Line",
+		filters={"parent": ["in", bills]},
+		fields=["cost_code_group", "this_period_amount"],
+	)
+	out = {}
+	for r in rows:
+		code = r.cost_code_group or ""
+		if not code:
+			continue
+		out[code] = out.get(code, 0) + (r.this_period_amount or 0)
+	return out
+
+
+@frappe.whitelist()
 def get_project_cost_codes(project: str):
 	"""BOQ groups + items for a project, as pickable cost codes for SOV lines."""
 	if not project:

--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -3,12 +3,22 @@
 
 """Whitelisted endpoints for the Subcontract module — Subcontractor Work Order
 read/save (its SOV child table can't be written reliably via frappe.client), the
-approval-workflow actions, and the BOQ cost-code picker used on SOV lines."""
+submittable lifecycle (submit / cancel / amend), and the BOQ cost-code picker used
+on SOV lines. The Work Order is natively submittable: state is docstatus, not a
+manual status field — Draft (0) → Submitted (1) → Cancelled (2), plus Amend."""
 
 import frappe
-from frappe.model.workflow import apply_workflow, get_transitions
+from frappe import _
 
 WORK_ORDER = "Subcontractor Work Order"
+
+# docstatus → the label the Vue screens show. There is no "Closed" state anymore.
+_WO_STATE = {0: "Draft", 1: "Submitted", 2: "Cancelled"}
+
+
+def _wo_state(doc):
+	return _WO_STATE.get(doc.docstatus, "Draft")
+
 
 _LINE_FIELDS = (
 	"scope",
@@ -23,13 +33,14 @@ _LINE_FIELDS = (
 
 
 def _available_actions(doc):
-	"""De-duplicated workflow actions available to the current user (get_transitions
-	returns one row per matching allowed-role)."""
-	out = []
-	for t in get_transitions(doc):
-		if t.action not in out:
-			out.append(t.action)
-	return out
+	"""Lifecycle actions for the WO's current docstatus (mirrors the prototype):
+	Draft → Edit / Submit / Delete; Submitted → Record measurement / Bill progress /
+	Cancel; Cancelled → Amend / Delete."""
+	if doc.docstatus == 0:
+		return ["edit", "submit", "delete"]
+	if doc.docstatus == 1:
+		return ["record_measurement", "bill_progress", "cancel"]
+	return ["amend", "delete"]
 
 
 def _serialize(doc):
@@ -42,7 +53,9 @@ def _serialize(doc):
 		"date": str(doc.date) if doc.date else None,
 		"delivery_type": doc.delivery_type,
 		"retention_percent": doc.retention_percent,
-		"status": doc.status,
+		"docstatus": doc.docstatus,
+		"status": _wo_state(doc),
+		"amended_from": doc.get("amended_from"),
 		"terms_template": doc.terms_template,
 		"terms": doc.terms,
 		"total_value": doc.total_value,
@@ -84,7 +97,10 @@ def _subcontractor_detail(supplier):
 	detail = {"trade": sup.get("custom_trade"), "tax_id": sup.get("tax_id")}
 	contact = frappe.get_all(
 		"Contact",
-		filters=[["Dynamic Link", "link_doctype", "=", "Supplier"], ["Dynamic Link", "link_name", "=", supplier]],
+		filters=[
+			["Dynamic Link", "link_doctype", "=", "Supplier"],
+			["Dynamic Link", "link_name", "=", supplier],
+		],
 		fields=["name", "first_name", "email_id", "mobile_no", "phone"],
 		limit=1,
 	)
@@ -158,17 +174,42 @@ def save_work_order(
 
 
 @frappe.whitelist()
-def apply_wo_action(work_order: str, action: str):
-	"""Apply an approval-workflow transition (Submit for Approval / Approve / …)."""
-	doc = frappe.get_doc(WORK_ORDER, work_order)
-	doc.check_permission("write")
-	apply_workflow(doc, action)
-	return {"status": doc.status, "actions": _available_actions(doc)}
+def submit_work_order(name: str):
+	"""Submit a draft Work Order — it becomes committed cost (docstatus 1)."""
+	doc = frappe.get_doc(WORK_ORDER, name)
+	doc.check_permission("submit")
+	doc.submit()
+	return get_work_order(name)
+
+
+@frappe.whitelist()
+def cancel_work_order(name: str):
+	"""Cancel a submitted Work Order (blocked by the controller if MBs/Bills reference it)."""
+	doc = frappe.get_doc(WORK_ORDER, name)
+	doc.check_permission("cancel")
+	doc.cancel()
+	return get_work_order(name)
+
+
+@frappe.whitelist()
+def amend_work_order(name: str):
+	"""Amend a cancelled Work Order — a fresh editable Draft copy linked via amended_from; the
+	original stays Cancelled."""
+	src = frappe.get_doc(WORK_ORDER, name)
+	src.check_permission("amend")
+	if src.docstatus != 2:
+		frappe.throw(_("Only a cancelled work order can be amended."))
+	amended = frappe.copy_doc(src)
+	amended.amended_from = name
+	amended.docstatus = 0
+	amended.flags.ignore_permissions = True
+	amended.insert()
+	return get_work_order(amended.name)
 
 
 @frappe.whitelist()
 def get_wo_transitions(name: str):
-	"""Workflow actions available to the current user for this Work Order."""
+	"""Lifecycle actions available for this Work Order (kept for the Vue action bar)."""
 	doc = frappe.get_doc(WORK_ORDER, name)
 	doc.check_permission("read")
 	return _available_actions(doc)
@@ -176,14 +217,15 @@ def get_wo_transitions(name: str):
 
 @frappe.whitelist()
 def committed_by_cost_code(project: str):
-	"""Sum of OPEN (Awarded / In Progress) Subcontractor Work Order line amounts for a
-	project, grouped by cost-code group. Feeds the BOQ 'Committed' column — how much of
-	each BOQ group's scope is already committed to subcontractors."""
+	"""Sum of SUBMITTED Subcontractor Work Order line amounts for a project, grouped by
+	cost-code group. Feeds the BOQ 'Committed' column — how much of each BOQ group's scope is
+	already committed to subcontractors. Only submitted (docstatus 1) WOs count as committed;
+	drafts and cancelled WOs are excluded."""
 	if not project:
 		return {}
 	wos = frappe.get_all(
 		WORK_ORDER,
-		filters={"project": project, "status": ["in", ["Awarded", "In Progress"]]},
+		filters={"project": project, "docstatus": 1},
 		pluck="name",
 	)
 	if not wos:
@@ -212,9 +254,7 @@ def get_project_cost_codes(project: str):
 		return []
 
 	# group name by (boq, code) so items can show their group.
-	groups = frappe.get_all(
-		"BOQ Group", filters={"boq": ["in", boqs]}, fields=["name", "code", "group_name"]
-	)
+	groups = frappe.get_all("BOQ Group", filters={"boq": ["in", boqs]}, fields=["name", "code", "group_name"])
 	group_code_by_name = {g.name: g.code for g in groups}
 
 	out = []

--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -164,6 +164,70 @@ def get_bill(name: str):
 
 
 @frappe.whitelist()
+def list_bills(project=None):
+	"""Subcontractor Bills for the list — the workflow state (from docstatus) plus the derived
+	payment status (Unpaid / Partly Paid / Paid) read through each bill's generated Purchase
+	Invoice, so the list can show both badges."""
+	PI = "Purchase Invoice"
+	filters = {}
+	if project:
+		filters["project"] = project
+	bills = frappe.get_all(
+		BILL,
+		filters=filters,
+		fields=[
+			"name",
+			"ra_no",
+			"is_direct",
+			"subcontractor_name",
+			"project",
+			"date",
+			"gross",
+			"retention_amount",
+			"net_payable",
+			"docstatus",
+			"purchase_invoice",
+		],
+		order_by="date desc, creation desc",
+	)
+	pi_names = [b.purchase_invoice for b in bills if b.purchase_invoice]
+	pis = {}
+	if pi_names:
+		for pi in frappe.get_all(
+			PI, filters={"name": ["in", pi_names]}, fields=["name", "grand_total", "outstanding_amount"]
+		):
+			pis[pi.name] = pi
+	out = []
+	for b in bills:
+		pay = None
+		if b.docstatus == 1 and b.purchase_invoice in pis:
+			pi = pis[b.purchase_invoice]
+			grand, outstanding = flt(pi.grand_total), flt(pi.outstanding_amount)
+			if outstanding <= 0.01 and grand > 0:
+				pay = "Paid"
+			elif grand - outstanding > 0.01:
+				pay = "Partly Paid"
+			else:
+				pay = "Unpaid"
+		out.append(
+			{
+				"name": b.name,
+				"ra_no": b.ra_no,
+				"is_direct": b.is_direct,
+				"subcontractor_name": b.subcontractor_name,
+				"project": b.project,
+				"date": str(b.date) if b.date else None,
+				"gross": flt(b.gross),
+				"retention_amount": flt(b.retention_amount),
+				"net_payable": flt(b.net_payable),
+				"status": {0: "Draft", 1: "Submitted", 2: "Cancelled"}.get(b.docstatus, "Draft"),
+				"payment_status": pay,
+			}
+		)
+	return out
+
+
+@frappe.whitelist()
 def get_wo_bill_context(work_order: str):
 	"""Everything the New (Work Order) bill screen needs: WO header, the derived this-period
 	lines (measured − previously billed), and the next RA number."""

--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -121,14 +121,14 @@ def _serialize(doc):
 
 def _available_actions(doc):
 	if doc.docstatus == 0:
-		return ["submit", "delete"]
+		return ["edit", "submit", "delete"]
 	if doc.docstatus == 1:
 		acts = []
 		if _payment_summary(doc)["outstanding"] > 0.01:
 			acts.append("pay")
 		acts.append("cancel")
 		return acts
-	return []
+	return ["amend", "delete"]  # cancelled
 
 
 def _payment_summary(doc):
@@ -349,6 +349,23 @@ def delete_bill(name: str):
 		frappe.throw(_("Cancel a submitted bill before deleting it."))
 	frappe.delete_doc(BILL, name)
 	return {"ok": True}
+
+
+@frappe.whitelist()
+def amend_bill(name: str):
+	"""Amend a cancelled bill — a fresh editable Draft copy linked via amended_from; the original
+	stays Cancelled."""
+	src = frappe.get_doc(BILL, name)
+	src.check_permission("amend")
+	if src.docstatus != 2:
+		frappe.throw(_("Only a cancelled bill can be amended."))
+	amended = frappe.copy_doc(src)
+	amended.amended_from = name
+	amended.docstatus = 0
+	amended.purchase_invoice = None  # a fresh Purchase Invoice is generated on resubmit
+	amended.flags.ignore_permissions = True
+	amended.insert()
+	return _serialize(amended)
 
 
 # --------------------------------------------------------------------------- #

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor/seed_print_assets.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor/seed_print_assets.py
@@ -64,7 +64,7 @@ _WO_PRINT_HTML = """
 		</div>
 		<div class="right">
 			<div class="muted">{{ frappe.utils.format_date(doc.date) }}</div>
-			<div style="margin-top:2px; font-weight:600;">{{ doc.status }}</div>
+			<div style="margin-top:2px; font-weight:600;">{{ {0: "Draft", 1: "Submitted", 2: "Cancelled"}.get(doc.docstatus, "Draft") }}</div>
 		</div>
 	</div>
 
@@ -173,6 +173,8 @@ def _seed_letter_head():
 
 def _seed_wo_print_format():
 	if frappe.db.exists("Print Format", WO_PRINT_FORMAT):
+		# Keep the body in sync on migrate (e.g. WO status now derives from docstatus).
+		frappe.db.set_value("Print Format", WO_PRINT_FORMAT, "html", _WO_PRINT_HTML)
 		return
 	frappe.get_doc(
 		{

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.py
@@ -38,7 +38,7 @@ class SubcontractorBill(Document):
 	def validate(self):
 		self._sync_from_work_order()
 		if self.work_order and not self.is_direct:
-			self._require_open_work_order()
+			self._require_submitted_work_order()
 		self._assign_ra_no()
 		self._default_expense_account()
 		self._validate_account_companies()
@@ -64,11 +64,13 @@ class SubcontractorBill(Document):
 			company = frappe.db.get_value(doctype, account, "company")
 			return not company or company == self.company
 
-		if self.taxes_and_charges and not _belongs(self.taxes_and_charges, "Purchase Taxes and Charges Template"):
+		if self.taxes_and_charges and not _belongs(
+			self.taxes_and_charges, "Purchase Taxes and Charges Template"
+		):
 			frappe.throw(
-				_("Tax template {0} belongs to a different company — pick one for {1} (this project's company).").format(
-					frappe.bold(self.taxes_and_charges), frappe.bold(self.company)
-				)
+				_(
+					"Tax template {0} belongs to a different company — pick one for {1} (this project's company)."
+				).format(frappe.bold(self.taxes_and_charges), frappe.bold(self.company))
 			)
 		for t in self.taxes:
 			if t.account_head and not _belongs(t.account_head):
@@ -98,6 +100,26 @@ class SubcontractorBill(Document):
 		self.purchase_invoice = generate_purchase_invoice(self)
 		self.db_set("purchase_invoice", self.purchase_invoice)
 		self._sync_status()
+
+	def before_cancel(self):
+		# Cancelling voids the bill and its Purchase Invoice — blocked while payments exist
+		# against it (the Payment Entries must be deleted first).
+		if self.purchase_invoice:
+			pes = frappe.get_all(
+				"Payment Entry Reference",
+				filters={
+					"reference_doctype": "Purchase Invoice",
+					"reference_name": self.purchase_invoice,
+					"docstatus": 1,
+				},
+				pluck="parent",
+			)
+			if pes:
+				frappe.throw(
+					_("Cannot cancel {0}: delete its payment entries first ({1}).").format(
+						self.name, ", ".join(sorted(set(pes)))
+					)
+				)
 
 	def on_cancel(self):
 		self._cancel_purchase_invoice()
@@ -130,14 +152,11 @@ class SubcontractorBill(Document):
 		if self.project:
 			self.company = frappe.db.get_value("Project", self.project, "company")
 
-	def _require_open_work_order(self):
-		status = frappe.db.get_value(WORK_ORDER, self.work_order, "status")
-		if status not in ("Awarded", "In Progress"):
-			frappe.throw(
-				_("A bill can only be raised against an Awarded or In Progress work order (this one is {0}).").format(
-					status or "—"
-				)
-			)
+	def _require_submitted_work_order(self):
+		# The Work Order is natively submittable now — only a SUBMITTED WO is a committed
+		# order you can bill progress against (drafts aren't committed; cancelled are void).
+		if frappe.db.get_value(WORK_ORDER, self.work_order, "docstatus") != 1:
+			frappe.throw(_("A bill can only be raised against a submitted work order."))
 
 	def _assign_ra_no(self):
 		if self.ra_no:
@@ -167,8 +186,11 @@ class SubcontractorBill(Document):
 		)
 		rate = 0
 		for r in rows:
-			if r.from_date and self.date and str(r.from_date) <= str(self.date) and (
-				not r.to_date or str(self.date) <= str(r.to_date)
+			if (
+				r.from_date
+				and self.date
+				and str(r.from_date) <= str(self.date)
+				and (not r.to_date or str(self.date) <= str(r.to_date))
 			):
 				rate = flt(r.tax_withholding_rate)
 				break
@@ -232,7 +254,9 @@ class SubcontractorBill(Document):
 			paid = flt(doc.grand_total) - flt(doc.outstanding_amount)
 			if paid > 0:
 				frappe.throw(
-					_("This bill's Purchase Invoice has payments against it. Cancel the Payment Entries first.")
+					_(
+						"This bill's Purchase Invoice has payments against it. Cancel the Payment Entries first."
+					)
 				)
 			doc.flags.ignore_permissions = True
 			doc.cancel()

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.js
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+// For license information, please see license.txt
+
+// frappe.ui.form.on("Subcontractor Work Order", {
+// 	refresh(frm) {
+
+// 	},
+// });

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.json
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "autoname": "SWO-.YYYY.-.#####",
- "creation": "2026-07-13 00:00:00.000000",
+ "creation": "2026-07-31 22:32:39.935541",
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
@@ -12,14 +12,14 @@
   "date",
   "delivery_type",
   "retention_percent",
-  "status",
   "sov_section",
   "lines",
   "total_value",
   "terms_section",
   "terms_template",
   "terms",
-  "company"
+  "company",
+  "amended_from"
  ],
  "fields": [
   {
@@ -72,16 +72,6 @@
    "label": "Retention %"
   },
   {
-   "default": "Draft",
-   "fieldname": "status",
-   "fieldtype": "Select",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Status",
-   "options": "Draft\nPending Approval\nAwarded\nIn Progress\nClosed",
-   "read_only": 1
-  },
-  {
    "fieldname": "sov_section",
    "fieldtype": "Section Break",
    "label": "Schedule of Values"
@@ -122,18 +112,31 @@
    "label": "Company",
    "options": "Company",
    "read_only": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Subcontractor Work Order",
+   "print_hide": 1,
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
+ "is_submittable": 1,
  "links": [],
- "modified": "2026-07-13 00:00:00.000000",
+ "modified": "2026-07-31 22:32:40.022080",
  "modified_by": "Administrator",
  "module": "BuildSuite Core",
  "name": "Subcontractor Work Order",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
+   "amend": 1,
+   "cancel": 1,
    "create": 1,
    "delete": 1,
    "email": 1,
@@ -143,9 +146,11 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/subcontractor_work_order.py
@@ -2,16 +2,53 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
 
 
 class SubcontractorWorkOrder(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		from buildsuite_core.buildsuite_core.doctype.subcontractor_work_order_line.subcontractor_work_order_line import (
+			SubcontractorWorkOrderLine,
+		)
+
+		amended_from: DF.Link | None
+		company: DF.Link | None
+		date: DF.Date
+		delivery_type: DF.Link | None
+		lines: DF.Table[SubcontractorWorkOrderLine]
+		project: DF.Link
+		retention_percent: DF.Percent
+		subcontractor: DF.Link
+		subcontractor_name: DF.Data | None
+		terms: DF.TextEditor | None
+		terms_template: DF.Link | None
+		total_value: DF.Currency
+	# end: auto-generated types
+
 	def validate(self):
 		self._compute_totals()
 		self._set_company()
-		if not self.status:
-			self.status = "Draft"
+
+	def before_cancel(self):
+		# A committed WO can only be cancelled if nothing has been claimed against it — cancelling
+		# would strand the Measurement Books / Bills that reference it.
+		mbs = frappe.db.count("Measurement Book", {"work_order": self.name, "docstatus": ["<", 2]})
+		bills = frappe.db.count("Subcontractor Bill", {"work_order": self.name, "docstatus": ["<", 2]})
+		if mbs or bills:
+			frappe.throw(
+				_(
+					"Cannot cancel {0}: it has {1} measurement book(s) and {2} bill(s) against it. Remove those first."
+				).format(self.name, mbs, bills)
+			)
 
 	def _compute_totals(self):
 		total = 0.0

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/test_subcontractor_work_order.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_work_order/test_subcontractor_work_order.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests import IntegrationTestCase
+
+
+# On IntegrationTestCase, the doctype test records and all
+# link-field test record dependencies are recursively loaded
+# Use these module variables to add/remove to/from that list
+EXTRA_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+IGNORE_TEST_RECORD_DEPENDENCIES = []  # eg. ["User"]
+
+
+
+class IntegrationTestSubcontractorWorkOrder(IntegrationTestCase):
+	"""
+	Integration tests for SubcontractorWorkOrder.
+	Use this class for testing interactions between multiple components.
+	"""
+
+	pass

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -3,6 +3,7 @@
 # Read docs to understand patches: https://frappeframework.com/docs/v14/user/en/database-migrations
 buildsuite_core.patches.rename_estimate_template_project_category
 buildsuite_core.patches.rename_subcontractor_tax_ids
+buildsuite_core.patches.wo_submittable_from_status
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
 buildsuite_core.patches.recase_buildsuite_module

--- a/buildsuite_core/patches/wo_submittable_from_status.py
+++ b/buildsuite_core/patches/wo_submittable_from_status.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""The Subcontractor Work Order became natively submittable — state is docstatus now, not the old
+approval `status` field/Workflow. Runs BEFORE model sync so the `status` column still exists:
+retire the approval Workflow and map the legacy status onto docstatus before the column is dropped.
+Committed states (Awarded / In Progress / Closed) → Submitted (docstatus 1); Draft / Pending
+Approval stay Draft (docstatus 0)."""
+
+import frappe
+
+
+def execute():
+	if frappe.db.exists("Workflow", "Subcontractor Work Order Approval"):
+		frappe.delete_doc(
+			"Workflow", "Subcontractor Work Order Approval", ignore_permissions=True, force=True
+		)
+
+	if frappe.db.has_column("Subcontractor Work Order", "status"):
+		frappe.db.sql(
+			"""
+			UPDATE `tabSubcontractor Work Order`
+			SET docstatus = 1
+			WHERE docstatus = 0 AND status IN ('Awarded', 'In Progress', 'Closed')
+			"""
+		)

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -536,22 +536,6 @@ SUBCONTRACT_BILL_ROLE_PERMS = {
 	"BuildSuite Site Engineer": _READ,
 }
 
-# Subcontractor Work Order Approval workflow (status is the workflow state field).
-_WO_CREATE_ROLES = _SUBCONTRACT_FULL_ROLES  # raise + submit a WO
-_WO_APPROVE_ROLES = ("BuildSuite PM", "BuildSuite Director", "BuildSuite Administrator")
-_WO_STATES = ("Draft", "Pending Approval", "Awarded", "In Progress", "Closed")
-_WO_ACTIONS = ("Submit for Approval", "Approve", "Reject", "Start", "Close")
-# (state, action, next_state, roles)
-_WO_TRANSITIONS = (
-	("Draft", "Submit for Approval", "Pending Approval", _WO_CREATE_ROLES),
-	("Pending Approval", "Approve", "Awarded", _WO_APPROVE_ROLES),
-	("Pending Approval", "Reject", "Draft", _WO_APPROVE_ROLES),
-	("Awarded", "Start", "In Progress", _WO_CREATE_ROLES),
-	("Awarded", "Close", "Closed", _WO_APPROVE_ROLES),
-	("In Progress", "Close", "Closed", _WO_APPROVE_ROLES),
-)
-
-
 # Scope Change Order — role matrix (SCO is header-only + status-based, not submittable,
 # so Submit/Cancel don't apply; "full" = CRWD). PM/QS prepare + quantify, Director
 # approves; approval is gated in api/sco.py to BOQ_APPROVE_ROLES (PM / Director / Admin).
@@ -639,62 +623,26 @@ def setup_subcontract_permissions():
 
 def _ensure_workflow_state(name):
 	if not frappe.db.exists("Workflow State", name):
-		frappe.get_doc(
-			{"doctype": "Workflow State", "workflow_state_name": name}
-		).insert(ignore_permissions=True)
+		frappe.get_doc({"doctype": "Workflow State", "workflow_state_name": name}).insert(
+			ignore_permissions=True
+		)
 
 
 def _ensure_workflow_action(name):
 	if not frappe.db.exists("Workflow Action Master", name):
-		frappe.get_doc(
-			{"doctype": "Workflow Action Master", "workflow_action_name": name}
-		).insert(ignore_permissions=True)
+		frappe.get_doc({"doctype": "Workflow Action Master", "workflow_action_name": name}).insert(
+			ignore_permissions=True
+		)
 
 
 def setup_subcontractor_wo_workflow():
-	"""Build the Subcontractor Work Order Approval workflow. Draft is editable by any
-	module user (DocPerm gates); later states are locked (edits via the workflow)."""
-	if not frappe.db.exists("DocType", "Subcontractor Work Order"):
-		return
-	for s in _WO_STATES:
-		_ensure_workflow_state(s)
-	for a in _WO_ACTIONS:
-		_ensure_workflow_action(a)
-
-	name = "Subcontractor Work Order Approval"
-	wf = frappe.get_doc("Workflow", name) if frappe.db.exists("Workflow", name) else frappe.new_doc(
-		"Workflow"
-	)
-	wf.workflow_name = name
-	wf.document_type = "Subcontractor Work Order"
-	wf.workflow_state_field = "status"
-	wf.is_active = 1
-	wf.send_email_alert = 0
-	wf.set("states", [])
-	for s in _WO_STATES:
-		wf.append(
-			"states",
-			{
-				"state": s,
-				"doc_status": "0",
-				"allow_edit": WORKFLOW_EDITOR_ROLE if s == "Draft" else "System Manager",
-			},
+	"""The Work Order is now natively submittable (docstatus: Draft → Submitted → Cancelled +
+	Amend), so the old approval Workflow is retired. Delete it idempotently — migrate keeps it
+	gone even if a stale record survives."""
+	if frappe.db.exists("Workflow", "Subcontractor Work Order Approval"):
+		frappe.delete_doc(
+			"Workflow", "Subcontractor Work Order Approval", ignore_permissions=True, force=True
 		)
-	wf.set("transitions", [])
-	for state, action, next_state, roles in _WO_TRANSITIONS:
-		for role in roles:
-			wf.append(
-				"transitions",
-				{
-					"state": state,
-					"action": action,
-					"next_state": next_state,
-					"allowed": role,
-					"allow_self_approval": 1,
-				},
-			)
-	wf.flags.ignore_permissions = True
-	wf.save()
 
 
 def setup_record_permissions():

--- a/buildsuite_core/tests/test_measurement_book.py
+++ b/buildsuite_core/tests/test_measurement_book.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""The Measurement Book records what was measured on site between the Work Order and the Bill.
+Quantity derives from nos x L x B x D (or is typed directly); deduction rows subtract. Only
+Certified books feed measured-to-date and are locked from editing until reverted to Draft."""
+
+import frappe
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestMeasurementBook(BuildSuiteTestCase):
+	def setUp(self):
+		super().setUp()
+		self.company = frappe.db.get_single_value("Global Defaults", "default_company") or self.company
+		self.project = self._make_project(company=self.company).name
+
+	def _submitted_wo(self):
+		from buildsuite_core.api.subcontract import save_work_order, submit_work_order
+
+		sub = (
+			frappe.get_doc(
+				{
+					"doctype": "Supplier",
+					"supplier_name": f"Sub {self._n}",
+					"supplier_type": "Subcontractor",
+					"supplier_group": "Subcontractor",
+					"custom_trade": frappe.db.get_value("Construction Trade", {}, "name"),
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+		name = save_work_order(
+			subcontractor=sub,
+			project=self.project,
+			date="2026-07-20",
+			retention_percent=5,
+			lines=frappe.as_json([{"scope": "Tiling", "uom": "Nos", "qty": 100, "rate": 85}]),
+		)["name"]
+		submit_work_order(name)
+		wo = frappe.get_doc("Subcontractor Work Order", name)
+		return wo.name, wo.lines[0].name
+
+	def _mb(self, wo, line, entries):
+		from buildsuite_core.api.subcontract import save_measurement_book
+
+		return save_measurement_book(
+			work_order=wo, project=self.project, date="2026-07-21", entries=frappe.as_json(entries)
+		)["name"]
+
+	def test_quantity_derived_and_deduction_signed(self):
+		"""nos x L x B x D fills quantity when not given; a deduction row subtracts from the total."""
+		wo, line = self._submitted_wo()
+		name = self._mb(
+			wo,
+			line,
+			[
+				{
+					"description": "Slab",
+					"work_order_line": line,
+					"nos": 2,
+					"length": 3,
+					"breadth": 4,
+					"depth": 1,
+				},
+				{"description": "Cutout", "work_order_line": line, "quantity": 4, "is_deduction": 1},
+			],
+		)
+		mb = frappe.get_doc("Measurement Book", name)
+		self.assertAlmostEqual(mb.entries[0].quantity, 24, places=2)  # 2*3*4*1
+		self.assertAlmostEqual(mb.measured_total, 20, places=2)  # 24 - 4
+
+	def test_certify_feeds_measured_and_locks_editing(self):
+		from buildsuite_core.api.subcontract import (
+			certify_measurement_book,
+			get_wo_measurements,
+			save_measurement_book,
+		)
+
+		wo, line = self._submitted_wo()
+		name = self._mb(wo, line, [{"description": "m", "work_order_line": line, "quantity": 30}])
+		# a Draft MB does not feed measured-to-date
+		self.assertEqual(get_wo_measurements(wo)["measured_by_line"].get(line, 0), 0)
+
+		certify_measurement_book(name)
+		self.assertAlmostEqual(get_wo_measurements(wo)["measured_by_line"].get(line), 30, places=2)
+		# a Certified book is locked from editing
+		self.assertRaises(
+			frappe.ValidationError,
+			save_measurement_book,
+			name=name,
+			work_order=wo,
+			project=self.project,
+			date="2026-07-21",
+			entries=frappe.as_json([{"description": "m", "work_order_line": line, "quantity": 99}]),
+		)
+
+	def test_revert_reopens_for_editing(self):
+		from buildsuite_core.api.subcontract import (
+			certify_measurement_book,
+			get_wo_measurements,
+			revert_measurement_book,
+			save_measurement_book,
+		)
+
+		wo, line = self._submitted_wo()
+		name = self._mb(wo, line, [{"description": "m", "work_order_line": line, "quantity": 30}])
+		certify_measurement_book(name)
+		revert_measurement_book(name)
+		# reverted → no longer feeds measured-to-date, and editable again
+		self.assertEqual(get_wo_measurements(wo)["measured_by_line"].get(line, 0), 0)
+		save_measurement_book(
+			name=name,
+			work_order=wo,
+			project=self.project,
+			date="2026-07-21",
+			entries=frappe.as_json([{"description": "m", "work_order_line": line, "quantity": 40}]),
+		)
+		self.assertAlmostEqual(frappe.get_doc("Measurement Book", name).measured_total, 40, places=2)

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -46,7 +46,7 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 				"lines": [{"scope": "Tiling", "uom": "Nos", "qty": qty, "rate": rate}],
 			}
 		).insert(ignore_permissions=True)
-		wo.db_set("status", "Awarded")
+		wo.submit()  # a committed (submitted) WO — bills bill against these
 		return wo.reload()
 
 	def _certified_mb(self, wo, qty):

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -358,6 +358,27 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		record_payment(bill.name, amount=20000, date="2026-07-21", mode_of_payment="Cash", paid_from=cash)
 		self.assertRaises(frappe.ValidationError, cancel_bill, bill.name)
 
+	def test_subcontract_actual_by_cost_code(self):
+		"""Submitted bill this-period amounts roll up to the BOQ 'Actual' by cost-code group;
+		a draft bill does not count."""
+		from buildsuite_core.api.subcontract import subcontract_actual_by_cost_code
+
+		sub = self._subcontractor()
+		bill = frappe.get_doc(
+			{
+				"doctype": "Subcontractor Bill",
+				"is_direct": 1,
+				"subcontractor": sub.name,
+				"project": self.project,
+				"date": "2026-07-20",
+				"retention_percent": 0,
+				"lines": [{"scope": "Groundworks", "cost_code_group": "G1", "this_period_amount": 50000}],
+			}
+		).insert(ignore_permissions=True)
+		self.assertEqual(subcontract_actual_by_cost_code(self.project).get("G1", 0), 0)  # draft
+		bill.submit()
+		self.assertAlmostEqual(subcontract_actual_by_cost_code(self.project).get("G1"), 50000, places=2)
+
 	def test_bill_requires_a_submitted_work_order(self):
 		# A WO bill can only be raised against a SUBMITTED work order (Phase 2 made WOs submittable).
 		from buildsuite_core.api.subcontract import save_work_order

--- a/buildsuite_core/tests/test_subcontractor_bill.py
+++ b/buildsuite_core/tests/test_subcontractor_bill.py
@@ -336,3 +336,39 @@ class TestSubcontractorBill(BuildSuiteTestCase):
 		)
 		pe = frappe.get_doc("Payment Entry", res["payment_entry"])
 		self.assertEqual(pe.paid_from, cash)
+
+	def test_amend_a_cancelled_bill(self):
+		from buildsuite_core.api.subcontractor_bill import amend_bill, cancel_bill, submit_bill
+
+		bill = self._direct_bill(self._subcontractor(), amount=100000, retention=10)
+		submit_bill(bill.name)
+		cancel_bill(bill.name)  # no payments → cancels
+		amended = amend_bill(bill.name)
+		self.assertEqual(amended["docstatus"], 0)
+		self.assertEqual(amended["amended_from"], bill.name)
+		self.assertNotEqual(amended["name"], bill.name)
+
+	def test_cancel_blocked_while_payment_exists(self):
+		from buildsuite_core.api.subcontractor_bill import cancel_bill, record_payment, submit_bill
+		from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+		cash = _ensure_account(self.company, "Cash", "Asset", "Cash", "Current Assets")
+		bill = self._direct_bill(self._subcontractor(), amount=100000, retention=10)
+		submit_bill(bill.name)
+		record_payment(bill.name, amount=20000, date="2026-07-21", mode_of_payment="Cash", paid_from=cash)
+		self.assertRaises(frappe.ValidationError, cancel_bill, bill.name)
+
+	def test_bill_requires_a_submitted_work_order(self):
+		# A WO bill can only be raised against a SUBMITTED work order (Phase 2 made WOs submittable).
+		from buildsuite_core.api.subcontract import save_work_order
+
+		sub = self._subcontractor()
+		wo = save_work_order(
+			subcontractor=sub.name,
+			project=self.project,
+			date="2026-07-20",
+			retention_percent=5,
+			lines=frappe.as_json([{"scope": "X", "uom": "Nos", "qty": 10, "rate": 100}]),
+		)["name"]  # a DRAFT work order
+		bill = frappe.get_doc({"doctype": "Subcontractor Bill", "work_order": wo, "date": "2026-07-21"})
+		self.assertRaises(frappe.ValidationError, bill.insert, ignore_permissions=True)

--- a/buildsuite_core/tests/test_work_order_submittable.py
+++ b/buildsuite_core/tests/test_work_order_submittable.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""The Subcontractor Work Order is natively submittable: Draft → Submitted → Cancelled + Amend.
+Only Submitted WOs count as committed cost; cancelling is blocked once measurements/bills exist."""
+
+import frappe
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestWorkOrderSubmittable(BuildSuiteTestCase):
+	def setUp(self):
+		super().setUp()
+		self.company = frappe.db.get_single_value("Global Defaults", "default_company") or self.company
+		self.project = self._make_project(company=self.company).name
+
+	def _subcontractor(self):
+		return (
+			frappe.get_doc(
+				{
+					"doctype": "Supplier",
+					"supplier_name": f"Sub {self._n}",
+					"supplier_type": "Subcontractor",
+					"supplier_group": "Subcontractor",
+					"custom_trade": frappe.db.get_value("Construction Trade", {}, "name"),
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
+
+	def _wo(self, cost_code_group="G1", qty=10, rate=100):
+		from buildsuite_core.api.subcontract import save_work_order
+
+		return save_work_order(
+			subcontractor=self._subcontractor(),
+			project=self.project,
+			date="2026-07-20",
+			retention_percent=5,
+			lines=frappe.as_json(
+				[
+					{
+						"scope": "Work",
+						"cost_code_type": "Group",
+						"cost_code_group": cost_code_group,
+						"uom": "Nos",
+						"qty": qty,
+						"rate": rate,
+					}
+				]
+			),
+		)["name"]
+
+	def test_submit_makes_it_committed(self):
+		"""A draft WO is not committed cost; submitting it makes its lines count toward the BOQ
+		committed column, grouped by cost code."""
+		from buildsuite_core.api.subcontract import committed_by_cost_code, get_work_order, submit_work_order
+
+		name = self._wo(cost_code_group="G1", qty=10, rate=100)  # 1000
+		self.assertEqual(get_work_order(name)["status"], "Draft")
+		self.assertEqual(committed_by_cost_code(self.project).get("G1", 0), 0)
+
+		submit_work_order(name)
+		self.assertEqual(frappe.db.get_value("Subcontractor Work Order", name, "docstatus"), 1)
+		data = get_work_order(name)
+		self.assertEqual(data["status"], "Submitted")
+		self.assertEqual(data["actions"], ["record_measurement", "bill_progress", "cancel"])
+		self.assertAlmostEqual(committed_by_cost_code(self.project).get("G1"), 1000, places=2)
+
+	def test_cancel_blocked_when_measurement_book_exists(self):
+		from buildsuite_core.api.subcontract import cancel_work_order, submit_work_order
+
+		name = self._wo()
+		submit_work_order(name)
+		wo = frappe.get_doc("Subcontractor Work Order", name)
+		frappe.get_doc(
+			{
+				"doctype": "Measurement Book",
+				"work_order": name,
+				"project": self.project,
+				"date": "2026-07-21",
+				"entries": [
+					{
+						"description": "m",
+						"work_order_line": wo.lines[0].name,
+						"quantity": 5,
+						"is_deduction": 0,
+					}
+				],
+			}
+		).insert(ignore_permissions=True)
+		self.assertRaises(frappe.ValidationError, cancel_work_order, name)
+
+	def test_amend_clones_to_a_new_draft(self):
+		from buildsuite_core.api.subcontract import amend_work_order, cancel_work_order, submit_work_order
+
+		name = self._wo()
+		submit_work_order(name)
+		cancel_work_order(name)  # no MBs/bills → cancels
+		amended = amend_work_order(name)
+		self.assertEqual(amended["status"], "Draft")
+		self.assertEqual(amended["amended_from"], name)
+		self.assertNotEqual(amended["name"], name)

--- a/frontend/src/components/TradePicker.vue
+++ b/frontend/src/components/TradePicker.vue
@@ -1,0 +1,126 @@
+<script setup>
+// Trade field — a searchable Construction Trade picker with an inline "+ New" that creates a
+// trade on the spot (saved permanently) and selects it, so a subcontractor's trade can be added
+// without leaving the form. Construction Trade is autonamed field:trade_name.
+import { ref } from "vue";
+import { useDataStore } from "@/stores";
+import { createDataAdapter } from "@/data/adapters";
+import { showToast } from "@/utils/appToast";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+
+defineProps({
+	modelValue: { type: String, default: "" },
+	error: { type: String, default: "" },
+});
+const emit = defineEmits(["update:modelValue"]);
+const adapter = createDataAdapter(useDataStore());
+
+const open = ref(false);
+const name = ref("");
+const saving = ref(false);
+const pickerKey = ref(0); // bump to refresh the picker's options after creating a trade
+
+function openCreate() {
+	name.value = "";
+	open.value = true;
+}
+async function createTrade() {
+	const trade = name.value.trim();
+	if (!trade) return;
+	saving.value = true;
+	try {
+		const res = await adapter.create("Construction Trade", { trade_name: trade, enabled: 1 });
+		emit("update:modelValue", res.name);
+		pickerKey.value++;
+		open.value = false;
+		showToast(`Trade "${res.name}" created.`);
+	} catch (err) {
+		showToast(err.message || "Could not create the trade.", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+</script>
+
+<template>
+	<div class="flex items-center gap-2">
+		<div class="flex-1 min-w-0">
+			<DeskLinkPicker
+				:key="pickerKey"
+				:model-value="modelValue"
+				doctype="Construction Trade"
+				label-field="name"
+				value-field="name"
+				placeholder="Pick a trade…"
+				:error="error"
+				@update:model-value="(v) => emit('update:modelValue', v)"
+			/>
+		</div>
+		<button
+			type="button"
+			class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-brand-700 rounded-md flex-shrink-0 whitespace-nowrap"
+			title="Create a new trade"
+			@click="openCreate"
+		>
+			+ New
+		</button>
+	</div>
+
+	<Teleport to="body">
+		<div
+			v-if="open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-sm shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Create new trade</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="open = false"
+					>
+						✕
+					</button>
+				</header>
+				<div class="px-4 py-4">
+					<label
+						class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+						>Trade name</label
+					>
+					<input
+						v-model="name"
+						type="text"
+						placeholder="e.g. Waterproofing"
+						class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+						@keyup.enter="createTrade"
+					/>
+				</div>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="saving || !name.trim()"
+						@click="createTrade"
+					>
+						{{ saving ? "Creating…" : "Create trade" }}
+					</button>
+				</footer>
+			</div>
+		</div>
+	</Teleport>
+</template>

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -59,6 +59,7 @@ export const getWoBillContext = (workOrder) =>
 export const saveBill = (payload) => billCall("save_bill", { payload: JSON.stringify(payload) });
 export const submitBill = (name) => billCall("submit_bill", { name });
 export const cancelBill = (name) => billCall("cancel_bill", { name });
+export const amendBill = (name) => billCall("amend_bill", { name });
 export const deleteBill = (name) => billCall("delete_bill", { name });
 export const listTaxTemplates = (company) => billCall("list_tax_templates", { company });
 export const getTaxTemplateRows = (template) => billCall("get_tax_template_rows", { template });

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -27,6 +27,10 @@ export const cancelWorkOrder = (name) => call("cancel_work_order", { name });
 export const amendWorkOrder = (name) => call("amend_work_order", { name });
 export const getProjectCostCodes = (project) => call("get_project_cost_codes", { project });
 export const getCommittedByCostCode = (project) => call("committed_by_cost_code", { project });
+// Subcontract actual (submitted bill this-period amounts) by cost-code group — added to the
+// BOQ's task-progress actuals.
+export const getSubcontractActualByCostCode = (project) =>
+	call("subcontract_actual_by_cost_code", { project });
 
 // Measurement Book — site measurements against a Work Order's SOV lines.
 export const getWorkOrderLines = (workOrder) =>

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -21,9 +21,10 @@ export const getWorkOrder = (name) => call("get_work_order", { name });
 export const getWoPrintData = (name) => call("get_wo_print_data", { name });
 export const saveWorkOrder = (payload) =>
 	call("save_work_order", { ...payload, lines: JSON.stringify(payload.lines || []) });
-export const applyWoAction = (workOrder, action) =>
-	call("apply_wo_action", { work_order: workOrder, action });
-export const getWoTransitions = (name) => call("get_wo_transitions", { name });
+// Native submittable lifecycle (docstatus): Draft → Submit → Cancelled, plus Amend.
+export const submitWorkOrder = (name) => call("submit_work_order", { name });
+export const cancelWorkOrder = (name) => call("cancel_work_order", { name });
+export const amendWorkOrder = (name) => call("amend_work_order", { name });
 export const getProjectCostCodes = (project) => call("get_project_cost_codes", { project });
 export const getCommittedByCostCode = (project) => call("committed_by_cost_code", { project });
 

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -58,6 +58,7 @@ async function billCall(method, args) {
 }
 
 export const getBill = (name) => billCall("get_bill", { name });
+export const listBills = (project) => billCall("list_bills", project ? { project } : {});
 export const getWoBillContext = (workOrder) =>
 	billCall("get_wo_bill_context", { work_order: workOrder });
 export const saveBill = (payload) => billCall("save_bill", { payload: JSON.stringify(payload) });

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -15,7 +15,7 @@ import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import { parseFrappeError } from "@/utils/frappeError";
 import * as boqApi from "@/utils/boqApi";
-import { getCommittedByCostCode } from "@/data/subcontractApi";
+import { getCommittedByCostCode, getSubcontractActualByCostCode } from "@/data/subcontractApi";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -123,7 +123,7 @@ watch(
 			projectBoqsRes.reload?.();
 		}
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 const baseBoq = computed(() => {
 	const bid = boq.value?.baseRevisionId;
@@ -162,7 +162,7 @@ const groups = computed(() =>
 		code: g.code,
 		name: g.group_name,
 		order: g.idx_order,
-	})),
+	}))
 );
 const allItems = computed(() =>
 	rowsOf(itemsRes).map((i) => ({
@@ -181,7 +181,7 @@ const allItems = computed(() =>
 		costHead: i.cost_head,
 		assemblyId: i.assembly,
 		drivingQty: i.driving_qty,
-	})),
+	}))
 );
 const allSubs = computed(() =>
 	rowsOf(subsRes).map((s) => ({
@@ -193,7 +193,7 @@ const allSubs = computed(() =>
 		uom: s.uom,
 		rate: s.rate,
 		amount: s.amount,
-	})),
+	}))
 );
 function boqItemsByGroup(groupId) {
 	return allItems.value.filter((i) => i.groupId === groupId);
@@ -210,7 +210,10 @@ const treeGridStyle =
 
 const totals = computed(() => {
 	const planned = allItems.value.reduce((a, i) => a + (i.plannedAmount || 0), 0);
-	const actual = allItems.value.reduce((a, i) => a + (i.actualAmount || 0), 0);
+	// Task-progress actuals + the subcontracted spend billed (submitted bills), added not replaced.
+	const subcontractActual = Object.values(subcontractActualMap.value).reduce((a, v) => a + v, 0);
+	const actual =
+		allItems.value.reduce((a, i) => a + (i.actualAmount || 0), 0) + subcontractActual;
 	const variance = actual - planned;
 	return {
 		planned,
@@ -330,7 +333,7 @@ function itemExpanded(item) {
 const visibleGroupsList = computed(() =>
 	searching.value
 		? groups.value.filter((g) => filterState.value?.visGroups.has(g.id))
-		: groups.value,
+		: groups.value
 );
 function visibleItemsFor(g) {
 	const items = boqItemsByGroup(g.id);
@@ -370,10 +373,35 @@ watch(
 			committedMap.value = {};
 		}
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 function groupCommitted(group) {
 	return committedMap.value[group.code] || 0;
+}
+
+// === Actual (subcontract) — submitted bill this-period amounts by cost-code group ===
+// Added to (never replacing) the task-progress actuals, so a group's Actual reflects both
+// site-progress spend and what has been billed by subcontractors.
+const subcontractActualMap = ref({}); // { cost_code_group: amount }
+watch(
+	() => boq.value?.projectId,
+	async (pid) => {
+		subcontractActualMap.value = {};
+		if (!pid) return;
+		try {
+			subcontractActualMap.value = (await getSubcontractActualByCostCode(pid)) || {};
+		} catch {
+			subcontractActualMap.value = {};
+		}
+	},
+	{ immediate: true }
+);
+function groupSubcontractActual(group) {
+	return subcontractActualMap.value[group.code] || 0;
+}
+// A group's Actual = task-progress actuals on its items + subcontracted spend billed to its code.
+function groupActual(group) {
+	return groupTotals(group.id).actual + groupSubcontractActual(group);
 }
 
 const wpRes = useDocTypeList("Work Package", {
@@ -427,7 +455,7 @@ async function submit() {
 }
 async function approve() {
 	const others = (projectBoqsRes.data || []).filter(
-		(b) => b.name !== boq.value.id && b.revision !== boq.value.revision,
+		(b) => b.name !== boq.value.id && b.revision !== boq.value.revision
 	);
 	void others;
 	const ok = await confirmDialog({
@@ -464,7 +492,7 @@ async function submitRevision() {
 		const name = await boqApi.createRevision(
 			boq.value.id,
 			revisionModal.value.sourceSco.trim() || null,
-			revisionModal.value.title.trim() || null,
+			revisionModal.value.title.trim() || null
 		);
 		revisionModal.value = null;
 		if (name) router.push(`/boq/${name}`);
@@ -511,7 +539,7 @@ function exportCsv() {
 	lines.push(
 		["BOQ", boq.value.id, "Rev", boq.value.revision, "Status", boq.value.status]
 			.map(csvCell)
-			.join(","),
+			.join(",")
 	);
 	lines.push(
 		[
@@ -528,7 +556,7 @@ function exportCsv() {
 			"Cost Head",
 		]
 			.map(csvCell)
-			.join(","),
+			.join(",")
 	);
 	for (const g of groups.value) {
 		lines.push(["Group", g.code, g.name].map(csvCell).join(","));
@@ -548,13 +576,13 @@ function exportCsv() {
 					it.costHead || "",
 				]
 					.map(csvCell)
-					.join(","),
+					.join(",")
 			);
 			for (const si of boqSubItemsByItem(it.id)) {
 				lines.push(
 					["Sub", "↳", si.description, "", si.qtyPerUnit, si.rate, si.amount]
 						.map(csvCell)
-						.join(","),
+						.join(",")
 				);
 			}
 		}
@@ -603,13 +631,13 @@ async function doClone() {
 				to_project: boq.value.projectId,
 				from_work_package: f.fromWorkPackage,
 				to_work_package: f.toWorkPackage,
-			}
+		  }
 		: {
 				from_project: boq.value.projectId,
 				to_project: f.toProject,
 				to_work_package: f.toWorkPackage || null,
 				title: f.title || null,
-			};
+		  };
 	try {
 		const res = await boqApi.cloneBoq(payload);
 		cloneModal.value = false;
@@ -624,7 +652,7 @@ async function doClone() {
 const canSubmit = computed(() => boq.value?.status === "Draft");
 const canApprove = computed(() => boq.value?.status === "Submitted");
 const isLocked = computed(
-	() => boq.value?.status === "Approved" || boq.value?.status === "Superseded",
+	() => boq.value?.status === "Approved" || boq.value?.status === "Superseded"
 );
 const isEditable = computed(() => boq.value?.status === "Draft");
 
@@ -695,7 +723,7 @@ async function deleteGroupConfirm(g) {
 	const msg = items.length
 		? `Delete group "${g.code} — ${g.name}" with ${items.length} item${
 				items.length === 1 ? "" : "s"
-			} and their sub-items?`
+		  } and their sub-items?`
 		: `Delete group "${g.code} — ${g.name}"?`;
 	if (
 		!(await confirmDialog({
@@ -731,7 +759,7 @@ const itemForm = ref({
 // so you can only link records that belong to this BOQ's project.
 const boqProjectId = computed(() => boq.value?.projectId || "");
 const itemPlannedAmountPreview = computed(
-	() => (Number(itemForm.value.plannedQty) || 0) * (Number(itemForm.value.rate) || 0),
+	() => (Number(itemForm.value.plannedQty) || 0) * (Number(itemForm.value.rate) || 0)
 );
 // Assemblies for the "Source" picker — pick one to auto-fill unit / rate /
 // description (the save handler then auto-explodes the line into sub-items).
@@ -828,7 +856,7 @@ async function saveItem() {
 				} catch (e) {
 					showToast(
 						parseFrappeError(e).summary ?? "Item saved, but explode failed",
-						"error",
+						"error"
 					);
 				}
 			}
@@ -847,7 +875,7 @@ async function deleteItemConfirm(item) {
 	const msg = subs.length
 		? `Delete item "${item.code} — ${item.description}" with ${subs.length} sub-item${
 				subs.length === 1 ? "" : "s"
-			}?`
+		  }?`
 		: `Delete item "${item.code} — ${item.description}"?`;
 	if (
 		!(await confirmDialog({
@@ -882,7 +910,7 @@ const rateMasterOptions = computed(() =>
 		description: r.rate_name,
 		currentRate: r.current_rate,
 		category: r.category,
-	})),
+	}))
 );
 function openAddSubItem(item) {
 	subItemForm.value = { rateMasterId: null, description: "", qtyPerUnit: 0, rate: 0 };
@@ -906,7 +934,7 @@ function onRateMasterPick(rateMasterId) {
 	}
 }
 const subItemAmountPreview = computed(
-	() => (Number(subItemForm.value.qtyPerUnit) || 0) * (Number(subItemForm.value.rate) || 0),
+	() => (Number(subItemForm.value.qtyPerUnit) || 0) * (Number(subItemForm.value.rate) || 0)
 );
 async function saveSubItem() {
 	const f = subItemForm.value;
@@ -957,7 +985,7 @@ async function deleteSubItemConfirm(si) {
 // Primary action dispatcher — Submit when Draft, Approve when Submitted.
 const showPrimary = computed(() => canSubmit.value || canApprove.value);
 const primaryLabel = computed(() =>
-	canSubmit.value ? "Submit for approval" : canApprove.value ? "Approve" : "",
+	canSubmit.value ? "Submit for approval" : canApprove.value ? "Approve" : ""
 );
 function primaryAction() {
 	if (canSubmit.value) submit();
@@ -1216,7 +1244,7 @@ const breadcrumbs = computed(() => {
 					{{
 						filterState?.matchCount
 							? filterState.matchCount +
-								(filterState.matchCount === 1 ? " match" : " matches")
+							  (filterState.matchCount === 1 ? " match" : " matches")
 							: "No matches"
 					}}
 				</span>
@@ -1300,27 +1328,29 @@ const breadcrumbs = computed(() => {
 						>
 							{{ fmtCompactINR(groupCommitted(g)) }}
 						</div>
-						<div class="px-3 py-2 text-right tabular-nums text-sm text-ink-700">
-							{{ fmtCompactINR(groupTotals(g.id).actual) }}
+						<div
+							class="px-3 py-2 text-right tabular-nums text-sm text-ink-700"
+							:title="`Task-progress actuals + subcontractor bills submitted against cost code ${g.code}`"
+						>
+							{{ fmtCompactINR(groupActual(g)) }}
 						</div>
 						<div
 							class="px-3 py-2 text-right text-sm tabular-nums font-medium"
 							:class="
 								variancePill(
-									((groupTotals(g.id).actual - groupTotals(g.id).planned) /
+									((groupActual(g) - groupTotals(g.id).planned) /
 										(groupTotals(g.id).planned || 1)) *
-										100,
+										100
 								)
 							"
 						>
 							{{
 								groupTotals(g.id).planned
 									? (
-											((groupTotals(g.id).actual -
-												groupTotals(g.id).planned) /
+											((groupActual(g) - groupTotals(g.id).planned) /
 												groupTotals(g.id).planned) *
 											100
-										).toFixed(1)
+									  ).toFixed(1)
 									: "0.0"
 							}}%
 						</div>
@@ -1467,7 +1497,7 @@ const breadcrumbs = computed(() => {
 										{{ item.plannedAmount > baseAmount(item.code) ? "+" : ""
 										}}{{
 											fmtCompactINR(
-												item.plannedAmount - baseAmount(item.code),
+												item.plannedAmount - baseAmount(item.code)
 											)
 										}}</span
 									>
@@ -1504,13 +1534,13 @@ const breadcrumbs = computed(() => {
 													item.actualAmount > item.plannedAmount
 														? 'bg-danger-500'
 														: item.actualAmount >
-															  item.plannedAmount * 0.9
-															? 'bg-warning-500'
-															: 'bg-success-500'
+														  item.plannedAmount * 0.9
+														? 'bg-warning-500'
+														: 'bg-success-500'
 												"
 												:style="`width: ${Math.min(
 													100,
-													pctOf(item.actualAmount, item.plannedAmount),
+													pctOf(item.actualAmount, item.plannedAmount)
 												).toFixed(1)}%`"
 											></div>
 										</div>
@@ -1522,7 +1552,7 @@ const breadcrumbs = computed(() => {
 										variancePill(
 											((item.actualAmount - item.plannedAmount) /
 												(item.plannedAmount || 1)) *
-												100,
+												100
 										)
 									"
 								>
@@ -1532,7 +1562,7 @@ const breadcrumbs = computed(() => {
 													((item.actualAmount - item.plannedAmount) /
 														item.plannedAmount) *
 													100
-												).toFixed(1)
+											  ).toFixed(1)
 											: "0.0"
 									}}%
 								</div>

--- a/frontend/src/views/NewSubcontractorBillView.vue
+++ b/frontend/src/views/NewSubcontractorBillView.vue
@@ -82,7 +82,7 @@ watch(
 								scope: l.scope || "",
 								cost_code: l.cost_code_label || null,
 								amount: l.this_period_amount || 0,
-							}))
+						  }))
 						: [{ scope: "", cost_code: null, amount: 0 }],
 				};
 				if (!bill.is_direct) loadWoContext(bill.work_order);
@@ -93,7 +93,7 @@ watch(
 			loadWoContext(form.value.work_order);
 		}
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 function onWorkOrderChange(wo) {
@@ -102,13 +102,15 @@ function onWorkOrderChange(wo) {
 }
 
 const woLines = computed(() => woContext.value?.lines || []);
-const woGross = computed(() => woLines.value.reduce((a, l) => a + (Number(l.this_period_amount) || 0), 0));
+const woGross = computed(() =>
+	woLines.value.reduce((a, l) => a + (Number(l.this_period_amount) || 0), 0)
+);
 const directGross = computed(() =>
-	form.value.lines.reduce((a, l) => a + (Number(l.amount) || 0), 0),
+	form.value.lines.reduce((a, l) => a + (Number(l.amount) || 0), 0)
 );
 const gross = computed(() => (mode.value === "wo" ? woGross.value : directGross.value));
 const retention = computed(
-	() => +((gross.value * (Number(form.value.retention_percent) || 0)) / 100).toFixed(2),
+	() => +((gross.value * (Number(form.value.retention_percent) || 0)) / 100).toFixed(2)
 );
 const netPayable = computed(() => +(gross.value - retention.value).toFixed(2));
 
@@ -146,7 +148,7 @@ async function onSave() {
 						work_order: form.value.work_order,
 						date: form.value.date,
 						retention_percent: form.value.retention_percent,
-					}
+				  }
 				: {
 						name: editingId.value || undefined,
 						is_direct: 1,
@@ -164,7 +166,7 @@ async function onSave() {
 										: l.cost_code || "",
 								amount: Number(l.amount) || 0,
 							})),
-					};
+				  };
 		const bill = await saveBill(payload);
 		router.push(`/subcontractor-bills/${bill.name}`);
 	} catch (err) {
@@ -177,16 +179,21 @@ function onCancel() {
 	router.back();
 }
 
-const pageTitle = computed(() => (isEdit.value ? `Edit ${editingId.value}` : "New Subcontractor Bill"));
+const pageTitle = computed(() =>
+	isEdit.value ? `Edit ${editingId.value}` : "New Subcontractor Bill"
+);
 const saveLabel = computed(() =>
-	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Create bill",
+	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Create Subcontractor bill"
 );
 const breadcrumbs = computed(() => [
 	{ label: "BuildSuite Core", to: "/" },
 	{ label: "Subcontract", to: "/subcontract" },
 	{ label: "Subcontractor Bills", to: "/subcontractor-bills" },
 	...(isEdit.value
-		? [{ label: editingId.value, to: `/subcontractor-bills/${editingId.value}` }, { label: "Edit" }]
+		? [
+				{ label: editingId.value, to: `/subcontractor-bills/${editingId.value}` },
+				{ label: "Edit" },
+		  ]
 		: [{ label: "New" }]),
 ]);
 </script>
@@ -195,7 +202,12 @@ const breadcrumbs = computed(() => [
 	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
 		<DeskForm>
 			<template #action-bar>
-				<DeskActionBar :save-label="saveLabel" :saving="saving" @save="onSave" @cancel="onCancel" />
+				<DeskActionBar
+					:save-label="saveLabel"
+					:saving="saving"
+					@save="onSave"
+					@cancel="onCancel"
+				/>
 			</template>
 
 			<!-- Mode toggle (create only) -->
@@ -203,7 +215,11 @@ const breadcrumbs = computed(() => [
 				<button
 					type="button"
 					class="px-3 py-1.5 text-xs rounded-md border"
-					:class="mode === 'wo' ? 'bg-brand-600 text-white border-brand-600' : 'border-ink-200 text-ink-700'"
+					:class="
+						mode === 'wo'
+							? 'bg-brand-600 text-white border-brand-600'
+							: 'border-ink-200 text-ink-700'
+					"
 					@click="mode = 'wo'"
 				>
 					From Work Order
@@ -211,7 +227,11 @@ const breadcrumbs = computed(() => [
 				<button
 					type="button"
 					class="px-3 py-1.5 text-xs rounded-md border"
-					:class="mode === 'direct' ? 'bg-brand-600 text-white border-brand-600' : 'border-ink-200 text-ink-700'"
+					:class="
+						mode === 'direct'
+							? 'bg-brand-600 text-white border-brand-600'
+							: 'border-ink-200 text-ink-700'
+					"
 					@click="mode = 'direct'"
 				>
 					Direct (no work order)
@@ -232,9 +252,16 @@ const breadcrumbs = computed(() => [
 							@update:model-value="onWorkOrderChange"
 						/>
 					</DeskField>
-					<DeskField label="Date" required><DeskInput v-model="form.date" type="date" /></DeskField>
+					<DeskField label="Date" required
+						><DeskInput v-model="form.date" type="date"
+					/></DeskField>
 					<DeskField label="Retention (%)">
-						<DeskInput v-model.number="form.retention_percent" type="number" min="0" step="0.5" />
+						<DeskInput
+							v-model.number="form.retention_percent"
+							type="number"
+							min="0"
+							step="0.5"
+						/>
 					</DeskField>
 				</DeskSection>
 
@@ -242,7 +269,8 @@ const breadcrumbs = computed(() => [
 					v-if="woContext"
 					class="mt-3 text-xs text-ink-600 bg-info-50 border border-info-100 rounded-md px-3 py-2"
 				>
-					{{ woContext.subcontractor_name }} · {{ woContext.project_name }} · This will be
+					{{ woContext.subcontractor_name }} · {{ woContext.project_name }} · This will
+					be
 					<span class="font-medium">Bill {{ woContext.next_ra_no }}</span>
 				</div>
 
@@ -252,7 +280,9 @@ const breadcrumbs = computed(() => [
 					</h3>
 					<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
 						<table class="w-full text-xs" style="min-width: 720px">
-							<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<thead
+								class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]"
+							>
 								<tr>
 									<th class="text-left px-3 py-2">Scope</th>
 									<th class="text-right px-3 py-2">Rate</th>
@@ -263,47 +293,78 @@ const breadcrumbs = computed(() => [
 								</tr>
 							</thead>
 							<tbody>
-								<tr v-for="(l, i) in woLines" :key="i" class="border-t border-ink-100">
+								<tr
+									v-for="(l, i) in woLines"
+									:key="i"
+									class="border-t border-ink-100"
+								>
 									<td class="px-3 py-2 text-ink-900">{{ l.scope }}</td>
 									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
-										{{ fmtINR(l.rate) }}<span class="text-ink-400">/{{ l.uom }}</span>
+										{{ fmtINR(l.rate)
+										}}<span class="text-ink-400">/{{ l.uom }}</span>
 									</td>
 									<td class="px-3 py-2 text-right tabular-nums text-info-700">
-										{{ Number(l.measured_qty_to_date).toLocaleString("en-IN") }}
+										{{
+											Number(l.measured_qty_to_date).toLocaleString("en-IN")
+										}}
 									</td>
 									<td class="px-3 py-2 text-right tabular-nums text-ink-500">
 										{{ Number(l.previous_qty).toLocaleString("en-IN") }}
 									</td>
-									<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+									<td
+										class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium"
+									>
 										{{ Number(l.this_period_qty).toLocaleString("en-IN") }}
 									</td>
-									<td class="px-3 py-2 text-right tabular-nums font-medium">{{ fmtINR(l.this_period_amount) }}</td>
+									<td class="px-3 py-2 text-right tabular-nums font-medium">
+										{{ fmtINR(l.this_period_amount) }}
+									</td>
 								</tr>
 								<tr v-if="!woLines.length">
-									<td colspan="6" class="px-3 py-4 text-center text-ink-400 italic">
+									<td
+										colspan="6"
+										class="px-3 py-4 text-center text-ink-400 italic"
+									>
 										Pick a work order to derive this period's lines.
 									</td>
 								</tr>
 							</tbody>
 							<tfoot v-if="woLines.length">
 								<tr class="bg-ink-50 border-t border-ink-200">
-									<td colspan="5" class="px-3 py-1.5 text-right text-ink-600">Gross this period</td>
-									<td class="px-3 py-1.5 text-right tabular-nums font-semibold">{{ fmtINR(woGross) }}</td>
+									<td colspan="5" class="px-3 py-1.5 text-right text-ink-600">
+										Gross this period
+									</td>
+									<td class="px-3 py-1.5 text-right tabular-nums font-semibold">
+										{{ fmtINR(woGross) }}
+									</td>
 								</tr>
 								<tr class="bg-ink-50">
 									<td colspan="5" class="px-3 py-1 text-right text-warning-700">
 										Less retention ({{ form.retention_percent }}%)
 									</td>
-									<td class="px-3 py-1 text-right tabular-nums text-warning-700">−{{ fmtINR(retention) }}</td>
+									<td class="px-3 py-1 text-right tabular-nums text-warning-700">
+										−{{ fmtINR(retention) }}
+									</td>
 								</tr>
 								<tr class="bg-ink-50 border-t border-ink-200">
-									<td colspan="5" class="px-3 py-1.5 text-right font-semibold text-ink-900">Net payable</td>
-									<td class="px-3 py-1.5 text-right tabular-nums font-bold text-brand-700">{{ fmtINR(netPayable) }}</td>
+									<td
+										colspan="5"
+										class="px-3 py-1.5 text-right font-semibold text-ink-900"
+									>
+										Net payable
+									</td>
+									<td
+										class="px-3 py-1.5 text-right tabular-nums font-bold text-brand-700"
+									>
+										{{ fmtINR(netPayable) }}
+									</td>
 								</tr>
 							</tfoot>
 						</table>
 					</div>
-					<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">{{ errors.lines }}</p>
+					<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">
+						{{ errors.lines }}
+					</p>
 				</section>
 			</template>
 
@@ -320,7 +381,12 @@ const breadcrumbs = computed(() => [
 							placeholder="Pick a subcontractor…"
 						/>
 					</DeskField>
-					<DeskField label="Project" required hint="Sets the accounting company." :error="errors.project">
+					<DeskField
+						label="Project"
+						required
+						hint="Sets the accounting company."
+						:error="errors.project"
+					>
 						<DeskLinkPicker
 							v-model="form.project"
 							doctype="Project"
@@ -329,35 +395,61 @@ const breadcrumbs = computed(() => [
 							placeholder="Pick a project…"
 						/>
 					</DeskField>
-					<DeskField label="Date" required><DeskInput v-model="form.date" type="date" /></DeskField>
+					<DeskField label="Date" required
+						><DeskInput v-model="form.date" type="date"
+					/></DeskField>
 					<DeskField label="Retention (%)">
-						<DeskInput v-model.number="form.retention_percent" type="number" min="0" step="0.5" />
+						<DeskInput
+							v-model.number="form.retention_percent"
+							type="number"
+							min="0"
+							step="0.5"
+						/>
 					</DeskField>
 				</DeskSection>
 
-				<div class="mt-3 text-xs text-ink-600 bg-info-50 border border-info-100 rounded-md px-3 py-2">
-					Direct bill — for one-off / lump-sum charges. Taxes are applied on the detail page.
+				<div
+					class="mt-3 text-xs text-ink-600 bg-info-50 border border-info-100 rounded-md px-3 py-2"
+				>
+					Direct bill — for one-off / lump-sum charges. Taxes are applied on the detail
+					page.
 				</div>
 
 				<section class="mt-6">
 					<div class="flex items-center justify-between mb-2">
-						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Charge lines</h3>
-						<button type="button" class="text-xs text-brand-700 hover:underline" @click="addLine">
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+							Charge lines
+						</h3>
+						<button
+							type="button"
+							class="text-xs text-brand-700 hover:underline"
+							@click="addLine"
+						>
 							+ Add line
 						</button>
 					</div>
 					<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
 						<table class="w-full text-xs" style="min-width: 560px">
-							<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<thead
+								class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]"
+							>
 								<tr>
-									<th class="text-left px-3 py-2 min-w-[220px]">Scope / description</th>
-									<th class="text-left px-3 py-2 min-w-[150px]">Cost code (optional)</th>
+									<th class="text-left px-3 py-2 min-w-[220px]">
+										Scope / description
+									</th>
+									<th class="text-left px-3 py-2 min-w-[150px]">
+										Cost code (optional)
+									</th>
 									<th class="text-right px-3 py-2 w-32">Amount</th>
 									<th class="w-8"></th>
 								</tr>
 							</thead>
 							<tbody>
-								<tr v-for="(l, i) in form.lines" :key="i" class="border-t border-ink-100">
+								<tr
+									v-for="(l, i) in form.lines"
+									:key="i"
+									class="border-t border-ink-100"
+								>
 									<td class="px-3 py-1">
 										<input
 											v-model="l.scope"
@@ -366,7 +458,11 @@ const breadcrumbs = computed(() => [
 										/>
 									</td>
 									<td class="px-3 py-1">
-										<CostCodePicker v-model="l.cost_code" :project-id="form.project" placeholder="Pick code…" />
+										<CostCodePicker
+											v-model="l.cost_code"
+											:project-id="form.project"
+											placeholder="Pick code…"
+										/>
 									</td>
 									<td class="px-3 py-1">
 										<input
@@ -377,32 +473,55 @@ const breadcrumbs = computed(() => [
 										/>
 									</td>
 									<td class="px-2 py-1 text-center">
-										<button type="button" class="text-ink-400 hover:text-danger-600" @click="removeLine(i)">✕</button>
+										<button
+											type="button"
+											class="text-ink-400 hover:text-danger-600"
+											@click="removeLine(i)"
+										>
+											✕
+										</button>
 									</td>
 								</tr>
 							</tbody>
 							<tfoot>
 								<tr class="bg-ink-50 border-t border-ink-200">
-									<td colspan="2" class="px-3 py-1.5 text-right text-ink-600">Gross</td>
-									<td class="px-3 py-1.5 text-right tabular-nums font-semibold">{{ fmtINR(directGross) }}</td>
+									<td colspan="2" class="px-3 py-1.5 text-right text-ink-600">
+										Gross
+									</td>
+									<td class="px-3 py-1.5 text-right tabular-nums font-semibold">
+										{{ fmtINR(directGross) }}
+									</td>
 									<td></td>
 								</tr>
 								<tr class="bg-ink-50">
 									<td colspan="2" class="px-3 py-1 text-right text-warning-700">
 										Less retention ({{ form.retention_percent }}%)
 									</td>
-									<td class="px-3 py-1 text-right tabular-nums text-warning-700">−{{ fmtINR(retention) }}</td>
+									<td class="px-3 py-1 text-right tabular-nums text-warning-700">
+										−{{ fmtINR(retention) }}
+									</td>
 									<td></td>
 								</tr>
 								<tr class="bg-ink-50 border-t border-ink-200">
-									<td colspan="2" class="px-3 py-1.5 text-right font-semibold text-ink-900">Net payable</td>
-									<td class="px-3 py-1.5 text-right tabular-nums font-bold text-brand-700">{{ fmtINR(netPayable) }}</td>
+									<td
+										colspan="2"
+										class="px-3 py-1.5 text-right font-semibold text-ink-900"
+									>
+										Net payable
+									</td>
+									<td
+										class="px-3 py-1.5 text-right tabular-nums font-bold text-brand-700"
+									>
+										{{ fmtINR(netPayable) }}
+									</td>
 									<td></td>
 								</tr>
 							</tfoot>
 						</table>
 					</div>
-					<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">{{ errors.lines }}</p>
+					<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">
+						{{ errors.lines }}
+					</p>
 				</section>
 			</template>
 		</DeskForm>

--- a/frontend/src/views/NewSubcontractorView.vue
+++ b/frontend/src/views/NewSubcontractorView.vue
@@ -16,7 +16,7 @@ import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
-import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import TradePicker from "@/components/TradePicker.vue";
 
 const router = useRouter();
 const adapter = createDataAdapter(useDataStore());
@@ -90,13 +90,7 @@ const breadcrumbs = [
 					<DeskInput v-model="form.subcontractor_name" />
 				</DeskField>
 				<DeskField label="Trade" required :error="errors.trade">
-					<DeskLinkPicker
-						v-model="form.trade"
-						doctype="Construction Trade"
-						label-field="name"
-						value-field="name"
-						placeholder="Pick a trade…"
-					/>
+					<TradePicker v-model="form.trade" :error="errors.trade" />
 				</DeskField>
 				<DeskField label="Status">
 					<DeskSelect v-model="form.status">
@@ -109,8 +103,8 @@ const breadcrumbs = [
 				/></DeskField>
 			</DeskSection>
 			<p class="text-xs text-ink-400 mt-3">
-				Contact person, phone and email are managed on the subcontractor's Supplier record in the
-				accounting desk.
+				Contact person, phone and email are managed on the subcontractor's Supplier record
+				in the accounting desk.
 			</p>
 		</DeskForm>
 	</DeskPage>

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -17,6 +17,7 @@ import {
 	saveBill,
 	submitBill,
 	cancelBill,
+	amendBill,
 	deleteBill,
 	getTaxTemplateRows,
 	recordBillPayment,
@@ -65,6 +66,7 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => bill.value?.docstatus === 0);
 const isSubmitted = computed(() => bill.value?.docstatus === 1);
+const isCancelled = computed(() => bill.value?.docstatus === 2);
 const editable = computed(() => isDraft.value);
 const payment = computed(
 	() => bill.value?.payment || { paid: 0, outstanding: 0, invoiced: 0, status: "Unpaid" }
@@ -403,10 +405,24 @@ async function onCancel() {
 		busy.value = false;
 	}
 }
+async function onAmend() {
+	busy.value = true;
+	try {
+		const res = await amendBill(bill.value.name);
+		showToast("Amended — a fresh draft was created.");
+		router.push(`/subcontractor-bills/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Amend failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
 async function onDelete() {
 	const ok = await confirmDialog({
 		title: `Delete Bill ${bill.value.ra_no}?`,
-		message: "This draft bill will be removed permanently.",
+		message: isCancelled.value
+			? "This cancelled bill will be removed permanently."
+			: "This draft bill will be removed permanently.",
 		confirmLabel: "Delete",
 		destructive: true,
 	});
@@ -568,7 +584,18 @@ const accountFilters = computed(() =>
 				</button>
 			</template>
 			<button
-				v-if="isDraft"
+				v-if="isCancelled"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				title="Create a fresh editable draft copy (the original stays cancelled)"
+				@click="onAmend"
+			>
+				Amend
+			</button>
+			<button
+				v-if="!isSubmitted"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/SubcontractorBillsListView.vue
+++ b/frontend/src/views/SubcontractorBillsListView.vue
@@ -2,9 +2,10 @@
 // Subcontractor Bill list — Desk-styled. Each bill generates a Purchase
 // Invoice on submit; the list shows gross / retention / net payable + status.
 
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
-import { useDocTypeList } from "@/composables/useDocTypeList";
+import { listBills } from "@/data/subcontractApi";
+import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -13,24 +14,13 @@ import { fmtDate, fmtINR } from "@/utils/format";
 
 const router = useRouter();
 
-const billsRes = useDocTypeList("Subcontractor Bill", {
-	fields: [
-		"name",
-		"ra_no",
-		"is_direct",
-		"subcontractor_name",
-		"project",
-		"date",
-		"gross",
-		"retention_amount",
-		"net_payable",
-		"status",
-	],
-	orderBy: "date desc",
-	pageLength: 0,
-	cache: "buildsuite-subcontractor-bill-list",
-	transform: (data) =>
-		data.map((b) => ({
+// Loaded via list_bills so each row carries the workflow state AND the derived payment status.
+const allBills = ref([]);
+const loading = ref(true);
+async function load() {
+	loading.value = true;
+	try {
+		allBills.value = (await listBills()).map((b) => ({
 			id: b.name,
 			ra_no: b.ra_no,
 			is_direct: b.is_direct,
@@ -41,19 +31,26 @@ const billsRes = useDocTypeList("Subcontractor Bill", {
 			retention: b.retention_amount,
 			net: b.net_payable,
 			status: b.status,
-		})),
-});
+			payment_status: b.payment_status,
+		}));
+	} catch (err) {
+		showToast(err.message || "Failed to load bills", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+onMounted(load);
 
 const search = ref("");
 const rows = computed(() => {
-	let data = billsRes.data || [];
+	let data = allBills.value;
 	const q = search.value.trim().toLowerCase();
 	if (q)
 		data = data.filter(
 			(b) =>
 				(b.id || "").toLowerCase().includes(q) ||
 				(b.subcontractor || "").toLowerCase().includes(q) ||
-				(b.project || "").toLowerCase().includes(q),
+				(b.project || "").toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -96,13 +93,17 @@ function onRowClick(row) {
 			@row-click="onRowClick"
 		>
 			<template #cell-id="{ row }">
-				<DeskLink :to="`/subcontractor-bills/${row.id}`" class="font-mono text-xs" @click.stop>{{
-					row.id
-				}}</DeskLink>
+				<DeskLink
+					:to="`/subcontractor-bills/${row.id}`"
+					class="font-mono text-xs"
+					@click.stop
+					>{{ row.id }}</DeskLink
+				>
 			</template>
 			<template #cell-ra_no="{ row }">
 				<span class="text-xs text-ink-700"
-					>Bill {{ row.ra_no }}<span v-if="row.is_direct" class="text-ink-400"> · direct</span></span
+					>Bill {{ row.ra_no
+					}}<span v-if="row.is_direct" class="text-ink-400"> · direct</span></span
 				>
 			</template>
 			<template #cell-subcontractor="{ row }">
@@ -118,18 +119,27 @@ function onRowClick(row) {
 				<span class="text-xs tabular-nums font-medium">{{ fmtINR(row.gross) }}</span>
 			</template>
 			<template #cell-retention="{ row }">
-				<span class="text-xs tabular-nums text-warning-700">{{ fmtINR(row.retention) }}</span>
+				<span class="text-xs tabular-nums text-warning-700">{{
+					fmtINR(row.retention)
+				}}</span>
 			</template>
 			<template #cell-net="{ row }">
 				<span class="text-xs tabular-nums font-medium">{{ fmtINR(row.net) }}</span>
 			</template>
 			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" />
+				<div class="flex items-center gap-1.5">
+					<StatusBadge :status="row.status" />
+					<StatusBadge
+						v-if="row.payment_status"
+						:status="row.payment_status"
+						size="xs"
+					/>
+				</div>
 			</template>
 
 			<template #empty>
 				<div class="text-sm text-ink-500">
-					{{ billsRes.loading ? "Loading bills…" : "No subcontractor bills yet." }}
+					{{ loading ? "Loading bills…" : "No subcontractor bills yet." }}
 				</div>
 			</template>
 		</DeskList>

--- a/frontend/src/views/SubcontractorDetailView.vue
+++ b/frontend/src/views/SubcontractorDetailView.vue
@@ -35,7 +35,7 @@ const doc = computed(() => resource?.doc || null);
 
 // Linked Work Orders for this subcontractor.
 const wosRes = useDocTypeList("Subcontractor Work Order", {
-	fields: ["name", "project", "date", "total_value", "status"],
+	fields: ["name", "project", "date", "total_value", "docstatus"],
 	filters: [["subcontractor", "=", props.id]],
 	orderBy: "date desc",
 	pageLength: 0,
@@ -250,7 +250,14 @@ const breadcrumbs = computed(() => [
 									{{ fmtCompactINR(wo.total_value) }}
 								</td>
 								<td class="px-3 py-2">
-									<StatusBadge :status="wo.status" size="xs" />
+									<StatusBadge
+										:status="
+											{ 0: 'Draft', 1: 'Submitted', 2: 'Cancelled' }[
+												wo.docstatus
+											] || 'Draft'
+										"
+										size="xs"
+									/>
 								</td>
 							</tr>
 						</tbody>

--- a/frontend/src/views/SubcontractorDetailView.vue
+++ b/frontend/src/views/SubcontractorDetailView.vue
@@ -16,7 +16,7 @@ import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
-import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import TradePicker from "@/components/TradePicker.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 
@@ -62,7 +62,7 @@ watch(
 	(v) => {
 		if (v && !editing.value) form.value = snapshot();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 function startEdit() {
@@ -104,7 +104,9 @@ async function onDelete() {
 	const ok = await confirmDialog({
 		title: `Delete ${doc.value?.supplier_name}?`,
 		message: n
-			? `${n} work order${n === 1 ? "" : "s"} reference this subcontractor and would be left dangling.`
+			? `${n} work order${
+					n === 1 ? "" : "s"
+			  } reference this subcontractor and would be left dangling.`
 			: "This subcontractor master record will be removed permanently.",
 		confirmLabel: "Delete",
 		destructive: true,
@@ -182,7 +184,9 @@ const breadcrumbs = computed(() => [
 					</div></DeskField
 				>
 				<DeskField label="Trade"
-					><div class="text-sm text-ink-700">{{ doc.custom_trade || "—" }}</div></DeskField
+					><div class="text-sm text-ink-700">
+						{{ doc.custom_trade || "—" }}
+					</div></DeskField
 				>
 				<DeskField label="Status"
 					><StatusBadge :status="doc.disabled ? 'Inactive' : 'Active'"
@@ -265,13 +269,7 @@ const breadcrumbs = computed(() => [
 					><DeskInput v-model="form.subcontractor_name"
 				/></DeskField>
 				<DeskField label="Trade" required :error="errors.trade">
-					<DeskLinkPicker
-						v-model="form.trade"
-						doctype="Construction Trade"
-						label-field="name"
-						value-field="name"
-						placeholder="Pick a trade…"
-					/>
+					<TradePicker v-model="form.trade" :error="errors.trade" />
 				</DeskField>
 				<DeskField label="Status">
 					<DeskSelect v-model="form.status"

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -10,6 +10,7 @@ import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
+import { useDocTypeList } from "@/composables/useDocTypeList";
 import {
 	getWorkOrder,
 	submitWorkOrder,
@@ -56,6 +57,21 @@ const isDraft = computed(() => wo.value?.status === "Draft");
 const isSubmitted = computed(() => wo.value?.status === "Submitted");
 const isCancelled = computed(() => wo.value?.status === "Cancelled");
 const mbs = computed(() => measurements.value.books || []);
+
+// Bills raised against this WO (state derives from docstatus).
+const billsRes = useDocTypeList("Subcontractor Bill", {
+	fields: ["name", "ra_no", "date", "gross", "net_payable", "docstatus"],
+	filters: [["work_order", "=", props.id]],
+	orderBy: "ra_no asc",
+	pageLength: 0,
+	cache: `buildsuite-wo-bills-${props.id}`,
+});
+const bills = computed(() =>
+	(billsRes.data || []).map((b) => ({
+		...b,
+		status: { 0: "Draft", 1: "Submitted", 2: "Cancelled" }[b.docstatus] || "Draft",
+	}))
+);
 const measuredByLine = computed(() => measurements.value.measured_by_line || {});
 function lineMeasured(name) {
 	return Number(measuredByLine.value[name] || 0);
@@ -162,6 +178,7 @@ const tab = ref("sov");
 const tabs = computed(() => [
 	{ id: "sov", label: "Schedule of values" },
 	{ id: "measurements", label: "Measurements", count: mbs.value.length },
+	{ id: "bills", label: "Bills", count: bills.value.length },
 	{ id: "terms", label: "Terms" },
 ]);
 </script>
@@ -458,6 +475,64 @@ const tabs = computed(() => [
 			</div>
 			<div v-else class="text-xs text-ink-400 italic">
 				No measurements recorded yet against this WO.
+			</div>
+		</section>
+
+		<!-- Bills raised against this WO -->
+		<section v-if="tab === 'bills'">
+			<div class="flex items-center justify-between mb-2 gap-3">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+					Bills ({{ bills.length }})
+				</h3>
+				<button
+					v-if="isSubmitted"
+					type="button"
+					class="text-xs text-brand-700 hover:underline"
+					@click="onRaiseBill"
+				>
+					+ Bill progress
+				</button>
+			</div>
+			<div
+				v-if="bills.length"
+				class="bg-white border border-ink-200 rounded-lg overflow-x-auto"
+			>
+				<table class="w-full text-xs" style="min-width: 520px">
+					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="text-left px-3 py-2">Bill</th>
+							<th class="text-left px-3 py-2">Date</th>
+							<th class="text-right px-3 py-2">Gross</th>
+							<th class="text-right px-3 py-2">Net payable</th>
+							<th class="text-left px-3 py-2">Status</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="b in bills"
+							:key="b.name"
+							class="border-t border-ink-100 hover:bg-brand-50/30 cursor-pointer"
+							@click="router.push(`/subcontractor-bills/${b.name}`)"
+						>
+							<td class="px-3 py-2">
+								<DeskLink :to="`/subcontractor-bills/${b.name}`" @click.stop
+									>Bill {{ b.ra_no }}</DeskLink
+								>
+							</td>
+							<td class="px-3 py-2 text-ink-500">{{ fmtDate(b.date) }}</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+								{{ fmtINR(b.gross) }}
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+								{{ fmtINR(b.net_payable) }}
+							</td>
+							<td class="px-3 py-2"><StatusBadge :status="b.status" size="xs" /></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+			<div v-else class="text-xs text-ink-400 italic">
+				No bills raised yet against this WO.
 			</div>
 		</section>
 

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -10,7 +10,13 @@ import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
-import { getWorkOrder, applyWoAction, getWoMeasurements } from "@/data/subcontractApi";
+import {
+	getWorkOrder,
+	submitWorkOrder,
+	cancelWorkOrder,
+	amendWorkOrder,
+	getWoMeasurements,
+} from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
@@ -47,6 +53,8 @@ async function load() {
 watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => wo.value?.status === "Draft");
+const isSubmitted = computed(() => wo.value?.status === "Submitted");
+const isCancelled = computed(() => wo.value?.status === "Cancelled");
 const mbs = computed(() => measurements.value.books || []);
 const measuredByLine = computed(() => measurements.value.measured_by_line || {});
 function lineMeasured(name) {
@@ -65,21 +73,59 @@ function onPrint() {
 	router.push(`/subcontractor-work-orders/${wo.value.name}/print`);
 }
 
-async function onAction(action) {
+async function onSubmit() {
 	const ok = await confirmDialog({
-		title: `${action}?`,
-		message: `Apply "${action}" to ${wo.value.name}? This moves the work order to its next approval state.`,
-		confirmLabel: action,
+		title: `Submit ${wo.value.name}?`,
+		message: `Submit this work order for ${fmtINR(
+			wo.value.total_value
+		)}? It becomes committed cost and its schedule of values is locked.`,
+		confirmLabel: "Submit",
 	});
 	if (!ok) return;
 	busy.value = true;
 	try {
-		const res = await applyWoAction(wo.value.name, action);
-		wo.value.status = res.status;
+		const res = await submitWorkOrder(wo.value.name);
 		actions.value = res.actions || [];
-		showToast(`Work order is now ${res.status}.`);
+		delete res.actions;
+		wo.value = res;
+		showToast("Work order submitted.");
 	} catch (err) {
-		showToast(err.message || "Action failed", "error");
+		showToast(err.message || "Submit failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onCancel() {
+	const ok = await confirmDialog({
+		title: `Cancel ${wo.value.name}?`,
+		message:
+			"This cancels the work order. It's blocked if measurement books or bills exist against it.",
+		confirmLabel: "Cancel work order",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		const res = await cancelWorkOrder(wo.value.name);
+		actions.value = res.actions || [];
+		delete res.actions;
+		wo.value = res;
+		showToast("Work order cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onAmend() {
+	busy.value = true;
+	try {
+		const res = await amendWorkOrder(wo.value.name);
+		showToast("Amended — a fresh draft was created.");
+		router.push(`/subcontractor-work-orders/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Amend failed", "error");
 	} finally {
 		busy.value = false;
 	}
@@ -139,18 +185,17 @@ const tabs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-for="action in actions"
-				:key="action"
+				v-if="isDraft"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
 				:disabled="busy"
-				@click="onAction(action)"
+				@click="onSubmit"
 			>
-				{{ action }}
+				Submit
 			</button>
 			<button
-				v-if="!isDraft && wo.status !== 'Closed'"
+				v-if="isSubmitted"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-info-200 bg-info-50 hover:bg-info-100 text-info-700 font-medium"
 				style="border-radius: 6px"
@@ -160,14 +205,35 @@ const tabs = computed(() => [
 				+ Record measurement
 			</button>
 			<button
-				v-if="!isDraft && wo.status !== 'Closed'"
+				v-if="isSubmitted"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium inline-flex items-center"
 				style="border-radius: 6px"
-				title="Raise a bill against this work order (derives this period from certified Measurement Books)"
+				title="Bill progress against this work order (derives this period from certified Measurement Books)"
 				@click="onRaiseBill"
 			>
-				+ Raise Bill
+				+ Bill progress
+			</button>
+			<button
+				v-if="isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onCancel"
+			>
+				Cancel
+			</button>
+			<button
+				v-if="isCancelled"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				title="Create a fresh editable draft copy (the original stays cancelled)"
+				@click="onAmend"
+			>
+				Amend
 			</button>
 			<button
 				type="button"
@@ -179,6 +245,7 @@ const tabs = computed(() => [
 				Print / PDF
 			</button>
 			<button
+				v-if="!isSubmitted"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -341,7 +408,7 @@ const tabs = computed(() => [
 					Measurement books ({{ mbs.length }})
 				</h3>
 				<button
-					v-if="!isDraft && wo.status !== 'Closed'"
+					v-if="isSubmitted"
 					type="button"
 					class="text-xs text-brand-700 hover:underline"
 					@click="onRecordMeasurement"

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -20,11 +20,12 @@ const wosRes = useDocTypeList("Subcontractor Work Order", {
 		"date",
 		"delivery_type",
 		"total_value",
-		"status",
+		"docstatus",
 	],
 	orderBy: "date desc",
 	pageLength: 0,
 	cache: "buildsuite-subcontractor-wo-list",
+	// The WO is natively submittable — state is docstatus (Draft/Submitted/Cancelled), not a field.
 	transform: (data) =>
 		data.map((w) => ({
 			id: w.name,
@@ -33,7 +34,7 @@ const wosRes = useDocTypeList("Subcontractor Work Order", {
 			date: w.date,
 			delivery_type: w.delivery_type,
 			total_value: w.total_value,
-			status: w.status,
+			status: { 0: "Draft", 1: "Submitted", 2: "Cancelled" }[w.docstatus] || "Draft",
 		})),
 });
 
@@ -46,7 +47,7 @@ const rows = computed(() => {
 			(w) =>
 				(w.id || "").toLowerCase().includes(q) ||
 				(w.subcontractor || "").toLowerCase().includes(q) ||
-				(w.project || "").toLowerCase().includes(q),
+				(w.project || "").toLowerCase().includes(q)
 		);
 	return data;
 });

--- a/frontend/src/views/SubcontractorsListView.vue
+++ b/frontend/src/views/SubcontractorsListView.vue
@@ -28,16 +28,27 @@ const subsRes = useDocTypeList("Supplier", {
 		})),
 });
 
+// Trade filter — the Construction Trade master drives the dropdown.
+const tradesRes = useDocTypeList("Construction Trade", {
+	fields: ["name"],
+	orderBy: "name asc",
+	pageLength: 0,
+	cache: "buildsuite-construction-trades",
+});
+const tradeOptions = computed(() => (tradesRes.data || []).map((t) => t.name));
+const tradeFilter = ref("");
+
 const search = ref("");
 const rows = computed(() => {
 	let data = subsRes.data || [];
+	if (tradeFilter.value) data = data.filter((s) => s.trade === tradeFilter.value);
 	const q = search.value.trim().toLowerCase();
 	if (q)
 		data = data.filter(
 			(s) =>
 				(s.name || "").toLowerCase().includes(q) ||
 				(s.trade || "").toLowerCase().includes(q) ||
-				(s.tax_id || "").toLowerCase().includes(q),
+				(s.tax_id || "").toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -64,6 +75,14 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Subcontractors" :breadcrumbs="breadcrumbs">
 		<template #actions>
+			<select
+				v-model="tradeFilter"
+				class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white text-ink-700 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+				title="Filter by trade"
+			>
+				<option value="">All trades</option>
+				<option v-for="t in tradeOptions" :key="t" :value="t">{{ t }}</option>
+			</select>
 			<RouterLink to="/subcontractors/new" class="desk-save-btn">+ New</RouterLink>
 		</template>
 


### PR DESCRIPTION
Aligns the Subcontractor module with the updated prototype, in phases (one commit per phase on this branch so it can be reviewed incrementally). Architecture confirmed with the team: **real Purchase Invoice** kept, **native Frappe docstatus** for the Work Order + Bill workflow, and the existing **Construction Trade** master reused.

### Phases
- [x] **1 · Trade** — inline "+ New trade" create in the picker + Trade filter on the subcontractor list *(this commit)*
- [ ] **2 · Work Order** — native submittable (docstatus), drop manual status, cancel-blocking, terms + import-from-template, detail tabs, Print Format, committed cost counts Submitted only
- [ ] **3 · Measurement Book** — nos×L×B×D→qty, `is_deduction`, Draft/Certified lock, entry `cost_code` + `work_order_line`, button rename
- [ ] **4 · Subcontractor Bill** — labels, two creation modes, submit/cancel/amend, live waterfall, real PI on submit, payment + attachments + list badges
- [ ] **5 · BOQ roll-up** — committed = Submitted WO lines by cost code; actual = Submitted bill `this_period_amount` by cost code

### Phase 1 (this commit)
The Construction Trade master and `Supplier.custom_trade` link already existed; this fills the two prototype gaps:
- **TradePicker** component — the searchable Construction Trade picker with an inline **"+ New"** that creates a trade (saved permanently) and selects it; used on the subcontractor create + edit forms.
- **Subcontractor list** — a **Trade filter** dropdown driven by the Construction Trade master, alongside the existing search.

Frontend builds clean. Further phases will be pushed as commits to this branch.
