### PR TITLE
fix: invoice form matches prototype defaults (tax template + discount unit)

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -757,8 +757,13 @@ def list_tax_templates(company=None):
 	filters = {"disabled": 0}
 	if company:
 		filters["company"] = company
+	# is_default first so a new invoice can pre-select the company's default template
+	# (mirrors the prototype starting each invoice with its default tax pre-filled).
 	return frappe.get_all(
-		"Sales Taxes and Charges Template", filters=filters, fields=["name", "title"], order_by="title asc"
+		"Sales Taxes and Charges Template",
+		filters=filters,
+		fields=["name", "title", "is_default"],
+		order_by="is_default desc, title asc",
 	)
 
 

--- a/frontend/src/data/invoiceApi.js
+++ b/frontend/src/data/invoiceApi.js
@@ -29,7 +29,8 @@ export const linkInvoiceAdvance = (args) => call("link_advance", args);
 export const unlinkInvoiceAdvance = (args) => call("unlink_advance", args);
 export const invoiceReceivablesSummary = () => call("receivables_summary", {});
 export const listDepositAccounts = () => call("list_deposit_accounts", {});
-export const listInvoiceTaxTemplates = () => call("list_tax_templates", {});
+export const listInvoiceTaxTemplates = (company) =>
+	call("list_tax_templates", company ? { company } : {});
 export const getInvoiceTaxTemplateRows = (template) => call("get_tax_template_rows", { template });
 export const getInvoiceTerms = (name) => call("get_terms", { name });
 export const listInvoicePaymentModes = () => call("list_payment_modes", {});

--- a/frontend/src/views/finance/FinanceInvoiceFormView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceFormView.vue
@@ -7,7 +7,13 @@
 import { computed, reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
-import { getInvoice, saveInvoice, getInvoiceTaxTemplateRows, getInvoiceTerms } from "@/data/invoiceApi";
+import {
+	getInvoice,
+	saveInvoice,
+	getInvoiceTaxTemplateRows,
+	getInvoiceTerms,
+	listInvoiceTaxTemplates,
+} from "@/data/invoiceApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
 import DeskActionBar from "@/components/desk/DeskActionBar.vue";
@@ -15,12 +21,13 @@ import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
-import { activeCompanyFilter } from "@/composables/useActiveCompany";
+import { activeCompanyFilter, useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, default: "" } });
 const router = useRouter();
 const companyFilter = activeCompanyFilter();
+const activeCompany = useActiveCompany();
 // Tax account heads: non-group accounts in the active (default) company only — so a tax
 // template / row can't pull an account from another company (which the Sales Invoice rejects).
 const accountFilters = computed(() => [["is_group", "=", 0], ...companyFilter.value]);
@@ -38,7 +45,7 @@ const form = reactive({
 	taxes_and_charges: "",
 	taxes: [],
 	discount_on: "Net Total",
-	discount_type: "%", // "%" | "₹"
+	discount_type: "₹", // "%" | "₹" — ₹ by default, matching the prototype
 	discount_value: 0,
 	tc_name: "",
 	terms: "",
@@ -60,12 +67,24 @@ if (isEdit.value) {
 				project: inv.project || "",
 				date: inv.date,
 				due_date: inv.due_date || "",
-				lines: (inv.items || []).map((l) => ({ description: l.description, qty: l.qty ?? 1, rate: l.rate })),
+				lines: (inv.items || []).map((l) => ({
+					description: l.description,
+					qty: l.qty ?? 1,
+					rate: l.rate,
+				})),
 				taxes_and_charges: inv.taxes_and_charges || "",
-				taxes: (inv.taxes || []).map((t) => ({ charge_type: t.charge_type, account_head: t.account_head, description: t.description, rate: t.rate })),
+				taxes: (inv.taxes || []).map((t) => ({
+					charge_type: t.charge_type,
+					account_head: t.account_head,
+					description: t.description,
+					rate: t.rate,
+				})),
 				discount_on: inv.additional_discount_on || "Net Total",
 				discount_type: Number(inv.discount_amount) > 0 ? "₹" : "%",
-				discount_value: Number(inv.discount_amount) > 0 ? Number(inv.discount_amount) : Number(inv.additional_discount_percentage) || 0,
+				discount_value:
+					Number(inv.discount_amount) > 0
+						? Number(inv.discount_amount)
+						: Number(inv.additional_discount_percentage) || 0,
 				tc_name: inv.tc_name || "",
 				terms: inv.terms || "",
 			});
@@ -74,6 +93,16 @@ if (isEdit.value) {
 		})
 		.catch((err) => showToast(err.message || "Failed to load invoice", "error"))
 		.finally(() => (loading.value = false));
