### PR TITLE
feat: M3 role permissions — Workforce, Equipment, Project Finance

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
+++ b/buildsuite_core/buildsuite_core/doctype/expense_entry/expense_entry.py
@@ -2,13 +2,27 @@
 # For license information, please see license.txt
 
 import frappe
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+	get_accounting_dimensions,
+)
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt
 
-from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
-	get_accounting_dimensions,
-)
+from buildsuite_core.utils.petty_cash import employee_for_user
+
+# M3 (Project Finance): a site role may record spend only against petty cash, and only
+# with themselves as the holder — "site roles are confined to their own money". Accounts
+# and the admin tier may record against any holder / any account (corrections, back-dated
+# entries), so holding any of those roles lifts the confinement.
+_SITE_CONFINED_ROLES = {"BuildSuite Site Engineer", "BuildSuite Foreman"}
+_UNRESTRICTED_EXPENSE_ROLES = {
+	"BuildSuite Accountant",
+	"BuildSuite Director",
+	"BuildSuite Administrator",
+	"System Manager",
+	"Administrator",
+}
 
 
 class ExpenseEntry(Document):
@@ -52,6 +66,8 @@ class ExpenseEntry(Document):
 		if self.paid_from == "Company":
 			self.employee = None
 
+		self.enforce_site_confinement()
+
 		self.total_amount = sum(flt(row.amount) for row in self.expense_entry_table)
 
 		for idx, row in enumerate(self.expense_entry_table, start=1):
@@ -64,6 +80,21 @@ class ExpenseEntry(Document):
 
 		self.validate_single_company()
 		self.set_description()
