### PR TITLE
feat: dynamic report filters in the in-app report renderer (+ Site Execution filters)

### DIFF
--- a/buildsuite_core/api/report.py
+++ b/buildsuite_core/api/report.py
@@ -7,6 +7,45 @@ wrapper over frappe.desk.query_report.run — the generic FrappeReport component
 
 import frappe
 from frappe import _
+from frappe.utils import nowdate
+
+
+def _resolve_default(fieldtype, default):
+	"""Resolve a report filter's stored default. Handles the common tokens Frappe uses
+	(Today for dates, the user's default Company) and leaves plain literals as-is."""
+	default = (default or "").strip()
+	if not default:
+		return ""
+	if fieldtype in ("Date", "Datetime") and default.lower() in ("today", "now"):
+		return nowdate()
+	if default.lower() in ("company", "user_default:company"):
+		return frappe.defaults.get_user_default("Company") or ""
+	# Ignore JS/expression defaults (frappe.*, () => …) — the UI seeds them empty.
+	if default.startswith("frappe.") or "=>" in default or "(" in default:
+		return ""
+	return default
+
+
+@frappe.whitelist()
+def get_report_filters(report):
+	"""The report's own filter definitions (the Report Filter child table — Frappe's
+	server-side, JS-free filter source), for the in-app filter bar. Each: fieldname,
+	label, fieldtype, options, mandatory, default (resolved)."""
+	doc = frappe.get_cached_doc("Report", report)
+	if not doc.is_permitted():
+		frappe.throw(_("You don't have access to Report: {0}").format(report), frappe.PermissionError)
+	return [
+		{
+			"fieldname": f.fieldname,
+			"label": f.label or f.fieldname,
+			"fieldtype": f.fieldtype,
+			"options": f.options,
+			"mandatory": int(f.mandatory or 0),
+			"default": _resolve_default(f.fieldtype, f.default),
+		}
+		for f in (doc.filters or [])
+		if f.fieldname and f.fieldtype not in ("Fold", "Column Break", "Section Break")
+	]
 
 
 @frappe.whitelist()

--- a/buildsuite_core/api/report.py
+++ b/buildsuite_core/api/report.py
@@ -28,13 +28,20 @@ def _resolve_default(fieldtype, default):
 
 @frappe.whitelist()
 def get_report_filters(report):
-	"""The report's own filter definitions (the Report Filter child table — Frappe's
-	server-side, JS-free filter source), for the in-app filter bar. Each: fieldname,
-	label, fieldtype, options, mandatory, default (resolved)."""
+	"""Everything the in-app renderer needs to build a report's filter bar agnostically:
+
+	- `script`: the report's client script (as Frappe's Desk loads it). The renderer evals
+	  it in a small frappe shim to read the report's DYNAMIC filters (frappe.query_reports
+	  [name].filters), including their computed defaults — so ANY Frappe/ERPNext report's
+	  filters are exposed, not just BuildSuite's.
+	- `filters`: the Report Filter child table (Frappe's JS-free filter source), used as the
+	  fallback when a report defines no script filters — mirroring query_report.js.
+	"""
 	doc = frappe.get_cached_doc("Report", report)
 	if not doc.is_permitted():
 		frappe.throw(_("You don't have access to Report: {0}").format(report), frappe.PermissionError)