+} else {
+	// New invoice: pre-select the company's default tax template so the tax section
+	// and totals waterfall start pre-filled (matches the prototype). Uses whatever
+	// template the site marks default — no hardcoded GST.
+	listInvoiceTaxTemplates(activeCompany.value)
+		.then((tpls) => {
+			const def = (tpls || []).find((t) => t.is_default);
+			if (def) applyTemplate(def.name);
+		})
+		.catch(() => {});
 }
 
 // --- items ---
@@ -122,10 +151,16 @@ async function onPickTerms(name) {
 // --- live waterfall ---
 const wf = computed(() => {
 	const net = form.lines.reduce((a, l) => a + lineAmount(l), 0);
-	const discBase = (base) => (form.discount_type === "%" ? (base * (Number(form.discount_value) || 0)) / 100 : Number(form.discount_value) || 0);
+	const discBase = (base) =>
+		form.discount_type === "%"
+			? (base * (Number(form.discount_value) || 0)) / 100
+			: Number(form.discount_value) || 0;
 	const netDiscount = form.discount_on === "Net Total" ? discBase(net) : 0;
 	const taxable = Math.max(0, net - netDiscount);
-	const taxRows = form.taxes.map((t) => ({ ...t, amount: (taxable * (Number(t.rate) || 0)) / 100 }));
+	const taxRows = form.taxes.map((t) => ({
+		...t,
+		amount: (taxable * (Number(t.rate) || 0)) / 100,
+	}));
 	const tax = taxRows.reduce((a, r) => a + r.amount, 0);
 	const grandTotal = taxable + tax;
 	const grandDiscount = form.discount_on === "Grand Total" ? discBase(grandTotal) : 0;
@@ -155,11 +190,23 @@ async function save() {
 			project: form.project || undefined,
 			date: form.date,
 			due_date: form.due_date || undefined,
-			items: lines.map((l) => ({ description: l.description.trim(), qty: Number(l.qty) || 1, rate: Number(l.rate) })),
+			items: lines.map((l) => ({
+				description: l.description.trim(),
+				qty: Number(l.qty) || 1,
+				rate: Number(l.rate),
+			})),
 			taxes_and_charges: form.taxes_and_charges || undefined,
-			taxes: form.taxes.filter((t) => t.account_head).map((t) => ({ charge_type: t.charge_type, account_head: t.account_head, description: t.description, rate: Number(t.rate) || 0 })),
+			taxes: form.taxes
+				.filter((t) => t.account_head)
+				.map((t) => ({
+					charge_type: t.charge_type,
+					account_head: t.account_head,
+					description: t.description,
+					rate: Number(t.rate) || 0,
+				})),
 			additional_discount_on: form.discount_on,
-			additional_discount_percentage: form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
+			additional_discount_percentage:
+				form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
 			discount_amount: form.discount_type === "₹" ? Number(form.discount_value) || 0 : 0,
 			tc_name: form.tc_name || undefined,
 			terms: form.terms || undefined,
@@ -175,39 +222,106 @@ async function save() {
 </script>
 
 <template>
-	<DeskPage :title="isEdit ? `Edit ${id}` : 'New Invoice'" :breadcrumbs="breadcrumbs" subtitle="Bills the customer — Submit posts it as a receivable.">
+	<DeskPage
+		:title="isEdit ? `Edit ${id}` : 'New Invoice'"
+		:breadcrumbs="breadcrumbs"
+		subtitle="Bills the customer — Submit posts it as a receivable."
+	>
 		<DeskForm>
 			<template #action-bar>
-				<DeskActionBar :save-label="isEdit ? 'Save invoice' : 'Create invoice'" :saving="saving" @save="save" @cancel="router.back()" />
+				<DeskActionBar
+					:save-label="isEdit ? 'Save invoice' : 'Create invoice'"
+					:saving="saving"
+					@save="save"
+					@cancel="router.back()"
+				/>
 			</template>
 
 			<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Loading…</div>
 			<template v-else>
 				<DeskSection title="Invoice details" :cols="4">
 					<DeskField label="Customer" required :error="errors.customer">
-						<DeskLinkPicker v-model="form.customer" doctype="Customer" label-field="customer_name" value-field="name" placeholder="Pick a customer…" />
+						<DeskLinkPicker
+							v-model="form.customer"
+							doctype="Customer"
+							label-field="customer_name"
+							value-field="name"
+							placeholder="Pick a customer…"
+						/>
 					</DeskField>
 					<DeskField label="Project" hint="Optional — tags the income to a project.">
-						<DeskLinkPicker v-model="form.project" doctype="Project" label-field="project_name" value-field="name" :filters="companyFilter" placeholder="None" />
+						<DeskLinkPicker
+							v-model="form.project"
+							doctype="Project"
+							label-field="project_name"
+							value-field="name"
+							:filters="companyFilter"
+							placeholder="None"
+						/>
 					</DeskField>
-					<DeskField label="Invoice date"><DeskInput v-model="form.date" type="date" /></DeskField>
-					<DeskField label="Due date"><DeskInput v-model="form.due_date" type="date" /></DeskField>
+					<DeskField label="Invoice date"
+						><DeskInput v-model="form.date" type="date"
+					/></DeskField>
+					<DeskField label="Due date"
+						><DeskInput v-model="form.due_date" type="date"
+					/></DeskField>
 				</DeskSection>
 
 				<DeskSection title="Items" :cols="1">
 					<div>
-						<div class="hidden md:grid grid-cols-[1fr_110px_140px_140px_36px] gap-2 text-[10px] uppercase tracking-wider text-ink-500 font-medium px-1 mb-1">
-							<span>Description</span><span class="text-right">Qty</span><span class="text-right">Rate</span><span class="text-right">Amount</span><span></span>
+						<div
+							class="hidden md:grid grid-cols-[1fr_110px_140px_140px_36px] gap-2 text-[10px] uppercase tracking-wider text-ink-500 font-medium px-1 mb-1"
+						>
+							<span>Description</span><span class="text-right">Qty</span
+							><span class="text-right">Rate</span
+							><span class="text-right">Amount</span><span></span>
 						</div>
-						<div v-for="(l, idx) in form.lines" :key="idx" class="grid grid-cols-2 md:grid-cols-[1fr_110px_140px_140px_36px] gap-2 items-center mb-2">
-							<DeskInput v-model="l.description" placeholder="e.g. Block A — RA-4 milestone" class="col-span-2 md:col-span-1" />
-							<DeskInput v-model.number="l.qty" type="number" min="0" placeholder="Qty" class="text-right" />
-							<DeskInput v-model.number="l.rate" type="number" min="0" placeholder="Rate" class="text-right" />
-							<div class="text-xs tabular-nums text-ink-700 text-right">{{ fmtINR(lineAmount(l)) }}</div>
-							<button type="button" class="text-ink-400 hover:text-danger-600 text-sm" aria-label="Remove line" @click="removeLine(idx)">✕</button>
+						<div
+							v-for="(l, idx) in form.lines"
+							:key="idx"
+							class="grid grid-cols-2 md:grid-cols-[1fr_110px_140px_140px_36px] gap-2 items-center mb-2"
+						>
+							<DeskInput
+								v-model="l.description"
+								placeholder="e.g. Block A — RA-4 milestone"
+								class="col-span-2 md:col-span-1"
+							/>
+							<DeskInput
+								v-model.number="l.qty"
+								type="number"
+								min="0"
+								placeholder="Qty"
+								class="text-right"
+							/>
+							<DeskInput
+								v-model.number="l.rate"
+								type="number"
+								min="0"
+								placeholder="Rate"
+								class="text-right"
+							/>
+							<div class="text-xs tabular-nums text-ink-700 text-right">
+								{{ fmtINR(lineAmount(l)) }}
+							</div>
+							<button
+								type="button"
+								class="text-ink-400 hover:text-danger-600 text-sm"
+								aria-label="Remove line"
+								@click="removeLine(idx)"
+							>
+								✕
+							</button>
 						</div>
-						<p v-if="errors.lines" class="text-[11px] text-danger-600 mb-2">{{ errors.lines }}</p>
-						<button type="button" class="text-xs text-brand-700 hover:underline" @click="addLine">+ Add item</button>
+						<p v-if="errors.lines" class="text-[11px] text-danger-600 mb-2">
+							{{ errors.lines }}
+						</p>
+						<button
+							type="button"
+							class="text-xs text-brand-700 hover:underline"
+							@click="addLine"
+						>
+							+ Add item
+						</button>
 					</div>
 				</DeskSection>
 
@@ -220,57 +334,192 @@ async function save() {
 							<hr class="desk-divider" />
 							<div class="flex items-center gap-2 mb-2 mt-2">
 								<div class="w-64">
-									<DeskLinkPicker :model-value="form.taxes_and_charges" doctype="Sales Taxes and Charges Template" label-field="title" value-field="name" :filters="companyFilter" placeholder="Tax template…" @update:model-value="applyTemplate" />
+									<DeskLinkPicker
+										:model-value="form.taxes_and_charges"
+										doctype="Sales Taxes and Charges Template"
+										label-field="title"
+										value-field="name"
+										:filters="companyFilter"
+										placeholder="Tax template…"
+										@update:model-value="applyTemplate"
+									/>
 								</div>
-								<button type="button" class="text-[11px] text-brand-700 hover:underline whitespace-nowrap" @click="addTaxRow">+ Add row</button>
+								<button
+									type="button"
+									class="text-[11px] text-brand-700 hover:underline whitespace-nowrap"
+									@click="addTaxRow"
+								>
+									+ Add row
+								</button>
 							</div>
 							<div v-if="form.taxes.length" class="space-y-1.5">
-								<div v-for="(row, idx) in form.taxes" :key="idx" class="flex items-center gap-2">
-									<div class="w-56"><DeskLinkPicker v-model="row.account_head" doctype="Account" label-field="name" value-field="name" :filters="accountFilters" placeholder="Tax account…" /></div>
-									<input v-model.number="row.rate" type="number" min="0" step="0.5" class="w-16 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200" />
+								<div
+									v-for="(row, idx) in form.taxes"
+									:key="idx"
+									class="flex items-center gap-2"
+								>
+									<div class="w-56">
+										<DeskLinkPicker
+											v-model="row.account_head"
+											doctype="Account"
+											label-field="name"
+											value-field="name"
+											:filters="accountFilters"
+											placeholder="Tax account…"
+										/>
+									</div>
+									<input
+										v-model.number="row.rate"
+										type="number"
+										min="0"
+										step="0.5"
+										class="w-16 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200"
+									/>
 									<span class="text-[10px] text-ink-400">%</span>
-									<button type="button" class="text-ink-400 hover:text-danger-600 text-xs" @click="removeTaxRow(idx)">✕</button>
+									<button
+										type="button"
+										class="text-ink-400 hover:text-danger-600 text-xs"
+										@click="removeTaxRow(idx)"
+									>
+										✕
+									</button>
 								</div>
 							</div>
 							<div class="flex items-center gap-2 flex-wrap mt-3">
 								<span class="text-xs text-ink-500">Discount</span>
-								<select v-model="form.discount_on" class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200">
+								<select
+									v-model="form.discount_on"
+									class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+								>
 									<option value="Net Total">On Net Total</option>
 									<option value="Grand Total">On Grand Total</option>
 								</select>
-								<input v-model.number="form.discount_value" type="number" min="0" class="w-24 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200" />
-								<div class="flex rounded-md border border-ink-200 overflow-hidden text-[11px]">
-									<button type="button" class="px-2 py-1" :class="form.discount_type === '₹' ? 'bg-ink-900 text-white' : 'text-ink-600'" @click="form.discount_type = '₹'">₹</button>
-									<button type="button" class="px-2 py-1" :class="form.discount_type === '%' ? 'bg-ink-900 text-white' : 'text-ink-600'" @click="form.discount_type = '%'">%</button>
+								<input
+									v-model.number="form.discount_value"
+									type="number"
+									min="0"
+									class="w-24 text-xs px-2 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200"
+								/>
+								<div
+									class="flex rounded-md border border-ink-200 overflow-hidden text-[11px]"
+								>
+									<button
+										type="button"
+										class="px-2 py-1"
+										:class="
+											form.discount_type === '₹'
+												? 'bg-ink-900 text-white'
+												: 'text-ink-600'
+										"
+										@click="form.discount_type = '₹'"
+									>
+										₹
+									</button>
+									<button
+										type="button"
+										class="px-2 py-1"
+										:class="
+											form.discount_type === '%'
+												? 'bg-ink-900 text-white'
+												: 'text-ink-600'
+										"
+										@click="form.discount_type = '%'"
+									>
+										%
+									</button>
 								</div>
 							</div>
 						</div>
 
 						<!-- collapsible terms -->
 						<div>
-							<button type="button" class="w-full flex items-center gap-2 text-left" @click="termsOpen = !termsOpen">
+							<button
+								type="button"
+								class="w-full flex items-center gap-2 text-left"
+								@click="termsOpen = !termsOpen"
+							>
 								<h3 class="desk-section-title">Terms &amp; conditions</h3>
-								<span v-if="form.terms && !termsOpen" class="text-[10px] px-1.5 py-0.5 bg-brand-50 text-brand-700 rounded-full">set</span>
-								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-ink-400 transition-transform" :class="termsOpen ? 'rotate-90' : ''"><path d="M9 18l6-6-6-6" /></svg>
+								<span
+									v-if="form.terms && !termsOpen"
+									class="text-[10px] px-1.5 py-0.5 bg-brand-50 text-brand-700 rounded-full"
+									>set</span
+								>
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									class="text-ink-400 transition-transform"
+									:class="termsOpen ? 'rotate-90' : ''"
+								>
+									<path d="M9 18l6-6-6-6" />
+								</svg>
 							</button>
 							<hr class="desk-divider" />
 							<div v-if="termsOpen" class="mt-2">
 								<div class="w-64 mb-2">
-									<DeskLinkPicker :model-value="form.tc_name" doctype="Terms and Conditions" label-field="name" value-field="name" placeholder="Import from template…" @update:model-value="onPickTerms" />
+									<DeskLinkPicker
+										:model-value="form.tc_name"
+										doctype="Terms and Conditions"
+										label-field="name"
+										value-field="name"
+										placeholder="Import from template…"
+										@update:model-value="onPickTerms"
+									/>
 								</div>
-								<textarea v-model="form.terms" rows="5" placeholder="Terms printed on the invoice — import a template above or write your own." class="w-full text-xs px-3 py-2 border border-ink-200 rounded-md leading-relaxed focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"></textarea>
+								<textarea
+									v-model="form.terms"
+									rows="5"
+									placeholder="Terms printed on the invoice — import a template above or write your own."
+									class="w-full text-xs px-3 py-2 border border-ink-200 rounded-md leading-relaxed focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+								></textarea>
 							</div>
 						</div>
 					</div>
 
 					<!-- live totals waterfall -->
 					<div class="bg-ink-50 rounded-lg px-4 py-3 text-sm space-y-1 self-start">
-						<div class="flex justify-between text-ink-600"><span>Net total</span><span class="tabular-nums">{{ fmtINR(wf.net) }}</span></div>
-						<div v-if="wf.netDiscount > 0" class="flex justify-between text-ink-600"><span>Discount (on net)</span><span class="tabular-nums text-danger-700">− {{ fmtINR(wf.netDiscount) }}</span></div>
-						<div v-if="wf.taxable !== wf.net" class="flex justify-between text-ink-600"><span>Taxable value</span><span class="tabular-nums">{{ fmtINR(wf.taxable) }}</span></div>
-						<div v-for="(row, idx) in wf.taxRows" :key="idx" class="flex justify-between text-ink-600"><span>{{ row.account_head || "Tax" }} ({{ row.rate }}%)</span><span class="tabular-nums">{{ fmtINR(row.amount) }}</span></div>
-						<div v-if="wf.grandDiscount > 0" class="flex justify-between text-ink-600"><span>Discount (on grand total)</span><span class="tabular-nums text-danger-700">− {{ fmtINR(wf.grandDiscount) }}</span></div>
-						<div class="flex justify-between font-semibold text-ink-900 border-t border-ink-200 pt-1.5"><span>Invoice total</span><span class="tabular-nums">{{ fmtINR(wf.invoiceTotal) }}</span></div>
+						<div class="flex justify-between text-ink-600">
+							<span>Net total</span
+							><span class="tabular-nums">{{ fmtINR(wf.net) }}</span>
+						</div>
+						<div v-if="wf.netDiscount > 0" class="flex justify-between text-ink-600">
+							<span>Discount (on net)</span
+							><span class="tabular-nums text-danger-700"
+								>− {{ fmtINR(wf.netDiscount) }}</span
+							>
+						</div>
+						<div
+							v-if="wf.taxable !== wf.net"
+							class="flex justify-between text-ink-600"
+						>
+							<span>Taxable value</span
+							><span class="tabular-nums">{{ fmtINR(wf.taxable) }}</span>
+						</div>
+						<div
+							v-for="(row, idx) in wf.taxRows"
+							:key="idx"
+							class="flex justify-between text-ink-600"
+						>
+							<span>{{ row.account_head || "Tax" }} ({{ row.rate }}%)</span
+							><span class="tabular-nums">{{ fmtINR(row.amount) }}</span>
+						</div>
+						<div v-if="wf.grandDiscount > 0" class="flex justify-between text-ink-600">
+							<span>Discount (on grand total)</span
+							><span class="tabular-nums text-danger-700"
+								>− {{ fmtINR(wf.grandDiscount) }}</span
+							>
+						</div>
+						<div
+							class="flex justify-between font-semibold text-ink-900 border-t border-ink-200 pt-1.5"
+						>
+							<span>Invoice total</span
+							><span class="tabular-nums">{{ fmtINR(wf.invoiceTotal) }}</span>
+						</div>
 					</div>
 				</div>
 			</template>


### PR DESCRIPTION
## Context
Reviewed the invoice-creation form (`FinanceInvoiceFormView`) against the prototype (`InvoiceFormView`). The live form is a faithful port — same page, sections (Invoice details / Items / Taxes & discount / collapsible Terms / live totals waterfall), grid, labels, and subtitle. Two first-load **defaults** were the only things making it look different.

## Changes
- **Discount unit → ₹ default** (was %), matching the prototype's ₹/% toggle.
- **Default tax template pre-selected on a new invoice** — so the tax section and totals waterfall start pre-filled like the prototype (which begins each invoice with its default tax). It uses whatever template the site marks **is_default** for the active company — **no hardcoded GST** (honours the 'compliance app owns GST' steer); if nothing is marked default it stays empty. `list_tax_templates` now returns `is_default` and orders default-first.

## Deliberately unchanged
- The **picker widgets** stay as `DeskLinkPicker`. It renders as the same bordered, chevron'd, input-height field as the prototype's `DeskSearchableSelect` (verified in markup), and it's the server-backed picker used **consistently across every live form** (bills, work orders, …). The prototype's dropdowns are backed by in-memory mock arrays; the live form must read the real database — that data source is the only reason the widget class differs. Swapping just this screen would make it inconsistent with the rest of the app.
- Project-list **grouping** (Projects / Sub-projects) is a mock-data convenience of the prototype's searchable select; the live picker lists active-company projects. Happy to add grouping if wanted, but it would require swapping this one field to the mock-style component.

## Verification
- `vite build --mode development` clean; eslint passes.
- On bs.local: `list_tax_templates` returns `is_default`; the site currently marks none default, so a new invoice stays empty (correct) — mark a template default in ERPNext to see it auto-fill.