+
+	def enforce_site_confinement(self):
+		"""Confine site roles to petty cash + themselves as holder (M3). Keyed to the
+		acting session user, so an Accountant editing a site user's entry is unrestricted."""
+		if frappe.flags.in_install or frappe.flags.in_migrate:
+			return
+		user = frappe.session.user
+		roles = set(frappe.get_roles(user))
+		if roles & _UNRESTRICTED_EXPENSE_ROLES or not (roles & _SITE_CONFINED_ROLES):
+			return
+		if self.paid_from != "Petty Cash":
+			frappe.throw(_("Site roles may only record Petty Cash expenses."))
+		own = employee_for_user(user)
+		if own and self.employee and self.employee != own:
+			frappe.throw(_("Site roles may only record expenses against themselves as the holder."))
 
 	def validate_single_company(self):
 		"""Every account + the holder must belong to this entry's company, else the Journal
@@ -112,11 +143,27 @@ class ExpenseEntry(Document):
 
 			# Debit: expense account (project cost — no holder)
 			accounts.append(
-				self.get_account_row(row, row.expense_account, flt(row.amount), 0, cost_center, accounting_dimensions, employee=None)
+				self.get_account_row(
+					row,
+					row.expense_account,
+					flt(row.amount),
+					0,
+					cost_center,
+					accounting_dimensions,
+					employee=None,
+				)
 			)
 			# Credit: payment account — Petty Cash (holder stamped) or the company's Bank/Cash
 			accounts.append(
-				self.get_account_row(row, row.payment_account, 0, flt(row.amount), cost_center, accounting_dimensions, employee=holder)
+				self.get_account_row(
+					row,
+					row.payment_account,
+					0,
+					flt(row.amount),
+					cost_center,
+					accounting_dimensions,
+					employee=holder,
+				)
 			)
 
 		if not accounts:

--- a/buildsuite_core/buildsuite_core/doctype/labour_attendance_register/labour_attendance_register.json
+++ b/buildsuite_core/buildsuite_core/doctype/labour_attendance_register/labour_attendance_register.json
@@ -189,21 +189,6 @@
    "share": 1,
    "submit": 1,
    "write": 1
-  },
-  {
-   "cancel": 1,
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "select": 1,
-   "share": 1,
-   "submit": 1,
-   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/buildsuite_core/buildsuite_core/doctype/overtime_attendance_register/overtime_attendance_register.json
+++ b/buildsuite_core/buildsuite_core/doctype/overtime_attendance_register/overtime_attendance_register.json
@@ -187,20 +187,6 @@
    "share": 1,
    "submit": 1,
    "write": 1
-  },
-  {
-   "cancel": 1,
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "All",
-   "share": 1,
-   "submit": 1,
-   "write": 1
   }
  ],
  "row_format": "Dynamic",

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -114,6 +114,7 @@ _FULL = {"read": 1, "write": 1, "create": 1, "delete": 1, "report": 1, "export":
 _FULL_SUB = {**_FULL, "submit": 1, "cancel": 1, "amend": 1}  # CRWDSX
 _RAISE = {"read": 1, "create": 1, "print": 1}  # CR — raise own records only
 _CRWS = {"read": 1, "write": 1, "create": 1, "submit": 1, "report": 1, "print": 1}  # CRWS
+_CRW = {"read": 1, "write": 1, "create": 1, "report": 1, "print": 1}  # CRW — edit, no delete
 
 # Assembly + Estimate Template: full for the estimation roles, hidden for the rest.
 ASSEMBLY_TEMPLATE_ROLE_PERMS = {role: _FULL for role in _ESTIMATION_ROLES}
@@ -621,6 +622,109 @@ def setup_subcontract_permissions():
 		_apply_role_perms(dt, _billing_read)
 
 
+# --- M3 — Workforce -----------------------------------------------------------
+# Field Attendance is the muster (submittable): Site Engineer + Foreman submit at
+# site; HR Manager has the same rights for office-side correction; PM full; Director
+# + Accountant read. Estimator / QS / Procurement / Store Keeper have no access.
+FIELD_ATTENDANCE_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite PM": _FULL_SUB,
+	"BuildSuite Site Engineer": _FULL_SUB,
+	"BuildSuite Foreman": _FULL_SUB,
+	"BuildSuite HR Manager": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite Accountant": _READ,
+}
+# Labour / Overtime Attendance are DERIVED registers — system-written when a Field
+# Attendance is submitted. No role edits them directly (corrections go through cancel
+# + amend on the muster), so every role that can see them is read-only.
+DERIVED_ATTENDANCE_ROLE_PERMS = {
+	role: _READ
+	for role in (
+		"BuildSuite Administrator",
+		"BuildSuite Director",
+		"BuildSuite PM",
+		"BuildSuite QS",
+		"BuildSuite Site Engineer",
+		"BuildSuite Foreman",
+		"BuildSuite Accountant",
+		"BuildSuite HR Manager",
+	)
+}
+
+
+def setup_workforce_permissions():
+	_apply_role_perms("Field Attendance", FIELD_ATTENDANCE_ROLE_PERMS, _SUBMIT_PTYPES)
+	for dt in ("Labour Attendance Register", "Overtime Attendance Register"):
+		# These registers historically shipped an over-broad `All` grant (write for every
+		# user). The derived rule is "no role edits directly", so drop any `All` custom
+		# grant before seeding the read-only BuildSuite matrix.
+		frappe.db.delete("Custom DocPerm", {"parent": dt, "role": "All"})
+		_apply_role_perms(dt, DERIVED_ATTENDANCE_ROLE_PERMS)
+
+
+# --- M3 — Equipment -----------------------------------------------------------
+# Machinery (the register) — Procurement + Store Keeper maintain it jointly
+# (Procurement buys/hires, Store Keeper holds custody); PM may edit; Site Engineer +
+# Foreman + Director + Accountant read. Non-submittable master, so CRWD is "full".
+MACHINERY_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Procurement Officer": _FULL,
+	"BuildSuite Store Keeper": _FULL,
+	"BuildSuite PM": _CRW,
+	"BuildSuite Director": _READ,
+	"BuildSuite Site Engineer": _READ,
+	"BuildSuite Foreman": _READ,
+	"BuildSuite Accountant": _READ,
+}
+# Machinery Usage (the plant usage log) — the site records usage (Site Engineer +
+# PM full, Foreman edits, Store Keeper holds custody); Procurement reads it as the
+# basis for hire bills; Director + Accountant read. Non-submittable, so CRWD is full.
+MACHINERY_USAGE_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite PM": _FULL,
+	"BuildSuite Site Engineer": _FULL,
+	"BuildSuite Store Keeper": _FULL,
+	"BuildSuite Foreman": _CRW,
+	"BuildSuite Director": _READ,
+	"BuildSuite Procurement Officer": _READ,
+	"BuildSuite Accountant": _READ,
+}
+
+
+def setup_equipment_permissions():
+	_apply_role_perms("Machinery", MACHINERY_ROLE_PERMS)
+	_apply_role_perms("Machinery Usage", MACHINERY_USAGE_ROLE_PERMS)
+
+
+# --- M3 — Project Finance (customer-side money) -------------------------------
+# Sales Invoice (money in) — Director + Accountant raise and submit; PM + QS read
+# for billing context. Native ERPNext doctype: BuildSuite DocPerms overlay ERPNext's
+# own Accounts roles (which keep their native access).
+SALES_INVOICE_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Director": _FULL_SUB,
+	"BuildSuite Accountant": _FULL_SUB,
+	"BuildSuite PM": _READ,
+	"BuildSuite QS": _READ,
+}
+# Payment Entry (money movement) — Accountant + admin tier create and submit; it is
+# created from the document being settled, never a blank form. Director + PM +
+# Procurement read (Procurement to know what is already paid).
+PAYMENT_ENTRY_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL_SUB,
+	"BuildSuite Accountant": _FULL_SUB,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _READ,
+	"BuildSuite Procurement Officer": _READ,
+}
+
+
+def setup_project_finance_permissions():
+	_apply_role_perms("Sales Invoice", SALES_INVOICE_ROLE_PERMS, _SUBMIT_PTYPES)
+	_apply_role_perms("Payment Entry", PAYMENT_ENTRY_ROLE_PERMS, _SUBMIT_PTYPES)
+
+
 def _ensure_workflow_state(name):
 	if not frappe.db.exists("Workflow State", name):
 		frappe.get_doc({"doctype": "Workflow State", "workflow_state_name": name}).insert(
@@ -665,6 +769,9 @@ def setup_record_permissions():
 	setup_subcontract_permissions()
 	setup_sco_permissions()
 	setup_petty_cash_permissions()
+	setup_workforce_permissions()
+	setup_equipment_permissions()
+	setup_project_finance_permissions()
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()
 	setup_subcontractor_wo_workflow()

--- a/buildsuite_core/tests/test_permissions.py
+++ b/buildsuite_core/tests/test_permissions.py
@@ -290,3 +290,70 @@ class TestPermissions(BuildSuiteTestCase):
 			self.assertEqual(rm.update_rates_from_po(purchase_order="PO-TEST", updates=[]), [])
 		finally:
 			frappe.set_user("Administrator")
+
+	# --- M3 access control (Workforce / Equipment / Project Finance) ----------
+	def test_store_keeper_maintains_machinery(self):
+		# M3-EQP — Store Keeper (with Procurement) maintains the Machinery register: full
+		# CRUD on Machinery + Machinery Usage; the muster (Field Attendance) is hidden.
+		self._as("Store Keeper", "storeeq")
+		try:
+			for dt in ("Machinery", "Machinery Usage"):
+				self.assertTrue(frappe.has_permission(dt, "create"), dt)
+				self.assertTrue(frappe.has_permission(dt, "write"), dt)
+			self.assertFalse(frappe.has_permission("Field Attendance", "read"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_site_engineer_equipment_split(self):
+		# M3-EQP — Site Engineer records plant usage (create Machinery Usage) but only
+		# reads the Machinery register (Procurement/Store own it).
+		self._as("Site Engineer", "seeq")
+		try:
+			self.assertTrue(frappe.has_permission("Machinery Usage", "create"))
+			self.assertTrue(frappe.has_permission("Machinery", "read"))
+			self.assertFalse(frappe.has_permission("Machinery", "write"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_derived_attendance_read_only(self):
+		# M3-WF — the derived Labour/Overtime registers are read-only for every role;
+		# they are system-written when the Field Attendance muster is submitted.
+		self._as("Foreman / Supervisor", "fmwf")
+		try:
+			for dt in ("Labour Attendance Register", "Overtime Attendance Register"):
+				self.assertTrue(frappe.has_permission(dt, "read"), dt)
+				self.assertFalse(frappe.has_permission(dt, "write"), dt)
+				self.assertFalse(frappe.has_permission(dt, "create"), dt)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_field_attendance_site_submits(self):
+		# M3-WF — Site Engineer submits the muster; Estimator has no access to it.
+		self._as("Site Engineer", "sewf")
+		try:
+			self.assertTrue(frappe.has_permission("Field Attendance", "create"))
+			self.assertTrue(frappe.has_permission("Field Attendance", "submit"))
+		finally:
+			frappe.set_user("Administrator")
+		self._as("Estimator", "estwf")
+		try:
+			self.assertFalse(frappe.has_permission("Field Attendance", "read"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_accountant_finance_vs_pm_read(self):
+		# M3-PF — Accountant raises + submits Sales Invoice and Payment Entry; PM only
+		# reads the invoice (billing context) and cannot create it.
+		self._as("Accountant", "acctpf")
+		try:
+			for dt in ("Sales Invoice", "Payment Entry"):
+				self.assertTrue(frappe.has_permission(dt, "create"), dt)
+				self.assertTrue(frappe.has_permission(dt, "submit"), dt)
+		finally:
+			frappe.set_user("Administrator")
+		self._as("Project Manager", "pmpf")
+		try:
+			self.assertTrue(frappe.has_permission("Sales Invoice", "read"))
+			self.assertFalse(frappe.has_permission("Sales Invoice", "create"))
+		finally:
+			frappe.set_user("Administrator")


### PR DESCRIPTION
## What

Completes the **DocType-level permission grid** from the M3 Roles & Permissions spec for every M3 DocType that already exists, extending `permissions/setup.py` (the single source of truth for per-persona base permissions). No M1/M2 row is changed.

### Modules wired
- **Workforce** — `Field Attendance` (the muster: Site Engineer / Foreman submit at site, HR Manager for office-side correction, PM full, Director + Accountant read). `Labour Attendance Register` + `Overtime Attendance Register` are **derived** (system-written when the muster is submitted) → read-only for every role. Dropped the over-broad `All` write grant these two shipped with (standard perm in JSON + a stray Custom DocPerm).
- **Equipment** — `Machinery` register (Procurement + Store Keeper maintain jointly, PM edits, Site Engineer/Foreman/Director/Accountant read) and `Machinery Usage` / plant-usage log (site records usage, Store custody, Procurement reads for hire bills).
- **Project Finance** — `Sales Invoice` + `Payment Entry` (Accountant + admin tier create/submit; PM/QS/Procurement read for context). BuildSuite DocPerms overlay ERPNext's native Accounts roles.

### Behavioural rule enforced server-side
`Expense Entry`: **site roles are confined to their own money** — a site role may record only Petty Cash spend and only with themselves as the holder; Accounts + admin tier remain unrestricted (corrections, back-dated entries). Keyed to the acting session user.

## Tests
5 new persona cases in `test_permissions.py` (Store Keeper machinery CRUD, Site Engineer equipment split, derived-register read-only, Field Attendance site-submit, Accountant finance vs PM read) — **18 pass**. `test_petty_cash`, `test_petty_cash_ledger`, `test_measurement_book` green. (`test_subcontractor_bill` has 2 failures that pre-exist on `develop` — a Payment Entry bank-reference validation, unrelated to this change.)

## Deferred (documented, out of scope here)
- **Masters that don't exist yet** — Subcontractor Profile, the Advance doctypes (Subcontractor/Supplier/Customer Advance), **Worker master + Crew**. Permissions can't be set on absent DocTypes.
- **The worker-master architecture decision** (Field Employee vs Employee + `is_labour`) — the spec explicitly defers it; blocks the remaining Workforce rows.
- **Field-level (permlevel) permissions** — 'Accountant owns the billing fields' needs a field→permlevel map the spec doesn't enumerate.
- `Finance Account` — needs a DocType mapping decision (ERPNext Account / Bank Account).