### PR TITLE
feat: project finance payments register

### DIFF
--- a/buildsuite_core/api/finance_payment.py
+++ b/buildsuite_core/api/finance_payment.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Project Finance › Payments — a unified register of party payments over ERPNext Payment
+Entries. Every invoice receipt, customer/supplier/subcontractor advance, bill payment and
+subcontractor payment IS a Payment Entry; this classifies each by direction (money in/out) and
+a friendly movement type, and cancels (reverses) one on request. Petty-cash disbursements are
+NOT payments (internal float transfer) — they live under Petty Cash. Single-company for now."""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+from buildsuite_core.utils.project import default_company
+
+PE = "Payment Entry"
+PI = "Purchase Invoice"
+SUPPLIER = "Supplier"
+
+
+def _subcontractor_suppliers():
+	return set(frappe.get_all(SUPPLIER, filters={"supplier_type": "Subcontractor"}, pluck="name"))
+
+
+def _classify(pe, refs, sub_suppliers):
+	"""Derive (movement type, direction, bank/cash account, reference) for a Payment Entry.
+	Receive → money in (customer receipt/advance); Pay → money out (bill/advance/subcontractor)."""
+	allocated = sum(flt(r.allocated_amount) for r in refs)
+	ref_name = refs[0].reference_name if refs else None
+
+	if pe.payment_type == "Receive":
+		movement = "Invoice receipt" if allocated > 0.01 else "Customer advance"
+		return movement, "in", pe.paid_to, ref_name
+
+	# Pay
+	if allocated > 0.01:
+		pi_ref = next((r.reference_name for r in refs if r.reference_doctype == PI), None)
+		sub_bill = frappe.db.get_value(PI, pi_ref, "subcontractor_bill") if pi_ref else None
+		if sub_bill:
+			return "Subcontractor payment", "out", pe.paid_from, sub_bill
+		return "Bill payment", "out", pe.paid_from, ref_name
+	movement = "Subcontractor advance" if pe.party in sub_suppliers else "Supplier advance"
+	return movement, "out", pe.paid_from, ref_name
+
+
+@frappe.whitelist()
+def list_payments(company=None):
+	"""Every submitted party Payment Entry for the active (default) company, newest first."""
+	company = company or default_company()
+	pes = frappe.get_all(
+		PE,
+		filters={
+			"docstatus": 1,
+			"company": company,
+			"payment_type": ["in", ["Receive", "Pay"]],
+			"party_type": ["in", ["Customer", SUPPLIER]],
+		},
+		fields=[
+			"name",
+			"payment_type",
+			"party_type",
+			"party",
+			"party_name",
+			"posting_date",
+			"paid_amount",
+			"paid_from",
+			"paid_to",
+			"mode_of_payment",
+			"reference_no",
+		],
+		order_by="posting_date desc, creation desc",
+	)
+	if not pes:
+		return []
+
+	refs = frappe.get_all(
+		"Payment Entry Reference",
+		filters={"parent": ["in", [p.name for p in pes]], "docstatus": 1},
+		fields=["parent", "reference_doctype", "reference_name", "allocated_amount"],
+	)
+	refs_by_pe = {}
+	for r in refs:
+		refs_by_pe.setdefault(r.parent, []).append(r)
+
+	sub_suppliers = _subcontractor_suppliers()
+	out = []
+	for p in pes:
+		movement, direction, account, ref_name = _classify(p, refs_by_pe.get(p.name, []), sub_suppliers)
+		out.append(
+			{
+				"name": p.name,
+				"date": str(p.posting_date) if p.posting_date else None,
+				"type": movement,
+				"party": p.party_name or p.party,
+				"account": account,
+				"dir": direction,
+				"amount": flt(p.paid_amount),
+				"mode_of_payment": p.mode_of_payment,
+				"reference_no": p.reference_no,
+				"ref": ref_name,
+			}
+		)
+	return out
+
+
+@frappe.whitelist()
+def cancel_payment(name):
+	"""Cancel (reverse) a Payment Entry. ERPNext discipline: posted transactions are cancelled,
+	not edited — the linked invoice/bill outstanding (or the party's unallocated advance)
+	recomputes automatically. Record a fresh payment if it was entered wrongly."""
+	pe = frappe.get_doc(PE, name)
+	pe.check_permission("cancel")
+	pe.flags.ignore_permissions = True
+	pe.cancel()
+	return {"name": name, "cancelled": True}

--- a/frontend/src/data/financePaymentApi.js
+++ b/frontend/src/data/financePaymentApi.js
@@ -1,0 +1,18 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Project Finance › Payments — the unified party-payment register over ERPNext Payment Entries
+// (buildsuite_core.api.finance_payment.*). Cancel reverses a posted Payment Entry.
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.finance_payment.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const listFinancePayments = () => call("list_payments", {});
+export const cancelFinancePayment = (name) => call("cancel_payment", { name });

--- a/frontend/src/views/finance/FinancePaymentsPanel.vue
+++ b/frontend/src/views/finance/FinancePaymentsPanel.vue
@@ -1,51 +1,338 @@
 <script setup>
-import { computed, ref } from "vue";
-import { useFinanceMock } from "@/data/financeMock";
+// S229 — Project Finance › Payments. Unified register of party payments
+// (invoice receipts, customer/supplier/subcontractor advances, bill payments,
+// subcontractor payment entries) with a Cancel action per row. Petty-cash
+// disbursements are NOT payments (internal float transfer); they're managed
+// under Petty Cash. Backed by real ERPNext Payment Entries
+// (buildsuite_core.api.finance_payment.*).
+// ERPNext discipline: posted transactions are CANCELLED (reversed), never
+// edited — cancel the wrong entry and record a fresh one. Because all balances
+// are derived, cancelling recomputes accounts / outstandings / floats cleanly.
+import { ref, computed, onMounted } from "vue";
+import { useDataStore } from "@/stores";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskSelect from "@/components/desk/DeskSelect.vue";
-import { fmtDate, fmtINR } from "@/utils/format";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import { fmtINR, fmtDate } from "@/utils/format";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import { listFinancePayments, cancelFinancePayment } from "@/data/financePaymentApi";
 
-const fin = useFinanceMock();
+const store = useDataStore();
+const confirmDialog = useConfirm();
+
+const canManage = computed(() => store.isAdmin);
+
+const movements = ref([]);
+const loading = ref(true);
+async function load() {
+	loading.value = true;
+	try {
+		movements.value = await listFinancePayments();
+	} catch (err) {
+		showToast(err.message || "Failed to load payments", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+onMounted(load);
+
+// ---- filters (S244f — full set, S243 pattern) ----
 const search = ref("");
-const dir = ref("");
-const rows = computed(() => {
-	const q = search.value.trim().toLowerCase();
-	return fin.allPayments.filter(
-		(p) => (!dir.value || p.dir === dir.value) && (!q || (p.type || "").toLowerCase().includes(q) || (p.party || "").toLowerCase().includes(q) || (p.ref || "").toLowerCase().includes(q)),
+const dirFilter = ref(""); // '' | 'in' | 'out'
+const accFilter = ref(""); // '' | account name
+const typeFilter = ref(""); // '' | movement type label
+const partyFilter = ref(""); // '' | party display name
+const from = ref("");
+const to = ref("");
+const amtMin = ref("");
+const amtMax = ref("");
+
+const MOVEMENT_TYPES = [
+	"Invoice receipt",
+	"Customer advance",
+	"Bill payment",
+	"Supplier advance",
+	"Subcontractor advance",
+	"Subcontractor payment",
+];
+const hasFilters = computed(
+	() =>
+		search.value ||
+		dirFilter.value ||
+		accFilter.value ||
+		typeFilter.value ||
+		partyFilter.value ||
+		from.value ||
+		to.value ||
+		amtMin.value !== "" ||
+		amtMax.value !== ""
+);
+function clearFilters() {
+	search.value = "";
+	dirFilter.value = "";
+	accFilter.value = "";
+	typeFilter.value = "";
+	partyFilter.value = "";
+	from.value = "";
+	to.value = "";
+	amtMin.value = "";
+	amtMax.value = "";
+}
+function inPeriod(d) {
+	return (!from.value || d >= from.value) && (!to.value || d <= to.value);
+}
+function inAmountRange(n) {
+	return (
+		(amtMin.value === "" || n >= (Number(amtMin.value) || 0)) &&
+		(amtMax.value === "" || n <= (Number(amtMax.value) || Infinity))
+	);
+}
+
+// Distinct accounts + parties across the register — the filter pools.
+const accountOptions = computed(() =>
+	[...new Set(movements.value.map((m) => m.account).filter(Boolean))].sort((a, b) =>
+		a.localeCompare(b)
+	)
+);
+const partyOptions = computed(() => {
+	const names = [...new Set(movements.value.map((m) => m.party).filter(Boolean))].sort((a, b) =>
+		a.localeCompare(b)
+	);
+	return names.map((n) => ({ value: n, label: n }));
+});
+
+const filtered = computed(() => {
+	const term = search.value.trim().toLowerCase();
+	return movements.value.filter(
+		(m) =>
+			(!dirFilter.value || m.dir === dirFilter.value) &&
+			(!accFilter.value || m.account === accFilter.value) &&
+			(!typeFilter.value || m.type === typeFilter.value) &&
+			(!partyFilter.value || m.party === partyFilter.value) &&
+			inPeriod(m.date) &&
+			inAmountRange(m.amount) &&
+			(!term ||
+				m.type.toLowerCase().includes(term) ||
+				(m.party || "").toLowerCase().includes(term) ||
+				(m.account || "").toLowerCase().includes(term) ||
+				(m.ref || "").toLowerCase().includes(term))
 	);
 });
-const totalIn = computed(() => fin.allPayments.filter((p) => p.dir === "in").reduce((a, p) => a + p.amount, 0));
-const totalOut = computed(() => fin.allPayments.filter((p) => p.dir === "out").reduce((a, p) => a + p.amount, 0));
+const totalIn = computed(() =>
+	filtered.value.filter((m) => m.dir === "in").reduce((a, m) => a + m.amount, 0)
+);
+const totalOut = computed(() =>
+	filtered.value.filter((m) => m.dir === "out").reduce((a, m) => a + m.amount, 0)
+);
+
+const CANCEL_NOTE = {
+	in: "The invoice's outstanding goes back up (or the customer advance is removed).",
+	out: "The bill's outstanding goes back up (or the advance paid is removed).",
+};
+async function onCancel(m) {
+	const ok = await confirmDialog({
+		title: `Cancel this ${m.type.toLowerCase()}?`,
+		message: `${m.type} of ${fmtINR(m.amount)} — ${m.party} (${fmtDate(m.date)}).\n\n${
+			CANCEL_NOTE[m.dir]
+		} Record a fresh transaction if it was entered wrongly — posted entries are cancelled, not edited.`,
+		confirmLabel: "Cancel transaction",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await cancelFinancePayment(m.name);
+		await load();
+		showToast("Transaction cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	}
+}
+
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Payments" }];
 </script>
 
 <template>
 	<DeskPage title="Payments" :breadcrumbs="breadcrumbs">
-		<div class="grid grid-cols-2 md:grid-cols-3 gap-3 mb-4">
-			<div class="bg-white border border-ink-200 rounded-lg px-3 py-2"><div class="text-[10px] uppercase tracking-wider text-ink-500">Money in</div><div class="text-base font-semibold text-success-700 tabular-nums">{{ fmtINR(totalIn) }}</div></div>
-			<div class="bg-white border border-ink-200 rounded-lg px-3 py-2"><div class="text-[10px] uppercase tracking-wider text-ink-500">Money out</div><div class="text-base font-semibold text-danger-700 tabular-nums">{{ fmtINR(totalOut) }}</div></div>
-			<div class="bg-white border border-ink-200 rounded-lg px-3 py-2"><div class="text-[10px] uppercase tracking-wider text-ink-500">Net</div><div class="text-base font-semibold text-ink-900 tabular-nums">{{ fmtINR(totalIn - totalOut) }}</div></div>
-		</div>
-		<div class="flex items-center gap-2 mb-2">
-			<input v-model="search" placeholder="Search type / party / ref…" class="desk-input max-w-xs" />
-			<DeskSelect v-model="dir" class="!w-40"><option value="">Direction: Any</option><option value="in">Money in</option><option value="out">Money out</option></DeskSelect>
-		</div>
-		<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
-			<table class="w-full text-xs" style="min-width: 640px">
-				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
-					<tr><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Type</th><th class="text-left px-3 py-2">Party</th><th class="text-left px-3 py-2">Account</th><th class="text-right px-3 py-2">Amount</th></tr>
-				</thead>
-				<tbody>
-					<tr v-for="p in rows" :key="p.id" class="border-t border-ink-100">
-						<td class="px-3 py-2 text-ink-500">{{ fmtDate(p.date) }}</td>
-						<td class="px-3 py-2 text-ink-900">{{ p.type }}</td>
-						<td class="px-3 py-2 text-ink-700">{{ p.party || "—" }}</td>
-						<td class="px-3 py-2 text-ink-500">{{ fin.accountById(p.account)?.name || p.account }}</td>
-						<td class="px-3 py-2 text-right tabular-nums font-medium" :class="p.dir === 'in' ? 'text-success-700' : 'text-danger-700'">{{ p.dir === "in" ? "+" : "−" }}{{ fmtINR(p.amount) }}</td>
-					</tr>
-					<tr v-if="!rows.length"><td colspan="5" class="px-3 py-4 text-center text-ink-400 italic">No movements.</td></tr>
-				</tbody>
-			</table>
+		<div class="space-y-4">
+			<div class="flex items-center gap-2 flex-wrap">
+				<input
+					v-model="search"
+					type="text"
+					placeholder="Search type, party, account, reference…"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-64 max-w-full"
+				/>
+				<select
+					v-model="typeFilter"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				>
+					<option value="">All types</option>
+					<option v-for="t in MOVEMENT_TYPES" :key="t" :value="t">{{ t }}</option>
+				</select>
+				<select
+					v-model="dirFilter"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				>
+					<option value="">In &amp; out</option>
+					<option value="in">Money in</option>
+					<option value="out">Money out</option>
+				</select>
+				<select
+					v-model="accFilter"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				>
+					<option value="">All accounts</option>
+					<option v-for="a in accountOptions" :key="a" :value="a">{{ a }}</option>
+				</select>
+				<div class="w-52">
+					<DeskSearchableSelect
+						v-model="partyFilter"
+						:options="partyOptions"
+						allow-clear
+						placeholder="All parties"
+						search-placeholder="Search parties…"
+					/>
+				</div>
+				<div class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>From</span
+					>
+					<input
+						v-model="from"
+						type="date"
+						class="text-xs px-2 py-1 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+					/>
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>To</span
+					>
+					<input
+						v-model="to"
+						type="date"
+						class="text-xs px-2 py-1 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+					/>
+				</div>
+				<div class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>₹</span
+					>
+					<input
+						v-model.number="amtMin"
+						type="number"
+						min="0"
+						placeholder="Min"
+						class="text-xs px-2 py-1 border border-ink-200 rounded-md w-20 text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200"
+					/>
+					<span class="text-ink-400 text-xs">–</span>
+					<input
+						v-model.number="amtMax"
+						type="number"
+						min="0"
+						placeholder="Max"
+						class="text-xs px-2 py-1 border border-ink-200 rounded-md w-24 text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200"
+					/>
+				</div>
+				<button
+					v-if="hasFilters"
+					type="button"
+					class="text-[11px] text-danger-600 hover:underline"
+					@click="clearFilters"
+				>
+					Clear filters
+				</button>
+				<div class="ml-auto flex items-center gap-4 text-xs">
+					<div>
+						<span class="text-ink-500">In</span>
+						<span class="tabular-nums text-success-700 font-medium">{{
+							fmtINR(totalIn)
+						}}</span>
+					</div>
+					<div>
+						<span class="text-ink-500">Out</span>
+						<span class="tabular-nums text-danger-700 font-medium">{{
+							fmtINR(totalOut)
+						}}</span>
+					</div>
+					<span class="text-ink-400"
+						>{{ filtered.length }} transaction{{
+							filtered.length === 1 ? "" : "s"
+						}}</span
+					>
+				</div>
+			</div>
+
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<table v-if="filtered.length" class="w-full text-xs">
+					<thead
+						class="text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200 bg-ink-50"
+					>
+						<tr>
+							<th class="text-left px-4 py-2">Date</th>
+							<th class="text-left px-4 py-2">Type</th>
+							<th class="text-left px-4 py-2">Party</th>
+							<th class="text-left px-4 py-2">Account</th>
+							<th class="text-left px-4 py-2">Ref</th>
+							<th class="text-right px-4 py-2">In</th>
+							<th class="text-right px-4 py-2">Out</th>
+							<th class="px-4 py-2"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="m in filtered"
+							:key="m.name"
+							class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30"
+						>
+							<td class="px-4 py-2.5 text-ink-500 whitespace-nowrap">
+								{{ fmtDate(m.date) }}
+							</td>
+							<td class="px-4 py-2.5">
+								<span
+									class="text-[10px] px-1.5 py-0.5 rounded-full"
+									:class="
+										m.dir === 'in'
+											? 'bg-success-50 text-success-700'
+											: 'bg-warning-50 text-warning-700'
+									"
+									>{{ m.type }}</span
+								>
+							</td>
+							<td class="px-4 py-2.5 text-ink-900">{{ m.party }}</td>
+							<td class="px-4 py-2.5 text-ink-500">{{ m.account || "—" }}</td>
+							<td class="px-4 py-2.5 font-mono text-ink-400 text-[10px]">
+								{{ m.ref || "—" }}
+							</td>
+							<td class="px-4 py-2.5 text-right tabular-nums text-success-700">
+								{{ m.dir === "in" ? fmtINR(m.amount) : "" }}
+							</td>
+							<td class="px-4 py-2.5 text-right tabular-nums text-danger-700">
+								{{ m.dir === "out" ? fmtINR(m.amount) : "" }}
+							</td>
+							<td class="px-4 py-2.5 text-right">
+								<button
+									v-if="canManage"
+									type="button"
+									class="text-[11px] text-danger-600 hover:underline"
+									@click="onCancel(m)"
+								>
+									Cancel
+								</button>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+				<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">
+					{{
+						loading
+							? "Loading payments…"
+							: hasFilters
+							? "No transactions match the filters."
+							: "No transactions recorded yet."
+					}}
+				</div>
+			</section>
+			<p class="text-[11px] text-ink-400">
+				Posted transactions are cancelled, not edited — cancel the wrong entry and record a
+				fresh one. All balances and outstandings recompute automatically.
+			</p>
 		</div>
 	</DeskPage>
 </template>


### PR DESCRIPTION
## Summary

Adds the **Project Finance › Payments** register — a unified view of all party payments, backed by real ERPNext Payment Entries (no mock data). Matches the prototype UI.

Every invoice receipt, customer/supplier/subcontractor advance, bill payment and subcontractor payment *is* a Payment Entry; this classifies each by:
- **direction** — money in (customer receipts/advances) vs money out (bills/advances/subcontractor payments)
- **movement type** — Invoice receipt · Customer advance · Bill payment · Supplier advance · Subcontractor advance · Subcontractor payment

Petty-cash disbursements are deliberately excluded (internal float transfer, managed under Petty Cash).

### Cancel, not edit
Following ERPNext discipline, a row's **Cancel** reverses (cancels) the posted Payment Entry rather than editing it — the linked invoice/bill outstanding or the party's unallocated advance recomputes automatically. Cancel is gated on `store.isAdmin` and the backend re-checks `cancel` permission.

### Changes
- `buildsuite_core/api/finance_payment.py` — `list_payments` (classify + serialize submitted party PEs for the default company) and `cancel_payment`
- `frontend/src/data/financePaymentApi.js` — `listFinancePayments` / `cancelFinancePayment`
- `frontend/src/views/finance/FinancePaymentsPanel.vue` — prototype filter bar (search, type, direction, account, searchable party, date range, amount range, clear), In/Out totals + count, register table, and the cancel-confirm flow; was mock-backed, now live

Single-company for now (routes via `default_company()`).

### Verification
- `list_payments()` on bs.local returns 14 classified transactions (6 Invoice receipts, 5 Bill payments, 3 Subcontractor payments)
- `vite build --mode development` compiles clean