### PR TITLE
feat: live Project Dashboard (S251 owner view) over real data

### DIFF
--- a/buildsuite_core/api/project_dashboard.py
+++ b/buildsuite_core/api/project_dashboard.py
@@ -1,0 +1,422 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Project Dashboard — the Site Execution owner/PM view (S251). One aggregate read backing the
+Vue dashboard, scoped to the whole portfolio or a single project (+ its sub-projects):
+
+  · KPIs        — active projects + at-risk, contract value (BOQ planned/budget), work done
+                  (BOQ earned value), and schedule (avg progress vs expected).
+  · health      — per project: progress vs expected, earned/contract, open tasks, risk reasons.
+  · cost_heads  — actual spend by head where a live source exists (Subcontractor bills,
+                  Machinery usage); Labour/Material/Overhead are pending (no cost-type source).
+  · decision    — approvals waiting on the owner (stage plans, SCOs, material requests, petty).
+  · commitments — subcontract committed/billed/remaining, POs on order, retention held.
+  · activity    — last 7 days of site reporting (progress entries, blockers, deliveries).
+  · attention   — project-level risks + overdue tasks.
+
+Derived numbers are computed server-side so the payload stays small. Single-company for now."""
+
+import math
+
+import frappe
+from frappe.utils import add_days, date_diff, flt, getdate, nowdate
+
+from buildsuite_core.utils.project import default_company
+
+_ACTIVE = ("New", "Ongoing", "Delayed")
+_BOQ_RANK = {"Approved": 2, "Submitted": 1}
+_HEALTH_LIMIT = 10
+
+
+# --------------------------------------------------------------------------- #
+# Scope
+# --------------------------------------------------------------------------- #
+def _subprojects(project):
+	out, stack = [], [project]
+	while stack:
+		cur = stack.pop()
+		kids = frappe.get_all("Project", filters={"parent_project": cur}, pluck="name")
+		out.extend(kids)
+		stack.extend(kids)
+	return out
+
+
+# --------------------------------------------------------------------------- #
+# Per-project schedule / cost / risk
+# --------------------------------------------------------------------------- #
+def _schedule(today, start, end, progress):
+	"""(expected_pct, days_to_end, delayed_days, variance_pct). Positive variance = behind."""
+	days_to_end = date_diff(end, today) if end else None
+	if not start or not end:
+		return 0.0, days_to_end, 0, 0.0
+	span = date_diff(end, start)
+	if span <= 0:
+		return 0.0, days_to_end, 0, 0.0
+	expected = max(0.0, min(100.0, date_diff(today, start) / span * 100.0))
+	variance = ((expected - progress) / expected * 100.0) if expected > 0 else 0.0
+	progress_slip = math.ceil((expected - progress) / 100.0 * span) if expected > progress else 0
+	overdue = date_diff(today, end)
+	overdue_days = overdue if (overdue > 0 and progress < 100) else 0
+	return expected, days_to_end, max(progress_slip, overdue_days), variance
+
+
+def _reasons(delayed, variance, days_to_end, progress):
+	out = []
+	if delayed > 0:
+		out.append(f"{delayed}d behind schedule")
+	elif variance > 10:
+		out.append(f"{round(variance)}% behind pace")
+	if days_to_end is not None and days_to_end < 0 and progress < 100:
+		out.append("past deadline")
+	return out
+
+
+def _current_boq(project_names):
+	if not project_names:
+		return {}
+	rows = frappe.get_all(
+		"BOQ",
+		filters={"project": ["in", project_names]},
+		fields=["project", "status", "planned_amount", "actual_amount"],
+		order_by="creation desc",
+	)
+	best = {}
+	for b in rows:
+		cur = best.get(b.project)
+		if not cur or _BOQ_RANK.get(b.status, 0) > _BOQ_RANK.get(cur.status, 0):
+			best[b.project] = b
+	return {p: (flt(b.planned_amount), flt(b.actual_amount)) for p, b in best.items()}
+
+
+def _sum(doctype, filters, field):
+	from frappe.query_builder.functions import Sum
+
+	dt = frappe.qb.DocType(doctype)
+	q = frappe.qb.from_(dt).select(Sum(getattr(dt, field)))
+	for k, v in filters.items():
+		col = getattr(dt, k)
+		q = q.where(col.isin(v[1])) if isinstance(v, (list, tuple)) and v[0] == "in" else q.where(col == v)
+	return flt(q.run()[0][0])
+
+
+@frappe.whitelist()
+def get_project_dashboard(project=None):
+	company = default_company()
+	today = getdate(nowdate())
+	since = add_days(today, -7)
+
+	# --- scope: one project (+ subs) or the whole portfolio ---
+	if project:
+		roots = frappe.get_all(
+			"Project",
+			filters={"name": project},
+			fields=[
+				"name",
+				"project_name",
+				"customer",
+				"status",
+				"project_status",
+				"percent_complete",
+				"expected_start_date",
+				"expected_end_date",
+				"estimated_costing",
+			],
+		)
+		scope_ids = [project, *_subprojects(project)]
+	else:
+		roots = frappe.get_all(
+			"Project",
+			filters={"company": company, "parent_project": ["in", ["", None]]},
+			fields=[
+				"name",
+				"project_name",
+				"customer",
+				"status",
+				"project_status",
+				"percent_complete",
+				"expected_start_date",
+				"expected_end_date",
+				"estimated_costing",
+			],
+			order_by="modified desc",
+		)
+		scope_ids = frappe.get_all("Project", filters={"company": company}, pluck="name")
+	scope_ids = scope_ids or ["__none__"]
+	proj_in = {"project": ["in", scope_ids]}
+
+	boq = _current_boq([p.name for p in roots])
+	customers = {p.customer for p in roots if p.customer}
+	cust_names = (
+		dict(
+			frappe.get_all(
+				"Customer",
+				filters={"name": ["in", list(customers)]},
+				fields=["name", "customer_name"],
+				as_list=True,
+			)
+		)
+		if customers
+		else {}
+	)
+
+	# --- per-root rows ---
+	rows = []
+	for p in roots:
+		planned, earned = boq.get(p.name, (flt(p.estimated_costing), None))
+		has_boq = p.name in boq
+		progress = flt(p.percent_complete)
+		expected, days_to_end, delayed, variance = _schedule(
+			today, p.expected_start_date, p.expected_end_date, progress
+		)
+		active = p.project_status in _ACTIVE and p.status != "Cancelled"
+		reasons = _reasons(delayed, variance, days_to_end, progress) if active else []
+		rows.append(
+			{
+				"id": p.name,
+				"name": p.project_name or p.name,
+				"client": cust_names.get(p.customer, p.customer) or "",
+				"status": p.project_status or "New",
+				"progress": round(progress, 1),
+				"expected": round(expected, 1),
+				"days_to_end": days_to_end,
+				"delayed": delayed,
+				"variance": round(variance, 1),
+				"planned": flt(planned),
+				"earned": flt(earned) if earned is not None else None,
+				"has_boq": has_boq,
+				"reasons": reasons,
+				"active": active,
+			}
+		)
+
+	active_rows = [r for r in rows if r["active"]]
+	at_risk = [r for r in active_rows if r["reasons"]]
+
+	# --- KPIs ---
+	total_planned = sum(r["planned"] for r in active_rows)
+	total_earned = sum((r["earned"] or 0) for r in active_rows)
+	with_boq = sum(1 for r in active_rows if r["has_boq"])
+	avg_progress = (sum(r["progress"] for r in active_rows) / len(active_rows)) if active_rows else 0
+	avg_expected = (sum(r["expected"] for r in active_rows) / len(active_rows)) if active_rows else 0
+	behind = sum(1 for r in active_rows if r["delayed"] > 0)
+	worst_delay = max((r["delayed"] for r in active_rows), default=0)
+
+	# --- health rows: the scoped project(s), else the most at-risk active ---
+	health_src = rows if project else sorted(active_rows, key=lambda r: (-r["delayed"], -r["variance"]))
+	health = health_src[:_HEALTH_LIMIT]
+	# open / total tasks for just the shown rows
+	for r in health:
+		ids = [r["id"], *_subprojects(r["id"])] if not project else scope_ids
+		total = frappe.db.count("Task", {"project": ["in", ids]})
+		done = frappe.db.count("Task", {"project": ["in", ids], "status": "Completed"})
+		r["open_tasks"] = total - done
+		r["total_tasks"] = total
+
+	# --- cost booked by head (live sources only) ---
+	subcontractor = _sum("Subcontractor Bill", {**proj_in, "docstatus": 1}, "gross")
+	mu = frappe.get_all(
+		"Machinery Usage", filters={**proj_in, "docstatus": 1}, fields=["rate", "quantity", "fuel_cost"]
+	)
+	machinery = sum(flt(m.rate) * flt(m.quantity) + flt(m.fuel_cost) for m in mu)
+	cost_total = subcontractor + machinery
+	cost_heads = [
+		{"key": "subcontractor", "label": "Subcontractor", "value": subcontractor, "bar": "bg-info-500"},
+		{"key": "machinery", "label": "Machinery", "value": machinery, "bar": "bg-warning-500"},
+		{"key": "labour", "label": "Labour", "value": 0, "bar": "bg-brand-500", "pending": True},
+		{"key": "material", "label": "Material", "value": 0, "bar": "bg-ink-300", "pending": True},
+		{"key": "overhead", "label": "Overhead", "value": 0, "bar": "bg-ink-400", "pending": True},
+	]
+	_mx = max([subcontractor, machinery, 1])
+	for h in cost_heads:
+		h["pct"] = 0 if h.get("pending") else h["value"] / _mx * 100
+
+	# --- decision queue ---
+	stage_ct = frappe.db.count("Stage Planning", {**proj_in, "workflow_state": "Pending Approval"})
+	scos = frappe.get_all(
+		"Scope Change Order",
+		filters={**proj_in, "status": "Pending Approval"},
+		fields=["name", "title", "project", "project_name", "impact", "raised_date"],
+	)
+	sco_value = sum(flt(s.impact) for s in scos)
+	mr_ct = frappe.db.count("Material Request", {**proj_in, "docstatus": 0})
+	petty = frappe.get_all(
+		"Petty Cash Request", filters={**proj_in, "status": "Requested"}, fields=["amount"]
+	)
+	decision = [
+		{
+			"key": "stage",
+			"label": "Stage plans",
+			"count": stage_ct,
+			"value": None,
+			"sub": "awaiting your approval",
+			"slug": "check-circle",
+			"tone": "bg-brand-50 text-brand-700",
+			"to": "/stage-plannings?status=Pending Approval",
+		},
+		{
+			"key": "sco",
+			"label": "Scope changes",
+			"count": len(scos),
+			"value": sco_value,
+			"sub": "cost impact pending",
+			"slug": "refresh-ccw",
+			"tone": "bg-warning-50 text-warning-700",
+			"to": "/sco",
+		},
+		{
+			"key": "mr",
+			"label": "Material requests",
+			"count": mr_ct,
+			"value": None,
+			"sub": "to approve for ordering",
+			"slug": "procurement",
+			"tone": "bg-info-50 text-info-700",
+			"to": "/procurement/material-requests",
+		},
+		{
+			"key": "petty",
+			"label": "Petty cash",
+			"count": len(petty),
+			"value": sum(flt(r.amount) for r in petty),
+			"sub": "requested by site",
+			"slug": "wallet",
+			"tone": "bg-success-50 text-success-700",
+			"to": "/project-finance/petty-cash",
+		},
+	]
+
+	# --- commitments ---
+	committed = _sum("Subcontractor Work Order", {**proj_in, "docstatus": 1}, "total_value")
+	billed = _sum("Subcontractor Bill", {**proj_in, "docstatus": 1}, "gross")
+	retention = _sum("Subcontractor Bill", {**proj_in, "docstatus": 1}, "retention_amount")
+	pos = frappe.get_all(
+		"Purchase Order",
+		filters={
+			**proj_in,
+			"docstatus": 1,
+			"status": ["not in", ["Closed", "Cancelled"]],
+			"per_received": ["<", 100],
+		},
+		fields=["grand_total"],
+	)
+	commitments = {
+		"committed": committed,
+		"billed": billed,
+		"remaining": max(0.0, committed - billed),
+		"on_order": sum(flt(p.grand_total) for p in pos),
+		"on_order_count": len(pos),
+		"retention": retention,
+	}
+
+	# --- site activity (7d). Task Progress Entry has no `project` — scope it via task. ---
+	if project:
+		task_ids = frappe.get_all("Task", filters={"project": ["in", scope_ids]}, pluck="name") or [
+			"__none__"
+		]
+		tpe_scope = {"task": ["in", task_ids]}
+	else:
+		tpe_scope = {}  # portfolio = company-wide
+	tpe = frappe.get_all(
+		"Task Progress Entry",
+		filters={**tpe_scope, "entry_date": [">=", str(since)]},
+		fields=["owner", "blocker"],
+	)
+	recent = frappe.get_all(
+		"Task Progress Entry",
+		filters=tpe_scope,
+		fields=["name", "task", "entry_date", "cumulative_progress", "blocker", "owner"],
+		order_by="entry_date desc, creation desc",
+		limit=5,
+	)
+	task_names = list({r.task for r in recent if r.task})
+	task_subjects = (
+		dict(
+			frappe.get_all(
+				"Task", filters={"name": ["in", task_names]}, fields=["name", "subject"], as_list=True
+			)
+		)
+		if task_names
+		else {}
+	)
+	last = frappe.get_all(
+		"Task Progress Entry",
+		filters=tpe_scope,
+		fields=["entry_date"],
+		order_by="entry_date desc",
+		limit=1,
+	)
+	activity = {
+		"entries": len(tpe),
+		"reporters": len({e.owner for e in tpe}),
+		"blockers": sum(1 for e in tpe if e.blocker),
+		"receipts": frappe.db.count(
+			"Purchase Receipt",
+			{"project": ["in", scope_ids], "docstatus": 1, "posting_date": [">=", str(since)]},
+		),
+		"man_days": None,  # no attendance source yet
+		"last_activity_date": str(last[0].entry_date) if last else None,
+		"recent": [
+			{
+				"id": r.name,
+				"task": task_subjects.get(r.task, r.task),
+				"entry_date": str(r.entry_date) if r.entry_date else None,
+				"progress": flt(r.cumulative_progress),
+				"blocker": bool(r.blocker),
+				"owner": r.owner,
+			}
+			for r in recent
+		],
+	}
+
+	# --- needs attention ---
+	attention = [
+		{
+			"key": f"risk-{r['id']}",
+			"tone": "bg-danger-500",
+			"kind": "Project at risk",
+			"title": " · ".join(r["reasons"]),
+			"context": r["name"],
+			"to": f"/projects/{r['id']}",
+		}
+		for r in at_risk[:6]
+	]
+	overdue = frappe.db.count(
+		"Task",
+		{"project": ["in", scope_ids], "status": ["!=", "Completed"], "exp_end_date": ["<", str(today)]},
+	)
+	if overdue:
+		attention.append(
+			{
+				"key": "overdue-tasks",
+				"tone": "bg-warning-500",
+				"kind": "Overdue tasks",
+				"title": f"{overdue} task{'s' if overdue != 1 else ''} past their end date and still open",
+				"context": "Across projects in scope",
+				"to": "/tasks?status=overdue",
+			}
+		)
+
+	return {
+		"scoped": bool(project),
+		"kpis": {
+			"active_projects": len(active_rows),
+			"at_risk": len(at_risk),
+			"contract_value": total_planned,
+			"work_done": total_earned,
+			"earned_pct": round((total_earned / total_planned * 100.0), 0) if total_planned else 0,
+			"boq_with": with_boq,
+			"boq_total": len(active_rows),
+			"avg_progress": round(avg_progress, 0),
+			"avg_expected": round(avg_expected, 0),
+			"behind": behind,
+			"worst_delay": worst_delay,
+		},
+		"health": health,
+		"total_projects": len(rows),
+		"cost": {"total_actual": cost_total, "heads": cost_heads},
+		"decision": decision,
+		"decision_total": sum(d["count"] for d in decision),
+		"commitments": commitments,
+		"activity": activity,
+		"attention": attention,
+	}

--- a/frontend/src/data/projectDashboardApi.js
+++ b/frontend/src/data/projectDashboardApi.js
@@ -1,0 +1,15 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Site Execution › Project Dashboard — one aggregate read, scoped to the whole portfolio
+// or a single project (buildsuite_core.api.project_dashboard.get_project_dashboard).
+export async function getProjectDashboard(project) {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.project_dashboard.get_project_dashboard",
+			params: project ? { project } : {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to load the dashboard.");
+	}
+}

--- a/frontend/src/views/workspaces/ProjectDashboardView.vue
+++ b/frontend/src/views/workspaces/ProjectDashboardView.vue
@@ -1,190 +1,80 @@
 <script setup>
-// Project Dashboard. Portfolio overview reached from the Site Execution
-// workspace's owner-gated dashboard tile (Director / PM / Admin / Accountant
-// / BSA).
-
-import { computed } from "vue";
+// Project Dashboard — the Site Execution owner/PM view (S251). Live over
+// buildsuite_core.api.project_dashboard, scoped to the whole portfolio or one project:
+// KPIs + earned value, project health, cost booked by head, the decision queue, site
+// activity (7d), commitments, and a needs-attention list. Everything derived server-side —
+// this view renders and re-fetches on scope change.
+import { ref, computed, onMounted } from "vue";
 import { RouterLink } from "vue-router";
-import { useDataStore } from "@/stores";
+import { getProjectDashboard } from "@/data/projectDashboardApi";
 import StatusBadge from "@/components/StatusBadge.vue";
+import UserAvatar from "@/components/UserAvatar.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { fmtCompactINR, fmtDate } from "@/utils/format";
 
-const store = useDataStore();
-const today = new Date();
-const todayLabel = today.toLocaleDateString("en-IN", {
+const data = ref(null);
+const loading = ref(true);
+const error = ref("");
+const scope = ref(""); // "" = portfolio, else a project id
+
+const todayLabel = new Date().toLocaleDateString("en-IN", {
 	weekday: "long",
 	day: "2-digit",
 	month: "short",
 	year: "numeric",
 });
 
-// ----- Variance / schedule helpers -------------------------------------------
-
-// Schedule-based variance — positive = behind plan.
-function projectVariance(p) {
-	const start = new Date(p.startDate).getTime();
-	const end = new Date(p.endDate).getTime();
-	const total = end - start;
-	if (total <= 0) return 0;
-	const elapsed = Math.max(0, Math.min(total, today.getTime() - start));
-	const expected = (elapsed / total) * 100;
-	if (expected <= 0) return 0;
-	return ((expected - p.progress) / expected) * 100;
+async function load() {
+	loading.value = true;
+	error.value = "";
+	try {
+		data.value = await getProjectDashboard(scope.value || undefined);
+	} catch (err) {
+		error.value = err.message || "Failed to load the dashboard.";
+	} finally {
+		loading.value = false;
+	}
 }
-
-function daysToEnd(p) {
-	const end = new Date(p.endDate).getTime();
-	return Math.ceil((end - today.getTime()) / 86400000);
+function setScope(v) {
+	scope.value = v || "";
+	load();
 }
+onMounted(load);
 
-// Days the project is running behind its expected schedule. Two contributions:
-//   1. Past-deadline calendar overrun (already an obvious delay)
-//   2. Behind-plan based on progress: (expected% - actual%) / 100 × totalDays
-// Returns 0 when on or ahead of plan AND not past deadline. Always rounded
-// up so 0.4 days behind still reads as "1d delayed" (matches civils reality —
-// a partial day's slippage is still slippage).
-function delayedDays(p) {
-	const start = new Date(p.startDate).getTime();
-	const end = new Date(p.endDate).getTime();
-	const total = end - start;
-	if (total <= 0) return 0;
-	const totalDays = total / 86400000;
-	const elapsed = Math.max(0, today.getTime() - start);
-	const expectedPct = Math.min(100, (elapsed / total) * 100);
-	// Progress-based slip: how many days of expected work are missing.
-	const progressSlip =
-		expectedPct > p.progress ? Math.ceil(((expectedPct - p.progress) / 100) * totalDays) : 0;
-	// Calendar slip: deadline already passed and still incomplete.
-	const overdueDays =
-		today.getTime() > end && p.progress < 100
-			? Math.ceil((today.getTime() - end) / 86400000)
-			: 0;
-	return Math.max(progressSlip, overdueDays);
-}
-
-function variancePill(pct) {
-	if (Math.abs(pct) < 0.5) return "text-ink-500";
-	return pct > 0 ? "text-danger-700" : "text-success-700";
-}
-
-// Deviation pill — paints positive (over-budget) red, negative (under-budget) green.
-function deviationPill(pct) {
-	if (Math.abs(pct) < 0.5) return "text-ink-500";
-	return pct > 0 ? "text-danger-700" : "text-success-700";
-}
-
-// ----- Cost helpers ----------------------------------------------------------
-
-// Planned cost for a project. Honours its own active BOQ's planned total if
-// one exists; otherwise falls back to the project's budget field. This makes
-// the dashboard match the source of truth a Director cares about — a
-// committed BOQ over an aspirational budget.
-function projectPlannedCost(p) {
-	const boq = store.activeBoqForProject(p.id);
-	if (boq) return store.boqTotals(boq.id).planned;
-	return p.budget || 0;
-}
-
-// Actual cost realised so far on a project. Driven by the active BOQ's actual
-// rollup (which projects task.progress × planned amount). Projects without
-// an Approved BOQ contribute zero — they're either pre-BOQ or hadn't been
-// rolled up yet.
-function projectActualCost(p) {
-	const boq = store.activeBoqForProject(p.id);
-	if (boq) return store.boqTotals(boq.id).actual;
-	return 0;
-}
-
-const activeRootProjects = computed(() => store.rootProjects.filter((p) => p.status === "Active"));
-
-const totalPlannedCost = computed(() =>
-	activeRootProjects.value.reduce((a, p) => a + projectPlannedCost(p), 0)
-);
-const totalActualCost = computed(() =>
-	activeRootProjects.value.reduce((a, p) => a + projectActualCost(p), 0)
-);
-const costDeviation = computed(() => totalActualCost.value - totalPlannedCost.value);
-const costDeviationPct = computed(() => {
-	if (!totalPlannedCost.value) return 0;
-	return (costDeviation.value / totalPlannedCost.value) * 100;
-});
-
-const pendingScosValue = computed(() =>
-	store.scos
-		.filter((s) => s.status === "Pending Approval")
-		.reduce((a, s) => a + (s.impact || 0), 0)
+const kpis = computed(() => data.value?.kpis || {});
+const health = computed(() => data.value?.health || []);
+const cost = computed(() => data.value?.cost || { total_actual: 0, heads: [] });
+const decision = computed(() => data.value?.decision || []);
+const commitments = computed(() => data.value?.commitments || {});
+const activity = computed(() => data.value?.activity || { recent: [] });
+const attention = computed(() => data.value?.attention || []);
+const showAllProjects = computed(() => (data.value?.total_projects || 0) > health.value.length);
+const activityQuiet = computed(
+	() => !activity.value.entries && !activity.value.man_days && !activity.value.receipts
 );
 
-const projectHealthRows = computed(() =>
-	store.rootProjects.slice(0, 6).map((p) => ({
-		...p,
-		variancePct: projectVariance(p),
-		days: daysToEnd(p),
-		delayedDays: delayedDays(p),
-		plannedCost: projectPlannedCost(p),
-		actualCost: projectActualCost(p),
-	}))
-);
-const showProjectsMore = computed(() => store.rootProjects.length > 6);
-
-const topRisks = computed(() => {
-	const out = [];
-	activeRootProjects.value.forEach((p) => {
-		const days = daysToEnd(p);
-		if (p.progress < 30 && days > 0 && days <= 90) {
-			out.push({
-				key: `sched-${p.id}`,
-				dot: "bg-danger-500",
-				kind: "Schedule risk",
-				title: `${p.progress}% complete with ${days} days to deadline`,
-				project: p.name,
-				to: `/projects/${p.id}`,
-			});
-		}
-		const v = projectVariance(p);
-		if (v > 10) {
-			out.push({
-				key: `cost-${p.id}`,
-				dot: "bg-warning-500",
-				kind: "Cost / pace risk",
-				title: `${v.toFixed(1)}% behind expected pace`,
-				project: p.name,
-				to: `/projects/${p.id}`,
-			});
-		}
-	});
-	store.scos
-		.filter((s) => s.status === "Pending Approval")
-		.forEach((s) => {
-			const daysAgo = Math.ceil(
-				(today.getTime() - new Date(s.raisedDate).getTime()) / 86400000
-			);
-			if (daysAgo > 7) {
-				const proj = store.projectById(s.projectId);
-				out.push({
-					key: `sco-${s.id}`,
-					dot: "bg-info-500",
-					kind: "Decision risk",
-					title: `${s.title} — ${daysAgo}d awaiting decision`,
-					project: proj?.name || "—",
-					to: "/sco",
-				});
-			}
-		});
-	return out.slice(0, 3);
-});
-
-const highValueApprovals = computed(() =>
-	store.scos
-		.filter((s) => s.status === "Pending Approval" && (s.impact || 0) > 1000000)
-		.sort((a, b) => (b.impact || 0) - (a.impact || 0))
-);
+function progressTone(r) {
+	if (r.variance > 10) return "bg-danger-500";
+	if (r.variance > 0) return "bg-warning-500";
+	return "bg-success-500";
+}
+// One schedule figure per row — late wins when late; else time remaining.
+function schedule(r) {
+	if (r.progress >= 100) return { text: "Complete", tone: "text-success-700" };
+	if (r.delayed > 0) return { text: `${r.delayed}d late`, tone: "text-danger-700 font-medium" };
+	if (r.days_to_end === null || r.days_to_end === undefined)
+		return { text: "No end date", tone: "text-ink-400" };
+	if (r.days_to_end < 0)
+		return { text: `${-r.days_to_end}d over`, tone: "text-danger-700 font-medium" };
+	return { text: `${r.days_to_end}d left`, tone: "text-ink-700" };
+}
 </script>
 
 <template>
 	<div class="bg-white min-h-full">
 		<div class="max-w-7xl mx-auto px-6 py-8">
-			<!-- Breadcrumb / back link -->
+			<!-- Breadcrumb -->
 			<div class="text-[11px] text-ink-500 mb-3">
 				<RouterLink to="/site-execution" class="hover:underline"
 					>Site Execution</RouterLink
@@ -193,179 +83,240 @@ const highValueApprovals = computed(() =>
 				<span class="text-ink-700">Project Dashboard</span>
 			</div>
 
-			<!-- Greeting / title strip -->
-			<div class="mb-2 flex items-center gap-3">
-				<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
-					>Portfolio overview</span
-				>
-				<span
-					class="text-[9px] px-1.5 py-0.5 bg-brand-100 text-brand-700 font-medium uppercase tracking-wider"
-					style="border-radius: 2px"
-					>Owner view</span
-				>
-			</div>
-			<h1 class="text-2xl font-semibold text-ink-900 tracking-tight">Project Dashboard</h1>
-			<p class="text-sm text-ink-500 mt-1">{{ todayLabel }}</p>
-
-			<!-- KPI strip -->
-			<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mt-8">
-				<!-- Active projects -->
-				<div class="bg-white border border-ink-200 rounded-xl p-4">
-					<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
-						Active projects
-					</div>
-					<div class="text-2xl font-semibold text-ink-900 mt-1">
-						{{ store.activeProjectsCount }}
-					</div>
-				</div>
-
-				<!-- Actual cost -->
-				<div class="bg-white border border-ink-200 rounded-xl p-4">
-					<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
-						Actual cost
-					</div>
-					<div class="text-2xl font-semibold text-ink-900 mt-1 tabular-nums">
-						{{ fmtCompactINR(totalActualCost) }}
-					</div>
-					<div class="text-[11px] text-ink-400 mt-0.5">Across active projects</div>
-				</div>
-
-				<!-- Actual vs Planned with deviation -->
-				<div class="bg-white border border-ink-200 rounded-xl p-4">
-					<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
-						Actual vs Planned
-					</div>
-					<div class="flex items-baseline gap-1 mt-1 tabular-nums">
-						<span class="text-2xl font-semibold text-ink-900">{{
-							fmtCompactINR(totalActualCost)
-						}}</span>
-						<span class="text-sm text-ink-400"
-							>/ {{ fmtCompactINR(totalPlannedCost) }}</span
-						>
-					</div>
+			<!-- Title + scope picker -->
+			<div class="flex flex-wrap items-end justify-between gap-4 mb-8">
+				<div>
 					<div
-						class="text-[11px] mt-0.5 tabular-nums"
-						:class="deviationPill(costDeviationPct)"
+						class="text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
 					>
-						<span class="font-medium"
-							>{{ costDeviation > 0 ? "+" : ""
-							}}{{ fmtCompactINR(Math.abs(costDeviation)) }}</span
-						>
-						<span class="ml-1"
-							>({{ costDeviationPct > 0 ? "+" : ""
-							}}{{ costDeviationPct.toFixed(1) }}%)</span
-						>
-						<span class="text-ink-400 ml-1">{{
-							costDeviationPct > 0 ? "over" : "under"
-						}}</span>
+						{{ scope ? "Project overview" : "Portfolio overview" }}
 					</div>
+					<h1 class="text-2xl font-semibold text-ink-900 tracking-tight">
+						Project Dashboard
+					</h1>
+					<p class="text-sm text-ink-500 mt-1">{{ todayLabel }}</p>
 				</div>
-
-				<!-- Open SCOs · value -->
-				<div class="bg-white border border-ink-200 rounded-xl p-4">
-					<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
-						Open SCOs · value
+				<div class="flex items-center gap-2">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Scope</span
+					>
+					<div class="w-56">
+						<DeskLinkPicker
+							:model-value="scope"
+							doctype="Project"
+							label-field="project_name"
+							value-field="name"
+							placeholder="All projects"
+							@update:model-value="setScope"
+						/>
 					</div>
-					<div class="text-2xl font-semibold text-warning-700 mt-1">
-						{{ fmtCompactINR(pendingScosValue) }}
-					</div>
-					<div class="text-[11px] text-ink-400 mt-0.5">
-						{{ store.pendingScosCount }} pending decisions
-					</div>
+					<button
+						v-if="scope"
+						type="button"
+						class="text-[11px] text-brand-600 hover:underline whitespace-nowrap"
+						@click="setScope('')"
+					>
+						Portfolio
+					</button>
 				</div>
 			</div>
 
-			<!-- Project health + Top risks -->
-			<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
-				<!-- Project health (2 cols) -->
-				<div
-					class="lg:col-span-2 bg-white border border-ink-200 rounded-xl overflow-hidden"
-				>
+			<div v-if="loading" class="py-20 text-center text-sm text-ink-400">
+				Loading portfolio…
+			</div>
+			<div
+				v-else-if="error"
+				class="bg-danger-50 border border-danger-200 rounded-lg px-4 py-6 text-sm text-danger-700"
+			>
+				{{ error }}
+			</div>
+
+			<template v-else>
+				<!-- ===== KPI strip ===== -->
+				<div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+					<div class="bg-white border border-ink-200 rounded-xl p-4">
+						<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
+							Active projects
+						</div>
+						<div class="text-2xl font-semibold text-ink-900 mt-1 tabular-nums">
+							{{ kpis.active_projects }}
+						</div>
+						<div
+							class="text-[11px] mt-1"
+							:class="
+								kpis.at_risk ? 'text-danger-700 font-medium' : 'text-success-700'
+							"
+						>
+							{{ kpis.at_risk }} at risk
+						</div>
+					</div>
+
+					<div class="bg-white border border-ink-200 rounded-xl p-4">
+						<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
+							Contract value
+						</div>
+						<div
+							class="text-2xl font-semibold text-ink-900 mt-1 tabular-nums whitespace-nowrap"
+						>
+							{{ fmtCompactINR(kpis.contract_value) }}
+						</div>
+						<div class="text-[11px] text-ink-400 mt-1">Approved BOQ, else budget</div>
+					</div>
+
+					<div class="bg-white border border-ink-200 rounded-xl p-4">
+						<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
+							Work done
+						</div>
+						<div
+							class="text-2xl font-semibold text-ink-900 mt-1 tabular-nums whitespace-nowrap"
+						>
+							{{ fmtCompactINR(kpis.work_done) }}
+						</div>
+						<div class="text-[11px] text-ink-400 mt-1 tabular-nums">
+							<template v-if="kpis.boq_with < kpis.boq_total"
+								>from {{ kpis.boq_with }} of {{ kpis.boq_total }} with a
+								BOQ</template
+							>
+							<template v-else>{{ kpis.earned_pct }}% of contract value</template>
+						</div>
+					</div>
+
+					<div class="bg-white border border-ink-200 rounded-xl p-4">
+						<div class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">
+							Schedule
+						</div>
+						<div class="flex items-baseline gap-1 mt-1 tabular-nums">
+							<span class="text-2xl font-semibold text-ink-900"
+								>{{ kpis.avg_progress }}%</span
+							>
+							<span class="text-sm text-ink-400"
+								>vs {{ kpis.avg_expected }}% planned</span
+							>
+						</div>
+						<div
+							class="text-[11px] mt-1"
+							:class="
+								kpis.behind ? 'text-danger-700 font-medium' : 'text-success-700'
+							"
+						>
+							<template v-if="kpis.behind"
+								>{{ kpis.behind }} behind · worst {{ kpis.worst_delay }}d</template
+							>
+							<template v-else>All on or ahead of plan</template>
+						</div>
+					</div>
+				</div>
+
+				<!-- ===== Project health ===== -->
+				<div class="bg-white border border-ink-200 rounded-xl overflow-hidden mt-6">
 					<div
-						class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+						class="px-4 py-3 border-b border-ink-200 flex items-center justify-between gap-3"
 					>
-						<h2 class="font-semibold text-ink-900 text-sm">Project health</h2>
+						<div>
+							<h2 class="font-semibold text-ink-900 text-sm">Project health</h2>
+							<p class="text-[11px] text-ink-500 mt-0.5">
+								Progress against plan · work done against contract value
+							</p>
+						</div>
 						<RouterLink
-							v-if="showProjectsMore"
+							v-if="showAllProjects"
 							to="/projects"
-							class="text-xs text-brand-600 hover:underline"
-							>View all →</RouterLink
+							class="text-xs text-brand-600 hover:underline flex-shrink-0"
+							>All projects →</RouterLink
 						>
 					</div>
+
+					<div
+						class="hidden lg:grid grid-cols-[minmax(240px,1.8fr)_220px_170px_120px] gap-4 px-4 py-2 bg-ink-50 border-b border-ink-100 text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+					>
+						<span>Project</span>
+						<span>Progress vs plan</span>
+						<span class="text-right">Work done / value</span>
+						<span class="text-right">Schedule</span>
+					</div>
+
 					<div class="divide-y divide-ink-100">
 						<RouterLink
-							v-for="p in projectHealthRows"
-							:key="p.id"
-							:to="`/projects/${p.id}`"
-							class="block px-4 py-3.5 hover:bg-ink-50"
+							v-for="r in health"
+							:key="r.id"
+							:to="`/projects/${r.id}`"
+							class="grid grid-cols-1 lg:grid-cols-[minmax(240px,1.8fr)_220px_170px_120px] gap-4 px-4 py-3.5 hover:bg-ink-50 items-center"
 						>
-							<div class="flex items-center gap-3">
-								<div class="flex-1 min-w-0">
-									<div class="flex items-center gap-2 flex-wrap">
-										<span class="font-medium text-ink-900 text-sm">{{
-											p.name
-										}}</span>
-										<StatusBadge :status="p.status" />
-									</div>
-									<!-- Timeline / cost / delay line. Adds "delayed by Nd" when the
-                       project is running behind its expected schedule. -->
-									<div class="text-xs text-ink-500 mt-0.5">
-										{{ p.client }} ·
-										<span class="tabular-nums"
-											>{{ fmtCompactINR(p.actualCost) }} /
-											{{ fmtCompactINR(p.plannedCost) }}</span
-										>
-										·
-										<span>{{
-											p.days > 0
-												? `${p.days}d to deadline`
-												: `${-p.days}d overdue`
-										}}</span>
-										<span
-											v-if="p.delayedDays > 0"
-											class="text-danger-700 font-medium"
-										>
-											· delayed by {{ p.delayedDays }}d</span
-										>
-									</div>
+							<div class="min-w-0">
+								<div class="flex items-center gap-2 flex-wrap">
+									<span
+										v-if="r.reasons.length"
+										class="w-1.5 h-1.5 rounded-full bg-danger-500 flex-shrink-0"
+										:title="r.reasons.join(' · ')"
+									></span>
+									<span class="font-medium text-ink-900 text-sm">{{
+										r.name
+									}}</span>
+									<StatusBadge :status="r.status" />
 								</div>
-								<div class="w-44 flex-shrink-0">
-									<div class="flex items-center gap-2">
-										<div
-											class="flex-1 h-1.5 bg-ink-100 rounded-full overflow-hidden"
-										>
-											<div
-												class="h-full"
-												:class="
-													p.progress > 80
-														? 'bg-success-500'
-														: p.progress > 40
-														? 'bg-brand-500'
-														: 'bg-warning-500'
-												"
-												:style="`width:${p.progress}%`"
-											></div>
-										</div>
-										<span
-											class="text-xs text-ink-700 tabular-nums w-10 text-right"
-											>{{ p.progress }}%</span
-										>
+								<div class="text-xs text-ink-500 mt-0.5 truncate">
+									<span v-if="r.client">{{ r.client }} · </span
+									>{{ r.open_tasks }}/{{ r.total_tasks }} tasks open
+								</div>
+							</div>
+
+							<div>
+								<div class="relative h-2 bg-ink-100 rounded-full overflow-hidden">
+									<div
+										class="h-full rounded-full"
+										:class="progressTone(r)"
+										:style="`width:${r.progress}%`"
+									></div>
+									<span
+										class="absolute top-0 bottom-0 w-0.5 stage-progress-tick"
+										:style="`left:${Math.min(99.5, r.expected)}%`"
+										:title="`Expected ${r.expected}% by today`"
+									></span>
+								</div>
+								<div
+									class="flex items-center justify-between mt-1 text-[11px] tabular-nums"
+								>
+									<span class="text-ink-700 font-medium">{{ r.progress }}%</span>
+									<span class="text-ink-400">plan {{ r.expected }}%</span>
+								</div>
+							</div>
+
+							<div class="text-right">
+								<template v-if="r.has_boq">
+									<div
+										class="text-sm text-ink-900 tabular-nums whitespace-nowrap"
+									>
+										{{ fmtCompactINR(r.earned) }}
 									</div>
 									<div
-										class="text-[11px] mt-1 text-right tabular-nums"
-										:class="variancePill(p.variancePct)"
+										class="text-[11px] text-ink-400 tabular-nums whitespace-nowrap"
 									>
-										{{ p.variancePct > 0 ? "+" : ""
-										}}{{ p.variancePct.toFixed(1) }}% variance
+										of {{ fmtCompactINR(r.planned) }}
 									</div>
+								</template>
+								<template v-else>
+									<div class="text-sm text-ink-400">—</div>
+									<div class="text-[11px] text-ink-400 whitespace-nowrap">
+										no approved BOQ
+									</div>
+								</template>
+							</div>
+
+							<div class="text-right">
+								<div
+									class="text-sm tabular-nums whitespace-nowrap"
+									:class="schedule(r).tone"
+								>
+									{{ schedule(r).text }}
 								</div>
 							</div>
 						</RouterLink>
+
 						<div
-							v-if="!projectHealthRows.length"
-							class="px-4 py-8 text-center text-sm text-ink-400"
+							v-if="!health.length"
+							class="px-4 py-10 text-center text-sm text-ink-400"
 						>
-							No projects yet ·
+							No projects in scope ·
 							<RouterLink to="/projects/new" class="text-brand-600 hover:underline"
 								>Create one →</RouterLink
 							>
@@ -373,94 +324,319 @@ const highValueApprovals = computed(() =>
 					</div>
 				</div>
 
-				<!-- Top risks -->
-				<div class="bg-white border border-ink-200 rounded-xl overflow-hidden">
-					<div class="px-4 py-3 border-b border-ink-200">
-						<h2 class="font-semibold text-ink-900 text-sm">Top risks</h2>
-						<p class="text-[11px] text-ink-500 mt-0.5">Schedule · cost · decisions</p>
-					</div>
-					<div class="divide-y divide-ink-100">
-						<RouterLink
-							v-for="r in topRisks"
-							:key="r.key"
-							:to="r.to"
-							class="block px-4 py-3 hover:bg-ink-50"
-						>
-							<div class="flex items-start gap-2.5">
-								<span
-									:class="r.dot"
-									class="w-2 h-2 rounded-full mt-1.5 flex-shrink-0"
-								></span>
-								<div class="flex-1 min-w-0">
-									<div
-										class="text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+				<!-- ===== Cost booked · Decision queue · Site activity ===== -->
+				<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
+					<!-- Cost booked by head -->
+					<div class="bg-white border border-ink-200 rounded-xl overflow-hidden">
+						<div class="px-4 py-3 border-b border-ink-200">
+							<h2 class="font-semibold text-ink-900 text-sm">Cost booked to date</h2>
+							<p class="text-[11px] text-ink-500 mt-0.5">
+								Actual spend by head — not the BOQ view above
+							</p>
+						</div>
+						<div class="p-4">
+							<div
+								class="text-2xl font-semibold text-ink-900 tabular-nums whitespace-nowrap"
+							>
+								{{ fmtCompactINR(cost.total_actual) }}
+							</div>
+							<div class="text-[11px] text-ink-400 mb-4">
+								across every task in scope
+							</div>
+
+							<div v-for="h in cost.heads" :key="h.key" class="mb-3 last:mb-0">
+								<div class="flex items-baseline justify-between text-xs mb-1">
+									<span class="text-ink-700">{{ h.label }}</span>
+									<span v-if="h.pending" class="text-[11px] text-ink-400 italic"
+										>no source yet</span
 									>
-										{{ r.kind }}
+									<span v-else class="text-ink-900 tabular-nums font-medium">{{
+										fmtCompactINR(h.value)
+									}}</span>
+								</div>
+								<div class="h-1.5 bg-ink-100 rounded-full overflow-hidden">
+									<div
+										class="h-full rounded-full"
+										:class="h.bar"
+										:style="`width:${h.pct}%`"
+									></div>
+								</div>
+							</div>
+						</div>
+					</div>
+
+					<!-- Decision queue -->
+					<div class="bg-white border border-ink-200 rounded-xl overflow-hidden">
+						<div
+							class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+						>
+							<div>
+								<h2 class="font-semibold text-ink-900 text-sm">Waiting on you</h2>
+								<p class="text-[11px] text-ink-500 mt-0.5">
+									Approvals across every module
+								</p>
+							</div>
+							<span
+								class="text-xs font-semibold px-2 py-0.5 rounded-full tabular-nums"
+								:class="
+									data.decision_total
+										? 'bg-warning-50 text-warning-700'
+										: 'bg-success-50 text-success-700'
+								"
+								>{{ data.decision_total }}</span
+							>
+						</div>
+						<div class="divide-y divide-ink-100">
+							<RouterLink
+								v-for="d in decision"
+								:key="d.key"
+								:to="d.to"
+								class="flex items-center gap-3 px-4 py-3 hover:bg-ink-50"
+							>
+								<span
+									class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+									:class="d.tone"
+								>
+									<svg
+										class="w-4 h-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.75"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										aria-hidden="true"
+										v-html="getWorkspaceIconPath(d.slug)"
+									/>
+								</span>
+								<div class="flex-1 min-w-0">
+									<div class="text-sm text-ink-900">{{ d.label }}</div>
+									<div class="text-[11px] text-ink-500 truncate">
+										<template v-if="d.count && d.value"
+											>{{ fmtCompactINR(d.value) }} {{ d.sub }}</template
+										>
+										<template v-else-if="d.count">{{ d.sub }}</template>
+										<template v-else>Nothing pending</template>
 									</div>
-									<div class="text-sm text-ink-900 leading-snug mt-0.5">
-										{{ r.title }}
+								</div>
+								<span
+									class="text-sm font-semibold tabular-nums flex-shrink-0"
+									:class="d.count ? 'text-ink-900' : 'text-ink-300'"
+									>{{ d.count }}</span
+								>
+							</RouterLink>
+						</div>
+					</div>
+
+					<!-- Site activity -->
+					<div class="bg-white border border-ink-200 rounded-xl overflow-hidden">
+						<div class="px-4 py-3 border-b border-ink-200">
+							<h2 class="font-semibold text-ink-900 text-sm">Site activity</h2>
+							<p class="text-[11px] text-ink-500 mt-0.5">Last 7 days</p>
+						</div>
+						<div class="p-4">
+							<div class="grid grid-cols-2 gap-3 mb-4">
+								<div>
+									<div class="text-xl font-semibold text-ink-900 tabular-nums">
+										{{ activity.entries }}
 									</div>
-									<div class="text-xs text-ink-500 mt-0.5 truncate">
-										{{ r.project }}
+									<div
+										class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-0.5"
+									>
+										Progress entries
+									</div>
+								</div>
+								<div>
+									<div class="text-xl font-semibold text-ink-900 tabular-nums">
+										{{ activity.man_days ?? "—" }}
+									</div>
+									<div
+										class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-0.5"
+									>
+										Man-days
+									</div>
+								</div>
+								<div>
+									<div
+										class="text-xl font-semibold tabular-nums"
+										:class="
+											activity.blockers ? 'text-danger-700' : 'text-ink-900'
+										"
+									>
+										{{ activity.blockers }}
+									</div>
+									<div
+										class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-0.5"
+									>
+										Blockers
+									</div>
+								</div>
+								<div>
+									<div class="text-xl font-semibold text-ink-900 tabular-nums">
+										{{ activity.receipts }}
+									</div>
+									<div
+										class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-0.5"
+									>
+										Deliveries
 									</div>
 								</div>
 							</div>
+
+							<p
+								v-if="activityQuiet"
+								class="text-[11px] text-ink-400 italic mb-3 -mt-1"
+							>
+								<template v-if="activity.last_activity_date"
+									>Nothing reported this week — the last report was
+									{{ fmtDate(activity.last_activity_date) }}.</template
+								>
+								<template v-else>No site reporting yet.</template>
+							</p>
+
+							<div class="border-t border-ink-100 pt-3">
+								<div
+									class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mb-2"
+								>
+									Latest reports
+								</div>
+								<div
+									v-for="e in activity.recent"
+									:key="e.id"
+									class="flex items-center gap-2 py-1.5"
+								>
+									<UserAvatar :user-id="e.owner" size="xs" />
+									<span class="flex-1 min-w-0">
+										<span class="block text-xs text-ink-900 truncate">{{
+											e.task
+										}}</span>
+										<span class="block text-[10px] text-ink-500"
+											>{{ fmtDate(e.entry_date) }} ·
+											{{ Math.round(e.progress) }}%</span
+										>
+									</span>
+									<span
+										v-if="e.blocker"
+										class="text-[10px] px-1.5 py-0.5 rounded-full bg-danger-50 text-danger-700 flex-shrink-0"
+										>Blocked</span
+									>
+								</div>
+								<div
+									v-if="!activity.recent.length"
+									class="text-xs text-ink-400 italic py-2"
+								>
+									No progress entries filed yet.
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- ===== Commitments ===== -->
+				<div class="bg-white border border-ink-200 rounded-xl overflow-hidden mt-6">
+					<div class="px-4 py-3 border-b border-ink-200">
+						<h2 class="font-semibold text-ink-900 text-sm">
+							Commitments &amp; exposure
+						</h2>
+						<p class="text-[11px] text-ink-500 mt-0.5">
+							Money promised to third parties, and what is still to come
+						</p>
+					</div>
+					<div
+						class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-ink-100"
+					>
+						<div class="p-4">
+							<div
+								class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+							>
+								Subcontract committed
+							</div>
+							<div
+								class="text-lg font-semibold text-ink-900 mt-1 tabular-nums whitespace-nowrap"
+							>
+								{{ fmtCompactINR(commitments.committed) }}
+							</div>
+							<div class="text-[11px] text-ink-400 mt-0.5 tabular-nums">
+								{{ fmtCompactINR(commitments.billed) }} billed ·
+								{{ fmtCompactINR(commitments.remaining) }} to come
+							</div>
+						</div>
+						<div class="p-4">
+							<div
+								class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+							>
+								On order
+							</div>
+							<div
+								class="text-lg font-semibold text-ink-900 mt-1 tabular-nums whitespace-nowrap"
+							>
+								{{ fmtCompactINR(commitments.on_order) }}
+							</div>
+							<div class="text-[11px] text-ink-400 mt-0.5">
+								{{ commitments.on_order_count }} open purchase orders
+							</div>
+						</div>
+						<div class="p-4">
+							<div
+								class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+							>
+								Retention held
+							</div>
+							<div
+								class="text-lg font-semibold text-ink-900 mt-1 tabular-nums whitespace-nowrap"
+							>
+								{{ fmtCompactINR(commitments.retention) }}
+							</div>
+							<div class="text-[11px] text-ink-400 mt-0.5">
+								withheld from subcontractors
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<!-- ===== Needs attention ===== -->
+				<div class="bg-white border border-ink-200 rounded-xl overflow-hidden mt-6 mb-4">
+					<div class="px-4 py-3 border-b border-ink-200">
+						<h2 class="font-semibold text-ink-900 text-sm">Needs attention</h2>
+						<p class="text-[11px] text-ink-500 mt-0.5">
+							Schedule · cost · decisions · supply
+						</p>
+					</div>
+					<div class="divide-y divide-ink-100">
+						<RouterLink
+							v-for="a in attention"
+							:key="a.key"
+							:to="a.to"
+							class="flex items-start gap-3 px-4 py-3 hover:bg-ink-50"
+						>
+							<span
+								:class="a.tone"
+								class="w-2 h-2 rounded-full mt-1.5 flex-shrink-0"
+							></span>
+							<div class="flex-1 min-w-0">
+								<div
+									class="text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+								>
+									{{ a.kind }}
+								</div>
+								<div class="text-sm text-ink-900 leading-snug mt-0.5">
+									{{ a.title }}
+								</div>
+								<div class="text-xs text-ink-500 mt-0.5 truncate">
+									{{ a.context }}
+								</div>
+							</div>
+							<span class="text-brand-600 text-sm flex-shrink-0">→</span>
 						</RouterLink>
-						<div v-if="!topRisks.length" class="px-4 py-8 text-center">
-							<div class="text-2xl mb-1">✓</div>
-							<div class="text-sm text-ink-700">No critical risks detected</div>
+						<div v-if="!attention.length" class="px-4 py-10 text-center">
+							<div class="text-sm text-ink-700">Nothing needs attention</div>
 							<p class="text-xs text-ink-500 mt-1">
-								Schedule, cost, and decisions all within tolerance.
+								Schedule, cost, decisions and supply are all within tolerance.
 							</p>
 						</div>
 					</div>
 				</div>
-			</div>
-
-			<!-- High-value approvals -->
-			<div class="bg-white border border-ink-200 rounded-xl overflow-hidden mt-6">
-				<div class="px-4 py-3 border-b border-ink-200 flex items-center justify-between">
-					<h2 class="font-semibold text-ink-900 text-sm">High-value approvals</h2>
-					<span class="text-[11px] text-ink-500">SCO impact &gt; ₹10 L</span>
-				</div>
-				<div class="divide-y divide-ink-100">
-					<RouterLink
-						v-for="s in highValueApprovals"
-						:key="s.id"
-						to="/sco"
-						class="flex items-center gap-4 px-4 py-3 hover:bg-ink-50"
-					>
-						<div
-							class="w-8 h-8 rounded-lg bg-warning-50 text-warning-700 flex items-center justify-center text-sm"
-						>
-							🔁
-						</div>
-						<div class="flex-1 min-w-0">
-							<div class="font-medium text-ink-900 text-sm truncate">
-								{{ s.title }}
-							</div>
-							<div class="text-xs text-ink-500 mt-0.5 font-mono">
-								{{ s.id }} · raised {{ fmtDate(s.raisedDate) }}
-							</div>
-						</div>
-						<div class="text-right flex-shrink-0">
-							<div class="text-sm font-semibold text-ink-900 tabular-nums">
-								{{ fmtCompactINR(s.impact) }}
-							</div>
-							<div class="text-[11px] text-ink-500">
-								{{ s.recoverable ? "recoverable" : "absorbed" }}
-							</div>
-						</div>
-						<span class="text-brand-600 text-sm flex-shrink-0">Review →</span>
-					</RouterLink>
-					<div
-						v-if="!highValueApprovals.length"
-						class="px-4 py-8 text-center text-sm text-ink-400"
-					>
-						No high-value approvals pending.
-					</div>
-				</div>
-			</div>
+			</template>
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
## What
Rebuilds the Site Execution **Project Dashboard** to the prototype's **S251** owner/PM layout and wires every panel to **live data** (it was entirely mock-store-backed). One backend aggregate — `api/project_dashboard.get_project_dashboard(project?)` — scoped to the whole portfolio or a single project (+ its sub-projects), with all derived numbers computed server-side so the payload stays small at portfolio scale.

## Panels (all live)
- **KPIs** — active projects + at-risk; contract value (each project's current Approved/Submitted **BOQ** planned, else budget); work done (**BOQ earned value** with coverage note); schedule (avg progress vs expected).
- **Project health** — progress-vs-expected bar (with the expected-% marker), earned/contract, open/total tasks, a single schedule figure, and a risk dot; most at-risk first.
- **Cost booked by head** — Subcontractor (bills) + Machinery (usage) live.
- **Waiting on you** — pending Stage plans, Scope changes (+ value), Material requests, Petty cash (+ value).
- **Site activity (7d)** — progress entries, reporters, blockers, deliveries (Purchase Receipt) + the latest 5 reports.
- **Commitments & exposure** — subcontract committed/billed/remaining, POs on order, retention held.
- **Needs attention** — project risks + overdue tasks.
- **Scope picker** (DeskLinkPicker + Portfolio reset) re-fetches server-side.

## Honest gaps (shown as pending, not faked)
This site/ERPNext build has no source for some prototype figures, so rather than invent them:
- **Man-days** — no attendance/timesheet-by-project source → shown as `—`.
- **Labour / Material / Overhead** cost heads — no cost-type field on spend → marked "no source yet" (Subcontractor + Machinery are real). Easy to fill in later once those sources land.

## Verification (bs.local, Administrator)
- Portfolio: 1398 active / 129 at-risk, contract ₹10.1 Cr, subcontract committed ₹10.19 Cr vs ₹5.49 Cr billed, retention ₹2.83 L, 59 stage plans pending, 7-day activity + latest reports resolve.
- Scoped (PROJ-1644): health = that project, committed ₹90.78 L / billed ₹49.64 L, cost ₹49.64 L.
- `vite build --mode development` clean; eslint passes.

Note: pulls from BOQ, Task, Subcontractor WO/Bill, Purchase Order/Receipt, Machinery Usage, Task Progress Entry, Stage Planning, SCO, Material Request, Petty Cash Request — Task Progress Entry is scoped via task (it has no `project` column).