### PR TITLE
fix: show project name (not id) across lists and dashboards

### DIFF
--- a/frontend/src/composables/useProjectNames.js
+++ b/frontend/src/composables/useProjectNames.js
@@ -1,0 +1,48 @@
+// Shared directory of Project name (id) → project_name. Lists and detail views
+// that only carry a project *link* (e.g. a Work Order's `project` = PROJ-0012)
+// use this to render the human project title instead of the raw id.
+//
+// One cached resource is shared across every caller (frappe-ui dedupes by the
+// cache key + the module-level singleton), so many lists resolving project names
+// trigger a single Project list fetch.
+
+import { computed } from "vue";
+import { useDataStore } from "@/stores";
+import { createDataAdapter } from "@/data/adapters";
+
+let _resource = null;
+
+function rows(resource) {
+	const raw = resource?.data;
+	if (Array.isArray(raw)) return raw;
+	if (Array.isArray(raw?.value)) return raw.value;
+	return [];
+}
+
+export function useProjectNames() {
+	if (!_resource) {
+		const adapter = createDataAdapter(useDataStore());
+		_resource = adapter.list("Project", {
+			fields: ["name", "project_name"],
+			pageLength: 0, // every project — the map must resolve any project link
+			cache: "buildsuite-project-directory",
+		});
+	}
+
+	const projectNamesMap = computed(() => {
+		const map = {};
+		rows(_resource).forEach((p) => {
+			map[p.name] = p.project_name || p.name;
+		});
+		return map;
+	});
+
+	// The project_name when known, else the id itself as a sensible placeholder
+	// until the directory resolves.
+	function projectName(id) {
+		if (!id) return "";
+		return projectNamesMap.value[id] || id;
+	}
+
+	return { projectName, projectNamesMap };
+}

--- a/frontend/src/views/MachineryDetailView.vue
+++ b/frontend/src/views/MachineryDetailView.vue
@@ -7,6 +7,7 @@ import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
 import { fmtINR, fmtDate } from "@/utils/format";
@@ -23,6 +24,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	machinery_name: "machinery_name",
 	machinery_type: "machinery_type",
