### PR TITLE
fix: BOQ submit, MB header/fields, project-delete message, SCO picker

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -340,10 +340,24 @@ _MB_ENTRY_FIELDS = (
 
 
 def _serialize_mb(doc):
+	# Project name + the WO's subcontractor / delivery type surface on the MB
+	# header (second line + the Project and Work Order summary cards).
+	project_name = frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None
+	wo = (
+		frappe.db.get_value(
+			WORK_ORDER, doc.work_order, ["subcontractor", "subcontractor_name", "delivery_type"], as_dict=True
+		)
+		if doc.work_order
+		else None
+	) or {}
 	return {
 		"name": doc.name,
 		"work_order": doc.work_order,
 		"project": doc.project,
+		"project_name": project_name,
+		"subcontractor": wo.get("subcontractor"),
+		"subcontractor_name": wo.get("subcontractor_name"),
+		"delivery_type": wo.get("delivery_type"),
 		"date": str(doc.date) if doc.date else None,
 		"measured_by": doc.measured_by,
 		"certified_by": doc.certified_by,

--- a/buildsuite_core/utils/project.py
+++ b/buildsuite_core/utils/project.py
@@ -102,20 +102,43 @@ def _projects_in_tree(project):
 
 
 def _assert_no_financial_links(project_names):
+	"""Block deletion when accounting/stock documents reference the project (or a
+	subproject), and name each linked document type with its count so the user knows
+	exactly what to remove or reassign first."""
+	counts = {}  # document type -> number of linked records
 	for doctype, field in _FINANCIAL_LINKS:
 		if not frappe.db.exists("DocType", doctype):
 			continue
-		# Only consider field if it exists on the doctype.
 		meta = frappe.get_meta(doctype)
 		if not meta.has_field(field):
 			continue
-		if frappe.db.exists(doctype, {field: ("in", project_names)}):
-			frappe.throw(
-				_(
-					"Cannot delete: {0} records are linked to this project (or a subproject). "
-					"Remove the accounting/stock entries first."
-				).format(doctype)
+		if meta.istable:
+			# Child table (e.g. Journal Entry Account) — report the parent document
+			# (Journal Entry), counting each parent once.
+			rows = frappe.get_all(
+				doctype, filters={field: ("in", project_names)}, fields=["parenttype", "parent"]
 			)
+			for ptype, _parent in {(r.parenttype, r.parent) for r in rows}:
+				counts[ptype] = counts.get(ptype, 0) + 1
+		else:
+			n = frappe.db.count(doctype, {field: ("in", project_names)})
+			if n:
+				counts[doctype] = counts.get(doctype, 0) + n
+
+	if not counts:
+		return
+
+	# GL Entry is a ledger derivative of the source documents — drop it from the
+	# message when a real document already explains the block.
+	if len(counts) > 1:
+		counts.pop("GL Entry", None)
+
+	linked = ", ".join(f"{dt} ({n})" for dt, n in counts.items())
+	frappe.throw(
+		_(
+			"Cannot delete this project — it has linked records in {0}. Remove or reassign these first."
+		).format(linked)
+	)
 
 
 def cascade_delete_project(doc, method=None):
@@ -261,9 +284,7 @@ def seed_from_template_on_insert(doc, method=None):
 		try:
 			_seed_stages_from_template(doc, template, tasks_by_stage)
 		except Exception:
-			frappe.log_error(
-				frappe.get_traceback(), f'BuildSuite: seed stages for project "{doc.name}"'
-			)
+			frappe.log_error(frappe.get_traceback(), f'BuildSuite: seed stages for project "{doc.name}"')
 
 
 @frappe.whitelist()

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -1028,7 +1028,7 @@ const breadcrumbs = computed(() => {
 					:show-save="showPrimary"
 					:save-label="primaryLabel"
 					:show-cancel="false"
-					@save="onPrimary"
+					@save="primaryAction"
 				>
 					<template #left>
 						<span v-if="sourceSco" class="text-xs text-ink-500">
@@ -2144,9 +2144,15 @@ const breadcrumbs = computed(() => {
 							label="Linked SCO"
 							hint="Optional reference to a Scope Change Order this revision addresses."
 						>
-							<DeskInput
+							<DeskLinkPicker
 								v-model="revisionModal.sourceSco"
-								placeholder="e.g. SCO-2026-0007"
+								doctype="Scope Change Order"
+								label-field="title"
+								value-field="name"
+								:search-fields="['title', 'name']"
+								:filters="[['project', '=', boq.projectId]]"
+								order-by="creation desc"
+								placeholder="Search this project's SCOs…"
 							/>
 						</DeskField>
 						<DeskField

--- a/frontend/src/views/MeasurementBookDetailView.vue
+++ b/frontend/src/views/MeasurementBookDetailView.vue
@@ -119,7 +119,7 @@ const breadcrumbs = computed(() => [
 	<DeskPage
 		v-if="mb"
 		:title="mb.name"
-		:subtitle="`${mb.project} · ${mb.work_order}`"
+		:subtitle="`${mb.project_name || mb.project} · ${mb.subcontractor_name || ''}`"
 		:breadcrumbs="breadcrumbs"
 		:status="mb.status"
 	>
@@ -164,7 +164,15 @@ const breadcrumbs = computed(() => [
 		</template>
 
 		<!-- Summary strip -->
-		<div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
+		<div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Project
+				</div>
+				<div class="text-sm text-ink-900 mt-0.5 truncate">
+					{{ mb.project_name || mb.project }}
+				</div>
+			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Work order
@@ -174,7 +182,10 @@ const breadcrumbs = computed(() => [
 						mb.work_order
 					}}</DeskLink>
 				</div>
-				<div class="text-[10px] text-ink-500">{{ mb.project }}</div>
+				<div class="text-[10px] text-ink-500">
+					{{ mb.subcontractor_name || "—"
+					}}{{ mb.delivery_type ? ` · ${mb.delivery_type}` : "" }}
+				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">

--- a/frontend/src/views/NewMeasurementBookView.vue
+++ b/frontend/src/views/NewMeasurementBookView.vue
@@ -53,6 +53,9 @@ const form = ref({
 	entries: [emptyEntry()],
 });
 const woLines = ref([]); // [{ name, scope, cost_code_*, uom }]
+// Project + Subcontractor surface read-only on the header, derived from the WO.
+const woProjectName = ref("");
+const woSubName = ref("");
 const errors = ref({});
 const saving = ref(false);
 const loading = ref(false);
@@ -71,11 +74,15 @@ function costCodeFromFields(src) {
 async function loadWorkOrder(wo, { autofillFirst = false } = {}) {
 	if (!wo) {
 		woLines.value = [];
+		woProjectName.value = "";
+		woSubName.value = "";
 		return;
 	}
 	try {
 		const doc = await getWorkOrder(wo);
 		form.value.project = doc.project || "";
+		woProjectName.value = doc.project_name || doc.project || "";
+		woSubName.value = doc.subcontractor_name || doc.subcontractor || "";
 		woLines.value = doc.lines || [];
 		// Single-line WO: default the first blank entry to that line.
 		if (
@@ -130,6 +137,8 @@ watch(
 				};
 				if (!form.value.entries.length) form.value.entries = [emptyEntry()];
 				woLines.value = mb.wo_lines || [];
+				woProjectName.value = mb.project_name || mb.project || "";
+				woSubName.value = mb.subcontractor_name || "";
 			} catch (err) {
 				showToast(err.message || "Failed to load measurement book", "error");
 			} finally {
@@ -139,7 +148,7 @@ watch(
 			loadWorkOrder(form.value.work_order, { autofillFirst: true });
 		}
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 // In create mode, reloading WO lines when the user changes the WO picker.
@@ -149,15 +158,20 @@ function onWorkOrderChange(wo) {
 }
 
 const woLineOptions = computed(() =>
-	woLines.value.map((l) => ({ value: l.name, label: l.scope || l.name })),
+	woLines.value.map((l) => ({ value: l.name, label: l.scope || l.name }))
 );
 
-// Picking a WO line for an entry defaults its cost code + uom from that line.
+// Changing the WO line on a row recomputes its dependent fields (cost code +
+// UOM) from the newly selected line, so they never stay stale on the old line.
 function onEntryLineChange(entry) {
 	const line = woLines.value.find((l) => l.name === entry.work_order_line);
-	if (!line) return;
-	if (!entry.cost_code) entry.cost_code = costCodeFromFields(line);
-	if (!entry.uom) entry.uom = line.uom || "";
+	if (!line) {
+		entry.cost_code = null;
+		entry.uom = "";
+		return;
+	}
+	entry.cost_code = costCodeFromFields(line);
+	entry.uom = line.uom || "";
 }
 
 function roundQty(n) {
@@ -168,7 +182,7 @@ function derivedQty(e) {
 		(Number(e.nos) || 0) *
 			(Number(e.length) || 0) *
 			(Number(e.breadth) || 0) *
-			(Number(e.depth) || 0),
+			(Number(e.depth) || 0)
 	);
 }
 function previewQty(e) {
@@ -187,7 +201,7 @@ function clearOverride(e) {
 }
 
 const measuredTotal = computed(() =>
-	form.value.entries.reduce((a, e) => a + (e.is_deduction ? -1 : 1) * previewQty(e), 0),
+	form.value.entries.reduce((a, e) => a + (e.is_deduction ? -1 : 1) * previewQty(e), 0)
 );
 
 function addRow() {
@@ -197,10 +211,18 @@ function removeRow(idx) {
 	form.value.entries.splice(idx, 1);
 }
 
+// A complete entry needs Description, WO line and UOM (cost code is optional).
+function entryIncomplete(e) {
+	return !(e.description || "").trim() || !e.work_order_line || !(e.uom || "").trim();
+}
 function validate() {
 	const e = {};
 	if (!form.value.work_order) e.work_order = "Pick a work order.";
-	if (!form.value.entries.length) e.entries = "Add at least one measurement entry.";
+	if (!form.value.entries.length) {
+		e.entries = "Add at least one measurement entry.";
+	} else if (form.value.entries.some(entryIncomplete)) {
+		e.entries = "Each entry needs a description, WO line and UOM.";
+	}
 	errors.value = e;
 	return Object.keys(e).length === 0;
 }
@@ -256,10 +278,10 @@ function onCancel() {
 }
 
 const pageTitle = computed(() =>
-	isEdit.value ? `Edit ${editingId.value}` : "New Measurement Book",
+	isEdit.value ? `Edit ${editingId.value}` : "New Measurement Book"
 );
 const saveLabel = computed(() =>
-	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Create MB",
+	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Create MB"
 );
 const breadcrumbs = computed(() => [
 	{ label: "BuildSuite Core", to: "/" },
@@ -269,7 +291,7 @@ const breadcrumbs = computed(() => [
 		? [
 				{ label: editingId.value, to: `/measurement-books/${editingId.value}` },
 				{ label: "Edit" },
-			]
+		  ]
 		: [{ label: "New" }]),
 ]);
 </script>
@@ -296,6 +318,23 @@ const breadcrumbs = computed(() => [
 						placeholder="Pick a work order…"
 						@update:model-value="onWorkOrderChange"
 					/>
+				</DeskField>
+				<!-- Read-only, derived from the work order. -->
+				<DeskField label="Project" hint="Derived from the work order.">
+					<div
+						class="text-sm pt-1.5"
+						:class="form.work_order ? 'text-ink-900' : 'text-ink-400'"
+					>
+						{{ form.work_order ? woProjectName || form.project || "—" : "—" }}
+					</div>
+				</DeskField>
+				<DeskField label="Subcontractor" hint="Derived from the work order.">
+					<div
+						class="text-sm pt-1.5"
+						:class="form.work_order ? 'text-ink-900' : 'text-ink-400'"
+					>
+						{{ form.work_order ? woSubName || "—" : "—" }}
+					</div>
 				</DeskField>
 				<DeskField label="Date" required
 					><DeskInput v-model="form.date" type="date"
@@ -333,15 +372,21 @@ const breadcrumbs = computed(() => [
 						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
 							<tr>
 								<th class="text-left px-2 py-2 w-8">#</th>
-								<th class="text-left px-2 py-2 min-w-[160px]">Description</th>
-								<th class="text-left px-2 py-2 min-w-[130px]">WO line</th>
+								<th class="text-left px-2 py-2 min-w-[160px]">
+									Description <span class="text-danger-600">*</span>
+								</th>
+								<th class="text-left px-2 py-2 min-w-[130px]">
+									WO line <span class="text-danger-600">*</span>
+								</th>
 								<th class="text-left px-2 py-2 min-w-[130px]">Cost code</th>
 								<th class="text-right px-2 py-2 w-14">Nos</th>
 								<th class="text-right px-2 py-2 w-16">L</th>
 								<th class="text-right px-2 py-2 w-16">B</th>
 								<th class="text-right px-2 py-2 w-14">D</th>
 								<th class="text-right px-2 py-2 w-20">Qty</th>
-								<th class="text-left px-2 py-2 w-20">UOM</th>
+								<th class="text-left px-2 py-2 w-20">
+									UOM <span class="text-danger-600">*</span>
+								</th>
 								<th class="text-center px-2 py-2 w-14">Deduct</th>
 								<th class="text-center px-2 py-2 w-8"></th>
 							</tr>

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -452,11 +452,37 @@ const stageBaseFilters = computed(() => {
 });
 
 // Scope Change Orders tab — backend-backed, scoped to the project + its subprojects.
+// scoCount tracks the live count emitted by the tab's list while it's open; the
+// eager count below shows the tab badge without the user opening the tab first.
 const scoCount = ref(null);
 const scoBaseFilters = computed(() => {
 	const ids = workPackageProjectIds.value;
 	if (!ids.length) return [];
 	return [["project", "in", ids]];
+});
+
+// Eagerly fetch the SCO count (not behind the tab v-if) so the "Scope Changes"
+// badge shows a number on first render — mirrors the attachment-count pattern.
+const scoCountResource = ref(null);
+function loadScoCount() {
+	const ids = workPackageProjectIds.value;
+	if (!ids.length) {
+		scoCountResource.value = null;
+		return;
+	}
+	scoCountResource.value = adapter.list("Scope Change Order", {
+		filters: [["project", "in", ids]],
+		fields: ["name"],
+		pageLength: 500,
+	});
+}
+watch(workPackageProjectIds, loadScoCount, { immediate: true });
+
+const scoCountEager = computed(() => {
+	const raw = scoCountResource.value?.data;
+	if (Array.isArray(raw)) return raw.length;
+	if (Array.isArray(raw?.value)) return raw.value.length;
+	return null;
 });
 
 // Attachment count — fetched eagerly (not behind the tab v-if) so the badge
@@ -974,7 +1000,7 @@ const tabs = computed(() => {
 		{ id: "tasks", label: "Tasks", count: tasks.value.length },
 		{ id: "stage-planning", label: "Stage Planning", count: stageCount.value },
 		{ id: "boq", label: "BOQ", count: boqs.value.length },
-		{ id: "scos", label: "Scope Changes", count: scoCount.value },
+		{ id: "scos", label: "Scope Changes", count: scoCountEager.value ?? scoCount.value },
 		{ id: "attachments", label: "Attachments", count: attachmentCount.value },
 		{ id: "team", label: "Team", count: projectTeam.value.length },
 	];

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -6,7 +6,7 @@ import { usePageTitle } from "@/composables/usePageTitle";
 
 import { ref, computed, watch, nextTick } from "vue";
 import AccessDenied from "@/components/AccessDenied.vue";
-import { isPermissionDenied } from "@/utils/frappeError";
+import { isPermissionDenied, parseFrappeError } from "@/utils/frappeError";
 import { useRouter, useRoute, RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
@@ -180,7 +180,7 @@ watch(
 				rows.map((r) => ({ name: r?.name, fullName: r?.full_name || r?.name })),
 		});
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 const pmName = computed(() => {
 	const rows = pmUserResource.value?.data;
@@ -189,7 +189,7 @@ const pmName = computed(() => {
 });
 const resolvedProjectId = computed(() => project.value?.id || props.id);
 const parent = computed(() =>
-	project.value?.parentId ? store.projectById(project.value.parentId) : null,
+	project.value?.parentId ? store.projectById(project.value.parentId) : null
 );
 // Resolve the master (parent) project's display name reliably in remote mode, where the
 // Pinia store may not hold the parent (TASK-116 — surface the master-project link on a subproject).
@@ -201,13 +201,17 @@ watch(
 			? adapter.read("Project", pid, {
 					fields: ["name", "project_name", "project_status", "status"],
 					cache: `buildsuite-project-parent:${pid}`,
-				})
+			  })
 			: null;
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 const parentName = computed(
-	() => parentResource.value?.doc?.project_name || parent.value?.name || project.value?.parentId || "",
+	() =>
+		parentResource.value?.doc?.project_name ||
+		parent.value?.name ||
+		project.value?.parentId ||
+		""
 );
 const parentStatus = computed(() => {
 	const d = parentResource.value?.doc;
@@ -263,7 +267,7 @@ watch(
 	() => {
 		loadSubprojectsResource();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 const subs = computed(() => {
@@ -277,7 +281,7 @@ const subprojectIdsKey = computed(() =>
 	subs.value
 		.map((p) => p.id)
 		.filter(Boolean)
-		.join("|"),
+		.join("|")
 );
 
 const workPackageProjectIds = computed(() => {
@@ -339,7 +343,7 @@ watch(
 	() => {
 		loadWorkPackagesResource();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 watch(subprojectIdsKey, (next, prev) => {
@@ -422,7 +426,7 @@ watch(
 	() => {
 		loadTasksResource();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 watch(subprojectIdsKey, (next, prev) => {
@@ -522,7 +526,12 @@ function loadBoqsResource() {
 					status: b.status,
 					sourceScoId: b.source_sco || "",
 					preparedDate: b.prepared_date,
-					totals: { planned, actual, variance, variancePct: planned ? (variance / planned) * 100 : 0 },
+					totals: {
+						planned,
+						actual,
+						variance,
+						variancePct: planned ? (variance / planned) * 100 : 0,
+					},
 				};
 			});
 		},
@@ -551,7 +560,7 @@ const actualCost = computed(() => {
 });
 const costDeviation = computed(() => actualCost.value - plannedCost.value);
 const costDeviationPct = computed(() =>
-	plannedCost.value ? (costDeviation.value / plannedCost.value) * 100 : 0,
+	plannedCost.value ? (costDeviation.value / plannedCost.value) * 100 : 0
 );
 function deviationColor(pct) {
 	if (Math.abs(pct) < 0.5) return "text-ink-500";
@@ -614,7 +623,7 @@ watch(
 	() => {
 		tab.value = "overview";
 		editing.value = false;
-	},
+	}
 );
 
 // Project team — read from the project's custom_team_members child table
@@ -647,7 +656,7 @@ function colorOf(id) {
 // The Project Team child row only carries user + full_name, so the human-readable
 // role lives on the User's `persona` custom field — same as the prototype shows.
 const teamUserIds = computed(() =>
-	(project.value?.teamMembers || []).map((m) => m.user).filter(Boolean),
+	(project.value?.teamMembers || []).map((m) => m.user).filter(Boolean)
 );
 const teamUsersResource = ref(null);
 watch(
@@ -665,7 +674,7 @@ watch(
 			transform: (rows) => rows.map((r) => ({ name: r?.name, persona: r?.persona || "" })),
 		});
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 const teamPersonaMap = computed(() => {
 	const raw = teamUsersResource.value?.data;
@@ -681,7 +690,7 @@ const projectTeam = computed(() =>
 		role: teamPersonaMap.value[m.user] || "", // the user's persona, e.g. "Project Manager"
 		initials: initialsOf(m.fullName || m.user),
 		color: colorOf(m.user),
-	})),
+	}))
 );
 
 // Users already on the team (+ the PM) — excluded from the add picker.
@@ -763,12 +772,12 @@ async function saveEdit() {
 			editForm.value.endDate,
 			b.start,
 			b.end,
-			"parent project",
+			"parent project"
 		);
 	}
 	if (boundsErr) {
 		setEditErrors(
-			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr },
+			boundsErr.startsWith("Start") ? { startDate: boundsErr } : { endDate: boundsErr }
 		);
 		showToast(boundsErr, "error");
 		return;
@@ -827,7 +836,9 @@ async function confirmDelete() {
 		await nextTick();
 		showToast("Project deleted");
 	} catch (err) {
-		showToast("Failed to delete project", "error");
+		// Surface the server's reason (e.g. linked accounting/stock records) instead
+		// of a generic failure, so the user knows exactly what blocks the delete.
+		showToast(parseFrappeError(err).summary || "Failed to delete project", "error");
 		console.error("deleteProject failed:", err);
 	} finally {
 		deleteLoading.value = false;
@@ -857,7 +868,7 @@ async function loadTemplateSummary(type) {
 			{
 				credentials: "include",
 				headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
-			},
+			}
 		);
 		const data = await res.json();
 		const s = data?.message || null;
@@ -889,7 +900,7 @@ async function seedFromTemplate() {
 					"X-Frappe-CSRF-Token": window.csrf_token || "",
 				},
 				body: body.toString(),
-			},
+			}
 		);
 		const data = await res.json().catch(() => ({}));
 		if (!res.ok) throw new Error(data?.exception || data?.exc_type || `HTTP ${res.status}`);
@@ -992,7 +1003,7 @@ const breadcrumbs = computed(() => {
 });
 
 const titleStatuses = computed(() =>
-	project.value ? [project.value.status, project.value.priority] : [],
+	project.value ? [project.value.status, project.value.priority] : []
 );
 
 // Schedule-based variance + progress-bar color, same as the list view.
@@ -1093,7 +1104,12 @@ usePageTitle(() => project.value?.name);
 					class="text-sm font-semibold text-ink-900 group-hover:text-brand-700 transition-colors truncate"
 					>{{ parentName }}</span
 				>
-				<StatusBadge v-if="parentStatus" :status="parentStatus" size="xs" class="flex-shrink-0" />
+				<StatusBadge
+					v-if="parentStatus"
+					:status="parentStatus"
+					size="xs"
+					class="flex-shrink-0"
+				/>
 				<span class="ml-auto text-brand-700 text-xs flex-shrink-0">Open parent →</span>
 			</button>
 
@@ -1598,7 +1614,9 @@ usePageTitle(() => project.value?.name);
 						<span class="tabular-nums">{{ fmtCompactINR(row.totals.planned) }}</span>
 					</template>
 					<template #cell-actual="{ row }">
-						<span class="tabular-nums text-ink-700">{{ fmtCompactINR(row.totals.actual) }}</span>
+						<span class="tabular-nums text-ink-700">{{
+							fmtCompactINR(row.totals.actual)
+						}}</span>
 					</template>
 					<template #cell-preparedDate="{ row }">
 						<span class="text-xs text-ink-500">{{ fmtDate(row.preparedDate) }}</span>


### PR DESCRIPTION
Batch of fixes from testing the Subcontract module.

## BOQ — 'Submit for approval' did nothing
The action bar bound `@save="onPrimary"`, but the handler is `primaryAction` — so the click threw `Property "onPrimary" ... is not defined` and never submitted. Wired to `primaryAction`.

## Project delete — opaque failure
Deleting a project with linked accounting/stock records showed a generic "Failed to delete project". Now:
- the backend guard names **every** linked document type with its count — e.g. *"Cannot delete this project — it has linked records in Purchase Invoice (3). Remove or reassign these first."* (child tables like Journal Entry Account roll up to their parent Journal Entry; GL Entry, a ledger derivative, is dropped when a source document already explains the block)
- the frontend surfaces the server reason instead of a hardcoded string.

## Measurement Book detail
- Second header line + a new **Project** card show the project **name** and subcontractor **name** (were project-id · WO-id).
- Work Order card subline shows **subcontractor · WO type**.
- 5 summary cards now (Project was missing).

## New Measurement Book form
- Added read-only **Project** + **Subcontractor** fields, derived from the WO (matches the prototype).
- **WO-line change now recomputes the row's Cost code + UOM** — previously they were only filled when empty, so changing the line left stale values.
- **Description, WO line and UOM are mandatory** per entry (cost code stays optional), with required markers + validation.

## BOQ create-revision
- **Linked SCO** is now a project-filtered, most-recent-first Link picker instead of a free-text box.

## Backend
- MB serializer exposes `project_name` / `subcontractor` / `subcontractor_name` / `delivery_type`.

### Verification
- `vite build --mode development` clean.
- `test_project` (21) and `test_measurement_book` (3) pass. The 2 `test_subcontractor_bill` failures are pre-existing ("Reference No … mandatory for Bank transaction", untouched payment-entry code).
- On bs.local: project-delete guard returns the named-records message; MB serializer resolves project/subcontractor names.