### PR TITLE
feat: Bank & Cash Accounts setting (S229)

### DIFF
--- a/buildsuite_core/api/finance_account.py
+++ b/buildsuite_core/api/finance_account.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Bank & Cash Accounts setting (S229) — the master of finance accounts that surface
+across Project Finance (Overview card, disburse / receive / pay modals, Cash & Bank
+statement). Backed by ERPNext `Account` (account_type Bank / Cash, company-scoped);
+the designated Petty Cash account is surfaced as its own type.
+
+Balances are DERIVED: current balance = the stored opening balance ± every recorded
+movement (the account's GL balance). Only the opening balance is editable here.
+Single-company for now — routes via default_company(). See the single-company seam."""
+
+import frappe
+from frappe import _
+from frappe.utils import flt
+
+from buildsuite_core.utils.petty_cash import get_petty_cash_account
+from buildsuite_core.utils.project import default_company
+
+# Roles allowed to manage the finance-account master (mirrors the admin-only setting tile).
+_MANAGE_ROLES = {
+	"System Manager",
+	"BuildSuite Administrator",
+	"BuildSuite Director",
+	"BuildSuite Accountant",
+}
+# type -> (root_type, account_type, parent group hint) for creating a new ledger account.
+_TYPE_MAP = {
+	"Bank": ("Asset", "Bank", "Bank Accounts"),
+	"Cash": ("Asset", "Cash", "Cash In Hand"),
+	"Petty Cash": ("Asset", "Cash", "Cash In Hand"),
+}
+
+
+def _can_manage():
+	return bool(_MANAGE_ROLES & set(frappe.get_roles()))
+
+
+def _guard():
+	if not _can_manage():
+		frappe.throw(_("You don't have permission to manage finance accounts."), frappe.PermissionError)
+
+
+def _ledger_balance(account, company):
+	from erpnext.accounts.utils import get_balance_on
+
+	return flt(get_balance_on(account=account, company=company))
+
+
+def _serialize(acc, petty, company):
+	"""Shape one Account row for the setting (opening + derived current balance)."""
+	opening = flt(acc.bs_opening_balance)
+	acc_type = "Petty Cash" if acc.name == petty else acc.account_type
+	return {
+		"id": acc.name,
+		"name": acc.account_name,
+		"type": acc_type,
+		"account_no": acc.account_number or "",
+		"opening_balance": opening,
+		"current_balance": opening + _ledger_balance(acc.name, company),
+	}
+
+
+@frappe.whitelist()
+def list_finance_accounts(company=None):
+	company = company or default_company()
+	if not company:
+		return []
+	petty = get_petty_cash_account(company)
+	accounts = frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]},
+		fields=["name", "account_name", "account_type", "account_number", "bs_opening_balance"],
+		order_by="account_type, account_name",
+	)
+	return [_serialize(a, petty, company) for a in accounts]
+
+
+@frappe.whitelist()
+def save_finance_account(name, type, account_no=None, opening_balance=0, account=None):
+	"""Create or edit a finance account. `account` is the Account id when editing."""
+	_guard()
+	company = default_company()
+	if not company:
+		frappe.throw(_("No default company is configured."))
+	name = (name or "").strip()
+	if not name:
+		frappe.throw(_("Account name is required."))
+	if type not in _TYPE_MAP:
+		frappe.throw(_("Invalid account type."))
+
+	if account:
+		doc = frappe.get_doc("Account", account)
+		if doc.company != company:
+			frappe.throw(_("That account belongs to another company."))
+		doc.account_name = name
+		doc.account_number = account_no or None
+		doc.bs_opening_balance = flt(opening_balance)
+		doc.flags.ignore_permissions = True
+		doc.save()
+		return _serialize(doc, get_petty_cash_account(company), company)
+
+	# --- create ---
+	if frappe.db.exists("Account", {"account_name": name, "company": company}):
+		frappe.throw(_("An account named {0} already exists.").format(name))
+	root_type, account_type, parent_hint = _TYPE_MAP[type]
+	from buildsuite_core.utils.subcontract_billing import _ensure_account
+
+	acc_name = _ensure_account(company, name, root_type, account_type, parent_hint)
+	doc = frappe.get_doc("Account", acc_name)
+	doc.account_number = account_no or None
+	doc.bs_opening_balance = flt(opening_balance)
+	doc.flags.ignore_permissions = True
+	doc.save()
+	return _serialize(doc, get_petty_cash_account(company), company)
+
+
+@frappe.whitelist()
+def delete_finance_account(account):
+	"""Delete a finance account. Refused if it has any posted GL movement."""
+	_guard()
+	company = default_company()
+	if frappe.db.get_value("Account", account, "company") != company:
+		frappe.throw(_("That account belongs to another company."))
+	if frappe.db.exists("GL Entry", {"account": account, "is_cancelled": 0}):
+		frappe.throw(_("Accounts with recorded movements can't be deleted."))
+	frappe.delete_doc("Account", account, ignore_permissions=True)
+	return {"ok": True}

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -510,4 +510,17 @@ CUSTOM_FIELD = {
 	# "Employee" Accounting Dimension (see install.seed_employee_accounting_dimension),
 	# not a bespoke custom field — so it groups natively in the standard GL / Financial
 	# Statements and is settable on any account (Cash/Bank included).
+	"Account": [
+		{
+			# Opening balance seed for the Bank & Cash Accounts setting (S229). The
+			# current balance shown there is this opening balance ± every recorded
+			# movement (the GL balance), so the opening is stored, not posted.
+			"fieldname": "bs_opening_balance",
+			"fieldtype": "Currency",
+			"label": "Opening Balance (BuildSuite)",
+			"insert_after": "account_number",
+			"options": "account_currency",
+			"module": "BuildSuite Core",
+		},
+	],
 }

--- a/buildsuite_core/tests/test_finance_account.py
+++ b/buildsuite_core/tests/test_finance_account.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Bank & Cash Accounts setting (S229) — the finance-account master CRUD."""
+
+import frappe
+
+from buildsuite_core.api import finance_account as fa
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestFinanceAccount(BuildSuiteTestCase):
+	def test_create_list_delete(self):
+		rec = fa.save_finance_account(name=f"UAT Cash {self._n}", type="Cash", opening_balance=1000)
+		self.assertEqual(rec["type"], "Cash")
+		self.assertEqual(rec["opening_balance"], 1000)
+		# No movements yet, so current balance == opening balance.
+		self.assertEqual(rec["current_balance"], 1000)
+
+		listed = fa.list_finance_accounts()
+		self.assertIn(rec["id"], [a["id"] for a in listed])
+
+		self.assertEqual(fa.delete_finance_account(rec["id"]), {"ok": True})
+		self.assertNotIn(rec["id"], [a["id"] for a in fa.list_finance_accounts()])
+
+	def test_account_no_persists_for_bank(self):
+		rec = fa.save_finance_account(
+			name=f"UAT Bank {self._n}", type="Bank", account_no="998877", opening_balance=0
+		)
+		try:
+			self.assertEqual(rec["account_no"], "998877")
+			self.assertEqual(rec["type"], "Bank")
+		finally:
+			fa.delete_finance_account(rec["id"])
+
+	def test_non_finance_role_cannot_manage(self):
+		user = frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": f"fa-se-{self._n}@example.com",
+				"first_name": "FA SE",
+				"send_welcome_email": 0,
+				"user_type": "System User",
+				"persona": "Site Engineer",
+				"company": self.company,
+			}
+		).insert(ignore_permissions=True)
+
+		frappe.set_user(user.name)
+		try:
+			self.assertRaises(
+				frappe.PermissionError,
+				fa.save_finance_account,
+				name=f"Blocked {self._n}",
+				type="Cash",
+			)
+		finally:
+			frappe.set_user("Administrator")

