### PR TITLE
feat: render Frappe/ERPNext reports in-app (generic renderer) + Site Execution reports

### DIFF
--- a/buildsuite_core/api/report.py
+++ b/buildsuite_core/api/report.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Run a Frappe/ERPNext Report (Query or Script) and return its columns + rows, so the Vue
+app can render any report in-app instead of bouncing to the Desk. A thin, permission-checked
+wrapper over frappe.desk.query_report.run — the generic FrappeReport component consumes it."""
+
+import frappe
+from frappe import _
+
+
+@frappe.whitelist()
+def run_report(report, filters=None):
+	"""Execute a Query/Script Report and return {report_name, ref_doctype, columns, result}.
+	`frappe.desk.query_report.run` enforces the report's own read permission."""
+	if isinstance(filters, str):
+		filters = frappe.parse_json(filters) or {}
+	filters = filters or {}
+
+	meta = frappe.db.get_value(
+		"Report", report, ["report_name", "report_type", "ref_doctype", "disabled"], as_dict=True
+	)
+	if not meta:
+		frappe.throw(_("Report {0} not found.").format(report))
+	if meta.disabled:
+		frappe.throw(_("Report {0} is disabled.").format(report))
+
+	from frappe.desk.query_report import run
+
+	res = run(report, filters=filters, ignore_prepared_report=True) or {}
+	return {
+		"report_name": meta.report_name or report,
+		"report_type": meta.report_type,
+		"ref_doctype": meta.ref_doctype,
+		"columns": res.get("columns") or [],
+		"result": res.get("result") or [],
+		"message": res.get("message"),
+	}

--- a/buildsuite_core/api/workspace_setting.py
+++ b/buildsuite_core/api/workspace_setting.py
@@ -33,12 +33,14 @@ def _require_admin():
 
 
 def _report_route(report_name):
-	"""Desk URL for a report, by its type."""
+	"""Route for a report tile. Query/Script Reports render IN-APP via the generic
+	FrappeReport renderer (/reports/view/<name>); Report Builder reports have no in-app
+	renderer, so they still open on the Desk."""
 	meta = frappe.db.get_value("Report", report_name, ["report_type", "ref_doctype"], as_dict=True)
 	if not meta:
 		return None
 	if meta.report_type in ("Query Report", "Script Report"):