@@ -56,7 +58,7 @@ watch(
 	(v) => {
 		if (v && !editing.value) form.value = snapshot();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 const rateDisplay = computed(() => {
@@ -185,7 +187,13 @@ const breadcrumbs = computed(() => [
 			>
 				Cancel
 			</button>
-			<button v-if="editing" type="button" class="desk-save-btn" :disabled="saving" @click="saveEdit">
+			<button
+				v-if="editing"
+				type="button"
+				class="desk-save-btn"
+				:disabled="saving"
+				@click="saveEdit"
+			>
 				{{ saving ? "Saving…" : "Save" }}
 			</button>
 		</template>
@@ -194,22 +202,28 @@ const breadcrumbs = computed(() => [
 		<div v-if="!editing">
 			<DeskSection title="Machinery" :cols="3">
 				<DeskField label="Type"
-					><div class="text-sm text-ink-700">{{ doc.machinery_type || "—" }}</div></DeskField
+					><div class="text-sm text-ink-700">
+						{{ doc.machinery_type || "—" }}
+					</div></DeskField
 				>
 				<DeskField label="Ownership"
 					><div class="text-sm text-ink-800">{{ doc.ownership }}</div></DeskField
 				>
 				<DeskField label="Rate"
-					><div class="text-sm text-ink-800 tabular-nums">{{ rateDisplay }}</div></DeskField
+					><div class="text-sm text-ink-800 tabular-nums">
+						{{ rateDisplay }}
+					</div></DeskField
 				>
 				<DeskField label="Owner / Vendor"
-					><div class="text-sm text-ink-800">{{ doc.owner_vendor || "—" }}</div></DeskField
+					><div class="text-sm text-ink-800">
+						{{ doc.owner_vendor || "—" }}
+					</div></DeskField
 				>
 				<DeskField label="Status"><StatusBadge :status="doc.status" /></DeskField>
 				<DeskField v-if="doc.ownership === 'Owned'" label="Linked asset (ERPNext)">
-					<DeskLink v-if="doc.asset" :href="`/app/asset/${doc.asset}`" target="_blank"
-						>{{ doc.asset }}</DeskLink
-					>
+					<DeskLink v-if="doc.asset" :href="`/app/asset/${doc.asset}`" target="_blank">{{
+						doc.asset
+					}}</DeskLink>
 					<div v-else class="text-sm text-ink-400">— not linked —</div>
 				</DeskField>
 				<DeskField label="Company"
@@ -237,9 +251,13 @@ const breadcrumbs = computed(() => [
 							@click="router.push(`/machinery-usage/${u.name}`)"
 						>
 							<td class="py-1.5 pr-3 text-ink-500">{{ fmtDate(u.date) }}</td>
-							<td class="py-1.5 pr-3 text-ink-700">{{ u.project || "—" }}</td>
+							<td class="py-1.5 pr-3 text-ink-700">
+								{{ projectName(u.project) || "—" }}
+							</td>
 							<td class="py-1.5 pr-3 text-ink-500">{{ u.task || "—" }}</td>
-							<td class="py-1.5 pr-3 text-right tabular-nums">{{ u.quantity }} {{ u.unit }}</td>
+							<td class="py-1.5 pr-3 text-right tabular-nums">
+								{{ u.quantity }} {{ u.unit }}
+							</td>
 							<td class="py-1.5 text-right tabular-nums text-ink-900 font-medium">
 								{{ fmtINR(usageTotal(u)) }}
 							</td>

--- a/frontend/src/views/MachineryUsageDetailView.vue
+++ b/frontend/src/views/MachineryUsageDetailView.vue
@@ -7,6 +7,7 @@ import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
 import { fmtINR, fmtDate } from "@/utils/format";
@@ -23,6 +24,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({ machine: "machine" });
 
 const resource = adapter.read("Machinery Usage", props.id, { fields: ["*"] });
@@ -39,7 +41,7 @@ const machineryOptions = computed(() =>
 		value: m.name,
 		label: m.machinery_name,
 		hint: [m.machinery_type, m.ownership].filter(Boolean).join(" · "),
-	})),
+	}))
 );
 const projectRes = useDocTypeList("Project", {
 	fields: ["name", "project_name"],
@@ -48,7 +50,7 @@ const projectRes = useDocTypeList("Project", {
 	cache: "buildsuite-project-options",
 });
 const projectOptions = computed(() =>
-	(projectRes.data || []).map((p) => ({ value: p.name, label: p.project_name, hint: p.name })),
+	(projectRes.data || []).map((p) => ({ value: p.name, label: p.project_name, hint: p.name }))
 );
 
 const editing = ref(false);
@@ -74,7 +76,7 @@ watch(
 	(v) => {
 		if (v && !editing.value) form.value = snapshot();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 function totalOf(o) {
@@ -179,7 +181,13 @@ const breadcrumbs = computed(() => [
 			>
 				Cancel
 			</button>
-			<button v-if="editing" type="button" class="desk-save-btn" :disabled="saving" @click="saveEdit">
+			<button
+				v-if="editing"
+				type="button"
+				class="desk-save-btn"
+				:disabled="saving"
+				@click="saveEdit"
+			>
 				{{ saving ? "Saving…" : "Save" }}
 			</button>
 		</template>
@@ -191,7 +199,9 @@ const breadcrumbs = computed(() => [
 					<DeskLink :to="`/machinery/${doc.machine}`">{{ doc.machine }}</DeskLink>
 				</DeskField>
 				<DeskField label="Project"
-					><div class="text-sm text-ink-700">{{ doc.project || "—" }}</div></DeskField
+					><div class="text-sm text-ink-700">
+						{{ projectName(doc.project) || "—" }}
+					</div></DeskField
 				>
 				<DeskField label="Task"
 					><div class="text-sm text-ink-700">{{ doc.task || "—" }}</div></DeskField
@@ -205,7 +215,9 @@ const breadcrumbs = computed(() => [
 					</div></DeskField
 				>
 				<DeskField label="Rate"
-					><div class="text-sm text-ink-800 tabular-nums">{{ fmtINR(doc.rate) }}</div></DeskField
+					><div class="text-sm text-ink-800 tabular-nums">
+						{{ fmtINR(doc.rate) }}
+					</div></DeskField
 				>
 				<DeskField label="Fuel cost"
 					><div class="text-sm text-ink-800 tabular-nums">

--- a/frontend/src/views/MachineryUsageListView.vue
+++ b/frontend/src/views/MachineryUsageListView.vue
@@ -4,15 +4,27 @@
 import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { fmtINR, fmtDate } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 
 const router = useRouter();
+const { projectName } = useProjectNames();
 
 const usageRes = useDocTypeList("Machinery Usage", {
-	fields: ["name", "machine", "project", "task", "date", "quantity", "unit", "rate", "fuel_cost"],
+	fields: [
+		"name",
+		"machine",
+		"project",
+		"task",
+		"date",
+		"quantity",
+		"unit",
+		"rate",
+		"fuel_cost",
+	],
 	orderBy: "date desc",
 	pageLength: 0,
 	cache: "buildsuite-machinery-usage-list",
@@ -31,7 +43,8 @@ const rows = computed(() => {
 		data = data.filter(
 			(u) =>
 				(u.machine || "").toLowerCase().includes(q) ||
-				(u.project || "").toLowerCase().includes(q),
+				(u.project || "").toLowerCase().includes(q) ||
+				projectName(u.project).toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -71,10 +84,12 @@ function onRowClick(row) {
 			@row-click="onRowClick"
 		>
 			<template #cell-machine="{ row }">
-				<DeskLink :to="`/machinery/${row.machine}`" @click.stop>{{ row.machine }}</DeskLink>
+				<DeskLink :to="`/machinery/${row.machine}`" @click.stop>{{
+					row.machine
+				}}</DeskLink>
 			</template>
 			<template #cell-project="{ row }">
-				<span class="text-ink-700">{{ row.project || "—" }}</span>
+				<span class="text-ink-700">{{ projectName(row.project) || "—" }}</span>
 			</template>
 			<template #cell-task="{ row }">
 				<span class="text-ink-500">{{ row.task || "—" }}</span>
@@ -86,13 +101,18 @@ function onRowClick(row) {
 				<span class="tabular-nums">{{ row.quantity }} {{ row.unit }}</span>
 			</template>
 			<template #cell-total="{ row }">
-				<span class="tabular-nums text-ink-900 font-medium">{{ fmtINR(totalFor(row)) }}</span>
+				<span class="tabular-nums text-ink-900 font-medium">{{
+					fmtINR(totalFor(row))
+				}}</span>
 			</template>
 
 			<template #empty>
 				<div class="text-sm text-ink-500">
 					{{ usageRes.loading ? "Loading usage log…" : "No usage logged yet." }}
-					<RouterLink v-if="!usageRes.loading" to="/machinery-usage/new" class="desk-link"
+					<RouterLink
+						v-if="!usageRes.loading"
+						to="/machinery-usage/new"
+						class="desk-link"
 						>Log usage →</RouterLink
 					>
 				</div>

--- a/frontend/src/views/MeasurementBooksListView.vue
+++ b/frontend/src/views/MeasurementBooksListView.vue
@@ -6,6 +6,7 @@
 import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -13,6 +14,7 @@ import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate } from "@/utils/format";
 
 const router = useRouter();
+const { projectName } = useProjectNames();
 
 const mbRes = useDocTypeList("Measurement Book", {
 	fields: ["name", "project", "work_order", "date", "measured_total", "status"],
@@ -39,7 +41,8 @@ const rows = computed(() => {
 			(m) =>
 				(m.id || "").toLowerCase().includes(q) ||
 				(m.work_order || "").toLowerCase().includes(q) ||
-				(m.project || "").toLowerCase().includes(q),
+				(m.project || "").toLowerCase().includes(q) ||
+				projectName(m.project).toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -87,7 +90,7 @@ function onRowClick(row) {
 				>
 			</template>
 			<template #cell-project="{ row }">
-				<span class="text-xs text-ink-700">{{ row.project }}</span>
+				<span class="text-xs text-ink-700">{{ projectName(row.project) }}</span>
 			</template>
 			<template #cell-work_order="{ row }">
 				<DeskLink

--- a/frontend/src/views/StagePlanningDetailView.vue
+++ b/frontend/src/views/StagePlanningDetailView.vue
@@ -14,6 +14,7 @@ import { useSessionStore } from "@/stores/session";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { createDataAdapter } from "@/data/adapters";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { outOfParentBoundsError } from "@/utils/dateBounds";
 import { fetchProjectBounds } from "@/utils/projectBounds";
 
@@ -82,6 +83,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const route = useRoute();
 const store = useDataStore();
+const { projectName } = useProjectNames();
 const session = useSessionStore();
 const adapter = createDataAdapter(store);
 
@@ -354,7 +356,7 @@ const userRoles = computed(() => session.access?.roles || []);
 const availableActions = computed(() => {
 	const state = stage.value?.workflowState || "Draft";
 	return (WORKFLOW_ACTIONS[state] || []).filter((a) =>
-		a.roles.some((r) => userRoles.value.includes(r)),
+		a.roles.some((r) => userRoles.value.includes(r))
 	);
 });
 
@@ -485,7 +487,7 @@ async function reviseRejectedStage() {
 					"X-Frappe-CSRF-Token": window.csrf_token || "",
 				},
 				body: body.toString(),
-			},
+			}
 		);
 		const data = await response.json().catch(() => ({}));
 		if (!response.ok) {
@@ -537,7 +539,7 @@ async function fetchActivity() {
 			{
 				credentials: "include",
 				headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
-			},
+			}
 		);
 		const data = await res.json().catch(() => ({}));
 		activityEntries.value = Array.isArray(data?.message) ? data.message : [];
@@ -573,7 +575,7 @@ async function confirmReject() {
 					"X-Frappe-CSRF-Token": window.csrf_token || "",
 				},
 				body: body.toString(),
-			},
+			}
 		);
 		if (!response.ok) {
 			const data = await response.json().catch(() => ({}));
@@ -610,7 +612,7 @@ watch(
 	(s) => {
 		if (s && !editing.value) editForm.value = snapshotStage(s);
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 // Load the activity feed when the stage resolves / changes; auto-enter edit mode
@@ -622,7 +624,7 @@ watch(
 		fetchActivity();
 		if (route.query.edit && canEdit.value && !editing.value) startEdit();
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 function startEdit() {
@@ -668,13 +670,11 @@ async function saveEdit() {
 		editForm.value.plannedEnd,
 		b.start,
 		b.end,
-		"project",
+		"project"
 	);
 	if (boundsErr) {
 		setErrors(
-			boundsErr.startsWith("Start")
-				? { plannedStart: boundsErr }
-				: { plannedEnd: boundsErr },
+			boundsErr.startsWith("Start") ? { plannedStart: boundsErr } : { plannedEnd: boundsErr }
 		);
 		showToast(boundsErr, "error");
 		return;
@@ -1069,8 +1069,8 @@ usePageTitle(() => stage.value?.stageName);
 						dependencyCount === 0
 							? "starts independently"
 							: dependencyCount === 1
-								? "stage must complete first"
-								: "stages must complete first"
+							? "stage must complete first"
+							: "stages must complete first"
 					}}
 				</div>
 			</div>
@@ -1108,7 +1108,7 @@ usePageTitle(() => stage.value?.stageName);
 						<DeskLink v-if="project" :to="`/projects/${project.id}`">{{
 							project.name
 						}}</DeskLink>
-						<span v-else class="text-ink-500">{{ stage.project }}</span>
+						<span v-else class="text-ink-500">{{ projectName(stage.project) }}</span>
 					</div>
 				</div>
 				<div>

--- a/frontend/src/views/SubcontractorBillsListView.vue
+++ b/frontend/src/views/SubcontractorBillsListView.vue
@@ -5,6 +5,7 @@
 import { computed, ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { listBills } from "@/data/subcontractApi";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -13,6 +14,7 @@ import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const router = useRouter();
+const { projectName } = useProjectNames();
 
 // Loaded via list_bills so each row carries the workflow state AND the derived payment status.
 const allBills = ref([]);
@@ -50,7 +52,8 @@ const rows = computed(() => {
 			(b) =>
 				(b.id || "").toLowerCase().includes(q) ||
 				(b.subcontractor || "").toLowerCase().includes(q) ||
-				(b.project || "").toLowerCase().includes(q)
+				(b.project || "").toLowerCase().includes(q) ||
+				projectName(b.project).toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -110,7 +113,7 @@ function onRowClick(row) {
 				<span class="text-xs font-medium text-ink-900">{{ row.subcontractor }}</span>
 			</template>
 			<template #cell-project="{ row }">
-				<span class="text-xs text-ink-500">{{ row.project }}</span>
+				<span class="text-xs text-ink-500">{{ projectName(row.project) }}</span>
 			</template>
 			<template #cell-date="{ row }">
 				<span class="text-xs text-ink-500">{{ fmtDate(row.date) }}</span>

--- a/frontend/src/views/SubcontractorDetailView.vue
+++ b/frontend/src/views/SubcontractorDetailView.vue
@@ -8,6 +8,7 @@ import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
 import { fmtCompactINR, fmtDate } from "@/utils/format";
@@ -24,6 +25,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	subcontractor_name: "subcontractor_name",
 	trade: "trade",
@@ -242,7 +244,9 @@ const breadcrumbs = computed(() => [
 										>{{ wo.name }}</DeskLink
 									>
 								</td>
-								<td class="px-3 py-2 text-ink-700">{{ wo.project }}</td>
+								<td class="px-3 py-2 text-ink-700">
+									{{ projectName(wo.project) }}
+								</td>
 								<td class="px-3 py-2 text-ink-500">{{ fmtDate(wo.date) }}</td>
 								<td
 									class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium"

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -4,6 +4,7 @@
 import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -11,6 +12,7 @@ import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtCompactINR } from "@/utils/format";
 
 const router = useRouter();
+const { projectName } = useProjectNames();
 
 const wosRes = useDocTypeList("Subcontractor Work Order", {
 	fields: [
@@ -47,7 +49,8 @@ const rows = computed(() => {
 			(w) =>
 				(w.id || "").toLowerCase().includes(q) ||
 				(w.subcontractor || "").toLowerCase().includes(q) ||
-				(w.project || "").toLowerCase().includes(q)
+				(w.project || "").toLowerCase().includes(q) ||
+				projectName(w.project).toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -101,7 +104,7 @@ function onRowClick(row) {
 				<span class="text-ink-900 font-medium">{{ row.subcontractor }}</span>
 			</template>
 			<template #cell-project="{ row }">
-				<span class="text-xs text-ink-700">{{ row.project }}</span>
+				<span class="text-xs text-ink-700">{{ projectName(row.project) }}</span>
 			</template>
 			<template #cell-date="{ row }">
 				<span class="text-xs text-ink-500">{{ fmtDate(row.date) }}</span>

--- a/frontend/src/views/finance/FinanceBillsPanel.vue
+++ b/frontend/src/views/finance/FinanceBillsPanel.vue
@@ -15,6 +15,7 @@ import {
 	listBillPayAccounts,
 	listSupplierBillPaymentModes,
 } from "@/data/supplierBillApi";
+import { useProjectNames } from "@/composables/useProjectNames";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
@@ -25,6 +26,7 @@ import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Bills" }];
 const router = useRouter();
+const { projectName } = useProjectNames();
 
 const payables = ref([]);
 const summary = reactive({ outstanding: 0, retention: 0, advances: 0 });
@@ -33,7 +35,15 @@ async function load() {
 	loading.value = true;
 	try {
 		payables.value = await listPayables();
-		payablesSummary().then((r) => Object.assign(summary, { outstanding: Number(r?.outstanding) || 0, retention: Number(r?.retention) || 0, advances: Number(r?.advances) || 0 })).catch(() => {});
+		payablesSummary()
+			.then((r) =>
+				Object.assign(summary, {
+					outstanding: Number(r?.outstanding) || 0,
+					retention: Number(r?.retention) || 0,
+					advances: Number(r?.advances) || 0,
+				})
+			)
+			.catch(() => {});
 	} catch (err) {
 		showToast(err.message || "Failed to load bills", "error");
 	} finally {
@@ -58,7 +68,10 @@ const rows = computed(() => {
 		(r) =>
 			(!typeFilter.value || r.kind === typeFilter.value) &&
 			(!statusFilter.value || r.status === statusFilter.value) &&
-			(!term || r.name.toLowerCase().includes(term) || (r.party || "").toLowerCase().includes(term) || (r.project || "").toLowerCase().includes(term)),
+			(!term ||
+				r.name.toLowerCase().includes(term) ||
+				(r.party || "").toLowerCase().includes(term) ||
+				(r.project || "").toLowerCase().includes(term))
 	);
 });
 
@@ -72,7 +85,11 @@ function aging(row) {
 }
 
 function openDetail(row) {
-	router.push(row.kind === "subcontractor" ? `/subcontractor-bills/${row.name}` : `/project-finance/supplier-bills/${row.name}`);
+	router.push(
+		row.kind === "subcontractor"
+			? `/subcontractor-bills/${row.name}`
+			: `/project-finance/supplier-bills/${row.name}`
+	);
 }
 
 // --- new bill (type chooser) ---
@@ -92,21 +109,36 @@ const payModes = ref([]);
 async function ensurePayRefs() {
 	if (payAccounts.value.length) return;
 	try {
-		[payAccounts.value, payModes.value] = await Promise.all([listBillPayAccounts(), listSupplierBillPaymentModes()]);
+		[payAccounts.value, payModes.value] = await Promise.all([
+			listBillPayAccounts(),
+			listSupplierBillPaymentModes(),
+		]);
 	} catch {
 		/* fall through */
 	}
 }
 
 // --- pay a supplier bill inline (subcontractor bills are paid from their detail screen) ---
-const pay = reactive({ open: false, row: null, amount: null, pay_from: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const pay = reactive({
+	open: false,
+	row: null,
+	amount: null,
+	pay_from: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 async function openPay(row) {
 	await ensurePayRefs();
 	Object.assign(pay, {
 		open: true,
 		row,
 		amount: Number(row.outstanding) || null,
-		pay_from: payAccounts.value.find((a) => a.account_type === "Bank")?.name || payAccounts.value[0]?.name || "",
+		pay_from:
+			payAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			payAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -116,11 +148,19 @@ async function openPay(row) {
 async function savePay() {
 	const amt = Number(pay.amount) || 0;
 	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
-	if (amt > Number(pay.row.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(pay.row.outstanding)}.`, "error");
+	if (amt > Number(pay.row.outstanding) + 0.01)
+		return showToast(`Can't exceed the outstanding ${fmtINR(pay.row.outstanding)}.`, "error");
 	if (!pay.pay_from) return showToast("Pick the account to pay from.", "error");
 	pay.saving = true;
 	try {
-		await recordSupplierBillPayment({ name: pay.row.name, amount: amt, date: pay.date, mode_of_payment: pay.mode_of_payment || undefined, pay_from: pay.pay_from, reference_no: pay.reference_no || undefined });
+		await recordSupplierBillPayment({
+			name: pay.row.name,
+			amount: amt,
+			date: pay.date,
+			mode_of_payment: pay.mode_of_payment || undefined,
+			pay_from: pay.pay_from,
+			reference_no: pay.reference_no || undefined,
+		});
 		pay.open = false;
 		load();
 		showToast("Payment made.");
@@ -132,14 +172,26 @@ async function savePay() {
 }
 
 // --- record supplier advance ---
-const adv = reactive({ open: false, supplier: "", amount: null, pay_from: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const adv = reactive({
+	open: false,
+	supplier: "",
+	amount: null,
+	pay_from: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 async function openAdvance() {
 	await ensurePayRefs();
 	Object.assign(adv, {
 		open: true,
 		supplier: "",
 		amount: null,
-		pay_from: payAccounts.value.find((a) => a.account_type === "Bank")?.name || payAccounts.value[0]?.name || "",
+		pay_from:
+			payAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			payAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -152,7 +204,14 @@ async function saveAdvance() {
 	if (!adv.pay_from) return showToast("Pick the account to pay from.", "error");
 	adv.saving = true;
 	try {
-		await recordSupplierAdvance({ supplier: adv.supplier, amount: Number(adv.amount), date: adv.date, pay_from: adv.pay_from, mode_of_payment: adv.mode_of_payment || undefined, reference_no: adv.reference_no || undefined });
+		await recordSupplierAdvance({
+			supplier: adv.supplier,
+			amount: Number(adv.amount),
+			date: adv.date,
+			pay_from: adv.pay_from,
+			mode_of_payment: adv.mode_of_payment || undefined,
+			reference_no: adv.reference_no || undefined,
+		});
 		adv.open = false;
 		load();
 		showToast("Advance recorded.");
@@ -168,130 +227,382 @@ async function saveAdvance() {
 	<DeskPage title="Bills" :breadcrumbs="breadcrumbs">
 		<template #actions>
 			<div class="flex items-center gap-2">
-				<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="openAdvance">Record advance</button>
-				<button type="button" class="desk-save-btn" @click="newOpen = true">+ New bill</button>
+				<button
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+					@click="openAdvance"
+				>
+					Record advance
+				</button>
+				<button type="button" class="desk-save-btn" @click="newOpen = true">
+					+ New bill
+				</button>
 			</div>
 		</template>
 
 		<div class="space-y-4">
 			<div class="flex items-center gap-4 text-sm">
-				<div><span class="text-ink-500">Payable</span> <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(summary.outstanding) }}</span></div>
-				<div v-if="summary.retention > 0"><span class="text-ink-500">Retention held</span> <span class="font-semibold text-warning-700 tabular-nums">{{ fmtINR(summary.retention) }}</span></div>
-				<div v-if="summary.advances > 0"><span class="text-ink-500">Advances paid</span> <span class="font-semibold text-info-700 tabular-nums">{{ fmtINR(summary.advances) }}</span></div>
+				<div>
+					<span class="text-ink-500">Payable</span>
+					<span class="font-semibold text-ink-900 tabular-nums">{{
+						fmtINR(summary.outstanding)
+					}}</span>
+				</div>
+				<div v-if="summary.retention > 0">
+					<span class="text-ink-500">Retention held</span>
+					<span class="font-semibold text-warning-700 tabular-nums">{{
+						fmtINR(summary.retention)
+					}}</span>
+				</div>
+				<div v-if="summary.advances > 0">
+					<span class="text-ink-500">Advances paid</span>
+					<span class="font-semibold text-info-700 tabular-nums">{{
+						fmtINR(summary.advances)
+					}}</span>
+				</div>
 			</div>
 
 			<div class="flex items-center gap-2 flex-wrap">
-				<input v-model="search" type="text" placeholder="Search bill, party, project…" class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-64 max-w-full" />
-				<select v-model="typeFilter" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+				<input
+					v-model="search"
+					type="text"
+					placeholder="Search bill, party, project…"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-64 max-w-full"
+				/>
+				<select
+					v-model="typeFilter"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				>
 					<option value="">All types</option>
 					<option value="supplier">Supplier</option>
 					<option value="subcontractor">Subcontractor</option>
 				</select>
-				<select v-model="statusFilter" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+				<select
+					v-model="statusFilter"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				>
 					<option value="">All statuses</option>
 					<option>Unpaid</option>
 					<option>Partly Paid</option>
 					<option>Paid</option>
 				</select>
-				<button v-if="hasFilters" type="button" class="text-[11px] text-danger-600 hover:underline" @click="clearFilters">Clear filters</button>
-				<span class="text-[11px] text-ink-400 ml-auto">{{ rows.length }} bill{{ rows.length === 1 ? "" : "s" }}</span>
+				<button
+					v-if="hasFilters"
+					type="button"
+					class="text-[11px] text-danger-600 hover:underline"
+					@click="clearFilters"
+				>
+					Clear filters
+				</button>
+				<span class="text-[11px] text-ink-400 ml-auto"
+					>{{ rows.length }} bill{{ rows.length === 1 ? "" : "s" }}</span
+				>
 			</div>
 
 			<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
 				<table v-if="rows.length" class="w-full text-xs" style="min-width: 800px">
-					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200">
-						<tr><th class="text-left px-3 py-2">Bill</th><th class="text-left px-3 py-2">Party</th><th class="text-left px-3 py-2">Project</th><th class="text-left px-3 py-2">Date</th><th class="text-left px-3 py-2">Due</th><th class="text-left px-3 py-2">Aging</th><th class="text-right px-3 py-2">Total</th><th class="text-right px-3 py-2">Outstanding</th><th class="text-left px-3 py-2">Status</th><th class="px-3 py-2"></th></tr>
+					<thead
+						class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200"
+					>
+						<tr>
+							<th class="text-left px-3 py-2">Bill</th>
+							<th class="text-left px-3 py-2">Party</th>
+							<th class="text-left px-3 py-2">Project</th>
+							<th class="text-left px-3 py-2">Date</th>
+							<th class="text-left px-3 py-2">Due</th>
+							<th class="text-left px-3 py-2">Aging</th>
+							<th class="text-right px-3 py-2">Total</th>
+							<th class="text-right px-3 py-2">Outstanding</th>
+							<th class="text-left px-3 py-2">Status</th>
+							<th class="px-3 py-2"></th>
+						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="r in rows" :key="r.kind + r.name" class="border-t border-ink-100 hover:bg-brand-50/40 cursor-pointer" @click="openDetail(r)">
+						<tr
+							v-for="r in rows"
+							:key="r.kind + r.name"
+							class="border-t border-ink-100 hover:bg-brand-50/40 cursor-pointer"
+							@click="openDetail(r)"
+						>
 							<td class="px-3 py-2">
 								<div class="flex items-center gap-1.5">
-									<span class="font-mono text-[11px] text-ink-500">{{ r.name }}</span>
-									<span v-if="r.kind === 'subcontractor'" class="text-[9px] px-1.5 py-0.5 bg-info-50 text-info-700 rounded-full uppercase tracking-wider whitespace-nowrap">Subcontractor</span>
+									<span class="font-mono text-[11px] text-ink-500">{{
+										r.name
+									}}</span>
+									<span
+										v-if="r.kind === 'subcontractor'"
+										class="text-[9px] px-1.5 py-0.5 bg-info-50 text-info-700 rounded-full uppercase tracking-wider whitespace-nowrap"
+										>Subcontractor</span
+									>
 								</div>
 							</td>
 							<td class="px-3 py-2 text-ink-900">{{ r.party }}</td>
-							<td class="px-3 py-2 text-ink-500">{{ r.project || "—" }}</td>
-							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">{{ fmtDate(r.date) }}</td>
-							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">{{ r.due_date ? fmtDate(r.due_date) : "—" }}</td>
-							<td class="px-3 py-2"><span v-if="aging(r)" class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="aging(r).cls">{{ aging(r).label }}</span><span v-else class="text-ink-300">—</span></td>
-							<td class="px-3 py-2 text-right tabular-nums text-ink-900">{{ fmtINR(r.total) }}</td>
-							<td class="px-3 py-2 text-right tabular-nums font-medium" :class="r.outstanding > 0.01 ? 'text-ink-900' : 'text-ink-400'">{{ fmtINR(r.outstanding) }}</td>
+							<td class="px-3 py-2 text-ink-500">
+								{{ projectName(r.project) || "—" }}
+							</td>
+							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+								{{ fmtDate(r.date) }}
+							</td>
+							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+								{{ r.due_date ? fmtDate(r.due_date) : "—" }}
+							</td>
+							<td class="px-3 py-2">
+								<span
+									v-if="aging(r)"
+									class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap"
+									:class="aging(r).cls"
+									>{{ aging(r).label }}</span
+								><span v-else class="text-ink-300">—</span>
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+								{{ fmtINR(r.total) }}
+							</td>
+							<td
+								class="px-3 py-2 text-right tabular-nums font-medium"
+								:class="r.outstanding > 0.01 ? 'text-ink-900' : 'text-ink-400'"
+							>
+								{{ fmtINR(r.outstanding) }}
+							</td>
 							<td class="px-3 py-2"><StatusBadge :status="r.status" size="xs" /></td>
 							<td class="px-3 py-2 text-right whitespace-nowrap">
-								<button v-if="r.kind === 'supplier' && r.outstanding > 0.01" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click.stop="openPay(r)">Pay</button>
+								<button
+									v-if="r.kind === 'supplier' && r.outstanding > 0.01"
+									type="button"
+									class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded"
+									@click.stop="openPay(r)"
+								>
+									Pay
+								</button>
 							</td>
 						</tr>
 					</tbody>
 				</table>
-				<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "No bills yet." }}</div>
+				<div v-else class="px-4 py-12 text-center text-xs text-ink-400 italic">
+					{{ loading ? "Loading…" : "No bills yet." }}
+				</div>
 			</section>
 		</div>
 
 		<!-- New bill type chooser -->
-		<div v-if="newOpen" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="newOpen = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">New bill</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="newOpen = false">✕</button></header>
-				<div class="px-4 py-4 space-y-2">
-					<button type="button" class="w-full text-left border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-4 py-3 transition-colors" @click="newSupplierBill">
-						<div class="text-sm font-medium text-ink-900">Supplier bill</div>
-						<div class="text-[11px] text-ink-500 mt-0.5">A direct purchase from a supplier (materials, services) — an ERPNext Purchase Invoice.</div>
+		<div
+			v-if="newOpen"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="newOpen = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">New bill</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="newOpen = false"
+					>
+						✕
 					</button>
-					<button type="button" class="w-full text-left border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-4 py-3 transition-colors" @click="newSubcontractorBill">
+				</header>
+				<div class="px-4 py-4 space-y-2">
+					<button
+						type="button"
+						class="w-full text-left border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-4 py-3 transition-colors"
+						@click="newSupplierBill"
+					>
+						<div class="text-sm font-medium text-ink-900">Supplier bill</div>
+						<div class="text-[11px] text-ink-500 mt-0.5">
+							A direct purchase from a supplier (materials, services) — an ERPNext
+							Purchase Invoice.
+						</div>
+					</button>
+					<button
+						type="button"
+						class="w-full text-left border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-4 py-3 transition-colors"
+						@click="newSubcontractorBill"
+					>
 						<div class="text-sm font-medium text-ink-900">Subcontractor bill</div>
-						<div class="text-[11px] text-ink-500 mt-0.5">An RA / work-done bill against a Subcontractor Work Order (with retention).</div>
+						<div class="text-[11px] text-ink-500 mt-0.5">
+							An RA / work-done bill against a Subcontractor Work Order (with
+							retention).
+						</div>
 					</button>
 				</div>
 			</div>
 		</div>
 
 		<!-- Pay modal (supplier bill) -->
-		<div v-if="pay.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="pay.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Pay bill</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="pay.open = false">✕</button></header>
+		<div
+			v-if="pay.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="pay.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Pay bill</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="pay.open = false"
+					>
+						✕
+					</button>
+				</header>
 				<div class="px-4 py-4 space-y-3">
-					<div class="text-sm text-ink-700">Pay <span class="font-medium">{{ pay.row?.party }}</span> against <span class="font-mono text-xs">{{ pay.row?.name }}</span>. Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(pay.row?.outstanding) }}</span>.</div>
+					<div class="text-sm text-ink-700">
+						Pay <span class="font-medium">{{ pay.row?.party }}</span> against
+						<span class="font-mono text-xs">{{ pay.row?.name }}</span
+						>. Outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(pay.row?.outstanding)
+						}}</span
+						>.
+					</div>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Amount" required><DeskInput v-model.number="pay.amount" type="number" min="0" /></DeskField>
-						<DeskField label="Date"><DeskInput v-model="pay.date" type="date" /></DeskField>
+						<DeskField label="Amount" required
+							><DeskInput v-model.number="pay.amount" type="number" min="0"
+						/></DeskField>
+						<DeskField label="Date"
+							><DeskInput v-model="pay.date" type="date"
+						/></DeskField>
 					</div>
 					<DeskField label="Pay from" required>
-						<DeskSelect v-model="pay.pay_from"><option value="" disabled>Bank / Cash account…</option><option v-for="a in payAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+						<DeskSelect v-model="pay.pay_from"
+							><option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in payAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option></DeskSelect
+						>
 					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Mode of payment"><DeskSelect v-model="pay.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
-						<DeskField label="Reference no."><DeskInput v-model="pay.reference_no" placeholder="UTR / cheque no." /></DeskField>
+						<DeskField label="Mode of payment"
+							><DeskSelect v-model="pay.mode_of_payment"
+								><option value="">—</option>
+								<option v-for="m in payModes" :key="m" :value="m">
+									{{ m }}
+								</option></DeskSelect
+							></DeskField
+						>
+						<DeskField label="Reference no."
+							><DeskInput v-model="pay.reference_no" placeholder="UTR / cheque no."
+						/></DeskField>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="pay.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="pay.saving" @click="savePay">{{ pay.saving ? "Paying…" : "Record payment" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="pay.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="pay.saving"
+						@click="savePay"
+					>
+						{{ pay.saving ? "Paying…" : "Record payment" }}
+					</button>
 				</footer>
 			</div>
 		</div>
 
 		<!-- Record supplier advance modal -->
-		<div v-if="adv.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="adv.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Record supplier advance</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="adv.open = false">✕</button></header>
+		<div
+			v-if="adv.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="adv.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Record supplier advance</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="adv.open = false"
+					>
+						✕
+					</button>
+				</header>
 				<div class="px-4 py-4 space-y-3">
-					<p class="text-[11px] text-ink-500">Money paid to a supplier before (or without) a bill — it stays on the supplier's account until a later bill draws it down.</p>
-					<DeskField label="Supplier" required><DeskLinkPicker v-model="adv.supplier" doctype="Supplier" label-field="supplier_name" value-field="name" placeholder="Pick a supplier…" /></DeskField>
+					<p class="text-[11px] text-ink-500">
+						Money paid to a supplier before (or without) a bill — it stays on the
+						supplier's account until a later bill draws it down.
+					</p>
+					<DeskField label="Supplier" required
+						><DeskLinkPicker
+							v-model="adv.supplier"
+							doctype="Supplier"
+							label-field="supplier_name"
+							value-field="name"
+							placeholder="Pick a supplier…"
+					/></DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Amount" required><DeskInput v-model.number="adv.amount" type="number" min="0" placeholder="0" /></DeskField>
-						<DeskField label="Date"><DeskInput v-model="adv.date" type="date" /></DeskField>
+						<DeskField label="Amount" required
+							><DeskInput
+								v-model.number="adv.amount"
+								type="number"
+								min="0"
+								placeholder="0"
+						/></DeskField>
+						<DeskField label="Date"
+							><DeskInput v-model="adv.date" type="date"
+						/></DeskField>
 					</div>
 					<DeskField label="Pay from" required>
-						<DeskSelect v-model="adv.pay_from"><option value="" disabled>Bank / Cash account…</option><option v-for="a in payAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+						<DeskSelect v-model="adv.pay_from"
+							><option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in payAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option></DeskSelect
+						>
 					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Mode of payment"><DeskSelect v-model="adv.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
-						<DeskField label="Reference no."><DeskInput v-model="adv.reference_no" placeholder="UTR / cheque no." /></DeskField>
+						<DeskField label="Mode of payment"
+							><DeskSelect v-model="adv.mode_of_payment"
+								><option value="">—</option>
+								<option v-for="m in payModes" :key="m" :value="m">
+									{{ m }}
+								</option></DeskSelect
+							></DeskField
+						>
+						<DeskField label="Reference no."
+							><DeskInput v-model="adv.reference_no" placeholder="UTR / cheque no."
+						/></DeskField>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="adv.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="adv.saving" @click="saveAdvance">{{ adv.saving ? "Recording…" : "Record advance" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="adv.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="adv.saving"
+						@click="saveAdvance"
+					>
+						{{ adv.saving ? "Recording…" : "Record advance" }}
+					</button>
 				</footer>
 			</div>
 		</div>

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -13,6 +13,7 @@ import {
 	listDepositAccounts,
 	listInvoicePaymentModes,
 } from "@/data/invoiceApi";
+import { useProjectNames } from "@/composables/useProjectNames";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
@@ -25,8 +26,11 @@ import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
 const router = useRouter();
+const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
-const baseFilters = computed(() => (activeCompany.value ? [["company", "=", activeCompany.value]] : []));
+const baseFilters = computed(() =>
+	activeCompany.value ? [["company", "=", activeCompany.value]] : []
+);
 
 // The list is a doctype resource; bump this to force a refresh after receive/advance.
 const listKey = ref(0);
@@ -63,7 +67,8 @@ function canReceive(row) {
 
 // --- aging (submitted + still owed) ---
 function aging(row) {
-	if (submissionOf(row.status) !== "Submitted" || !(Number(row.outstanding_amount) > 0.01)) return null;
+	if (submissionOf(row.status) !== "Submitted" || !(Number(row.outstanding_amount) > 0.01))
+		return null;
 	if (!row.due_date) return null;
 	const d = Math.floor((Date.now() - new Date(row.due_date).getTime()) / 86400000);
 	if (d <= 0) return { label: "Not due", cls: "bg-ink-100 text-ink-500" };
@@ -88,19 +93,38 @@ const payModes = ref([]);
 async function ensurePayRefs() {
 	if (depositAccounts.value.length) return;
 	try {
-		[depositAccounts.value, payModes.value] = await Promise.all([listDepositAccounts(), listInvoicePaymentModes()]);
+		[depositAccounts.value, payModes.value] = await Promise.all([
+			listDepositAccounts(),
+			listInvoicePaymentModes(),
+		]);
 	} catch {
 		/* fall through */
 	}
 }
-const rec = reactive({ open: false, inv: null, amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const rec = reactive({
+	open: false,
+	inv: null,
+	amount: null,
+	deposit_to: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 async function openReceive(row) {
 	await ensurePayRefs();
 	Object.assign(rec, {
 		open: true,
-		inv: { name: row.name, customer_name: row.customer_name, outstanding: Number(row.outstanding_amount) || 0 },
+		inv: {
+			name: row.name,
+			customer_name: row.customer_name,
+			outstanding: Number(row.outstanding_amount) || 0,
+		},
 		amount: Number(row.outstanding_amount) || null,
-		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		deposit_to:
+			depositAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			depositAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -110,11 +134,19 @@ async function openReceive(row) {
 async function saveReceive() {
 	const amt = Number(rec.amount) || 0;
 	if (amt <= 0) return showToast("Enter an amount greater than zero.", "error");
-	if (amt > Number(rec.inv.outstanding) + 0.01) return showToast(`Can't exceed the outstanding ${fmtINR(rec.inv.outstanding)}.`, "error");
+	if (amt > Number(rec.inv.outstanding) + 0.01)
+		return showToast(`Can't exceed the outstanding ${fmtINR(rec.inv.outstanding)}.`, "error");
 	if (!rec.deposit_to) return showToast("Pick the account to deposit into.", "error");
 	rec.saving = true;
 	try {
-		await recordInvoiceReceipt({ name: rec.inv.name, amount: amt, date: rec.date, mode_of_payment: rec.mode_of_payment || undefined, deposit_to: rec.deposit_to, reference_no: rec.reference_no || undefined });
+		await recordInvoiceReceipt({
+			name: rec.inv.name,
+			amount: amt,
+			date: rec.date,
+			mode_of_payment: rec.mode_of_payment || undefined,
+			deposit_to: rec.deposit_to,
+			reference_no: rec.reference_no || undefined,
+		});
 		rec.open = false;
 		refreshList();
 		showToast("Payment received.");
@@ -126,14 +158,26 @@ async function saveReceive() {
 }
 
 // --- record customer advance (on-account receipt) ---
-const adv = reactive({ open: false, customer: "", amount: null, deposit_to: "", date: "", mode_of_payment: "", reference_no: "", saving: false });
+const adv = reactive({
+	open: false,
+	customer: "",
+	amount: null,
+	deposit_to: "",
+	date: "",
+	mode_of_payment: "",
+	reference_no: "",
+	saving: false,
+});
 async function openAdvance() {
 	await ensurePayRefs();
 	Object.assign(adv, {
 		open: true,
 		customer: "",
 		amount: null,
-		deposit_to: depositAccounts.value.find((a) => a.account_type === "Bank")?.name || depositAccounts.value[0]?.name || "",
+		deposit_to:
+			depositAccounts.value.find((a) => a.account_type === "Bank")?.name ||
+			depositAccounts.value[0]?.name ||
+			"",
 		date: new Date().toISOString().slice(0, 10),
 		mode_of_payment: payModes.value[0] || "",
 		reference_no: "",
@@ -146,7 +190,14 @@ async function saveAdvance() {
 	if (!adv.deposit_to) return showToast("Pick the account to deposit into.", "error");
 	adv.saving = true;
 	try {
-		await recordCustomerAdvance({ customer: adv.customer, amount: Number(adv.amount), date: adv.date, deposit_to: adv.deposit_to, mode_of_payment: adv.mode_of_payment || undefined, reference_no: adv.reference_no || undefined });
+		await recordCustomerAdvance({
+			customer: adv.customer,
+			amount: Number(adv.amount),
+			date: adv.date,
+			deposit_to: adv.deposit_to,
+			mode_of_payment: adv.mode_of_payment || undefined,
+			reference_no: adv.reference_no || undefined,
+		});
 		adv.open = false;
 		refreshList();
 		showToast("Advance recorded.");
@@ -162,29 +213,57 @@ async function saveAdvance() {
 	<DeskPage title="Invoices" :breadcrumbs="breadcrumbs">
 		<template #actions>
 			<div class="flex items-center gap-2">
-				<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="openAdvance">Record advance</button>
+				<button
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+					@click="openAdvance"
+				>
+					Record advance
+				</button>
 				<button type="button" class="desk-save-btn" @click="openNew">+ New invoice</button>
 			</div>
 		</template>
 
 		<div class="space-y-4">
 			<div class="flex items-center gap-4 text-sm">
-				<div><span class="text-ink-500">Outstanding</span> <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(summary.outstanding) }}</span></div>
-				<div v-if="summary.advances > 0"><span class="text-ink-500">Advances held</span> <span class="font-semibold text-info-700 tabular-nums">{{ fmtINR(summary.advances) }}</span></div>
+				<div>
+					<span class="text-ink-500">Outstanding</span>
+					<span class="font-semibold text-ink-900 tabular-nums">{{
+						fmtINR(summary.outstanding)
+					}}</span>
+				</div>
+				<div v-if="summary.advances > 0">
+					<span class="text-ink-500">Advances held</span>
+					<span class="font-semibold text-info-700 tabular-nums">{{
+						fmtINR(summary.advances)
+					}}</span>
+				</div>
 			</div>
 
 			<DocTypeListView
 				v-if="activeCompany"
 				:key="listKey"
 				doctype="Sales Invoice"
-				:field-order="['customer_name', 'project', 'posting_date', 'due_date', 'grand_total', 'outstanding_amount', 'status']"
+				:field-order="[
+					'customer_name',
+					'project',
+					'posting_date',
+					'due_date',
+					'grand_total',
+					'outstanding_amount',
+					'status',
+				]"
 				:columns="[
 					{ key: 'name', label: 'Invoice' },
 					{ key: 'customer_name', label: 'Customer' },
 					{ key: 'project', label: 'Project' },
 					{ key: 'posting_date', label: 'Date' },
 					{ key: 'due_date', label: 'Due' },
-					{ key: 'aging', label: 'Aging', fields: ['due_date', 'outstanding_amount', 'status'] },
+					{
+						key: 'aging',
+						label: 'Aging',
+						fields: ['due_date', 'outstanding_amount', 'status'],
+					},
 					{ key: 'grand_total', label: 'Total', align: 'right' },
 					{ key: 'outstanding_amount', label: 'Outstanding', align: 'right' },
 					{ key: 'status', label: 'Status', fields: ['status', 'outstanding_amount'] },
@@ -213,76 +292,246 @@ async function saveAdvance() {
 					</DeskSelect>
 				</template>
 
-				<template #cell-name="{ row }"><span class="font-mono text-[11px] text-ink-500">{{ row.name }}</span></template>
-				<template #cell-customer_name="{ row }"><span class="text-ink-900">{{ row.customer_name }}</span></template>
-				<template #cell-project="{ row }"><span class="text-ink-500">{{ row.project || "—" }}</span></template>
-				<template #cell-posting_date="{ row }"><span class="text-ink-500 whitespace-nowrap">{{ fmtDate(row.posting_date) }}</span></template>
-				<template #cell-due_date="{ row }"><span class="text-ink-500 whitespace-nowrap">{{ fmtDate(row.due_date) }}</span></template>
+				<template #cell-name="{ row }"
+					><span class="font-mono text-[11px] text-ink-500">{{
+						row.name
+					}}</span></template
+				>
+				<template #cell-customer_name="{ row }"
+					><span class="text-ink-900">{{ row.customer_name }}</span></template
+				>
+				<template #cell-project="{ row }"
+					><span class="text-ink-500">{{
+						projectName(row.project) || "—"
+					}}</span></template
+				>
+				<template #cell-posting_date="{ row }"
+					><span class="text-ink-500 whitespace-nowrap">{{
+						fmtDate(row.posting_date)
+					}}</span></template
+				>
+				<template #cell-due_date="{ row }"
+					><span class="text-ink-500 whitespace-nowrap">{{
+						fmtDate(row.due_date)
+					}}</span></template
+				>
 				<template #cell-aging="{ row }">
-					<span v-if="aging(row)" class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="aging(row).cls">{{ aging(row).label }}</span>
+					<span
+						v-if="aging(row)"
+						class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap"
+						:class="aging(row).cls"
+						>{{ aging(row).label }}</span
+					>
 					<span v-else class="text-ink-300">—</span>
 				</template>
-				<template #cell-grand_total="{ row }"><span class="tabular-nums text-ink-900">{{ fmtINR(row.grand_total) }}</span></template>
-				<template #cell-outstanding_amount="{ row }"><span class="tabular-nums font-medium" :class="Number(row.outstanding_amount) > 0.01 ? 'text-ink-900' : 'text-ink-400'">{{ fmtINR(row.outstanding_amount) }}</span></template>
+				<template #cell-grand_total="{ row }"
+					><span class="tabular-nums text-ink-900">{{
+						fmtINR(row.grand_total)
+					}}</span></template
+				>
+				<template #cell-outstanding_amount="{ row }"
+					><span
+						class="tabular-nums font-medium"
+						:class="
+							Number(row.outstanding_amount) > 0.01 ? 'text-ink-900' : 'text-ink-400'
+						"
+						>{{ fmtINR(row.outstanding_amount) }}</span
+					></template
+				>
 				<template #cell-status="{ row }">
 					<div class="flex items-center gap-1.5">
 						<StatusBadge :status="submissionOf(row.status)" size="xs" />
-						<StatusBadge v-if="paymentOf(row.status)" :status="paymentOf(row.status)" size="xs" />
+						<StatusBadge
+							v-if="paymentOf(row.status)"
+							:status="paymentOf(row.status)"
+							size="xs"
+						/>
 					</div>
 				</template>
 				<template #cell-actions="{ row }">
-					<button v-if="canReceive(row)" type="button" class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded" @click.stop="openReceive(row)">Receive</button>
+					<button
+						v-if="canReceive(row)"
+						type="button"
+						class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded"
+						@click.stop="openReceive(row)"
+					>
+						Receive
+					</button>
 				</template>
 			</DocTypeListView>
 		</div>
 
 		<!-- Receive payment modal -->
-		<div v-if="rec.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="rec.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Receive payment</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="rec.open = false">✕</button></header>
+		<div
+			v-if="rec.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="rec.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Receive payment</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="rec.open = false"
+					>
+						✕
+					</button>
+				</header>
 				<div class="px-4 py-4 space-y-3">
-					<div class="text-sm text-ink-700">From <span class="font-medium">{{ rec.inv?.customer_name }}</span> against <span class="font-mono text-xs">{{ rec.inv?.name }}</span>. Outstanding <span class="font-semibold text-ink-900 tabular-nums">{{ fmtINR(rec.inv?.outstanding) }}</span>.</div>
+					<div class="text-sm text-ink-700">
+						From <span class="font-medium">{{ rec.inv?.customer_name }}</span> against
+						<span class="font-mono text-xs">{{ rec.inv?.name }}</span
+						>. Outstanding
+						<span class="font-semibold text-ink-900 tabular-nums">{{
+							fmtINR(rec.inv?.outstanding)
+						}}</span
+						>.
+					</div>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Amount" required><DeskInput v-model.number="rec.amount" type="number" min="0" /></DeskField>
-						<DeskField label="Date"><DeskInput v-model="rec.date" type="date" /></DeskField>
+						<DeskField label="Amount" required
+							><DeskInput v-model.number="rec.amount" type="number" min="0"
+						/></DeskField>
+						<DeskField label="Date"
+							><DeskInput v-model="rec.date" type="date"
+						/></DeskField>
 					</div>
 					<DeskField label="Deposit into" required>
-						<DeskSelect v-model="rec.deposit_to"><option value="" disabled>Bank / Cash account…</option><option v-for="a in depositAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+						<DeskSelect v-model="rec.deposit_to"
+							><option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in depositAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option></DeskSelect
+						>
 					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Mode of payment"><DeskSelect v-model="rec.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
-						<DeskField label="Reference no."><DeskInput v-model="rec.reference_no" placeholder="UTR / cheque no." /></DeskField>
+						<DeskField label="Mode of payment"
+							><DeskSelect v-model="rec.mode_of_payment"
+								><option value="">—</option>
+								<option v-for="m in payModes" :key="m" :value="m">
+									{{ m }}
+								</option></DeskSelect
+							></DeskField
+						>
+						<DeskField label="Reference no."
+							><DeskInput v-model="rec.reference_no" placeholder="UTR / cheque no."
+						/></DeskField>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="rec.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="rec.saving" @click="saveReceive">{{ rec.saving ? "Receiving…" : "Record receipt" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="rec.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="rec.saving"
+						@click="saveReceive"
+					>
+						{{ rec.saving ? "Receiving…" : "Record receipt" }}
+					</button>
 				</footer>
 			</div>
 		</div>
 
 		<!-- Record customer advance modal -->
-		<div v-if="adv.open" class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto" @click.self="adv.open = false">
-			<div class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl" @click.stop>
-				<header class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"><h2 class="text-sm font-semibold text-ink-900">Record customer advance</h2><button type="button" class="text-ink-400 hover:text-ink-900" @click="adv.open = false">✕</button></header>
+		<div
+			v-if="adv.open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="adv.open = false"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Record customer advance</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="adv.open = false"
+					>
+						✕
+					</button>
+				</header>
 				<div class="px-4 py-4 space-y-3">
-					<p class="text-[11px] text-ink-500">Money received before (or without) an invoice — it stays on the customer's account until a later invoice draws it down.</p>
-					<DeskField label="Customer" required><DeskLinkPicker v-model="adv.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" /></DeskField>
+					<p class="text-[11px] text-ink-500">
+						Money received before (or without) an invoice — it stays on the customer's
+						account until a later invoice draws it down.
+					</p>
+					<DeskField label="Customer" required
+						><DeskLinkPicker
+							v-model="adv.customer"
+							doctype="Customer"
+							label-field="customer_name"
+							value-field="name"
+							placeholder="Pick a customer…"
+					/></DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Amount" required><DeskInput v-model.number="adv.amount" type="number" min="0" placeholder="0" /></DeskField>
-						<DeskField label="Date"><DeskInput v-model="adv.date" type="date" /></DeskField>
+						<DeskField label="Amount" required
+							><DeskInput
+								v-model.number="adv.amount"
+								type="number"
+								min="0"
+								placeholder="0"
+						/></DeskField>
+						<DeskField label="Date"
+							><DeskInput v-model="adv.date" type="date"
+						/></DeskField>
 					</div>
 					<DeskField label="Deposit into" required>
-						<DeskSelect v-model="adv.deposit_to"><option value="" disabled>Bank / Cash account…</option><option v-for="a in depositAccounts" :key="a.name" :value="a.name">{{ a.name }} ({{ a.account_type }})</option></DeskSelect>
+						<DeskSelect v-model="adv.deposit_to"
+							><option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in depositAccounts" :key="a.name" :value="a.name">
+								{{ a.name }} ({{ a.account_type }})
+							</option></DeskSelect
+						>
 					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
-						<DeskField label="Mode of payment"><DeskSelect v-model="adv.mode_of_payment"><option value="">—</option><option v-for="m in payModes" :key="m" :value="m">{{ m }}</option></DeskSelect></DeskField>
-						<DeskField label="Reference no."><DeskInput v-model="adv.reference_no" placeholder="UTR / cheque no." /></DeskField>
+						<DeskField label="Mode of payment"
+							><DeskSelect v-model="adv.mode_of_payment"
+								><option value="">—</option>
+								<option v-for="m in payModes" :key="m" :value="m">
+									{{ m }}
+								</option></DeskSelect
+							></DeskField
+						>
+						<DeskField label="Reference no."
+							><DeskInput v-model="adv.reference_no" placeholder="UTR / cheque no."
+						/></DeskField>
 					</div>
 				</div>
-				<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2">
-					<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="adv.open = false">Cancel</button>
-					<button type="button" class="text-xs desk-save-btn" :disabled="adv.saving" @click="saveAdvance">{{ adv.saving ? "Recording…" : "Record advance" }}</button>
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="adv.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="adv.saving"
+						@click="saveAdvance"
+					>
+						{{ adv.saving ? "Recording…" : "Record advance" }}
+					</button>
 				</footer>
 			</div>
 		</div>

--- a/frontend/src/views/workspaces/EquipmentDashboardView.vue
+++ b/frontend/src/views/workspaces/EquipmentDashboardView.vue
@@ -6,12 +6,14 @@ import { RouterLink, useRouter } from "vue-router";
 import { fmtINR, fmtCompactINR, fmtDate } from "@/utils/format";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { getEquipmentDashboard } from "@/data/equipmentApi";
+import { useProjectNames } from "@/composables/useProjectNames";
 import StatusBadge from "@/components/StatusBadge.vue";
 
 const router = useRouter();
+const { projectName } = useProjectNames();
 
 const today = computed(() =>
-	new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" }),
+	new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
 );
 
 const loading = ref(true);
@@ -121,7 +123,9 @@ const register = computed(() => kpis.value?.register || []);
 								/>
 								<h2 class="text-sm font-semibold text-ink-900">Recent usage</h2>
 							</div>
-							<RouterLink to="/machinery-usage" class="text-xs text-brand-700 hover:underline"
+							<RouterLink
+								to="/machinery-usage"
+								class="text-xs text-brand-700 hover:underline"
 								>View all →</RouterLink
 							>
 						</div>
@@ -133,15 +137,22 @@ const register = computed(() => kpis.value?.register || []);
 								@click="router.push(`/machinery-usage/${u.name}`)"
 							>
 								<div class="flex items-center justify-between">
-									<span class="text-sm text-ink-900 font-medium">{{ u.machine }}</span>
-									<span class="text-sm text-ink-900 tabular-nums">{{ fmtCompactINR(u.total) }}</span>
+									<span class="text-sm text-ink-900 font-medium">{{
+										u.machine
+									}}</span>
+									<span class="text-sm text-ink-900 tabular-nums">{{
+										fmtCompactINR(u.total)
+									}}</span>
 								</div>
 								<div class="text-[11px] text-ink-500 mt-0.5">
-									{{ u.project || "—" }} · {{ fmtDate(u.date) }} · {{ u.quantity }} {{ u.unit }}
+									{{ projectName(u.project) || "—" }} · {{ fmtDate(u.date) }} ·
+									{{ u.quantity }} {{ u.unit }}
 								</div>
 							</li>
 						</ul>
-						<div v-else class="px-4 py-6 text-sm text-ink-400">No usage logged yet.</div>
+						<div v-else class="px-4 py-6 text-sm text-ink-400">
+							No usage logged yet.
+						</div>
 					</div>
 
 					<!-- Register -->
@@ -163,7 +174,9 @@ const register = computed(() => kpis.value?.register || []);
 								/>
 								<h2 class="text-sm font-semibold text-ink-900">Register</h2>
 							</div>
-							<RouterLink to="/machinery" class="text-xs text-brand-700 hover:underline"
+							<RouterLink
+								to="/machinery"
+								class="text-xs text-brand-700 hover:underline"
 								>View all →</RouterLink
 							>
 						</div>
@@ -175,18 +188,26 @@ const register = computed(() => kpis.value?.register || []);
 								@click="router.push(`/machinery/${m.name}`)"
 							>
 								<div class="flex items-center justify-between">
-									<span class="text-sm text-ink-900 font-medium">{{ m.machinery_name }}</span>
-									<span class="text-sm text-ink-700 tabular-nums"
-										>{{ m.rate ? fmtINR(m.rate) + "/" + (m.rate_unit || "—") : "—" }}</span
-									>
+									<span class="text-sm text-ink-900 font-medium">{{
+										m.machinery_name
+									}}</span>
+									<span class="text-sm text-ink-700 tabular-nums">{{
+										m.rate ? fmtINR(m.rate) + "/" + (m.rate_unit || "—") : "—"
+									}}</span>
 								</div>
-								<div class="text-[11px] text-ink-500 mt-0.5 flex items-center gap-1.5">
+								<div
+									class="text-[11px] text-ink-500 mt-0.5 flex items-center gap-1.5"
+								>
 									<StatusBadge :status="m.status" size="xs" />
-									<span>· {{ m.machinery_type || "—" }} · {{ m.ownership }}</span>
+									<span
+										>· {{ m.machinery_type || "—" }} · {{ m.ownership }}</span
+									>
 								</div>
 							</li>
 						</ul>
-						<div v-else class="px-4 py-6 text-sm text-ink-400">No machines registered.</div>
+						<div v-else class="px-4 py-6 text-sm text-ink-400">
+							No machines registered.
+						</div>
 					</div>
 				</div>
 			</template>

--- a/frontend/src/views/workspaces/ProcurementDashboardView.vue
+++ b/frontend/src/views/workspaces/ProcurementDashboardView.vue
@@ -4,12 +4,14 @@ import { RouterLink } from "vue-router";
 import { fmtCompactINR, fmtDate } from "@/utils/format";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { getProcurementDashboard } from "@/data/procurementApi";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { dayjs } from "frappe-ui";
 
 const today = computed(() =>
 	new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" })
 );
 
+const { projectName } = useProjectNames();
 const loading = ref(true);
 const error = ref("");
 const kpis = ref(null);
@@ -35,7 +37,9 @@ function plural(n) {
 // Frappe Desk list URL with filters, e.g. per_received=["<",100].
 function deskUrl(doctype, filters = {}) {
 	const qs = Object.entries(filters)
-		.map(([k, v]) => `${k}=${encodeURIComponent(typeof v === "string" ? v : JSON.stringify(v))}`)
+		.map(
+			([k, v]) => `${k}=${encodeURIComponent(typeof v === "string" ? v : JSON.stringify(v))}`
+		)
 		.join("&");
 	return `/app/${doctype}?${qs}`;
 }
@@ -285,40 +289,40 @@ function grnTone(status) {
 									:href="row.href"
 									class="px-4 py-3 flex items-center gap-3 hover:bg-ink-50 transition-colors"
 								>
-								<span
-									:class="[
-										'w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0',
-										toneClasses(row.tone).chip,
-									]"
-								>
-									<svg
-										class="w-4 h-4"
-										viewBox="0 0 24 24"
-										fill="none"
-										stroke="currentColor"
-										stroke-width="1.75"
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										aria-hidden="true"
-										v-html="getWorkspaceIconPath(row.icon)"
-									/>
-								</span>
-								<div class="flex-1 min-w-0">
-									<div class="text-sm font-medium text-ink-900 truncate">
-										{{ row.label }}
+									<span
+										:class="[
+											'w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0',
+											toneClasses(row.tone).chip,
+										]"
+									>
+										<svg
+											class="w-4 h-4"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="1.75"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											aria-hidden="true"
+											v-html="getWorkspaceIconPath(row.icon)"
+										/>
+									</span>
+									<div class="flex-1 min-w-0">
+										<div class="text-sm font-medium text-ink-900 truncate">
+											{{ row.label }}
+										</div>
+										<div class="text-[11px] text-ink-500 truncate mt-0.5">
+											{{ row.sub }}
+										</div>
 									</div>
-									<div class="text-[11px] text-ink-500 truncate mt-0.5">
-										{{ row.sub }}
-									</div>
-								</div>
-								<span
-									:class="[
-										'text-base font-semibold tabular-nums flex-shrink-0',
-										toneClasses(row.tone).count,
-									]"
-									>{{ row.count }}</span
-								>
-								<span class="text-ink-300">›</span>
+									<span
+										:class="[
+											'text-base font-semibold tabular-nums flex-shrink-0',
+											toneClasses(row.tone).count,
+										]"
+										>{{ row.count }}</span
+									>
+									<span class="text-ink-300">›</span>
 								</a>
 							</li>
 						</ul>
@@ -374,7 +378,7 @@ function grnTone(status) {
 										>
 									</div>
 									<div class="text-[11px] text-ink-500 mt-0.5 truncate">
-										{{ grn.project }} · {{ grn.supplier }} ·
+										{{ projectName(grn.project) }} · {{ grn.supplier }} ·
 										{{ fmtDate(grn.posting_date) }} · {{ grn.name }}
 									</div>
 								</div>

--- a/frontend/src/views/workspaces/SubcontractorDashboardView.vue
+++ b/frontend/src/views/workspaces/SubcontractorDashboardView.vue
@@ -7,6 +7,7 @@
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtCompactINR } from "@/utils/format";
@@ -15,6 +16,8 @@ const today = computed(() => {
 	const d = new Date();
 	return d.toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
 });
+
+const { projectName } = useProjectNames();
 
 const wosRes = useDocTypeList("Subcontractor Work Order", {
 	fields: [
@@ -50,13 +53,13 @@ const subs = computed(() => subsRes.data || []);
 const recentMBs = computed(() => (mbsRes.data || []).slice(0, 5));
 
 const openWos = computed(() =>
-	wos.value.filter((w) => w.status === "Awarded" || w.status === "In Progress"),
+	wos.value.filter((w) => w.status === "Awarded" || w.status === "In Progress")
 );
 const openWosValue = computed(() =>
-	openWos.value.reduce((a, w) => a + (Number(w.total_value) || 0), 0),
+	openWos.value.reduce((a, w) => a + (Number(w.total_value) || 0), 0)
 );
 const totalWoValue = computed(() =>
-	wos.value.reduce((a, w) => a + (Number(w.total_value) || 0), 0),
+	wos.value.reduce((a, w) => a + (Number(w.total_value) || 0), 0)
 );
 const activeSubs = computed(() => subs.value.filter((s) => !s.disabled).length);
 
@@ -169,7 +172,7 @@ const recentWorkOrders = computed(() => wos.value.slice(0, 6));
 							class="text-[11px] text-ink-500 mt-0.5 truncate flex items-center gap-1.5 flex-wrap"
 						>
 							<StatusBadge :status="wo.status" size="xs" />
-							<span>· {{ wo.project }}</span>
+							<span>· {{ projectName(wo.project) }}</span>
 							<span class="text-ink-400">· {{ fmtDate(wo.date) }}</span>
 							<span v-if="wo.delivery_type" class="text-ink-400"
 								>· {{ wo.delivery_type }}</span
@@ -220,7 +223,7 @@ const recentWorkOrders = computed(() => wos.value.slice(0, 6));
 								<StatusBadge :status="mb.status" size="xs" />
 							</div>
 							<div class="text-[11px] text-ink-500 mt-0.5 truncate">
-								{{ mb.project }} ·
+								{{ projectName(mb.project) }} ·
 								<RouterLink
 									:to="`/subcontractor-work-orders/${mb.work_order}`"
 									class="text-brand-700 hover:underline"


### PR DESCRIPTION
Lists and detail views that carry a project *link* were showing the raw id (e.g. `PROJ-0012`) instead of the human `project_name`.

## Fix
New shared composable **`useProjectNames()`** — one cached Project fetch (name → project_name), mirroring the existing `useUserNames()` pattern — exposes `projectName(id)`. Applied everywhere a bare id was rendered:

**Subcontract** (the reported cases)
- Work Order list, Measurement Book list, Subcontractor Bill list
- Subcontractor detail (WO table), Subcontractor dashboard (WO + MB)
- List search now also matches the project name

**Equipment**
- Machinery Usage list, Machinery detail, Usage detail, Equipment dashboard

**Finance**
- Invoices + Bills panels

**Procurement / Stage Planning**
- Procurement dashboard (GRN row), Stage Planning detail (project fallback)

`projectName(id)` falls back to the id itself until the directory resolves (and for values that aren't project ids), so it is safe to apply broadly. The three store-backed landings (Director/PM landing, Project dashboard) already display the store's project display name, so they're left untouched.

## Verification
- `vite build --mode development` clean; eslint passes.
- Grep sweep confirms no remaining real-data view renders a bare `*.project` id.