--- a/frontend/src/data/financeAccountApi.js
+++ b/frontend/src/data/financeAccountApi.js
@@ -1,0 +1,40 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Settings › Bank & Cash Accounts (S229). The finance-account master backed by ERPNext
+// Account (Bank / Cash, company-scoped) — see buildsuite_core.api.finance_account.
+// Balances are derived server-side: current = opening ± recorded movements.
+
+export async function listFinanceAccounts() {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.finance_account.list_finance_accounts",
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to load accounts.");
+	}
+}
+
+export async function saveFinanceAccount(payload) {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.finance_account.save_finance_account",
+			method: "POST",
+			params: payload,
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to save the account.");
+	}
+}
+
+export async function deleteFinanceAccount(account) {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.finance_account.delete_finance_account",
+			method: "POST",
+			params: { account },
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to delete the account.");
+	}
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -650,6 +650,11 @@ const routes = [
 				component: () => import("@/views/settings/CoreSettingsView.vue"),
 			},
 			{
+				path: "settings/finance-accounts",
+				name: "settings-finance-accounts",
+				component: () => import("@/views/settings/FinanceAccountsView.vue"),
+			},
+			{
 				path: "settings/workspaces",
 				name: "settings-workspaces",
 				component: () => import("@/views/settings/WorkspaceSettingsView.vue"),

--- a/frontend/src/views/settings/FinanceAccountsView.vue
+++ b/frontend/src/views/settings/FinanceAccountsView.vue
@@ -1,0 +1,357 @@
+<script setup>
+// S229 — Settings › Bank & Cash Accounts. Master for the finance accounts that surface
+// across Project Finance (Overview card, disburse / receive / pay modals, Cash & Bank
+// statement). Backed by ERPNext Account (Bank / Cash) — balances are DERIVED (opening
+// balance ± movements), so only the opening balance is editable here.
+import { ref, computed, onMounted } from "vue";
+import { useDataStore } from "@/stores";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
+import { fmtINR } from "@/utils/format";
+import { useConfirm } from "@/composables/useConfirm";
+import {
+	listFinanceAccounts,
+	saveFinanceAccount,
+	deleteFinanceAccount,
+} from "@/data/financeAccountApi";
+
+const store = useDataStore();
+const confirmDialog = useConfirm();
+
+const canManage = computed(() => store.isAdmin);
+
+const accounts = ref([]);
+const loading = ref(true);
+const loadError = ref("");
+
+async function reload() {
+	loading.value = true;
+	loadError.value = "";
+	try {
+		accounts.value = await listFinanceAccounts();
+	} catch (err) {
+		loadError.value = err.message || "Failed to load accounts.";
+	} finally {
+		loading.value = false;
+	}
+}
+onMounted(reload);
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Settings", to: "/settings" },
+	{ label: "Bank & Cash Accounts" },
+];
+
+// --- add/edit modal ---
+const modalOpen = ref(false);
+const editingId = ref(null);
+const form = ref(blank());
+const error = ref("");
+const saving = ref(false);
+
+function blank() {
+	return { name: "", type: "Bank", account_no: "", opening_balance: null };
+}
+function openNew() {
+	editingId.value = null;
+	form.value = blank();
+	error.value = "";
+	modalOpen.value = true;
+}
+function openEdit(acc) {
+	editingId.value = acc.id;
+	form.value = {
+		name: acc.name,
+		type: acc.type,
+		account_no: acc.account_no || "",
+		opening_balance: acc.opening_balance,
+	};
+	error.value = "";
+	modalOpen.value = true;
+}
+async function save() {
+	if (!form.value.name.trim()) {
+		error.value = "Account name is required.";
+		return;
+	}
+	saving.value = true;
+	error.value = "";
+	try {
+		await saveFinanceAccount({
+			account: editingId.value || undefined,
+			name: form.value.name.trim(),
+			type: form.value.type,
+			account_no: form.value.account_no || "",
+			opening_balance: form.value.opening_balance || 0,
+		});
+		modalOpen.value = false;
+		await reload();
+	} catch (err) {
+		error.value = err.message || "Failed to save the account.";
+	} finally {
+		saving.value = false;
+	}
+}
+async function del(acc) {
+	const ok = await confirmDialog({
+		title: "Delete account?",
+		message: `Delete "${acc.name}"? Accounts with recorded movements can't be deleted.`,
+		confirmLabel: "Delete",
+		danger: true,
+	});
+	if (!ok) return;
+	try {
+		await deleteFinanceAccount(acc.id);
+		await reload();
+	} catch (err) {
+		loadError.value = err.message || "Failed to delete the account.";
+	}
+}
+</script>
+
+<template>
+	<DeskPage
+		title="Bank & Cash Accounts"
+		subtitle="Accounts shown across Project Finance — balances derive from movements"
+		:breadcrumbs="breadcrumbs"
+	>
+		<template #actions>
+			<button v-if="canManage" type="button" class="desk-save-btn !text-xs" @click="openNew">
+				+ New Account
+			</button>
+		</template>
+
+		<div
+			v-if="!canManage"
+			class="bg-warning-50 border border-warning-200 rounded-lg px-4 py-6 text-sm text-warning-700"
+		>
+			You don't have permission to manage finance accounts.
+		</div>
+
+		<template v-else>
+			<div
+				v-if="loadError"
+				class="bg-danger-50 border border-danger-200 rounded-lg px-4 py-4 text-sm text-danger-700 mb-3"
+			>
+				{{ loadError }}
+			</div>
+
+			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<table class="w-full text-xs">
+					<thead
+						class="text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200 bg-ink-50"
+					>
+						<tr>
+							<th class="text-left px-4 py-2">Account</th>
+							<th class="text-left px-4 py-2">Type</th>
+							<th class="text-left px-4 py-2">Account no.</th>
+							<th class="text-right px-4 py-2">Opening balance</th>
+							<th class="text-right px-4 py-2">Current balance</th>
+							<th class="px-4 py-2"></th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="acc in accounts"
+							:key="acc.id"
+							class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30"
+						>
+							<td class="px-4 py-2.5">
+								<div class="flex items-center gap-2">
+									<div
+										class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+										:class="
+											acc.type === 'Bank'
+												? 'bg-info-50 text-info-700'
+												: 'bg-success-50 text-success-700'
+										"
+									>
+										<svg
+											width="16"
+											height="16"
+											viewBox="0 0 24 24"
+											fill="none"
+											stroke="currentColor"
+											stroke-width="1.75"
+											stroke-linecap="round"
+											stroke-linejoin="round"
+											v-html="
+												getWorkspaceIconPath(
+													acc.type === 'Bank'
+														? 'building-2'
+														: 'hand-coins'
+												)
+											"
+										></svg>
+									</div>
+									<span class="text-ink-900 font-medium">{{ acc.name }}</span>
+								</div>
+							</td>
+							<td class="px-4 py-2.5">
+								<span
+									class="text-[10px] px-1.5 py-0.5 rounded-full"
+									:class="
+										acc.type === 'Bank'
+											? 'bg-info-50 text-info-700'
+											: 'bg-success-50 text-success-700'
+									"
+									>{{ acc.type }}</span
+								>
+							</td>
+							<td class="px-4 py-2.5 font-mono text-ink-500">
+								{{ acc.account_no || "—" }}
+							</td>
+							<td class="px-4 py-2.5 text-right tabular-nums text-ink-700">
+								{{ fmtINR(acc.opening_balance) }}
+							</td>
+							<td
+								class="px-4 py-2.5 text-right tabular-nums font-semibold text-ink-900"
+							>
+								{{ fmtINR(acc.current_balance) }}
+							</td>
+							<td class="px-4 py-2.5 text-right whitespace-nowrap">
+								<button
+									type="button"
+									class="text-[11px] px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+									@click="openEdit(acc)"
+								>
+									Edit
+								</button>
+								<button
+									type="button"
+									class="text-[11px] px-2 py-1 ml-1 text-danger-600 hover:underline"
+									@click="del(acc)"
+								>
+									Delete
+								</button>
+							</td>
+						</tr>
+						<tr v-if="loading">
+							<td colspan="6" class="px-4 py-10 text-center text-xs text-ink-400">
+								Loading accounts…
+							</td>
+						</tr>
+						<tr v-else-if="!accounts.length">
+							<td
+								colspan="6"
+								class="px-4 py-10 text-center text-xs text-ink-400 italic"
+							>
+								No accounts yet — add your bank and cash accounts.
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</section>
+
+			<p class="text-[11px] text-ink-400 mt-3">
+				Current balance = opening balance ± every recorded movement (receipts, payments,
+				disbursements, advances). Accounts with history can't be deleted.
+			</p>
+		</template>
+
+		<!-- Add/edit modal -->
+		<Teleport to="body">
+			<div
+				v-if="modalOpen"
+				class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6"
+				@click.self="modalOpen = false"
+			>
+				<div
+					class="bg-white border border-ink-200 w-full max-w-md shadow-fp-lg rounded-xl"
+					@click.stop
+				>
+					<header
+						class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+					>
+						<h2 class="text-sm font-semibold text-ink-900">
+							{{ editingId ? "Edit account" : "New account" }}
+						</h2>
+						<button
+							type="button"
+							class="text-ink-400 hover:text-ink-900"
+							@click="modalOpen = false"
+						>
+							✕
+						</button>
+					</header>
+					<div class="px-4 py-4 space-y-3">
+						<div>
+							<label
+								class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Account name <span class="text-danger-600">*</span></label
+							>
+							<input
+								v-model="form.name"
+								type="text"
+								class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+								placeholder="e.g. ICICI Current A/c"
+							/>
+						</div>
+						<div class="grid grid-cols-2 gap-3">
+							<div>
+								<label
+									class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+									>Type</label
+								>
+								<select
+									v-model="form.type"
+									:disabled="!!editingId"
+									class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400 disabled:bg-ink-50 disabled:text-ink-400"
+								>
+									<option value="Bank">Bank</option>
+									<option value="Cash">Cash</option>
+									<option value="Petty Cash">Petty Cash</option>
+								</select>
+							</div>
+							<div>
+								<label
+									class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+									>Opening balance</label
+								>
+								<input
+									v-model.number="form.opening_balance"
+									type="number"
+									class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md text-right focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+									placeholder="0"
+								/>
+							</div>
+						</div>
+						<div v-if="form.type === 'Bank'">
+							<label
+								class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+								>Account no.
+								<span class="text-ink-400 normal-case">(optional)</span></label
+							>
+							<input
+								v-model="form.account_no"
+								type="text"
+								class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md font-mono focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+							/>
+						</div>
+						<div v-if="error" class="text-[11px] text-danger-600">{{ error }}</div>
+					</div>
+					<footer
+						class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+					>
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+							@click="modalOpen = false"
+						>
+							Cancel
+						</button>
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 bg-brand-600 hover:bg-brand-700 text-white font-medium rounded-md disabled:opacity-50"
+							:disabled="saving"
+							@click="save"
+						>
+							{{ saving ? "Saving…" : "Save" }}
+						</button>
+					</footer>
+				</div>
+			</div>
+		</Teleport>
+	</DeskPage>
+</template>