-		return f"/app/query-report/{quote(report_name)}"
+		return f"/reports/view/{quote(report_name)}"
 	doctype_route = frappe.scrub(meta.ref_doctype or "").replace("_", "-")
 	return f"/app/{doctype_route}/view/report/{quote(report_name)}"
 

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -1,0 +1,203 @@
+<script setup>
+// Generic renderer for a Frappe/ERPNext Report (Query or Script) inside the SPA.
+// Runs the report via buildsuite_core.api.report.run_report and renders its typed
+// columns + rows — cell formatting by fieldtype (Currency / Float / Int / Percent /
+// Date / Link), a client-side search, and pagination. Reusable on any workspace's
+// report tiles.
+import { ref, computed, watch } from "vue";
+import { runReport } from "@/data/reportApi";
+import { fmtINR, fmtDate } from "@/utils/format";
+
+const props = defineProps({
+	report: { type: String, required: true },
+	filters: { type: Object, default: () => ({}) },
+	pageSize: { type: Number, default: 50 },
+});
+
+const loading = ref(true);
+const error = ref("");
+const columns = ref([]);
+const rows = ref([]);
+
+const NUMERIC = new Set(["Currency", "Float", "Int", "Percent"]);
+
+async function load() {
+	loading.value = true;
+	error.value = "";
+	try {
+		const res = await runReport(props.report, props.filters);
+		columns.value = (res.columns || [])
+			.filter((c) => c && (c.label || c.fieldname))
+			.map((c, i) => ({
+				label: c.label || c.fieldname || `Column ${i + 1}`,
+				fieldname: c.fieldname || c.label || String(i),
+				fieldtype: c.fieldtype || "Data",
+				index: i,
+				align: NUMERIC.has(c.fieldtype) ? "right" : "left",
+			}));
+		rows.value = res.result || [];
+		page.value = 1;
+	} catch (err) {
+		error.value = err.message || "Failed to run report.";
+		columns.value = [];
+		rows.value = [];
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => [props.report, props.filters], load, { immediate: true, deep: true });
+
+// Rows come back as dicts keyed by fieldname (query reports) or as arrays.
+function cellRaw(row, col) {
+	if (Array.isArray(row)) return row[col.index];
+	return row?.[col.fieldname];
+}
+function cellText(row, col) {
+	const v = cellRaw(row, col);
+	if (v === null || v === undefined || v === "") return "—";
+	switch (col.fieldtype) {
+		case "Currency":
+			return fmtINR(v);
+		case "Percent":
+			return `${Math.round((Number(v) || 0) * 100) / 100}%`;
+		case "Int":
+			return Number(v).toLocaleString("en-IN");
+		case "Float":
+			return Number(v).toLocaleString("en-IN", {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			});
+		case "Date":
+		case "Datetime":
+			return fmtDate(v);
+		default:
+			return String(v);
+	}
+}
+
+const search = ref("");
+const filtered = computed(() => {
+	const q = search.value.trim().toLowerCase();
+	if (!q) return rows.value;
+	return rows.value.filter((row) =>
+		columns.value.some((col) => {
+			const v = cellRaw(row, col);
+			return v != null && String(v).toLowerCase().includes(q);
+		})
+	);
+});
+
+const page = ref(1);
+const pageCount = computed(() => Math.max(1, Math.ceil(filtered.value.length / props.pageSize)));
+const paged = computed(() => {
+	const start = (page.value - 1) * props.pageSize;
+	return filtered.value.slice(start, start + props.pageSize);
+});
+watch(search, () => (page.value = 1));
+function go(delta) {
+	page.value = Math.min(pageCount.value, Math.max(1, page.value + delta));
+}
+</script>
+
+<template>
+	<div>
+		<!-- Toolbar: search + count -->
+		<div class="flex items-center gap-3 mb-3 flex-wrap">
+			<input
+				v-model="search"
+				type="text"
+				placeholder="Search this report…"
+				class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-64 max-w-full"
+			/>
+			<span v-if="!loading && !error" class="text-[11px] text-ink-400">
+				{{ filtered.length.toLocaleString("en-IN") }} row{{
+					filtered.length === 1 ? "" : "s"
+				}}
+			</span>
+		</div>
+
+		<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Running report…</div>
+		<div
+			v-else-if="error"
+			class="bg-danger-50 border border-danger-200 rounded-lg px-4 py-6 text-sm text-danger-700"
+		>
+			{{ error }}
+		</div>
+
+		<template v-else>
+			<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+				<table class="w-full text-xs">
+					<thead
+						class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200"
+					>
+						<tr>
+							<th
+								v-for="col in columns"
+								:key="col.fieldname"
+								class="px-3 py-2 whitespace-nowrap"
+								:class="col.align === 'right' ? 'text-right' : 'text-left'"
+							>
+								{{ col.label }}
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="(row, i) in paged"
+							:key="i"
+							class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30"
+						>
+							<td
+								v-for="col in columns"
+								:key="col.fieldname"
+								class="px-3 py-2 whitespace-nowrap"
+								:class="[
+									col.align === 'right'
+										? 'text-right tabular-nums'
+										: 'text-left',
+									col.fieldtype === 'Link'
+										? 'font-mono text-ink-600'
+										: 'text-ink-800',
+								]"
+							>
+								{{ cellText(row, col) }}
+							</td>
+						</tr>
+						<tr v-if="!paged.length">
+							<td
+								:colspan="columns.length || 1"
+								class="px-3 py-12 text-center text-xs text-ink-400 italic"
+							>
+								{{ search ? "No rows match the search." : "No rows." }}
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Pagination -->
+			<div
+				v-if="pageCount > 1"
+				class="flex items-center justify-end gap-3 mt-3 text-xs text-ink-500"
+			>
+				<button
+					type="button"
+					class="px-2 py-1 border border-ink-200 rounded-md disabled:opacity-40 hover:bg-ink-50"
+					:disabled="page <= 1"
+					@click="go(-1)"
+				>
+					← Prev
+				</button>
+				<span>Page {{ page }} / {{ pageCount }}</span>
+				<button
+					type="button"
+					class="px-2 py-1 border border-ink-200 rounded-md disabled:opacity-40 hover:bg-ink-50"
+					:disabled="page >= pageCount"
+					@click="go(1)"
+				>
+					Next →
+				</button>
+			</div>
+		</template>
+	</div>
+</template>

