### PR TITLE
feat: live Home + Desk overview dashboards

### DIFF
--- a/buildsuite_core/api/home.py
+++ b/buildsuite_core/api/home.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Home dashboard — the app-wide snapshot backing AppHomeView (`/home`) and the denser
+Desk overview DashboardView (`/dashboard`). One aggregate read so both views are thin
+renderers (mirrors api/project_dashboard.py):
+
+  · kpis     — active projects, open + overdue tasks, pending SCOs, progress filed today,
+               users, and the total order book (BOQ contract value of active projects).
+  · projects — active root projects with progress + a schedule tone (for the bar colour).
+  · pending_scos      — Scope Change Orders awaiting approval (title + cost impact).
+  · tasks_in_progress — the Working tasks, with their assignee.
+
+Derived numbers are computed server-side so the payload stays small. Single-company for now."""
+
+import json
+
+import frappe
+from frappe.utils import date_diff, flt, getdate, nowdate
+
+from buildsuite_core.utils.project import default_company
+
+_ACTIVE = ("New", "Ongoing", "Delayed")
+_BOQ_RANK = {"Approved": 2, "Submitted": 1}
+_PROJECT_LIMIT = 12
+_TASK_LIMIT = 6
+_SCO_LIMIT = 8
+_OPEN_TASK = ("Completed", "Cancelled", "Template")
+
+
+def _current_boq(project_names):
+	"""The best current BOQ per project (Approved > Submitted > latest) → planned amount."""
+	if not project_names:
+		return {}
+	rows = frappe.get_all(
+		"BOQ",
+		filters={"project": ["in", project_names]},
+		fields=["project", "status", "planned_amount"],
+		order_by="creation desc",
+	)
+	best = {}
+	for b in rows:
+		cur = best.get(b.project)
+		if not cur or _BOQ_RANK.get(b.status, 0) > _BOQ_RANK.get(cur.status, 0):
+			best[b.project] = b
+	return {p: flt(b.planned_amount) for p, b in best.items()}
+
+
+def _expected_pct(today, start, end):
+	"""Schedule-expected % complete for `today` given the planned window (0 if undated)."""
+	if not start or not end:
+		return 0.0
+	span = date_diff(end, start)
+	if span <= 0:
+		return 0.0
+	return max(0.0, min(100.0, date_diff(today, start) / span * 100.0))
+
+
+def _tone(expected, progress):
+	"""Schedule-variance tone for the progress bar, same convention as the Projects list."""
+	if expected <= 0:
+		return "success"
+	variance = (expected - progress) / expected * 100.0
+	if variance > 15:
+		return "danger"
+	if variance > 5:
+		return "warning"
+	return "success"
+
+
+def _first_assignee(assign):
+	"""ERPNext stores assignments as a JSON list in `_assign`; take the first."""
+	if not assign:
+		return None
+	try:
+		users = json.loads(assign)
+		return users[0] if users else None
+	except (ValueError, TypeError):
+		return None
+
+
+@frappe.whitelist()
+def get_home_dashboard():
+	company = default_company()
+	today = getdate(nowdate())
+
+	project_ids = frappe.get_all("Project", filters={"company": company}, pluck="name") or ["__none__"]
+	proj_in = {"project": ["in", project_ids]}
+
+	# --- active root projects → the list + the order book ---
+	roots = frappe.get_all(
+		"Project",
+		filters={"company": company, "parent_project": ["in", ["", None]]},
+		fields=[
+			"name",
+			"project_name",
+			"customer",
+			"status",
+			"project_status",
+			"percent_complete",
+			"expected_start_date",
+			"expected_end_date",
+			"estimated_costing",
+			"project_manager",
+		],
+		order_by="modified desc",
+	)
+	boq = _current_boq([p.name for p in roots])
+	customers = {p.customer for p in roots if p.customer}
+	cust_names = (
+		dict(
+			frappe.get_all(
+				"Customer",
+				filters={"name": ["in", list(customers)]},
+				fields=["name", "customer_name"],
+				as_list=True,
+			)
+		)
+		if customers
+		else {}
+	)
+
+	projects, order_book, active_ct = [], 0.0, 0
+	for p in roots:
+		if not (p.project_status in _ACTIVE and p.status != "Cancelled"):
+			continue
+		active_ct += 1
+		planned = boq.get(p.name, flt(p.estimated_costing))
+		order_book += flt(planned)
+		progress = flt(p.percent_complete)
+		expected = _expected_pct(today, p.expected_start_date, p.expected_end_date)
+		if len(projects) < _PROJECT_LIMIT:
+			projects.append(
+				{
+					"id": p.name,
+					"name": p.project_name or p.name,
+					"client": cust_names.get(p.customer, p.customer) or "",
+					"status": p.project_status or "New",
+					"progress": round(progress, 1),
+					"budget": flt(planned),
+					"pm": p.project_manager or "",
+					"tone": _tone(expected, progress),
+				}
+			)
+
+	# --- task + SCO counts (company-scoped via project) ---
+	open_tasks = frappe.db.count("Task", {**proj_in, "status": ["not in", _OPEN_TASK]})
+	overdue_tasks = frappe.db.count(
+		"Task",
+		{**proj_in, "status": ["not in", _OPEN_TASK], "exp_end_date": ["<", str(today)]},
+	)
+	progress_today = frappe.db.count("Task Progress Entry", {"entry_date": str(today)})
+	users = frappe.db.count("User", {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]})
+
+	scos = frappe.get_all(
+		"Scope Change Order",
+		filters={**proj_in, "status": "Pending Approval"},
+		fields=["name", "title", "impact"],
+		order_by="modified desc",
+		limit=_SCO_LIMIT,
+	)
+	pending_scos_ct = frappe.db.count("Scope Change Order", {**proj_in, "status": "Pending Approval"})
+
+	# --- tasks in progress (Working), with assignee ---
+	working = frappe.get_all(
+		"Task",
+		filters={**proj_in, "status": "Working"},
+		fields=["name", "subject", "progress", "_assign", "owner"],
+		order_by="modified desc",
+		limit=_TASK_LIMIT,
+	)
+	tasks_in_progress = [
+		{
+			"id": t.name,
+			"name": t.subject or t.name,
+			"progress": flt(t.progress),
+			"assignee": _first_assignee(t._assign) or t.owner,
+		}
+		for t in working
+	]
+
+	return {
+		"kpis": {
+			"active_projects": active_ct,
+			"open_tasks": open_tasks,
+			"overdue_tasks": overdue_tasks,
+			"pending_scos": pending_scos_ct,
+			"progress_today": progress_today,
+			"users": users,
+			"total_order_book": order_book,
+		},
+		"projects": projects,
+		"pending_scos": [{"id": s.name, "title": s.title or s.name, "impact": flt(s.impact)} for s in scos],
+		"tasks_in_progress": tasks_in_progress,
+	}

--- a/frontend/src/data/homeDashboardApi.js
+++ b/frontend/src/data/homeDashboardApi.js
@@ -1,0 +1,15 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Home / Desk overview — one aggregate read backing AppHomeView (/home) and DashboardView
+// (/dashboard): app-wide KPIs, active projects, pending SCOs and in-progress tasks
+// (buildsuite_core.api.home.get_home_dashboard).
+export async function getHomeDashboard() {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.home.get_home_dashboard",
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to load the dashboard.");
+	}
+}

--- a/frontend/src/views/AppHomeView.vue
+++ b/frontend/src/views/AppHomeView.vue
@@ -1,12 +1,27 @@
 <script setup>
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
+import { useSessionStore } from "@/stores/session";
+import { useUserNames } from "@/composables/useUserNames";
+import { getHomeDashboard } from "@/data/homeDashboardApi";
 
 const store = useDataStore();
+const session = useSessionStore();
+const { userName: resolveUserName } = useUserNames();
+
+// One live aggregate read backs every metric below (api.home.get_home_dashboard).
+const dash = ref(null);
+onMounted(async () => {
+	try {
+		dash.value = await getHomeDashboard();
+	} catch {
+		dash.value = null; // fall through to the fallback numbers
+	}
+});
+const kpis = computed(() => dash.value?.kpis || {});
 
 const now = new Date();
-const todayISO = now.toISOString().slice(0, 10);
 
 const greeting = computed(() => {
 	const hour = now.getHours();
@@ -15,7 +30,10 @@ const greeting = computed(() => {
 	return "Good evening";
 });
 
-const userName = computed(() => store.user?.name || "Admin User");
+const userName = computed(() => {
+	const id = session.user && session.user !== "Guest" ? session.user : null;
+	return (id && resolveUserName(id)) || store.user?.name || "Admin User";
+});
 
 const roleLabel = computed(() =>
 	store.isAdmin ? "System Manager (Admin)" : store.currentRole?.name || "User"
@@ -38,29 +56,14 @@ const initials = computed(() => {
 	return `${parts[0][0] || ""}${parts[1][0] || ""}`.toUpperCase();
 });
 
-const activeProjectsCount = computed(() => store.activeProjectsCount || 0);
-const openTasksCount = computed(() => store.openTasksCount || 0);
-const usersCount = computed(() => {
-	const ids = new Set((store.team || []).map((u) => u.id));
-	if (store.user?.id) ids.add(store.user.id);
-	return ids.size;
-});
+const activeProjectsCount = computed(() => kpis.value.active_projects);
+const openTasksCount = computed(() => kpis.value.open_tasks);
+const usersCount = computed(() => kpis.value.users);
 const workspacesCount = computed(() => (store.visibleWorkspaces || []).length);
 
-const pendingScosCount = computed(() => store.pendingScosCount || 0);
-const overdueTasksCount = computed(
-	() =>
-		(store.tasks || []).filter(
-			(t) =>
-				t.endDate &&
-				t.endDate < todayISO &&
-				t.status !== "Completed" &&
-				t.status !== "Cancelled"
-		).length
-);
-const progressTodayCount = computed(
-	() => (store.taskProgressEntries || []).filter((e) => e.entryDate === todayISO).length
-);
+const pendingScosCount = computed(() => kpis.value.pending_scos);
+const overdueTasksCount = computed(() => kpis.value.overdue_tasks);
+const progressTodayCount = computed(() => kpis.value.progress_today);
 
 const quickActions = [
 	{ label: "Users", to: "/settings/users", icon: "users" },

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,48 +4,41 @@
 // denser Desk-styled overview accessed via "Browse all workspaces" from a landing, or
 // the legacy `/` redirect.
 
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { RouterLink } from "vue-router";
-import { useDataStore } from "@/stores";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import { fmtCompactINR } from "@/utils/format";
+import { getHomeDashboard } from "@/data/homeDashboardApi";
 
-const store = useDataStore();
-const rootProjects = computed(() => store.rootProjects);
-const pendingScos = computed(() => store.scos.filter((s) => s.status === "Pending Approval"));
-const inProgressTasks = computed(() =>
-	store.tasks.filter((t) => t.status === "In Progress").slice(0, 6)
-);
+// One live aggregate read backs the whole overview (api.home.get_home_dashboard).
+const dash = ref(null);
+const loading = ref(true);
+onMounted(async () => {
+	try {
+		dash.value = await getHomeDashboard();
+	} finally {
+		loading.value = false;
+	}
+});
+const kpis = computed(() => dash.value?.kpis || {});
+const rootProjects = computed(() => dash.value?.projects || []);
+const pendingScos = computed(() => dash.value?.pending_scos || []);
+const inProgressTasks = computed(() => dash.value?.tasks_in_progress || []);
 
-// Schedule-based progress-bar color, same convention as Projects list.
-const today = new Date();
+// Schedule tone → progress-bar color, resolved server-side (same convention as Projects list).
+const TONE_BAR = { danger: "bg-danger-500", warning: "bg-warning-500", success: "bg-success-500" };
 function progressBarColor(p) {
-	if (!p.startDate || !p.endDate) return "bg-success-500";
-	const start = new Date(p.startDate).getTime();
-	const end = new Date(p.endDate).getTime();
-	const total = end - start;
-	if (total <= 0) return "bg-success-500";
-	const elapsed = Math.max(0, Math.min(total, today.getTime() - start));
-	const expected = (elapsed / total) * 100;
-	if (expected <= 0) return "bg-success-500";
-	const v = ((expected - p.progress) / expected) * 100;
-	if (v > 15) return "bg-danger-500";
-	if (v > 5) return "bg-warning-500";
-	return "bg-success-500";
+	return TONE_BAR[p.tone] || "bg-success-500";
 }
 
 const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Dashboard" }];
 </script>
 
 <template>
-	<DeskPage
-		title="Dashboard"
-		subtitle="Operations overview · live from local storage"
-		:breadcrumbs="breadcrumbs"
-	>
+	<DeskPage title="Dashboard" subtitle="Operations overview · live" :breadcrumbs="breadcrumbs">
 		<template #actions>
 			<RouterLink
 				to="/tasks/new"
@@ -63,7 +56,7 @@ const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Dashboard"
 					Active projects
 				</div>
 				<div class="text-base font-semibold text-ink-900 mt-0.5">
-					{{ store.activeProjectsCount }}
+					{{ kpis.active_projects ?? "—" }}
 				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
@@ -71,7 +64,7 @@ const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Dashboard"
 					Open tasks
 				</div>
 				<div class="text-base font-semibold text-ink-900 mt-0.5">
-					{{ store.openTasksCount }}
+					{{ kpis.open_tasks ?? "—" }}
 				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
@@ -79,7 +72,7 @@ const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Dashboard"
 					Pending SCOs
 				</div>
 				<div class="text-base font-semibold text-warning-700 mt-0.5">
-					{{ store.pendingScosCount }}
+					{{ kpis.pending_scos ?? "—" }}
 				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 2px">
@@ -87,7 +80,7 @@ const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Dashboard"
 					Total order book
 				</div>
 				<div class="text-base font-semibold text-ink-900 mt-0.5 tabular-nums">
-					{{ fmtCompactINR(store.totalOrderBook) }}
+					{{ fmtCompactINR(kpis.total_order_book || 0) }}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## What

Wires the two remaining reachable overview dashboards to live backend data, retiring their reliance on the prototype mock store:

- **`/home`** (`AppHomeView`) — today's snapshot KPIs + the three alert cards.
- **`/dashboard`** (`DashboardView`) — the denser Desk operations overview (KPI strip + active projects, pending SCOs, tasks-in-progress panels).

## How

New whitelisted aggregator **`api.home.get_home_dashboard`** computes everything server-side, company-scoped, in one read (mirrors the Project Dashboard pattern):

- **KPIs** — active projects, open + overdue tasks, pending SCOs, progress entries filed today, users, and the order book (BOQ contract value of active projects).
- **Lists** — active root projects (with a schedule tone for the progress-bar colour), pending SCOs (title + impact), and in-progress `Working` tasks (with assignee from `_assign`).

Both views become thin renderers. The home greeting now reads the **live session user** (resolved to a full name) instead of the mock store.

## Notes

- Single-company for now (routes via `default_company()`), consistent with the other live dashboards.
- The four workspace dashboards (Project, Procurement, Equipment, Subcontractor) were already live; the 11 role-landing views under `views/landings/` are unreachable prototype code (not wired to the router) and are intentionally out of scope.