--- a/frontend/src/views/settings/SettingsHubView.vue
+++ b/frontend/src/views/settings/SettingsHubView.vue
@@ -88,6 +88,14 @@ const groups = computed(() => [
 				adminOnly: true,
 			},
 			{
+				slug: "finance-accounts",
+				icon: "wallet",
+				label: "Bank & Cash Accounts",
+				desc: "Bank, cash and petty cash accounts shown across Project Finance — with opening and derived current balances.",
+				to: "/settings/finance-accounts",
+				adminOnly: true,
+			},
+			{
 				slug: "workspace-setting",
 				icon: "site-execution",
 				label: "Workspace Setting",
@@ -201,7 +209,7 @@ const visibleGroups = computed(() =>
 				return true;
 			}),
 		}))
-		.filter((g) => g.tiles.length),
+		.filter((g) => g.tiles.length)
 );
 
 function onTileClick(tile) {


### PR DESCRIPTION
## What

Adds the **Bank & Cash Accounts** master under **Settings › BuildSuite product settings**, ported from the prototype (S229). It's the master for the finance accounts that surface across Project Finance — the Overview card, the disburse / receive / pay modals, and the Cash & Bank statement.

![where it lives: Settings → BuildSuite product settings → Bank & Cash Accounts]

## How

Backed by ERPNext **Account** (`account_type` Bank / Cash, company-scoped); the designated **Petty Cash** account is surfaced as its own type. Matches the prototype's model exactly — **balances are derived**: current balance = the stored **opening balance ± every recorded movement** (the account's GL balance). A new `Account.bs_opening_balance` custom field holds the opening seed, so no opening Journal Entry machinery is needed.

- **`api/finance_account.py`** — `list_finance_accounts` / `save_finance_account` / `delete_finance_account`, whitelisted and **role-guarded** (System Manager / BuildSuite Administrator / Director / Accountant). Create resolves the right Bank/Cash parent group via the existing `_ensure_account` helper; **delete is refused once an account has posted GL movements**.
- **`Account.bs_opening_balance`** custom field (in `custom_field.py`, installed on migrate).
- **Frontend** — `settings/FinanceAccountsView.vue` (table + add/edit modal, matching the prototype), `financeAccountApi.js`, the `/settings/finance-accounts` route, and the tile in the *BuildSuite product settings* group. Admin-gated (`store.isAdmin`).

Type is fixed once an account is created (a ledger account can't be reclassified), so the Type select is disabled when editing — the one intentional deviation from the mock.

## Tests
`test_finance_account.py` — 3 pass: create→list→delete round-trip, bank account-no persistence, and the non-finance-role permission guard. Frontend `vite build` clean.

## Notes
- Single-company for now (routes via `default_company()`), consistent with the rest of Project Finance.