--- a/frontend/src/data/reportApi.js
+++ b/frontend/src/data/reportApi.js
@@ -1,0 +1,18 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Runs a Frappe/ERPNext Report (Query or Script) and returns its columns + rows for the
+// generic FrappeReport renderer (buildsuite_core.api.report.run_report).
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.report.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const runReport = (report, filters) =>
+	call("run_report", { report, filters: filters ? JSON.stringify(filters) : undefined });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -272,6 +272,12 @@ const routes = [
 				component: () => import("@/views/workspaces/ProjectDashboardView.vue"),
 			},
 			{
+				path: "reports/view/:report",
+				name: "report-view",
+				component: () => import("@/views/ReportView.vue"),
+				props: true,
+			},
+			{
 				path: "reports/:slug",
 				name: "report-stub",
 				component: () => import("@/views/workspaces/ReportStubView.vue"),

--- a/frontend/src/views/ReportView.vue
+++ b/frontend/src/views/ReportView.vue
@@ -1,0 +1,28 @@
+<script setup>
+// Routed page for any Frappe/ERPNext report, rendered in-app via <FrappeReport>.
+// Reached from a workspace's report tiles (route /reports/view/:report). The report
+// name is the route param.
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import FrappeReport from "@/components/FrappeReport.vue";
+
+const route = useRoute();
+const report = computed(() => route.params.report || "");
+// Where this report belongs, so the breadcrumb points back (defaults to Reports).
+const backTo = computed(() => route.query.from || "");
+const backLabel = computed(() => route.query.fromLabel || "Reports");
+
+const breadcrumbs = computed(() => {
+	const crumbs = [{ label: "BuildSuite Core", to: "/" }];
+	if (backTo.value) crumbs.push({ label: backLabel.value, to: backTo.value });
+	crumbs.push({ label: report.value });
+	return crumbs;
+});
+</script>
+
+<template>
+	<DeskPage :title="report" subtitle="Report" :breadcrumbs="breadcrumbs">
+		<FrappeReport :report="report" />
+	</DeskPage>
+</template>


### PR DESCRIPTION
## What
A **generic report component** that renders any Frappe/ERPNext **Query or Script Report** inside the Vue app, wired into the **Site Execution** workspace's report tiles (they previously bounced out to the Desk).

## Pieces
- **`api/report.py` → `run_report(report, filters)`** — a permission-checked wrapper over `frappe.desk.query_report.run`, returning `{report_name, ref_doctype, columns, result}`. Works for Query **and** Script reports.
- **`FrappeReport.vue`** — the generic renderer: typed column headers, per-fieldtype cell formatting (Currency / Float / Int / Percent / Date; Link shown monospace), numeric right-alignment, a client-side search, and pagination. Handles both dict-keyed and array rows. Drop it anywhere: `<FrappeReport report="…" :filters="…" />`.
- **`ReportView.vue` + route `/reports/view/:report`** — the routed page wrapper (DeskPage chrome + breadcrumb).
- **`workspace_setting._report_route`** — Query/Script report tiles now resolve to the in-app `/reports/view/<name>` (`external: false`) instead of `/app/query-report/…`. Report Builder reports (no in-app renderer yet) still open on the Desk. **This changes how report tiles route for every workspace**, per your OK to change workspace-settings behaviour.

## Site Execution
Its 6 tiles were **already** linked to real Reports (Completed Tasks, Pending Progress Entries, Progress Entries, Stage Plan vs Actual, Project Status Summary, …) — they now open **in-app** with no config change.

## Verification (bs.local, as Administrator)
- `get_workspace_reports("site-execution")` → all tiles `external: false`, routing to `/reports/view/…`.
- `run_report` runs each: Completed Tasks (176), Pending Progress Entries (1145), Progress Entries (616), Stage Plan vs Actual (606), Project Status Summary (1463), Delayed Tasks Summary — Script Report (1710). Columns come back typed; rows are dict-keyed.
- `vite build --mode development` clean; eslint passes.

Any workspace (Estimation / Procurement / Subcontract / Finance) whose tiles link Query/Script reports now benefits automatically.