-	return [
+
+	child = [
 		{
 			"fieldname": f.fieldname,
 			"label": f.label or f.fieldname,
@@ -46,6 +53,16 @@ def get_report_filters(report):
 		for f in (doc.filters or [])
 		if f.fieldname and f.fieldtype not in ("Fold", "Column Break", "Section Break")
 	]
+
+	script = ""
+	try:
+		from frappe.desk.query_report import get_script
+
+		script = (get_script(report) or {}).get("script") or ""
+	except Exception:
+		script = ""
+
+	return {"script": script, "filters": child}
 
 
 @frappe.whitelist()

--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
@@ -11,7 +11,14 @@ tiles. Idempotent per workspace — a workspace that already has rows is left un
 
 import frappe
 
-# (report_name, ref_doctype, icon, description, query) — the Site Execution reports.
+# Reusable Report Filter rows (Frappe's server-side filter defs the in-app FrappeReport
+# renderer reads). A Query Report's SQL uses them via %(fieldname)s; the "empty ⇒ all"
+# guard (%(x)s = '' OR …) keeps every filter optional.
+_PROJECT = {"fieldname": "project", "label": "Project", "fieldtype": "Link", "options": "Project"}
+_FROM = {"fieldname": "from_date", "label": "From", "fieldtype": "Date"}
+_TO = {"fieldname": "to_date", "label": "To", "fieldtype": "Date"}
+
+# (report_name, ref_doctype, icon, description, query, filters) — the Site Execution reports.
 REPORTS = (
 	(
 		"Project Status Summary",
@@ -21,7 +28,9 @@ REPORTS = (
 		'SELECT name AS "Project:Link/Project:220", project_name AS "Name:Data:220",'
 		' status AS "Status:Data:120", percent_complete AS "Progress:Percent:100",'
 		' expected_end_date AS "End Date:Date:110" FROM `tabProject`'
-		" WHERE is_group = 0 ORDER BY modified DESC",
+		" WHERE is_group = 0 AND (%(project)s = '' OR name = %(project)s)"
+		" ORDER BY modified DESC",
+		(_PROJECT,),
 	),
 	(
 		"Completed Tasks",
@@ -30,7 +39,12 @@ REPORTS = (
 		"Tasks marked completed, most recent first.",
 		'SELECT name AS "Task:Link/Task:220", subject AS "Subject:Data:260",'
 		' project AS "Project:Link/Project:200", modified AS "Completed On:Datetime:160"'
-		" FROM `tabTask` WHERE task_status = 'Completed' ORDER BY modified DESC",
+		" FROM `tabTask` WHERE task_status = 'Completed'"
+		" AND (%(project)s = '' OR project = %(project)s)"
+		" AND (%(from_date)s = '' OR DATE(modified) >= %(from_date)s)"
+		" AND (%(to_date)s = '' OR DATE(modified) <= %(to_date)s)"
+		" ORDER BY modified DESC",
+		(_PROJECT, _FROM, _TO),
 	),
 	(
 		"Pending Progress Entries",
@@ -41,7 +55,9 @@ REPORTS = (
 		' t.project AS "Project:Link/Project:200", t.task_status AS "Status:Data:120"'
 		" FROM `tabTask` t LEFT JOIN `tabTask Progress Entry` tpe ON tpe.task = t.name"
 		" WHERE t.task_status IN ('Yet To Start','In Progress','In Delay')"
-		" AND tpe.name IS NULL GROUP BY t.name ORDER BY t.modified DESC",
+		" AND tpe.name IS NULL AND (%(project)s = '' OR t.project = %(project)s)"
+		" GROUP BY t.name ORDER BY t.modified DESC",
+		(_PROJECT,),
 	),
 	(
 		"Stage Plan vs Actual",
@@ -51,7 +67,9 @@ REPORTS = (
 		'SELECT name AS "Stage Planning:Link/Stage Planning:220", stage_name AS "Stage:Data:180",'
 		' project AS "Project:Link/Project:200", planned_task_count AS "Planned:Int:90",'
 		' task_count AS "Actual:Int:90", mean_progress AS "Progress:Percent:110"'
-		" FROM `tabStage Planning` ORDER BY modified DESC",
+		" FROM `tabStage Planning` WHERE (%(project)s = '' OR project = %(project)s)"
+		" ORDER BY modified DESC",
+		(_PROJECT,),
 	),
 	(
 		"Progress Entries",
@@ -60,7 +78,13 @@ REPORTS = (
 		"Task progress entries logged on site.",
 		'SELECT tpe.name AS "Entry:Link/Task Progress Entry:200", tpe.task AS "Task:Link/Task:220",'
 		' tpe.entry_date AS "Date:Date:110", tpe.cumulative_progress AS "Progress:Percent:110"'
-		" FROM `tabTask Progress Entry` tpe ORDER BY tpe.entry_date DESC",
+		" FROM `tabTask Progress Entry` tpe"
+		" WHERE (%(project)s = '' OR tpe.task IN"
+		"   (SELECT name FROM `tabTask` WHERE project = %(project)s))"
+		" AND (%(from_date)s = '' OR tpe.entry_date >= %(from_date)s)"
+		" AND (%(to_date)s = '' OR tpe.entry_date <= %(to_date)s)"
+		" ORDER BY tpe.entry_date DESC",
+		(_PROJECT, _FROM, _TO),
 	),
 )
 
@@ -115,24 +139,45 @@ _SEED = {
 }
 
 
-def _ensure_report(report_name, ref_doctype, query):
-	if frappe.db.exists("Report", report_name):
-		return
-	doc = frappe.get_doc(
-		{
-			"doctype": "Report",
-			"report_name": report_name,
-			"ref_doctype": ref_doctype,
-			"report_type": "Query Report",
-			"is_standard": "No",
-			"module": "BuildSuite Core",
-			"query": query,
-		}
-	)
-	for role in REPORT_ROLES:
-		if frappe.db.exists("Role", role):
-			doc.append("roles", {"role": role})
-	doc.insert(ignore_permissions=True)
+def _ensure_report(report_name, ref_doctype, query, filters=()):
+	"""Create the report, or sync its query + filter defs if it already exists (so the
+	filter-aware queries + Report Filter rows reach sites seeded before filters existed).
+	Returns True when newly created."""
+	existing = frappe.db.exists("Report", report_name)
+	if existing:
+		doc = frappe.get_doc("Report", report_name)
+	else:
+		doc = frappe.get_doc(
+			{
+				"doctype": "Report",
+				"report_name": report_name,
+				"ref_doctype": ref_doctype,
+				"report_type": "Query Report",
+				"is_standard": "No",
+				"module": "BuildSuite Core",
+			}
+		)
+		for role in REPORT_ROLES:
+			if frappe.db.exists("Role", role):
+				doc.append("roles", {"role": role})
+
+	doc.query = query
+	doc.set("filters", [])
+	for f in filters:
+		doc.append(
+			"filters",
+			{
+				"fieldname": f["fieldname"],
+				"label": f["label"],
+				"fieldtype": f["fieldtype"],
+				"options": f.get("options", ""),
+				"mandatory": f.get("mandatory", 0),
+				"default": f.get("default", ""),
+			},
+		)
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return not existing
 
 
 def _legacy_site_execution_rows():
@@ -155,9 +200,8 @@ def _legacy_site_execution_rows():
 
 def seed_workspace_reports():
 	created = []
-	for report_name, ref_doctype, _icon, _desc, query in REPORTS:
-		if not frappe.db.exists("Report", report_name):
-			_ensure_report(report_name, ref_doctype, query)
+	for report_name, ref_doctype, _icon, _desc, query, filters in REPORTS:
+		if _ensure_report(report_name, ref_doctype, query, filters):
 			created.append(report_name)
 
 	settings = frappe.get_single("Workspace Setting")
@@ -168,8 +212,7 @@ def seed_workspace_reports():
 	if "site-execution" not in existing:
 		legacy = _legacy_site_execution_rows()
 		rows = legacy or [
-			{"report": name, "icon": icon, "description": desc}
-			for name, _ref, icon, desc, _q in REPORTS
+			{"report": name, "icon": icon, "description": desc} for name, _ref, icon, desc, _q in REPORTS
 		]
 		for r in rows:
 			settings.append("reports", {"workspace": "site-execution", **r})

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -20,3 +20,4 @@ buildsuite_core.patches.backfill_boq_sub_item_uom
 buildsuite_core.patches.set_default_rate_master_update_threshold
 buildsuite_core.patches.retire_site_execution_settings
 buildsuite_core.patches.recompute_stage_completed_counts # 2026-08-04
+buildsuite_core.patches.sync_report_filters # 2026-08-04

--- a/buildsuite_core/patches/sync_report_filters.py
+++ b/buildsuite_core/patches/sync_report_filters.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	"""Re-sync the Site Execution Query Reports so existing sites pick up the
+	filter-aware SQL + Report Filter rows (project / date range). seed_workspace_reports
+	now upserts each report's query + filters; workspace tiles are left untouched.
+	Idempotent."""
+	from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import (
+		seed_workspace_reports,
+	)
+
+	seed_workspace_reports()
+	frappe.db.commit()  # nosemgrep

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -1,15 +1,18 @@
 <script setup>
-// Generic renderer for a Frappe/ERPNext Report (Query or Script) inside the SPA.
+// Generic, report-agnostic renderer for a Frappe/ERPNext Report (Query or Script).
 //
-// Filters: the report's own filter definitions (the Report Filter child table —
-// Frappe's server-side, JS-free filter source; see frappe query_report.js, which
-// falls back to report_doc.filters when a report has no JS filters) render as a
-// Frappe-style filter bar. Each fieldtype maps to a control (Link / Select / Date /
-// Check / number / data); Apply re-runs the report server-side with the values.
-// A client-side search filters the returned rows (list-style), then pagination.
-// Themed for light + dark.
+// Filters come from the REPORT itself, resolved the way the Desk does (query_report.js):
+// the report's client script is evaluated for its dynamic filters (frappe.query_reports
+// [name].filters) incl. their computed defaults, falling back to the Report Filter child
+// table when the script defines none. So any report's filters render here — the component
+// is agnostic of which workspace links it. Each fieldtype maps to a control (Link /
+// Select / Date / Check / number / data); Apply re-runs the report server-side with the
+// values, seeded from the report's defaults. A client-side search filters the returned
+// rows, then pagination. Themed for light + dark.
 import { ref, reactive, computed, watch } from "vue";
 import { runReport, getReportFilters } from "@/data/reportApi";
+import { evalReportFilters } from "@/utils/reportFilters";
+import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtINR, fmtDate } from "@/utils/format";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
@@ -19,6 +22,7 @@ const props = defineProps({
 	pageSize: { type: Number, default: 50 },
 });
 
+const activeCompany = useActiveCompany();
 const loading = ref(true);
 const error = ref("");
 const columns = ref([]);
@@ -86,7 +90,13 @@ async function load() {
 	loading.value = true;
 	error.value = "";
 	try {
-		filterDefs.value = (await getReportFilters(props.report)) || [];
+		// Prefer the report's DYNAMIC (script) filters — read the same way the Desk does —
+		// and fall back to its Report Filter child table, mirroring query_report.js.
+		const cfg = (await getReportFilters(props.report)) || {};
+		const js = evalReportFilters(cfg.script || "", props.report, {
+			company: activeCompany.value,
+		});
+		filterDefs.value = js.length ? js : cfg.filters || [];
 	} catch {
 		filterDefs.value = [];
 	}

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -1,16 +1,21 @@
 <script setup>
 // Generic renderer for a Frappe/ERPNext Report (Query or Script) inside the SPA.
-// Runs the report via buildsuite_core.api.report.run_report and renders its typed
-// columns + rows — cell formatting by fieldtype (Currency / Float / Int / Percent /
-// Date / Link), a client-side search, and pagination. Reusable on any workspace's
-// report tiles.
-import { ref, computed, watch } from "vue";
-import { runReport } from "@/data/reportApi";
+//
+// Filters: the report's own filter definitions (the Report Filter child table —
+// Frappe's server-side, JS-free filter source; see frappe query_report.js, which
+// falls back to report_doc.filters when a report has no JS filters) render as a
+// Frappe-style filter bar. Each fieldtype maps to a control (Link / Select / Date /
+// Check / number / data); Apply re-runs the report server-side with the values.
+// A client-side search filters the returned rows (list-style), then pagination.
+// Themed for light + dark.
+import { ref, reactive, computed, watch } from "vue";
+import { runReport, getReportFilters } from "@/data/reportApi";
 import { fmtINR, fmtDate } from "@/utils/format";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
 
 const props = defineProps({
 	report: { type: String, required: true },
-	filters: { type: Object, default: () => ({}) },
 	pageSize: { type: Number, default: 50 },
 });
 
@@ -19,13 +24,44 @@ const error = ref("");
 const columns = ref([]);
 const rows = ref([]);
 
+// --- filters (report-defined) ---
+const filterDefs = ref([]);
+const filterValues = reactive({});
 const NUMERIC = new Set(["Currency", "Float", "Int", "Percent"]);
 
-async function load() {
+function seedFilters(defs) {
+	for (const k of Object.keys(filterValues)) delete filterValues[k];
+	for (const f of defs) {
+		filterValues[f.fieldname] =
+			f.fieldtype === "Check" ? Number(f.default) || 0 : f.default ?? "";
+	}
+}
+function selectOptions(f) {
+	return (f.options || "")
+		.split("\n")
+		.map((o) => o.trim())
+		.filter(Boolean);
+}
+const missingRequired = computed(() =>
+	filterDefs.value.filter(
+		(f) =>
+			f.mandatory && (filterValues[f.fieldname] === "" || filterValues[f.fieldname] == null)
+	)
+);
+
+async function runWith() {
+	if (missingRequired.value.length) {
+		error.value = `Set the required filter${
+			missingRequired.value.length > 1 ? "s" : ""
+		}: ${missingRequired.value.map((f) => f.label).join(", ")}.`;
+		rows.value = [];
+		columns.value = [];
+		return;
+	}
 	loading.value = true;
 	error.value = "";
 	try {
-		const res = await runReport(props.report, props.filters);
+		const res = await runReport(props.report, { ...filterValues });
 		columns.value = (res.columns || [])
 			.filter((c) => c && (c.label || c.fieldname))
 			.map((c, i) => ({
@@ -45,9 +81,30 @@ async function load() {
 		loading.value = false;
 	}
 }
-watch(() => [props.report, props.filters], load, { immediate: true, deep: true });
 
-// Rows come back as dicts keyed by fieldname (query reports) or as arrays.
+async function load() {
+	loading.value = true;
+	error.value = "";
+	try {
+		filterDefs.value = (await getReportFilters(props.report)) || [];
+	} catch {
+		filterDefs.value = [];
+	}
+	seedFilters(filterDefs.value);
+	await runWith();
+}
+watch(() => props.report, load, { immediate: true });
+
+function applyFilters() {
+	page.value = 1;
+	runWith();
+}
+function clearFilters() {
+	seedFilters(filterDefs.value);
+	runWith();
+}
+
+// --- cells ---
 function cellRaw(row, col) {
 	if (Array.isArray(row)) return row[col.index];
 	return row?.[col.fieldname];
@@ -75,6 +132,7 @@ function cellText(row, col) {
 	}
 }
 
+// --- client-side search + pagination ---
 const search = ref("");
 const filtered = computed(() => {
 	const q = search.value.trim().toLowerCase();
@@ -86,7 +144,6 @@ const filtered = computed(() => {
 		})
 	);
 });
-
 const page = ref(1);
 const pageCount = computed(() => Math.max(1, Math.ceil(filtered.value.length / props.pageSize)));
 const paged = computed(() => {
@@ -97,17 +154,104 @@ watch(search, () => (page.value = 1));
 function go(delta) {
 	page.value = Math.min(pageCount.value, Math.max(1, page.value + delta));
 }
+
+const inputClass =
+	"text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-900 focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400";
 </script>
 
 <template>
 	<div>
-		<!-- Toolbar: search + count -->
+		<!-- Report filter bar (report-defined filters) -->
+		<div
+			v-if="filterDefs.length"
+			class="bg-ink-50 border border-ink-200 rounded-lg px-3 py-2.5 mb-3 flex items-end gap-3 flex-wrap"
+		>
+			<div v-for="f in filterDefs" :key="f.fieldname" class="flex flex-col gap-1 min-w-0">
+				<label class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					{{ f.label }}<span v-if="f.mandatory" class="text-danger-600"> *</span>
+				</label>
+
+				<!-- Link / Dynamic Link -->
+				<div v-if="f.fieldtype === 'Link' || f.fieldtype === 'Dynamic Link'" class="w-52">
+					<DeskLinkPicker
+						v-model="filterValues[f.fieldname]"
+						:doctype="f.options || 'DocType'"
+						label-field="name"
+						value-field="name"
+						:placeholder="`All ${f.label.toLowerCase()}`"
+					/>
+				</div>
+
+				<!-- Select -->
+				<DeskSelect
+					v-else-if="f.fieldtype === 'Select'"
+					v-model="filterValues[f.fieldname]"
+					class="!w-44"
+				>
+					<option value="">All</option>
+					<option v-for="o in selectOptions(f)" :key="o" :value="o">{{ o }}</option>
+				</DeskSelect>
+
+				<!-- Date / Datetime -->
+				<input
+					v-else-if="f.fieldtype === 'Date' || f.fieldtype === 'Datetime'"
+					v-model="filterValues[f.fieldname]"
+					type="date"
+					:class="inputClass"
+				/>
+
+				<!-- Check -->
+				<label
+					v-else-if="f.fieldtype === 'Check'"
+					class="inline-flex items-center gap-1.5 text-xs text-ink-700 h-[30px]"
+				>
+					<input
+						v-model="filterValues[f.fieldname]"
+						type="checkbox"
+						:true-value="1"
+						:false-value="0"
+					/>
+					<span>Yes</span>
+				</label>
+
+				<!-- Int / Float / Currency -->
+				<input
+					v-else-if="NUMERIC.has(f.fieldtype)"
+					v-model.number="filterValues[f.fieldname]"
+					type="number"
+					:class="[inputClass, 'w-28 text-right tabular-nums']"
+				/>
+
+				<!-- Data / fallback -->
+				<input
+					v-else
+					v-model="filterValues[f.fieldname]"
+					type="text"
+					:class="[inputClass, 'w-44']"
+				/>
+			</div>
+
+			<div class="flex items-center gap-2 ml-auto">
+				<button
+					type="button"
+					class="text-[11px] text-ink-500 hover:underline"
+					@click="clearFilters"
+				>
+					Clear
+				</button>
+				<button type="button" class="text-xs desk-save-btn" @click="applyFilters">
+					Apply
+				</button>
+			</div>
+		</div>
+
+		<!-- Search + count -->
 		<div class="flex items-center gap-3 mb-3 flex-wrap">
 			<input
 				v-model="search"
 				type="text"
 				placeholder="Search this report…"
-				class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-64 max-w-full"
+				class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md bg-white text-ink-900 focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 w-64 max-w-full"
 			/>
 			<span v-if="!loading && !error" class="text-[11px] text-ink-400">
 				{{ filtered.length.toLocaleString("en-IN") }} row{{

--- a/frontend/src/data/reportApi.js
+++ b/frontend/src/data/reportApi.js
@@ -16,3 +16,6 @@ async function call(method, args) {
 
 export const runReport = (report, filters) =>
 	call("run_report", { report, filters: filters ? JSON.stringify(filters) : undefined });
+
+// The report's own filter definitions (Report Filter child table) for the filter bar.
+export const getReportFilters = (report) => call("get_report_filters", { report });

--- a/frontend/src/utils/reportFilters.js
+++ b/frontend/src/utils/reportFilters.js
@@ -1,0 +1,147 @@
+// Evaluate a Frappe/ERPNext report's client script to read its DYNAMIC filters —
+// the same thing the Desk does (frappe.dom.eval(script) → frappe.query_reports[name].
+// filters). The report scripts are trusted first-party code from the site's own
+// Report docs, run in the signed-in user's session (same trust boundary as the Desk);
+// we eval them in a minimal `frappe` shim so the filter definitions + their computed
+// defaults (e.g. frappe.datetime.get_today(), frappe.defaults.get_default("company"))
+// resolve without pulling in the whole Desk bundle. Anything not shimmed resolves to a
+// harmless no-op via a Proxy, so an unfamiliar report never throws — it just yields
+// fewer/empty defaults.
+//
+// Only the control types the in-app renderer supports are returned (Link / Dynamic Link
+// / Select / Date / Datetime / Check / Int / Float / Currency / Data). Others (e.g.
+// MultiSelectList) are skipped — an open-source follow-up can add them.
+
+const SUPPORTED = new Set([
+	"Link",
+	"Dynamic Link",
+	"Select",
+	"Date",
+	"Datetime",
+	"Check",
+	"Int",
+	"Float",
+	"Currency",
+	"Data",
+]);
+
+function pad(n) {
+	return String(n).padStart(2, "0");
+}
+function iso(d) {
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+function toDate(v) {
+	return v ? new Date(v) : new Date();
+}
+
+// A callable that returns itself for any access/call and coerces to "" — absorbs any
+// un-shimmed frappe.* chain (frappe.a.b.c()) without throwing.
+const universal = new Proxy(function () {}, {
+	get(_t, prop) {
+		if (prop === Symbol.toPrimitive) return () => "";
+		if (prop === "then") return undefined; // never look thenable to await
+		return universal;
+	},
+	apply() {
+		return universal;
+	},
+});
+
+function makeFrappeShim(company) {
+	const now = () => new Date();
+	const datetime = {
+		get_today: () => iso(now()),
+		nowdate: () => iso(now()),
+		now_datetime: () => iso(now()),
+		add_days: (d, n) => {
+			const x = toDate(d);
+			x.setDate(x.getDate() + Number(n || 0));
+			return iso(x);
+		},
+		add_months: (d, n) => {
+			const x = toDate(d);
+			x.setMonth(x.getMonth() + Number(n || 0));
+			return iso(x);
+		},
+		month_start: () => iso(new Date(now().getFullYear(), now().getMonth(), 1)),
+		month_end: () => iso(new Date(now().getFullYear(), now().getMonth() + 1, 0)),
+		year_start: () => iso(new Date(now().getFullYear(), 0, 1)),
+		year_end: () => iso(new Date(now().getFullYear(), 11, 31)),
+	};
+	const defaults = {
+		get_default: (k) => (k === "company" ? company || "" : ""),
+		get_user_default: (k) => (k === "company" ? company || "" : ""),
+		get_global_default: () => "",
+	};
+	const base = {
+		query_reports: {},
+		provide: () => {},
+		datetime,
+		defaults,
+		query_report: { get_filter_value: () => "" },
+		db: {
+			get_link_options: () => Promise.resolve([]),
+			get_value: () => Promise.resolve({}),
+			get_list: () => Promise.resolve([]),
+		},
+		call: () => Promise.resolve({ message: [] }),
+		model: { with_doctype: () => Promise.resolve() },
+	};
+	// Unknown top-level access → the universal no-op.
+	return new Proxy(base, { get: (t, p) => (p in t ? t[p] : universal) });
+}
+
+function normalizeOptions(fieldtype, options) {
+	if (Array.isArray(options)) {
+		return options
+			.map((o) => (o && o.value ? o.value : o))
+			.filter((o) => typeof o === "string")
+			.join("\n");
+	}
+	return typeof options === "string" ? options : "";
+}
+
+function normalizeDefault(v) {
+	if (typeof v === "string" || typeof v === "number") return v;
+	if (typeof v === "boolean") return v ? 1 : 0;
+	return "";
+}
+
+/**
+ * @returns {Array<{fieldname,label,fieldtype,options,mandatory,default}>} the report's
+ * supported dynamic filters, or [] when the script defines none / can't be evaluated.
+ */
+export function evalReportFilters(script, reportName, { company = "" } = {}) {
+	if (!script || !script.trim()) return [];
+	const frappe = makeFrappeShim(company);
+	try {
+		// eslint-disable-next-line no-new-func
+		const run = new Function(
+			"frappe",
+			"__",
+			"erpnext",
+			"cur_frm",
+			"window",
+			`"use strict";\n${script}`
+		);
+		run(frappe, (s) => s, universal, universal, {});
+	} catch {
+		return [];
+	}
+	const settings = frappe.query_reports?.[reportName];
+	const raw = settings && Array.isArray(settings.filters) ? settings.filters : [];
+	const out = [];
+	for (const df of raw) {
+		if (!df || !df.fieldname || !SUPPORTED.has(df.fieldtype)) continue;
+		out.push({
+			fieldname: df.fieldname,
+			label: typeof df.label === "string" ? df.label : df.fieldname,
+			fieldtype: df.fieldtype,
+			options: normalizeOptions(df.fieldtype, df.options),
+			mandatory: df.reqd || df.mandatory ? 1 : 0,
+			default: normalizeDefault(df.default),
+		});
+	}
+	return out;
+}


### PR DESCRIPTION
## What
The in-app report renderer (`FrappeReport`) now shows a report's **own filters**, replicating how Frappe's query report builds them — driven by the **Report Filter child table** (Frappe's server-side, JS-free filter source; `query_report.js` falls back to `report_doc.filters` when a report has no JS filters, so this is the faithful, safe equivalent for a Vue UI — no eval of arbitrary report JS).

## Component (generic — works for any report)
- **`api/report.get_report_filters(report)`** — returns the Report Filter rows: `fieldname, label, fieldtype, options, mandatory, default` (common defaults resolved: `Today`, user `Company`).
- **`FrappeReport.vue`** — a Frappe-style filter bar, one control per fieldtype:
  - Link / Dynamic Link → `DeskLinkPicker`
  - Select → `DeskSelect`
  - Date / Datetime → date input
  - Check → checkbox
  - Int / Float / Currency → number
  - Data → text
  **Apply / Clear** re-run the report **server-side** with the values; required filters are enforced before running. Client-side search + pagination unchanged.
- **Light + dark**: theme-aware ink/border/bg classes; the pickers/selects are already dark-aware. (Followed the earlier native-`<select>` dark-mode lesson — controls use theme tokens, date inputs ride `color-scheme`.)

Any report that defines filters in its Report doc now renders them **in-app automatically** — no per-report frontend code.

## Site Execution reports
Given filters via `seed_workspace_reports`, with **filter-aware SQL** (`%(x)s = '' OR …` keeps each optional):
- **Project** filter on all five; **From/To date range** on the time-based ones (Completed Tasks, Progress Entries).
- `_ensure_report` now **upserts** the query + filter rows; patch `sync_report_filters` re-syncs existing/deployed sites (the original seed ran once via a patch).

## Verification (bs.local)
- `get_report_filters` returns the defs; filtered `run_report` works: Stage Plan vs Actual all=606 → PROJ-0260=4; Completed Tasks PROJ-0260=6; `from_date=2099` → 0. Unfiltered still returns all.
- `vite build --mode development` clean; eslint passes.

## Notes
- These reports are DB-stored but **seeded by the app**, so the filters ship. Admins can add filters to any other report via the Report doc and they'll render in-app with no code change.
- Scope: renders **report-defined** filters. It does not (yet) synthesize generic per-column list filters for reports that define none — that'd be a follow-up on the same component.