### PR TITLE
fix: version-robust make_purchase_invoice import (supplier bill from PO 500)

### DIFF
--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -362,7 +362,12 @@ def get_po_bill_lines(purchase_order):
 	"""Confirm-don't-construct: map a Purchase Order to its unbilled bill lines (item, remaining
 	qty, uom, PO rate) via ERPNext's native mapper, so the covered PO lines flip billed on submit.
 	Returns the supplier + project too, to lock the bill header to the PO."""
-	from erpnext.buying.doctype.purchase_order.mapper import make_purchase_invoice
+	# ERPNext moved make_purchase_invoice into a `mapper` submodule in newer versions;
+	# older versions keep it in purchase_order.py. Support both.
+	try:
+		from erpnext.buying.doctype.purchase_order.mapper import make_purchase_invoice
+	except ModuleNotFoundError:
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
 
 	po = frappe.get_doc("Purchase Order", purchase_order)
 	po.check_permission("read")


### PR DESCRIPTION
## Bug
On the deployed env, selecting a PO on the supplier-bill form 500'd:
```
ModuleNotFoundError: No module named 'erpnext.buying.doctype.purchase_order.mapper'
  … supplier_bill.py get_po_bill_lines → from erpnext…purchase_order.mapper import make_purchase_invoice
```

## Cause
ERPNext **moved** `make_purchase_invoice` into a `purchase_order.mapper` submodule in newer versions. My local dev has that layout; the deployed ERPNext is an **older** version where the function still lives in `purchase_order.py` — so the import failed there (but not locally).

## Fix
Try the `mapper` submodule first, fall back to `purchase_order.py`:
```python
try:
    from erpnext.buying.doctype.purchase_order.mapper import make_purchase_invoice
except ModuleNotFoundError:
    from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
```

Verified `get_po_bill_lines` still works locally (mapper path); the fallback covers the deployed layout. Follows up the merged #134.