### PR TITLE
feat: project Progress Report (Daily/Weekly/Monthly, S167)

### DIFF
--- a/buildsuite_core/api/progress_report.py
+++ b/buildsuite_core/api/progress_report.py
@@ -1,0 +1,315 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Project Progress Report — Daily / Weekly / Monthly (S167).
+
+One aggregate read backing the Vue report surface: every project-scoped slice (tasks,
+task progress entries, stages, material requests / purchase orders / receipts, scope
+changes, attachments) rolled up against a moving date window. The window is set by the
+caller:  period = daily | weekly | monthly, ending on `date` (today if omitted):
+  daily   = the single day
+  weekly  = the 7-day window ending on `date`
+  monthly = the 30-day rolling window ending on `date`
+
+Scoped to the project + its sub-projects, so the rollups capture subproject activity too.
+Derived numbers are computed server-side so the Vue view stays a thin renderer."""
+
+import frappe
+from frappe.utils import add_days, flt, getdate, nowdate
+
+from buildsuite_core.api.project_dashboard import _subprojects
+
+_ACTIVE_TASK_DONE = "Completed"
+_SPANS = {"daily": 1, "weekly": 7, "monthly": 30}
+
+
+def _window(period, end):
+	"""(start, end) inclusive for the period ending on `end`."""
+	span = _SPANS.get(period, 7)
+	return add_days(end, -(span - 1)), end
+
+
+def _in(d, start, end):
+	return bool(d) and start <= getdate(d) <= end
+
+
+@frappe.whitelist()
+def get_progress_report(project, period="weekly", date=None):
+	if not project or not frappe.db.exists("Project", project):
+		frappe.throw(frappe._("Project not found."))
+	period = period if period in _SPANS else "weekly"
+	end = getdate(date) if date else getdate(nowdate())
+	start, end = _window(period, end)
+	today = getdate(nowdate())
+
+	scope_ids = [project, *_subprojects(project)]
+
+	proj = frappe.db.get_value(
+		"Project",
+		project,
+		[
+			"name",
+			"project_name",
+			"custom_project_id",
+			"customer",
+			"project_manager",
+			"project_status",
+			"expected_start_date",
+			"expected_end_date",
+		],
+		as_dict=True,
+	)
+	client = ""
+	if proj.customer:
+		client = frappe.db.get_value("Customer", proj.customer, "customer_name") or proj.customer
+	pm_name = frappe.db.get_value("User", proj.project_manager, "full_name") if proj.project_manager else ""
+
+	# --- tasks in scope ---
+	tasks = frappe.get_all(
+		"Task",
+		filters={"project": ["in", scope_ids]},
+		fields=["name", "subject", "task_status", "progress", "exp_end_date"],
+	)
+	task_ids = [t.name for t in tasks] or ["__none__"]
+
+	# latest progress-entry date per task (for "completed in period" + last-update)
+	entries = frappe.get_all(
+		"Task Progress Entry",
+		filters={"task": ["in", task_ids]},
+		fields=["name", "task", "entry_date", "skilled", "unskilled", "blocker", "blocker_detail", "owner"],
+		order_by="entry_date desc, creation desc",
+	)
+	latest_entry = {}
+	for e in entries:
+		latest_entry.setdefault(e.task, e.entry_date)
+
+	entries_in = [e for e in entries if _in(e.entry_date, start, end)]
+	entry_task_ids = {e.task for e in entries_in}
+
+	# --- status snapshot (current, not period-scoped) ---
+	stats = {
+		"total": len(tasks),
+		"completed": 0,
+		"in_progress": 0,
+		"yet_to_start": 0,
+		"delayed": 0,
+		"blocked": 0,
+		"overdue": 0,
+	}
+	_map = {
+		"Completed": "completed",
+		"In Progress": "in_progress",
+		"Yet To Start": "yet_to_start",
+		"In Delay": "delayed",
+		"Blocked": "blocked",
+	}
+	for t in tasks:
+		key = _map.get(t.task_status)
+		if key:
+			stats[key] += 1
+		if t.task_status != _ACTIVE_TASK_DONE and t.exp_end_date and getdate(t.exp_end_date) < today:
+			stats["overdue"] += 1
+
+	tasks_completed_in = [
+		t for t in tasks if t.task_status == _ACTIVE_TASK_DONE and _in(latest_entry.get(t.name), start, end)
+	]
+	task_activity = [
+		{
+			"id": t.name,
+			"name": t.subject or t.name,
+			"status": t.task_status or "Yet To Start",
+			"progress": flt(t.progress),
+			"last_update": str(latest_entry.get(t.name)) if latest_entry.get(t.name) else None,
+		}
+		for t in tasks
+		if t.name in entry_task_ids
+	]
+
+	# --- labour + blockers (from period entries) ---
+	skilled = sum(int(e.skilled or 0) for e in entries_in)
+	unskilled = sum(int(e.unskilled or 0) for e in entries_in)
+	task_name = {t.name: (t.subject or t.name) for t in tasks}
+	blocker_entries = [e for e in entries_in if e.blocker]
+	owners = {e.owner for e in blocker_entries if e.owner}
+	owner_names = (
+		dict(
+			frappe.get_all(
+				"User", filters={"name": ["in", list(owners)]}, fields=["name", "full_name"], as_list=True
+			)
+		)
+		if owners
+		else {}
+	)
+	blockers = [
+		{
+			"id": e.name,
+			"task": task_name.get(e.task, e.task),
+			"note": e.blocker_detail or "No detail provided.",
+			"entry_date": str(e.entry_date) if e.entry_date else None,
+			"owner": owner_names.get(e.owner, e.owner),
+		}
+		for e in blocker_entries
+	]
+
+	# --- stages touching the window ---
+	stage_rows = frappe.get_all(
+		"Stage Planning",
+		filters={"project": ["in", scope_ids]},
+		fields=[
+			"name",
+			"stage_name",
+			"workflow_state",
+			"planned_start",
+			"planned_end",
+			"description",
+			"modified",
+		],
+	)
+	stages = [
+		{
+			"id": s.name,
+			"name": s.stage_name or s.name,
+			"workflow_state": s.workflow_state or "Draft",
+			"planned_start": str(s.planned_start) if s.planned_start else None,
+			"planned_end": str(s.planned_end) if s.planned_end else None,
+			"description": s.description or "",
+		}
+		for s in stage_rows
+		if (
+			(
+				s.planned_start
+				and s.planned_end
+				and not (getdate(s.planned_end) < start or getdate(s.planned_start) > end)
+			)
+			or _in(s.modified, start, end)
+		)
+	]
+
+	# --- materials (MR / PO raised, receipts) ---
+	proj_in = {"project": ["in", scope_ids]}
+	mrs = frappe.get_all("Material Request", filters=proj_in, fields=["name", "transaction_date"])
+	mr_in = [m for m in mrs if _in(m.transaction_date, start, end)]
+	pos = frappe.get_all(
+		"Purchase Order", filters=proj_in, fields=["name", "transaction_date", "grand_total"]
+	)
+	po_in = [p for p in pos if _in(p.transaction_date, start, end)]
+	po_value = sum(flt(p.grand_total) for p in po_in)
+
+	prs = frappe.get_all(
+		"Purchase Receipt",
+		filters={**proj_in, "docstatus": 1},
+		fields=["name", "posting_date", "supplier", "supplier_name", "status"],
+	)
+	pr_in = [g for g in prs if _in(g.posting_date, start, end)]
+	grns = []
+	for g in pr_in:
+		first = frappe.get_all(
+			"Purchase Receipt Item",
+			filters={"parent": g.name},
+			fields=["item_name", "received_qty", "uom"],
+			order_by="idx",
+			limit=1,
+		)
+		item = first[0] if first else {}
+		grns.append(
+			{
+				"date": str(g.posting_date) if g.posting_date else None,
+				"item": item.get("item_name") or "—",
+				"supplier": g.supplier_name or g.supplier or "",
+				"qty": flt(item.get("received_qty")),
+				"uom": item.get("uom") or "",
+				"status": g.status or "",
+			}
+		)
+
+	# --- scope changes raised in the window ---
+	sco_rows = frappe.get_all(
+		"Scope Change Order",
+		filters=proj_in,
+		fields=["name", "raised_date", "title", "status", "impact", "recoverable"],
+		order_by="raised_date desc",
+	)
+	sco_in = [s for s in sco_rows if _in(s.raised_date, start, end)]
+	scope_changes = [
+		{
+			"id": s.name,
+			"raised_date": str(s.raised_date) if s.raised_date else None,
+			"title": s.title or s.name,
+			"status": s.status or "",
+			"impact": flt(s.impact),
+			"recoverable": bool(s.recoverable),
+		}
+		for s in sco_in
+	]
+	scos_approved = sum(1 for s in sco_in if s.status == "Approved")
+	scos_pending = sum(1 for s in sco_in if s.status == "Pending Approval")
+
+	# --- attachments added on the project(s) in the window ---
+	att_rows = frappe.get_all(
+		"File",
+		filters={"attached_to_doctype": "Project", "attached_to_name": ["in", scope_ids], "is_folder": 0},
+		fields=["creation"],
+	)
+	attachments_added = sum(1 for a in att_rows if _in(a.creation, start, end))
+
+	# --- look-ahead: tasks due in the next same-length window ---
+	la_start = add_days(end, 1)
+	la_end = add_days(la_start, _SPANS[period] - 1)
+	look_ahead_tasks = sorted(
+		[
+			{
+				"due": str(getdate(t.exp_end_date)),
+				"name": t.subject or t.name,
+				"status": t.task_status or "Yet To Start",
+				"progress": flt(t.progress),
+			}
+			for t in tasks
+			if t.task_status != _ACTIVE_TASK_DONE and _in(t.exp_end_date, la_start, la_end)
+		],
+		key=lambda r: r["due"],
+	)
+
+	return {
+		"project": {
+			"id": proj.name,
+			"name": proj.project_name or proj.name,
+			"code": proj.custom_project_id or proj.name,
+			"client": client,
+			"pm": proj.project_manager or "",
+			"pm_name": pm_name or proj.project_manager or "",
+			"status": proj.project_status or "New",
+			"start_date": str(proj.expected_start_date) if proj.expected_start_date else None,
+			"end_date": str(proj.expected_end_date) if proj.expected_end_date else None,
+		},
+		"period": period,
+		"date": str(end),
+		"window": {"start": str(start), "end": str(end)},
+		"look_ahead": {"start": str(la_start), "end": str(la_end)},
+		"task_stats": stats,
+		"kpis": {
+			"tasks_completed": len(tasks_completed_in),
+			"entries": len(entries_in),
+			"labour": {"skilled": skilled, "unskilled": unskilled, "total": skilled + unskilled},
+			"deliveries": len(pr_in),
+			"mr_count": len(mr_in),
+			"po_count": len(po_in),
+			"po_value": po_value,
+			"blockers": len(blocker_entries),
+			"scope_changes": len(sco_in),
+			"scos_approved": scos_approved,
+			"scos_pending": scos_pending,
+			"attachments": attachments_added,
+		},
+		"task_activity": task_activity,
+		"stages": stages,
+		"materials": {
+			"mr_count": len(mr_in),
+			"po_count": len(po_in),
+			"po_value": po_value,
+			"grn_count": len(pr_in),
+			"grns": grns,
+		},
+		"scope_changes": scope_changes,
+		"blockers": blockers,
+		"look_ahead_tasks": look_ahead_tasks,
+	}

--- a/buildsuite_core/api/progress_report.py
+++ b/buildsuite_core/api/progress_report.py
@@ -14,13 +14,45 @@ caller:  period = daily | weekly | monthly, ending on `date` (today if omitted):
 Scoped to the project + its sub-projects, so the rollups capture subproject activity too.
 Derived numbers are computed server-side so the Vue view stays a thin renderer."""
 
+import math
+
 import frappe
-from frappe.utils import add_days, flt, getdate, nowdate
+from frappe.utils import add_days, cint, date_diff, flt, getdate, nowdate
 
 from buildsuite_core.api.project_dashboard import _subprojects
 
 _ACTIVE_TASK_DONE = "Completed"
 _SPANS = {"daily": 1, "weekly": 7, "monthly": 30}
+_AUDIENCES = ("client", "internal")
+_IMAGE_EXT = (".jpg", ".jpeg", ".png", ".webp", ".heic", ".gif")
+
+
+def _programme(actual, start, end, as_of):
+	"""Actual vs where the contract programme says we should be as of `as_of`."""
+	if not start or not end:
+		return {"actual": actual, "expected": 0, "slip_days": 0, "variance": 0, "days_left": None}
+	span = date_diff(end, start)
+	if span <= 0:
+		return {"actual": actual, "expected": 0, "slip_days": 0, "variance": 0, "days_left": None}
+	expected = max(0.0, min(100.0, date_diff(as_of, start) / span * 100.0))
+	slip = math.ceil((expected - actual) / 100.0 * span) if expected > actual else 0
+	return {
+		"actual": round(actual, 1),
+		"expected": round(expected, 1),
+		"slip_days": slip,
+		"variance": round(actual - expected, 1),
+		"days_left": date_diff(end, as_of),
+	}
+
+
+def _stage_state(pct, planned_start, planned_end, as_of):
+	if pct is not None and pct >= 100:
+		return "Complete"
+	if planned_end and getdate(planned_end) < as_of:
+		return "Overdue"
+	if planned_start and getdate(planned_start) > as_of:
+		return "Not started"
+	return "In progress"
 
 
 def _window(period, end):
@@ -34,10 +66,11 @@ def _in(d, start, end):
 
 
 @frappe.whitelist()
-def get_progress_report(project, period="weekly", date=None):
+def get_progress_report(project, period="weekly", date=None, audience="client"):
 	if not project or not frappe.db.exists("Project", project):
 		frappe.throw(frappe._("Project not found."))
 	period = period if period in _SPANS else "weekly"
+	audience = audience if audience in _AUDIENCES else "client"
 	end = getdate(date) if date else getdate(nowdate())
 	start, end = _window(period, end)
 	today = getdate(nowdate())
@@ -52,8 +85,10 @@ def get_progress_report(project, period="weekly", date=None):
 			"project_name",
 			"custom_project_id",
 			"customer",
+			"company",
 			"project_manager",
 			"project_status",
+			"percent_complete",
 			"expected_start_date",
 			"expected_end_date",
 		],
@@ -76,12 +111,29 @@ def get_progress_report(project, period="weekly", date=None):
 	entries = frappe.get_all(
 		"Task Progress Entry",
 		filters={"task": ["in", task_ids]},
-		fields=["name", "task", "entry_date", "skilled", "unskilled", "blocker", "blocker_detail", "owner"],
+		fields=[
+			"name",
+			"task",
+			"entry_date",
+			"cumulative_progress",
+			"skilled",
+			"unskilled",
+			"blocker",
+			"blocker_detail",
+			"owner",
+		],
 		order_by="entry_date desc, creation desc",
 	)
-	latest_entry = {}
+	# entries are newest-first; per task track the latest date + the progress at the
+	# window end (closing) and just before the window (opening) → the period's delta.
+	latest_entry, closing_prog, opening_prog = {}, {}, {}
 	for e in entries:
 		latest_entry.setdefault(e.task, e.entry_date)
+		d = getdate(e.entry_date) if e.entry_date else None
+		if d and d <= end and e.task not in closing_prog:
+			closing_prog[e.task] = flt(e.cumulative_progress)
+		if d and d < start and e.task not in opening_prog:
+			opening_prog[e.task] = flt(e.cumulative_progress)
 
 	entries_in = [e for e in entries if _in(e.entry_date, start, end)]
 	entry_task_ids = {e.task for e in entries_in}
@@ -113,17 +165,21 @@ def get_progress_report(project, period="weekly", date=None):
 	tasks_completed_in = [
 		t for t in tasks if t.task_status == _ACTIVE_TASK_DONE and _in(latest_entry.get(t.name), start, end)
 	]
-	task_activity = [
-		{
-			"id": t.name,
-			"name": t.subject or t.name,
-			"status": t.task_status or "Yet To Start",
-			"progress": flt(t.progress),
-			"last_update": str(latest_entry.get(t.name)) if latest_entry.get(t.name) else None,
-		}
-		for t in tasks
-		if t.name in entry_task_ids
-	]
+	task_activity = sorted(
+		[
+			{
+				"id": t.name,
+				"name": t.subject or t.name,
+				"status": t.task_status or "Yet To Start",
+				"progress": flt(t.progress),
+				"delta": round(closing_prog.get(t.name, flt(t.progress)) - opening_prog.get(t.name, 0.0), 1),
+				"last_update": str(latest_entry.get(t.name)) if latest_entry.get(t.name) else None,
+			}
+			for t in tasks
+			if t.name in entry_task_ids
+		],
+		key=lambda r: (-r["delta"], -r["progress"]),
+	)
 
 	# --- labour + blockers (from period entries) ---
 	skilled = sum(int(e.skilled or 0) for e in entries_in)
@@ -163,27 +219,45 @@ def get_progress_report(project, period="weekly", date=None):
 			"planned_end",
 			"description",
 			"modified",
+			"task_count",
+			"completed_task_count",
+			"mean_progress",
 		],
 	)
-	stages = [
-		{
-			"id": s.name,
-			"name": s.stage_name or s.name,
-			"workflow_state": s.workflow_state or "Draft",
-			"planned_start": str(s.planned_start) if s.planned_start else None,
-			"planned_end": str(s.planned_end) if s.planned_end else None,
-			"description": s.description or "",
-		}
-		for s in stage_rows
-		if (
-			(
-				s.planned_start
-				and s.planned_end
-				and not (getdate(s.planned_end) < start or getdate(s.planned_start) > end)
-			)
-			or _in(s.modified, start, end)
+	stages = []
+	for s in stage_rows:
+		touches = (
+			s.planned_start
+			and s.planned_end
+			and not (getdate(s.planned_end) < start or getdate(s.planned_start) > end)
+		) or _in(s.modified, start, end)
+		if not touches:
+			continue
+		# % complete describes how much WORK is done (mean task progress), not the
+		# plan's approval state — that is what a reader wants beside a stage.
+		pct = round(flt(s.mean_progress)) if s.task_count else None
+		is_current = bool(
+			s.planned_start
+			and s.planned_end
+			and getdate(s.planned_start) <= end <= getdate(s.planned_end)
+			and (pct is None or pct < 100)
 		)
-	]
+		stages.append(
+			{
+				"id": s.name,
+				"name": s.stage_name or s.name,
+				"workflow_state": s.workflow_state or "Draft",
+				"planned_start": str(s.planned_start) if s.planned_start else None,
+				"planned_end": str(s.planned_end) if s.planned_end else None,
+				"description": s.description or "",
+				"pct": pct,
+				"task_count": cint(s.task_count),
+				"done_count": cint(s.completed_task_count),
+				"state": _stage_state(pct, s.planned_start, s.planned_end, end),
+				"is_current": is_current,
+				"days_left": date_diff(s.planned_end, end) if s.planned_end else None,
+			}
+		)
 
 	# --- materials (MR / PO raised, receipts) ---
 	proj_in = {"project": ["in", scope_ids]}
@@ -244,13 +318,66 @@ def get_progress_report(project, period="weekly", date=None):
 	scos_approved = sum(1 for s in sco_in if s.status == "Approved")
 	scos_pending = sum(1 for s in sco_in if s.status == "Pending Approval")
 
-	# --- attachments added on the project(s) in the window ---
-	att_rows = frappe.get_all(
+	# --- attachments + site photographs (image files) in the window ---
+	# Project-level files (drawings, site records) uploaded in the window …
+	proj_files = frappe.get_all(
 		"File",
 		filters={"attached_to_doctype": "Project", "attached_to_name": ["in", scope_ids], "is_folder": 0},
-		fields=["creation"],
+		fields=["file_name", "file_url", "creation", "owner"],
 	)
-	attachments_added = sum(1 for a in att_rows if _in(a.creation, start, end))
+	proj_files = [a for a in proj_files if _in(a.creation, start, end)]
+	attachments_added = len(proj_files)
+
+	# … plus photographs filed against a progress entry inside the window — those are
+	# the site photographs the report is really asking for (captioned by their task).
+	entry_ids = [e.name for e in entries_in] or ["__none__"]
+	entry_task = {e.name: e.task for e in entries_in}
+	tpe_files = frappe.get_all(
+		"File",
+		filters={
+			"attached_to_doctype": "Task Progress Entry",
+			"attached_to_name": ["in", entry_ids],
+			"is_folder": 0,
+		},
+		fields=["file_name", "file_url", "creation", "owner", "attached_to_name"],
+	)
+	photos = []
+	for a in tpe_files:
+		if not (a.file_url or "").lower().endswith(_IMAGE_EXT):
+			continue
+		tid = entry_task.get(a.attached_to_name)
+		photos.append(
+			{
+				"url": a.file_url,
+				"caption": task_name.get(tid, "Site progress"),
+				"taken_on": str(getdate(a.creation)) if a.creation else None,
+				"by": a.owner,
+			}
+		)
+	for a in proj_files:
+		if not (a.file_url or "").lower().endswith(_IMAGE_EXT):
+			continue
+		photos.append(
+			{
+				"url": a.file_url,
+				"caption": a.file_name,
+				"taken_on": str(getdate(a.creation)) if a.creation else None,
+				"by": a.owner,
+			}
+		)
+	photos.sort(key=lambda p: p["taken_on"] or "", reverse=True)
+
+	# --- programme position + variations (client-facing) ---
+	programme = _programme(flt(proj.percent_complete), proj.expected_start_date, proj.expected_end_date, end)
+	variations = [s for s in scope_changes if s["recoverable"]]
+	variations_value = sum(s["impact"] for s in variations if s["status"] == "Approved")
+
+	# --- issuing company (letterhead) ---
+	company_row = (
+		frappe.db.get_value("Company", proj.company, ["company_name", "company_logo"], as_dict=True)
+		if proj.company
+		else None
+	)
 
 	# --- look-ahead: tasks due in the next same-length window ---
 	la_start = add_days(end, 1)
@@ -281,10 +408,16 @@ def get_progress_report(project, period="weekly", date=None):
 			"start_date": str(proj.expected_start_date) if proj.expected_start_date else None,
 			"end_date": str(proj.expected_end_date) if proj.expected_end_date else None,
 		},
+		"company": {
+			"name": (company_row.company_name if company_row else None) or proj.company or "BuildSuite",
+			"logo": company_row.company_logo if company_row else None,
+		},
+		"audience": audience,
 		"period": period,
 		"date": str(end),
 		"window": {"start": str(start), "end": str(end)},
 		"look_ahead": {"start": str(la_start), "end": str(la_end)},
+		"programme": programme,
 		"task_stats": stats,
 		"kpis": {
 			"tasks_completed": len(tasks_completed_in),
@@ -310,6 +443,8 @@ def get_progress_report(project, period="weekly", date=None):
 			"grns": grns,
 		},
 		"scope_changes": scope_changes,
+		"variations": {"items": variations, "value": variations_value},
 		"blockers": blockers,
 		"look_ahead_tasks": look_ahead_tasks,
+		"photos": photos,
 	}

--- a/buildsuite_core/tests/test_progress_report.py
+++ b/buildsuite_core/tests/test_progress_report.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Project Progress Report (S167) — the windowed aggregate."""
+
+import frappe
+from frappe.utils import add_days, nowdate
+
+from buildsuite_core.api import progress_report as pr
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestProgressReport(BuildSuiteTestCase):
+	def test_report_shape_and_window(self):
+		p = self._make_project(company=self.company)
+		t = self._make_task(p.name, task_status="In Progress")
+		self._file_tpe(t.name, 60)
+
+		rep = pr.get_progress_report(p.name, period="weekly")
+		# 7-day window ending today.
+		self.assertEqual(rep["window"]["end"], nowdate())
+		self.assertEqual(rep["window"]["start"], add_days(nowdate(), -6))
+		# Structure the Vue renderer depends on.
+		for key in (
+			"project",
+			"task_stats",
+			"kpis",
+			"task_activity",
+			"stages",
+			"materials",
+			"look_ahead_tasks",
+		):
+			self.assertIn(key, rep)
+		self.assertEqual(rep["project"]["id"], p.name)
+		self.assertEqual(rep["task_stats"]["total"], 1)
+		# The progress entry filed today falls in the window → 1 entry, task touched.
+		self.assertEqual(rep["kpis"]["entries"], 1)
+		self.assertIn(t.name, [r["id"] for r in rep["task_activity"]])
+
+	def test_invalid_period_defaults_to_weekly(self):
+		p = self._make_project(company=self.company)
+		rep = pr.get_progress_report(p.name, period="fortnightly")
+		self.assertEqual(rep["period"], "weekly")
+
+	def test_missing_project_throws(self):
+		self.assertRaises(frappe.ValidationError, pr.get_progress_report, project="NOPE-DOES-NOT-EXIST")

--- a/buildsuite_core/tests/test_progress_report.py
+++ b/buildsuite_core/tests/test_progress_report.py
@@ -36,11 +36,18 @@ class TestProgressReport(BuildSuiteTestCase):
 		# The progress entry filed today falls in the window → 1 entry, task touched.
 		self.assertEqual(rep["kpis"]["entries"], 1)
 		self.assertIn(t.name, [r["id"] for r in rep["task_activity"]])
+		# Enriched payload the client report renders.
+		self.assertEqual(rep["audience"], "client")
+		for key in ("programme", "variations", "photos", "company"):
+			self.assertIn(key, rep)
+		for key in ("actual", "expected", "slip_days", "variance", "days_left"):
+			self.assertIn(key, rep["programme"])
 
-	def test_invalid_period_defaults_to_weekly(self):
+	def test_invalid_period_and_audience_default(self):
 		p = self._make_project(company=self.company)
-		rep = pr.get_progress_report(p.name, period="fortnightly")
+		rep = pr.get_progress_report(p.name, period="fortnightly", audience="press")
 		self.assertEqual(rep["period"], "weekly")
+		self.assertEqual(rep["audience"], "client")
 
 	def test_missing_project_throws(self):
 		self.assertRaises(frappe.ValidationError, pr.get_progress_report, project="NOPE-DOES-NOT-EXIST")

--- a/frontend/src/data/progressReportApi.js
+++ b/frontend/src/data/progressReportApi.js
@@ -1,0 +1,16 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Project Progress Report (S167) — one windowed aggregate read
+// (buildsuite_core.api.progress_report.get_progress_report). period = daily|weekly|monthly,
+// ending on `date` (today if omitted); scoped to the project + its sub-projects.
+export async function getProgressReport(project, period = "weekly", date) {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.progress_report.get_progress_report",
+			params: { project, period, ...(date ? { date } : {}) },
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to load the progress report.");
+	}
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,6 +11,7 @@ const PAGE_TITLES = {
 	projects: "Projects",
 	"project-new": "New Project",
 	"project-detail": "Project",
+	"project-progress-report": "Progress Report",
 	"work-packages": "Work Packages",
 	"wp-new": "New Work Package",
 	"wp-detail": "Work Package",
@@ -125,6 +126,12 @@ const routes = [
 				path: "projects/:id",
 				name: "project-detail",
 				component: () => import("@/views/ProjectDetailView.vue"),
+				props: true,
+			},
+			{
+				path: "projects/:id/progress-report",
+				name: "project-progress-report",
+				component: () => import("@/views/ProgressReportView.vue"),
 				props: true,
 			},
 			{

--- a/frontend/src/views/ProgressReportView.vue
+++ b/frontend/src/views/ProgressReportView.vue
@@ -1,0 +1,636 @@
+<script setup>
+// Project Progress Report — Daily / Weekly / Monthly (S167). Vue-styled report
+// surface rendered inside DeskShell. All rollups are computed server-side against a
+// moving date window (buildsuite_core.api.progress_report); this view is a thin
+// renderer. The window is set via query params: ?period=daily|weekly|monthly[&date=…].
+//
+// PDF export: window.print() + the global @media print rule in style.css hides the
+// DeskShell chrome (.report-root / .print:hidden). The user picks "Save as PDF".
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter, RouterLink } from "vue-router";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtINR, fmtCompactINR, fmtDate } from "@/utils/format";
+import { getProgressReport } from "@/data/progressReportApi";
+
+const route = useRoute();
+const router = useRouter();
+
+const VALID_PERIODS = ["daily", "weekly", "monthly"];
+const projectId = computed(() => route.params.id);
+const period = ref(VALID_PERIODS.includes(route.query.period) ? route.query.period : "weekly");
+const reportDate = ref(/^\d{4}-\d{2}-\d{2}$/.test(route.query.date) ? route.query.date : "");
+
+const report = ref(null);
+const loading = ref(true);
+const error = ref("");
+
+async function load() {
+	loading.value = true;
+	error.value = "";
+	try {
+		report.value = await getProgressReport(
+			projectId.value,
+			period.value,
+			reportDate.value || undefined
+		);
+		// Adopt the server-resolved window end as the picker value.
+		if (!reportDate.value && report.value?.date) reportDate.value = report.value.date;
+	} catch (err) {
+		error.value = err.message || "Failed to load the progress report.";
+		report.value = null;
+	} finally {
+		loading.value = false;
+	}
+}
+load();
+
+// Mirror controls to the URL (deep-link / print context) and re-fetch.
+watch([period, reportDate], () => {
+	router.replace({
+		query: { period: period.value, ...(reportDate.value ? { date: reportDate.value } : {}) },
+	});
+	load();
+});
+
+const project = computed(() => report.value?.project);
+const window_ = computed(() => report.value?.window || {});
+const lookAhead = computed(() => report.value?.look_ahead || {});
+const stats = computed(() => report.value?.task_stats || {});
+const kpis = computed(() => report.value?.kpis || {});
+const labour = computed(() => kpis.value.labour || {});
+const materials = computed(() => report.value?.materials || {});
+
+const periodLabel = computed(
+	() =>
+		({ daily: "Daily report", weekly: "Weekly report", monthly: "Monthly report" }[
+			period.value
+		])
+);
+
+function plural(n, one, many) {
+	return n === 1 ? one : many;
+}
+const summarySentences = computed(() => {
+	if (!report.value) return [];
+	const t = stats.value;
+	const k = kpis.value;
+	const out = [];
+	out.push(
+		`Of ${t.total} tasks, ${t.completed} complete, ${t.in_progress} in progress, ${t.yet_to_start} not started` +
+			`${t.delayed ? `, ${t.delayed} in delay` : ""}${
+				t.blocked ? `, ${t.blocked} blocked` : ""
+			}.`
+	);
+	if (k.tasks_completed)
+		out.push(
+			`${k.tasks_completed} ${plural(
+				k.tasks_completed,
+				"task",
+				"tasks"
+			)} completed in this period.`
+		);
+	if (k.entries)
+		out.push(
+			`${k.entries} progress ${plural(k.entries, "entry", "entries")} filed; ${
+				labour.value.total
+			} ` +
+				`${plural(labour.value.total, "labour-day", "labour-days")} deployed (${
+					labour.value.skilled
+				} skilled / ${labour.value.unskilled} unskilled).`
+		);
+	if (k.deliveries)
+		out.push(`${k.deliveries} ${plural(k.deliveries, "delivery", "deliveries")} received.`);
+	if (k.blockers)
+		out.push(
+			`${k.blockers} ${plural(k.blockers, "blocker", "blockers")} raised — see Issues.`
+		);
+	if (k.scope_changes)
+		out.push(
+			`${k.scope_changes} scope ${plural(k.scope_changes, "change", "changes")} raised.`
+		);
+	if (t.overdue)
+		out.push(`${t.overdue} ${plural(t.overdue, "task is", "tasks are")} currently overdue.`);
+	return out;
+});
+
+function grnTone(s) {
+	if (["Completed", "To Bill"].includes(s)) return "bg-success-50 text-success-700";
+	if (s === "Draft") return "bg-ink-100 text-ink-700";
+	return "bg-warning-50 text-warning-700";
+}
+function generatedOnLabel() {
+	return new Date().toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" });
+}
+function printReport() {
+	window.print();
+}
+function backToProject() {
+	router.push(`/projects/${projectId.value}`);
+}
+</script>
+
+<template>
+	<div class="bg-white min-h-full report-root">
+		<!-- Control bar (hidden in print) -->
+		<header
+			class="report-controls border-b border-ink-200 bg-white sticky top-0 z-10 print:hidden"
+		>
+			<div class="max-w-5xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+				<button
+					type="button"
+					class="text-xs text-ink-600 hover:text-ink-900 flex items-center gap-1"
+					@click="backToProject"
+				>
+					<span>←</span><span>Back to project</span>
+				</button>
+				<span class="text-ink-300">|</span>
+				<div class="flex border border-ink-200 rounded overflow-hidden">
+					<button
+						v-for="p in VALID_PERIODS"
+						:key="p"
+						type="button"
+						class="px-3 py-1 text-xs capitalize border-l border-ink-200 first:border-l-0"
+						:class="
+							period === p
+								? 'bg-brand-50 text-brand-700 font-medium'
+								: 'bg-white text-ink-600 hover:bg-ink-50'
+						"
+						@click="period = p"
+					>
+						{{ p }}
+					</button>
+				</div>
+				<label class="text-xs text-ink-500">As of</label>
+				<input
+					v-model="reportDate"
+					type="date"
+					class="text-xs px-2 py-1 border border-ink-200 rounded bg-white focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+				/>
+				<button
+					type="button"
+					class="ml-auto text-xs px-3 py-1.5 rounded bg-ink-900 text-white hover:bg-ink-800 flex items-center gap-1.5"
+					title="Opens the browser print dialog. Pick 'Save as PDF' to export."
+					@click="printReport"
+				>
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.75"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					>
+						<polyline points="6 9 6 2 18 2 18 9" />
+						<path
+							d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"
+						/>
+						<rect x="6" y="14" width="12" height="8" />
+					</svg>
+					<span>Export PDF</span>
+				</button>
+			</div>
+		</header>
+
+		<div v-if="loading" class="max-w-5xl mx-auto px-6 py-16 text-center text-sm text-ink-400">
+			Building report…
+		</div>
+		<div v-else-if="error" class="max-w-5xl mx-auto px-6 py-16 text-center">
+			<div class="text-sm text-danger-700">{{ error }}</div>
+			<RouterLink
+				to="/projects"
+				class="text-brand-700 hover:underline text-sm mt-2 inline-block"
+				>← Back to projects</RouterLink
+			>
+		</div>
+
+		<main v-else-if="project" class="report-content max-w-5xl mx-auto px-6 py-8">
+			<!-- Cover header -->
+			<section class="report-section mb-6 pb-4 border-b border-ink-200">
+				<div class="text-xs text-ink-500 mb-1">{{ periodLabel }} · {{ project.code }}</div>
+				<h1 class="text-2xl font-semibold text-ink-900">{{ project.name }}</h1>
+				<div class="text-sm text-ink-600 mt-1">{{ project.client }}</div>
+				<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 text-xs">
+					<div>
+						<div class="text-ink-500 uppercase tracking-wider text-[10px]">Period</div>
+						<div class="text-ink-900 font-medium mt-0.5">
+							{{ fmtDate(window_.start) }} → {{ fmtDate(window_.end) }}
+						</div>
+					</div>
+					<div>
+						<div class="text-ink-500 uppercase tracking-wider text-[10px]">
+							Project Manager
+						</div>
+						<div class="text-ink-900 font-medium mt-0.5">
+							{{ project.pm_name || "—" }}
+						</div>
+					</div>
+					<div>
+						<div class="text-ink-500 uppercase tracking-wider text-[10px]">
+							Project timeline
+						</div>
+						<div class="text-ink-900 font-medium mt-0.5">
+							{{ fmtDate(project.start_date) }} → {{ fmtDate(project.end_date) }}
+						</div>
+					</div>
+					<div>
+						<div class="text-ink-500 uppercase tracking-wider text-[10px]">Status</div>
+						<div class="mt-0.5"><StatusBadge :status="project.status" /></div>
+					</div>
+				</div>
+			</section>
+
+			<!-- Executive summary -->
+			<section class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Executive summary
+				</h2>
+				<div
+					class="p-4 bg-brand-50/40 border border-brand-100 rounded-lg text-sm text-ink-800 leading-relaxed"
+				>
+					<p v-for="(s, i) in summarySentences" :key="i" class="mb-1 last:mb-0">
+						{{ s }}
+					</p>
+				</div>
+			</section>
+
+			<!-- Period KPIs -->
+			<section class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Key metrics
+				</h2>
+				<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Tasks completed
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ kpis.tasks_completed }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">in this period</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Progress entries
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ kpis.entries }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">site updates filed</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Labour-days
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ labour.total }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">
+							{{ labour.skilled }} skilled · {{ labour.unskilled }} unskilled
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Deliveries received
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ kpis.deliveries }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">goods receipts</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Materials ordered
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ fmtCompactINR(kpis.po_value) }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">
+							{{ kpis.po_count }} PO{{ kpis.po_count === 1 ? "" : "s" }} placed
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Blockers raised
+						</div>
+						<div
+							class="text-xl font-semibold tabular-nums mt-1"
+							:class="kpis.blockers ? 'text-danger-700' : 'text-ink-900'"
+						>
+							{{ kpis.blockers }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">via progress entries</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Scope changes
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ kpis.scope_changes }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">
+							{{ kpis.scos_approved }} approved · {{ kpis.scos_pending }} pending
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Attachments added
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ kpis.attachments }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">files uploaded</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- Task activity -->
+			<section class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Task activity
+				</h2>
+				<div
+					v-if="report.task_activity.length"
+					class="border border-ink-200 rounded-lg overflow-hidden"
+				>
+					<table class="w-full text-xs">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2">Task</th>
+								<th class="text-left px-3 py-2">Status</th>
+								<th class="text-right px-3 py-2">Progress</th>
+								<th class="text-left px-3 py-2">Last update</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="t in report.task_activity"
+								:key="t.id"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2 text-ink-900">{{ t.name }}</td>
+								<td class="px-3 py-2"><StatusBadge :status="t.status" /></td>
+								<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+									{{ t.progress }}%
+								</td>
+								<td class="px-3 py-2 text-ink-500">
+									{{ fmtDate(t.last_update) }}
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-else class="text-xs text-ink-500 italic">
+					No task activity recorded in this period.
+				</div>
+			</section>
+
+			<!-- Stages -->
+			<section class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Stages
+				</h2>
+				<div v-if="report.stages.length" class="grid grid-cols-1 md:grid-cols-2 gap-3">
+					<div
+						v-for="s in report.stages"
+						:key="s.id"
+						class="p-3 border border-ink-200 rounded-lg"
+					>
+						<div class="flex items-center justify-between gap-2 mb-1">
+							<div class="text-sm font-medium text-ink-900 truncate">
+								{{ s.name }}
+							</div>
+							<StatusBadge :status="s.workflow_state" />
+						</div>
+						<div v-if="s.planned_start" class="text-[11px] text-ink-500">
+							{{ fmtDate(s.planned_start) }} → {{ fmtDate(s.planned_end) }}
+						</div>
+						<div v-if="s.description" class="text-xs text-ink-700 mt-1">
+							{{ s.description }}
+						</div>
+					</div>
+				</div>
+				<div v-else class="text-xs text-ink-500 italic">No stages touch this period.</div>
+			</section>
+
+			<!-- Materials -->
+			<section class="report-section mb-6 page-break-inside-avoid">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Materials
+				</h2>
+				<div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Material requests raised
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ materials.mr_count }}
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Purchase orders placed
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ materials.po_count }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">
+							{{ fmtCompactINR(materials.po_value) }} committed
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Goods received on site
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ materials.grn_count }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">site GRNs</div>
+					</div>
+				</div>
+				<div
+					v-if="materials.grns.length"
+					class="border border-ink-200 rounded-lg overflow-hidden"
+				>
+					<table class="w-full text-xs">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2">Date</th>
+								<th class="text-left px-3 py-2">Item</th>
+								<th class="text-left px-3 py-2">Supplier</th>
+								<th class="text-right px-3 py-2">Qty</th>
+								<th class="text-left px-3 py-2">Status</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(g, i) in materials.grns"
+								:key="i"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+									{{ fmtDate(g.date) }}
+								</td>
+								<td class="px-3 py-2 text-ink-900">{{ g.item }}</td>
+								<td class="px-3 py-2 text-ink-700">{{ g.supplier }}</td>
+								<td class="px-3 py-2 text-right tabular-nums">
+									{{ g.qty }} {{ g.uom }}
+								</td>
+								<td class="px-3 py-2">
+									<span
+										class="text-[10px] px-2 py-0.5 rounded-full font-medium"
+										:class="grnTone(g.status)"
+										>{{ g.status }}</span
+									>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<!-- Scope changes -->
+			<section v-if="report.scope_changes.length" class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Scope changes
+				</h2>
+				<div class="border border-ink-200 rounded-lg overflow-hidden">
+					<table class="w-full text-xs">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2">Raised</th>
+								<th class="text-left px-3 py-2">Title</th>
+								<th class="text-left px-3 py-2">Status</th>
+								<th class="text-right px-3 py-2">Cost impact</th>
+								<th class="text-left px-3 py-2">Recoverable</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="s in report.scope_changes"
+								:key="s.id"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+									{{ fmtDate(s.raised_date) }}
+								</td>
+								<td class="px-3 py-2 text-ink-900">{{ s.title }}</td>
+								<td class="px-3 py-2"><StatusBadge :status="s.status" /></td>
+								<td class="px-3 py-2 text-right tabular-nums">
+									{{ fmtINR(s.impact) }}
+								</td>
+								<td class="px-3 py-2 text-ink-700">
+									{{ s.recoverable ? "Yes" : "No" }}
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+			</section>
+
+			<!-- Issues / blockers -->
+			<section v-if="report.blockers.length" class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Issues raised
+				</h2>
+				<ul class="space-y-2">
+					<li
+						v-for="b in report.blockers"
+						:key="b.id"
+						class="p-3 border border-danger-200 bg-danger-50/30 rounded-lg flex gap-3"
+					>
+						<span class="text-danger-700 text-base flex-shrink-0">🚩</span>
+						<div class="flex-1 min-w-0">
+							<div class="text-sm font-medium text-ink-900">{{ b.task }}</div>
+							<div class="text-xs text-ink-700 mt-1 whitespace-pre-line">
+								{{ b.note }}
+							</div>
+							<div class="text-[11px] text-ink-500 mt-1">
+								{{ fmtDate(b.entry_date) }} · {{ b.owner }}
+							</div>
+						</div>
+					</li>
+				</ul>
+			</section>
+
+			<!-- Look-ahead -->
+			<section class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Coming up · {{ fmtDate(lookAhead.start) }} → {{ fmtDate(lookAhead.end) }}
+				</h2>
+				<div
+					v-if="report.look_ahead_tasks.length"
+					class="border border-ink-200 rounded-lg overflow-hidden"
+				>
+					<table class="w-full text-xs">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2">Due</th>
+								<th class="text-left px-3 py-2">Task</th>
+								<th class="text-left px-3 py-2">Status</th>
+								<th class="text-right px-3 py-2">Progress</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(t, i) in report.look_ahead_tasks"
+								:key="i"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+									{{ fmtDate(t.due) }}
+								</td>
+								<td class="px-3 py-2 text-ink-900">{{ t.name }}</td>
+								<td class="px-3 py-2"><StatusBadge :status="t.status" /></td>
+								<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+									{{ t.progress }}%
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-else class="text-xs text-ink-500 italic">
+					No tasks due in the look-ahead window.
+				</div>
+			</section>
+
+			<footer
+				class="report-section mt-8 pt-4 border-t border-ink-200 text-[11px] text-ink-500 flex items-center justify-between"
+			>
+				<div>Generated {{ generatedOnLabel() }}</div>
+				<div>BuildSuite Core · {{ project.code }}</div>
+			</footer>
+		</main>
+	</div>
+</template>
+
+<style scoped>
+.page-break-inside-avoid {
+	page-break-inside: avoid;
+}
+@media print {
+	.report-section {
+		page-break-inside: avoid;
+	}
+	.report-section h2 {
+		break-after: avoid-page;
+	}
+}
+</style>

--- a/frontend/src/views/ProgressReportView.vue
+++ b/frontend/src/views/ProgressReportView.vue
@@ -1,11 +1,13 @@
 <script setup>
-// Project Progress Report — Daily / Weekly / Monthly (S167). Vue-styled report
+// Project Progress Report — Daily / Weekly / Monthly (S167 / S258–S266). A Vue report
 // surface rendered inside DeskShell. All rollups are computed server-side against a
-// moving date window (buildsuite_core.api.progress_report); this view is a thin
-// renderer. The window is set via query params: ?period=daily|weekly|monthly[&date=…].
+// moving date window (buildsuite_core.api.progress_report); this view renders them.
 //
-// PDF export: window.print() + the global @media print rule in style.css hides the
-// DeskShell chrome (.report-root / .print:hidden). The user picks "Save as PDF".
+// Audience (S258/S266): `client` (default) is a document you can hand to the customer —
+// commercial figures (supplier spend, PO/MR values) are dropped, and it leads with the
+// programme position + a look-ahead + site photographs. `internal` shows everything and
+// carries a "not for issue" banner. PDF export = window.print() + the global .report-root
+// print rules; the user picks "Save as PDF".
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter, RouterLink } from "vue-router";
 import StatusBadge from "@/components/StatusBadge.vue";
@@ -16,8 +18,12 @@ const route = useRoute();
 const router = useRouter();
 
 const VALID_PERIODS = ["daily", "weekly", "monthly"];
+const VALID_AUDIENCES = ["client", "internal"];
 const projectId = computed(() => route.params.id);
 const period = ref(VALID_PERIODS.includes(route.query.period) ? route.query.period : "weekly");
+const audience = ref(
+	VALID_AUDIENCES.includes(route.query.audience) ? route.query.audience : "client"
+);
 const reportDate = ref(/^\d{4}-\d{2}-\d{2}$/.test(route.query.date) ? route.query.date : "");
 
 const report = ref(null);
@@ -31,9 +37,9 @@ async function load() {
 		report.value = await getProgressReport(
 			projectId.value,
 			period.value,
-			reportDate.value || undefined
+			reportDate.value || undefined,
+			audience.value
 		);
-		// Adopt the server-resolved window end as the picker value.
 		if (!reportDate.value && report.value?.date) reportDate.value = report.value.date;
 	} catch (err) {
 		error.value = err.message || "Failed to load the progress report.";
@@ -44,21 +50,30 @@ async function load() {
 }
 load();
 
-// Mirror controls to the URL (deep-link / print context) and re-fetch.
-watch([period, reportDate], () => {
+watch([period, reportDate, audience], () => {
 	router.replace({
-		query: { period: period.value, ...(reportDate.value ? { date: reportDate.value } : {}) },
+		query: {
+			period: period.value,
+			audience: audience.value,
+			...(reportDate.value ? { date: reportDate.value } : {}),
+		},
 	});
 	load();
 });
 
+const isClient = computed(() => audience.value === "client");
 const project = computed(() => report.value?.project);
+const company = computed(() => report.value?.company || {});
 const window_ = computed(() => report.value?.window || {});
 const lookAhead = computed(() => report.value?.look_ahead || {});
+const programme = computed(() => report.value?.programme || {});
 const stats = computed(() => report.value?.task_stats || {});
 const kpis = computed(() => report.value?.kpis || {});
 const labour = computed(() => kpis.value.labour || {});
 const materials = computed(() => report.value?.materials || {});
+const variations = computed(() => report.value?.variations || { items: [], value: 0 });
+const currentStages = computed(() => (report.value?.stages || []).filter((s) => s.is_current));
+const otherStages = computed(() => (report.value?.stages || []).filter((s) => !s.is_current));
 
 const periodLabel = computed(
 	() =>
@@ -67,6 +82,28 @@ const periodLabel = computed(
 		])
 );
 
+// Company monogram — up to two words, so "Acme Commercial Pvt Ltd" reads AC.
+const companyMonogram = computed(() => {
+	const name = company.value.name || "BuildSuite";
+	return name
+		.split(/\s+/)
+		.filter((w) => !/^(pvt|private|ltd|limited|llp|inc|co|and|&)$/i.test(w))
+		.slice(0, 2)
+		.map((w) => w[0]?.toUpperCase() || "")
+		.join("");
+});
+
+const programmePosition = computed(() => {
+	const v = programme.value.variance ?? 0;
+	if (v >= 0) return { label: "On / ahead of programme", tone: "text-success-700" };
+	return {
+		label: `${programme.value.slip_days} day${
+			programme.value.slip_days === 1 ? "" : "s"
+		} behind`,
+		tone: "text-danger-700",
+	};
+});
+
 function plural(n, one, many) {
 	return n === 1 ? one : many;
 }
@@ -74,12 +111,93 @@ const summarySentences = computed(() => {
 	if (!report.value) return [];
 	const t = stats.value;
 	const k = kpis.value;
+	const pr = programme.value;
 	const out = [];
+	if (isClient.value) {
+		out.push(
+			`The works are ${pr.actual}% complete against a programme position of ${Math.round(
+				pr.expected
+			)}% as at ${fmtDate(window_.value.end)}.`
+		);
+		out.push(
+			pr.slip_days > 0
+				? `This represents a slippage of approximately ${pr.slip_days} ${plural(
+						pr.slip_days,
+						"day",
+						"days"
+				  )} against programme.`
+				: "The works are on or ahead of programme."
+		);
+		if (currentStages.value.length) {
+			const named = currentStages.value
+				.map((s) => `${s.name}${s.pct !== null ? ` (${s.pct}% complete)` : ""}`)
+				.join(", ");
+			out.push(
+				`Work is currently in ${
+					currentStages.value.length === 1 ? "the" : "the following stages:"
+				} ${named}${currentStages.value.length === 1 ? " stage" : ""}.`
+			);
+		}
+		const advanced = (report.value.task_activity || []).filter((r) => r.delta > 0);
+		if (advanced.length)
+			out.push(
+				`${advanced.length} ${plural(
+					advanced.length,
+					"activity",
+					"activities"
+				)} advanced during the period${
+					k.tasks_completed ? `, of which ${k.tasks_completed} reached completion` : ""
+				}.`
+			);
+		if (labour.value.total)
+			out.push(
+				`${labour.value.total} ${plural(
+					labour.value.total,
+					"labour-day",
+					"labour-days"
+				)} were deployed on site.`
+			);
+		if (k.blockers)
+			out.push(
+				`${k.blockers} ${plural(
+					k.blockers,
+					"constraint",
+					"constraints"
+				)} affecting progress ${plural(
+					k.blockers,
+					"is",
+					"are"
+				)} listed under Delays & constraints.`
+			);
+		if (variations.value.items.length)
+			out.push(
+				`${variations.value.items.length} ${plural(
+					variations.value.items.length,
+					"variation",
+					"variations"
+				)} chargeable to the contract ${plural(
+					variations.value.items.length,
+					"was",
+					"were"
+				)} raised in the period.`
+			);
+		return out;
+	}
 	out.push(
-		`Of ${t.total} tasks, ${t.completed} complete, ${t.in_progress} in progress, ${t.yet_to_start} not started` +
-			`${t.delayed ? `, ${t.delayed} in delay` : ""}${
-				t.blocked ? `, ${t.blocked} blocked` : ""
-			}.`
+		`Project is ${pr.actual}% complete against ${Math.round(
+			pr.expected
+		)}% expected by ${fmtDate(window_.value.end)}${
+			pr.slip_days > 0
+				? ` — ${pr.slip_days} ${plural(pr.slip_days, "day", "days")} behind programme`
+				: " — on or ahead of programme"
+		}.`
+	);
+	out.push(
+		`Of ${t.total} tasks, ${t.completed} complete, ${t.in_progress} in progress, ${
+			t.yet_to_start
+		} not started${t.delayed ? `, ${t.delayed} in delay` : ""}${
+			t.blocked ? `, ${t.blocked} blocked` : ""
+		}.`
 	);
 	if (k.tasks_completed)
 		out.push(
@@ -93,16 +211,19 @@ const summarySentences = computed(() => {
 		out.push(
 			`${k.entries} progress ${plural(k.entries, "entry", "entries")} filed; ${
 				labour.value.total
-			} ` +
-				`${plural(labour.value.total, "labour-day", "labour-days")} deployed (${
-					labour.value.skilled
-				} skilled / ${labour.value.unskilled} unskilled).`
+			} ${plural(labour.value.total, "labour-day", "labour-days")} deployed (${
+				labour.value.skilled
+			} skilled / ${labour.value.unskilled} unskilled).`
 		);
 	if (k.deliveries)
 		out.push(`${k.deliveries} ${plural(k.deliveries, "delivery", "deliveries")} received.`);
 	if (k.blockers)
 		out.push(
-			`${k.blockers} ${plural(k.blockers, "blocker", "blockers")} raised — see Issues.`
+			`${k.blockers} ${plural(
+				k.blockers,
+				"blocker",
+				"blockers"
+			)} raised — see Delays & constraints.`
 		);
 	if (k.scope_changes)
 		out.push(
@@ -113,11 +234,35 @@ const summarySentences = computed(() => {
 	return out;
 });
 
+const STAGE_TONE = {
+	Complete: "bg-success-50 text-success-700",
+	Overdue: "bg-danger-50 text-danger-700",
+	"Not started": "bg-ink-100 text-ink-600",
+	"In progress": "bg-info-50 text-info-700",
+};
+const STAGE_BAR = {
+	Complete: "bg-success-500",
+	Overdue: "bg-danger-500",
+	"Not started": "bg-ink-300",
+	"In progress": "bg-brand-500",
+};
 function grnTone(s) {
 	if (["Completed", "To Bill"].includes(s)) return "bg-success-50 text-success-700";
 	if (s === "Draft") return "bg-ink-100 text-ink-700";
 	return "bg-warning-50 text-warning-700";
 }
+
+const showAllPhotos = ref(false);
+const PHOTO_CAP = { daily: 8, weekly: 12, monthly: 18 };
+const photos = computed(() => report.value?.photos || []);
+const shownPhotos = computed(() => {
+	const cap = PHOTO_CAP[period.value] ?? 12;
+	return showAllPhotos.value ? photos.value : photos.value.slice(0, cap);
+});
+const photosCurated = computed(
+	() => !showAllPhotos.value && photos.value.length > (PHOTO_CAP[period.value] ?? 12)
+);
+
 function generatedOnLabel() {
 	return new Date().toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" });
 }
@@ -132,9 +277,7 @@ function backToProject() {
 <template>
 	<div class="bg-white min-h-full report-root">
 		<!-- Control bar (hidden in print) -->
-		<header
-			class="report-controls border-b border-ink-200 bg-white sticky top-0 z-10 print:hidden"
-		>
+		<header class="border-b border-ink-200 bg-white sticky top-0 z-10 print:hidden">
 			<div class="max-w-5xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
 				<button
 					type="button"
@@ -158,6 +301,24 @@ function backToProject() {
 						@click="period = p"
 					>
 						{{ p }}
+					</button>
+				</div>
+				<span class="text-ink-300">|</span>
+				<!-- Audience: client (redacted, default) vs internal (full). -->
+				<div class="flex border border-ink-200 rounded overflow-hidden">
+					<button
+						v-for="a in VALID_AUDIENCES"
+						:key="a"
+						type="button"
+						class="px-3 py-1 text-xs capitalize border-l border-ink-200 first:border-l-0"
+						:class="
+							audience === a
+								? 'bg-brand-50 text-brand-700 font-medium'
+								: 'bg-white text-ink-600 hover:bg-ink-50'
+						"
+						@click="audience = a"
+					>
+						{{ a }}
 					</button>
 				</div>
 				<label class="text-xs text-ink-500">As of</label>
@@ -201,21 +362,82 @@ function backToProject() {
 			<RouterLink
 				to="/projects"
 				class="text-brand-700 hover:underline text-sm mt-2 inline-block"
-				>← Back to projects</RouterLink
 			>
+				← Back to projects
+			</RouterLink>
 		</div>
 
 		<main v-else-if="project" class="report-content max-w-5xl mx-auto px-6 py-8">
+			<!-- Internal watermark: the paper must say it isn't the client's copy. -->
+			<div
+				v-if="!isClient"
+				class="report-section mb-5 flex items-center gap-2 px-3 py-2 rounded-lg bg-warning-50 border border-warning-200"
+			>
+				<span class="text-[11px] text-warning-700">
+					<strong>Internal report.</strong> Contains supplier pricing and procurement
+					commitments — not for issue to the client. Switch to the client audience before
+					sharing.
+				</span>
+			</div>
+
+			<!-- Letterhead (client) -->
+			<section
+				v-if="isClient"
+				class="report-section mb-6 pb-4 border-b-2 border-ink-900 flex items-center gap-3"
+			>
+				<img
+					v-if="company.logo"
+					:src="company.logo"
+					:alt="company.name"
+					class="h-11 w-auto object-contain flex-shrink-0"
+				/>
+				<div
+					v-else
+					class="h-11 w-11 rounded-lg bg-brand-600 text-white flex items-center justify-center font-semibold text-base flex-shrink-0"
+				>
+					{{ companyMonogram }}
+				</div>
+				<div>
+					<div class="text-lg font-semibold text-ink-900 leading-tight">
+						{{ company.name }}
+					</div>
+					<div class="text-[11px] text-ink-500 mt-0.5">
+						Registered office address · GSTIN · Contact
+					</div>
+				</div>
+			</section>
+
 			<!-- Cover header -->
 			<section class="report-section mb-6 pb-4 border-b border-ink-200">
 				<div class="text-xs text-ink-500 mb-1">{{ periodLabel }} · {{ project.code }}</div>
 				<h1 class="text-2xl font-semibold text-ink-900">{{ project.name }}</h1>
-				<div class="text-sm text-ink-600 mt-1">{{ project.client }}</div>
+				<div
+					v-if="isClient"
+					class="text-[10px] uppercase tracking-wider text-ink-500 mt-3"
+				>
+					Issued to
+				</div>
+				<div
+					class="text-sm text-ink-600"
+					:class="isClient ? 'font-medium text-ink-900' : 'mt-1'"
+				>
+					{{ project.client || "—" }}
+				</div>
 				<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 text-xs">
 					<div>
-						<div class="text-ink-500 uppercase tracking-wider text-[10px]">Period</div>
+						<div class="text-ink-500 uppercase tracking-wider text-[10px]">
+							Reporting period
+						</div>
 						<div class="text-ink-900 font-medium mt-0.5">
 							{{ fmtDate(window_.start) }} → {{ fmtDate(window_.end) }}
+						</div>
+					</div>
+					<div>
+						<div class="text-ink-500 uppercase tracking-wider text-[10px]">
+							Contract programme
+						</div>
+						<div class="text-ink-900 font-medium mt-0.5">
+							{{ fmtDate(project.start_date) }} → {{ fmtDate(project.end_date) }}
 						</div>
 					</div>
 					<div>
@@ -228,15 +450,11 @@ function backToProject() {
 					</div>
 					<div>
 						<div class="text-ink-500 uppercase tracking-wider text-[10px]">
-							Project timeline
+							Progress
 						</div>
-						<div class="text-ink-900 font-medium mt-0.5">
-							{{ fmtDate(project.start_date) }} → {{ fmtDate(project.end_date) }}
+						<div class="text-ink-900 font-medium mt-0.5 tabular-nums">
+							{{ programme.actual }}%
 						</div>
-					</div>
-					<div>
-						<div class="text-ink-500 uppercase tracking-wider text-[10px]">Status</div>
-						<div class="mt-0.5"><StatusBadge :status="project.status" /></div>
 					</div>
 				</div>
 			</section>
@@ -257,7 +475,61 @@ function backToProject() {
 				</div>
 			</section>
 
-			<!-- Period KPIs -->
+			<!-- Programme position -->
+			<section class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					{{
+						isClient
+							? "Progress against programme"
+							: "Project progress & schedule position"
+					}}
+				</h2>
+				<div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">Actual</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ programme.actual }}%
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Programme
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ Math.round(programme.expected) }}%
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Variance
+						</div>
+						<div
+							class="text-xl font-semibold tabular-nums mt-1"
+							:class="programmePosition.tone"
+						>
+							{{ programme.variance > 0 ? "+" : "" }}{{ programme.variance }}%
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							Position
+						</div>
+						<div class="text-sm font-semibold mt-1.5" :class="programmePosition.tone">
+							{{ programmePosition.label }}
+						</div>
+						<div
+							v-if="programme.days_left != null"
+							class="text-[10px] text-ink-400 mt-0.5"
+						>
+							{{ programme.days_left }} days to programme end
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- Key metrics -->
 			<section class="report-section mb-6">
 				<h2
 					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
@@ -274,7 +546,7 @@ function backToProject() {
 						</div>
 						<div class="text-[10px] text-ink-400 mt-0.5">in this period</div>
 					</div>
-					<div class="p-3 border border-ink-200 rounded-lg">
+					<div v-if="!isClient" class="p-3 border border-ink-200 rounded-lg">
 						<div class="text-[10px] uppercase tracking-wider text-ink-500">
 							Progress entries
 						</div>
@@ -303,7 +575,8 @@ function backToProject() {
 						</div>
 						<div class="text-[10px] text-ink-400 mt-0.5">goods receipts</div>
 					</div>
-					<div class="p-3 border border-ink-200 rounded-lg">
+					<!-- Commercial: internal only. -->
+					<div v-if="!isClient" class="p-3 border border-ink-200 rounded-lg">
 						<div class="text-[10px] uppercase tracking-wider text-ink-500">
 							Materials ordered
 						</div>
@@ -312,6 +585,17 @@ function backToProject() {
 						</div>
 						<div class="text-[10px] text-ink-400 mt-0.5">
 							{{ kpis.po_count }} PO{{ kpis.po_count === 1 ? "" : "s" }} placed
+						</div>
+					</div>
+					<div class="p-3 border border-ink-200 rounded-lg">
+						<div class="text-[10px] uppercase tracking-wider text-ink-500">
+							{{ isClient ? "Variations raised" : "Scope changes" }}
+						</div>
+						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
+							{{ isClient ? variations.items.length : kpis.scope_changes }}
+						</div>
+						<div class="text-[10px] text-ink-400 mt-0.5">
+							{{ kpis.scos_approved }} approved · {{ kpis.scos_pending }} pending
 						</div>
 					</div>
 					<div class="p-3 border border-ink-200 rounded-lg">
@@ -325,17 +609,6 @@ function backToProject() {
 							{{ kpis.blockers }}
 						</div>
 						<div class="text-[10px] text-ink-400 mt-0.5">via progress entries</div>
-					</div>
-					<div class="p-3 border border-ink-200 rounded-lg">
-						<div class="text-[10px] uppercase tracking-wider text-ink-500">
-							Scope changes
-						</div>
-						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
-							{{ kpis.scope_changes }}
-						</div>
-						<div class="text-[10px] text-ink-400 mt-0.5">
-							{{ kpis.scos_approved }} approved · {{ kpis.scos_pending }} pending
-						</div>
 					</div>
 					<div class="p-3 border border-ink-200 rounded-lg">
 						<div class="text-[10px] uppercase tracking-wider text-ink-500">
@@ -354,7 +627,7 @@ function backToProject() {
 				<h2
 					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
 				>
-					Task activity
+					{{ isClient ? "Work progressed this period" : "Task activity" }}
 				</h2>
 				<div
 					v-if="report.task_activity.length"
@@ -365,6 +638,7 @@ function backToProject() {
 							<tr>
 								<th class="text-left px-3 py-2">Task</th>
 								<th class="text-left px-3 py-2">Status</th>
+								<th class="text-right px-3 py-2">Moved</th>
 								<th class="text-right px-3 py-2">Progress</th>
 								<th class="text-left px-3 py-2">Last update</th>
 							</tr>
@@ -377,6 +651,12 @@ function backToProject() {
 							>
 								<td class="px-3 py-2 text-ink-900">{{ t.name }}</td>
 								<td class="px-3 py-2"><StatusBadge :status="t.status" /></td>
+								<td
+									class="px-3 py-2 text-right tabular-nums"
+									:class="t.delta > 0 ? 'text-success-700' : 'text-ink-400'"
+								>
+									{{ t.delta > 0 ? "+" : "" }}{{ t.delta }}%
+								</td>
 								<td class="px-3 py-2 text-right tabular-nums text-ink-700">
 									{{ t.progress }}%
 								</td>
@@ -392,44 +672,70 @@ function backToProject() {
 				</div>
 			</section>
 
-			<!-- Stages -->
+			<!-- Stage progress -->
 			<section class="report-section mb-6">
 				<h2
 					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
 				>
-					Stages
+					Stage progress
 				</h2>
-				<div v-if="report.stages.length" class="grid grid-cols-1 md:grid-cols-2 gap-3">
+				<div
+					v-if="[...currentStages, ...otherStages].length"
+					class="grid grid-cols-1 md:grid-cols-2 gap-3"
+				>
 					<div
-						v-for="s in report.stages"
+						v-for="s in [...currentStages, ...otherStages]"
 						:key="s.id"
-						class="p-3 border border-ink-200 rounded-lg"
+						class="p-3 border rounded-lg"
+						:class="
+							s.is_current ? 'border-brand-300 bg-brand-50/30' : 'border-ink-200'
+						"
 					>
-						<div class="flex items-center justify-between gap-2 mb-1">
+						<div class="flex items-center justify-between gap-2 mb-1.5">
 							<div class="text-sm font-medium text-ink-900 truncate">
 								{{ s.name }}
 							</div>
-							<StatusBadge :status="s.workflow_state" />
+							<span
+								class="text-[10px] px-2 py-0.5 rounded-full font-medium"
+								:class="STAGE_TONE[s.state]"
+							>
+								{{ s.state }}
+							</span>
 						</div>
-						<div v-if="s.planned_start" class="text-[11px] text-ink-500">
-							{{ fmtDate(s.planned_start) }} → {{ fmtDate(s.planned_end) }}
+						<div v-if="s.pct !== null" class="flex items-center gap-2">
+							<div class="flex-1 h-1.5 bg-ink-100 rounded-full overflow-hidden">
+								<div
+									class="h-full"
+									:class="STAGE_BAR[s.state]"
+									:style="`width:${s.pct}%`"
+								></div>
+							</div>
+							<span class="text-[11px] text-ink-700 tabular-nums w-10 text-right"
+								>{{ s.pct }}%</span
+							>
 						</div>
-						<div v-if="s.description" class="text-xs text-ink-700 mt-1">
-							{{ s.description }}
+						<div class="text-[11px] text-ink-500 mt-1.5">
+							<span v-if="s.task_count"
+								>{{ s.done_count }}/{{ s.task_count }} tasks</span
+							>
+							<span v-if="s.planned_start">
+								· {{ fmtDate(s.planned_start) }} →
+								{{ fmtDate(s.planned_end) }}</span
+							>
 						</div>
 					</div>
 				</div>
 				<div v-else class="text-xs text-ink-500 italic">No stages touch this period.</div>
 			</section>
 
-			<!-- Materials -->
+			<!-- Materials (deliveries always; commercial figures internal only) -->
 			<section class="report-section mb-6 page-break-inside-avoid">
 				<h2
 					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
 				>
 					Materials
 				</h2>
-				<div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
+				<div v-if="!isClient" class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-3">
 					<div class="p-3 border border-ink-200 rounded-lg">
 						<div class="text-[10px] uppercase tracking-wider text-ink-500">
 							Material requests raised
@@ -456,7 +762,6 @@ function backToProject() {
 						<div class="text-xl font-semibold text-ink-900 tabular-nums mt-1">
 							{{ materials.grn_count }}
 						</div>
-						<div class="text-[10px] text-ink-400 mt-0.5">site GRNs</div>
 					</div>
 				</div>
 				<div
@@ -468,7 +773,7 @@ function backToProject() {
 							<tr>
 								<th class="text-left px-3 py-2">Date</th>
 								<th class="text-left px-3 py-2">Item</th>
-								<th class="text-left px-3 py-2">Supplier</th>
+								<th v-if="!isClient" class="text-left px-3 py-2">Supplier</th>
 								<th class="text-right px-3 py-2">Qty</th>
 								<th class="text-left px-3 py-2">Status</th>
 							</tr>
@@ -483,7 +788,9 @@ function backToProject() {
 									{{ fmtDate(g.date) }}
 								</td>
 								<td class="px-3 py-2 text-ink-900">{{ g.item }}</td>
-								<td class="px-3 py-2 text-ink-700">{{ g.supplier }}</td>
+								<td v-if="!isClient" class="px-3 py-2 text-ink-700">
+									{{ g.supplier }}
+								</td>
 								<td class="px-3 py-2 text-right tabular-nums">
 									{{ g.qty }} {{ g.uom }}
 								</td>
@@ -491,17 +798,67 @@ function backToProject() {
 									<span
 										class="text-[10px] px-2 py-0.5 rounded-full font-medium"
 										:class="grnTone(g.status)"
-										>{{ g.status }}</span
 									>
+										{{ g.status }}
+									</span>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+				<div v-else class="text-xs text-ink-500 italic">
+					No deliveries received in this period.
+				</div>
+			</section>
+
+			<!-- Variations (client) / Scope changes (internal) -->
+			<section v-if="isClient && variations.items.length" class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Variations
+				</h2>
+				<div class="border border-ink-200 rounded-lg overflow-hidden">
+					<table class="w-full text-xs">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2">Raised</th>
+								<th class="text-left px-3 py-2">Variation</th>
+								<th class="text-left px-3 py-2">Status</th>
+								<th class="text-right px-3 py-2">Chargeable</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="s in variations.items"
+								:key="s.id"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+									{{ fmtDate(s.raised_date) }}
+								</td>
+								<td class="px-3 py-2 text-ink-900">{{ s.title }}</td>
+								<td class="px-3 py-2"><StatusBadge :status="s.status" /></td>
+								<td class="px-3 py-2 text-right tabular-nums">
+									{{ fmtINR(s.impact) }}
+								</td>
+							</tr>
+							<tr class="border-t border-ink-200 bg-ink-50/60 font-medium">
+								<td class="px-3 py-2 text-ink-700" colspan="3">
+									Approved chargeable this period
+								</td>
+								<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+									{{ fmtINR(variations.value) }}
 								</td>
 							</tr>
 						</tbody>
 					</table>
 				</div>
 			</section>
-
-			<!-- Scope changes -->
-			<section v-if="report.scope_changes.length" class="report-section mb-6">
+			<section
+				v-else-if="!isClient && report.scope_changes.length"
+				class="report-section mb-6"
+			>
 				<h2
 					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
 				>
@@ -541,12 +898,12 @@ function backToProject() {
 				</div>
 			</section>
 
-			<!-- Issues / blockers -->
+			<!-- Delays & constraints -->
 			<section v-if="report.blockers.length" class="report-section mb-6">
 				<h2
 					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
 				>
-					Issues raised
+					Delays &amp; constraints
 				</h2>
 				<ul class="space-y-2">
 					<li
@@ -611,11 +968,46 @@ function backToProject() {
 				</div>
 			</section>
 
+			<!-- Site photographs -->
+			<section v-if="photos.length" class="report-section mb-6">
+				<h2
+					class="text-sm font-semibold text-ink-900 mb-2 uppercase tracking-wider text-[11px]"
+				>
+					Site photographs
+				</h2>
+				<div class="grid grid-cols-2 sm:grid-cols-3 gap-3">
+					<figure
+						v-for="(p, i) in shownPhotos"
+						:key="i"
+						class="border border-ink-200 rounded-lg overflow-hidden"
+					>
+						<img
+							:src="p.url"
+							:alt="p.caption"
+							class="w-full h-36 object-cover bg-ink-50"
+							loading="lazy"
+						/>
+						<figcaption class="px-2 py-1.5">
+							<div class="text-[11px] text-ink-800 truncate">{{ p.caption }}</div>
+							<div class="text-[10px] text-ink-400">{{ fmtDate(p.taken_on) }}</div>
+						</figcaption>
+					</figure>
+				</div>
+				<button
+					v-if="photosCurated"
+					type="button"
+					class="text-xs text-brand-700 hover:underline mt-2 print:hidden"
+					@click="showAllPhotos = true"
+				>
+					Show all {{ photos.length }} photographs ▾
+				</button>
+			</section>
+
 			<footer
 				class="report-section mt-8 pt-4 border-t border-ink-200 text-[11px] text-ink-500 flex items-center justify-between"
 			>
 				<div>Generated {{ generatedOnLabel() }}</div>
-				<div>BuildSuite Core · {{ project.code }}</div>
+				<div>{{ company.name }} · {{ project.code }}</div>
 			</footer>
 		</main>
 	</div>

--- a/frontend/src/views/project-detail/projectDetailConfig.js
+++ b/frontend/src/views/project-detail/projectDetailConfig.js
@@ -52,15 +52,19 @@ export const TEAM_COLS = [
 	{ key: "flag", label: "" },
 ];
 
+// S270/S271 — Reports grid. The Progress Report is an ACTION (it produces a document),
+// not an analysis, so it's `primary`: colour-distinguished by a brand tint rather than a
+// larger control. Four tiles show by default (filling the two-column grid); the rest sit
+// behind "Show more" (`more: true`). Analytical tiles route to the generic /reports/<slug>
+// stub; the Progress Report carries its own project-scoped route (routeName).
 export const PROJECT_REPORTS = [
 	{
-		// Progress Report sits at the TOP of the Reports list (S168). It carries its own
-		// route (project-scoped surface) instead of the generic /reports/<slug> stub.
 		slug: "progress-report",
 		routeName: "project-progress-report",
 		icon: "file-text",
-		label: "Daily / Weekly / Monthly progress report",
-		desc: "Exportable PDF with KPIs, task activity, materials, blockers and look-ahead.",
+		label: "Progress report",
+		primary: true,
+		desc: "Daily / weekly / monthly document. Client issue by default; internal detail is an option inside.",
 	},
 	{
 		slug: "project-status-summary",
@@ -85,11 +89,13 @@ export const PROJECT_REPORTS = [
 		icon: "file-text",
 		label: "Pending progress",
 		desc: "Tasks silent for 3+ days.",
+		more: true,
 	},
 	{
 		slug: "labour-deployed",
 		icon: "workforce",
 		label: "Labour deployed",
 		desc: "Skilled + unskilled labour by task / week.",
+		more: true,
 	},
 ];

--- a/frontend/src/views/project-detail/projectDetailConfig.js
+++ b/frontend/src/views/project-detail/projectDetailConfig.js
@@ -54,6 +54,15 @@ export const TEAM_COLS = [
 
 export const PROJECT_REPORTS = [
 	{
+		// Progress Report sits at the TOP of the Reports list (S168). It carries its own
+		// route (project-scoped surface) instead of the generic /reports/<slug> stub.
+		slug: "progress-report",
+		routeName: "project-progress-report",
+		icon: "file-text",
+		label: "Daily / Weekly / Monthly progress report",
+		desc: "Exportable PDF with KPIs, task activity, materials, blockers and look-ahead.",
+	},
+	{
 		slug: "project-status-summary",
 		icon: "chart-line",
 		label: "Status summary",

--- a/frontend/src/views/project-detail/tabs/OverviewTab.vue
+++ b/frontend/src/views/project-detail/tabs/OverviewTab.vue
@@ -18,6 +18,19 @@ const props = defineProps({
 
 const emit = defineEmits(["edit"]);
 
+// Most report tiles are stubs at /reports/<slug>; the Progress Report routes to its own
+// project-scoped surface (S168) carrying the project id + a default period.
+function reportLink(rt) {
+	if (rt.routeName === "project-progress-report") {
+		return {
+			name: "project-progress-report",
+			params: { id: props.project.id },
+			query: { period: "weekly" },
+		};
+	}
+	return `/reports/${rt.slug}`;
+}
+
 const store = useDataStore();
 
 function plannedCost() {
@@ -238,7 +251,7 @@ function deviationColor(pct) {
 							<RouterLink
 								v-for="rt in projectReports"
 								:key="rt.slug"
-								:to="`/reports/${rt.slug}`"
+								:to="reportLink(rt)"
 								class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 p-3 transition-colors group block"
 								style="border-radius: 8px"
 							>

--- a/frontend/src/views/project-detail/tabs/OverviewTab.vue
+++ b/frontend/src/views/project-detail/tabs/OverviewTab.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { ref, computed } from "vue";
 import { RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import StatusBadge from "@/components/StatusBadge.vue";
@@ -30,6 +31,13 @@ function reportLink(rt) {
 	}
 	return `/reports/${rt.slug}`;
 }
+
+// S271 — four tiles show by default (fills the two-column grid); the `more` tiles sit
+// behind Show more.
+const reportsShowMore = ref(false);
+const visibleReports = computed(() =>
+	reportsShowMore.value ? props.projectReports : props.projectReports.filter((r) => !r.more)
+);
 
 const store = useDataStore();
 
@@ -245,19 +253,37 @@ function deviationColor(pct) {
 							v-html="getWorkspaceIconPath('chart-line')"
 						/>
 						<h3 class="text-sm font-semibold text-ink-900">Reports</h3>
+						<span class="text-[11px] text-ink-500 tabular-nums">{{
+							projectReports.length
+						}}</span>
 					</header>
 					<div class="p-4">
+						<!-- S270 — the Progress Report (primary) is an action, distinguished by a
+										 brand tint rather than a larger control. -->
 						<div class="grid grid-cols-1 md:grid-cols-2 gap-2">
 							<RouterLink
-								v-for="rt in projectReports"
+								v-for="rt in visibleReports"
 								:key="rt.slug"
 								:to="reportLink(rt)"
-								class="bg-white border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 p-3 transition-colors group block"
+								class="border p-2.5 flex items-center gap-2.5 transition-colors group"
+								:class="
+									rt.primary
+										? 'bg-brand-50 border-brand-300 hover:bg-brand-100'
+										: 'bg-white border-ink-200 hover:border-brand-400 hover:bg-brand-50'
+								"
 								style="border-radius: 8px"
+								:title="rt.desc"
 							>
-								<div class="flex items-start gap-2.5">
+								<span
+									class="w-7 h-7 rounded-md flex items-center justify-center flex-shrink-0 transition-colors"
+									:class="
+										rt.primary
+											? 'bg-brand-600 text-white'
+											: 'bg-ink-50 group-hover:bg-brand-50 text-ink-600 group-hover:text-brand-700'
+									"
+								>
 									<svg
-										class="w-5 h-5 text-ink-600 flex-shrink-0 mt-0.5"
+										class="w-4 h-4"
 										viewBox="0 0 24 24"
 										fill="none"
 										stroke="currentColor"
@@ -267,25 +293,31 @@ function deviationColor(pct) {
 										aria-hidden="true"
 										v-html="getWorkspaceIconPath(rt.icon)"
 									/>
-									<div class="flex-1 min-w-0">
-										<div class="flex items-center gap-1.5 flex-wrap">
-											<div
-												class="text-sm font-medium text-ink-900 group-hover:text-brand-700 transition-colors"
-											>
-												{{ rt.label }}
-											</div>
-											<span
-												class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 font-medium uppercase tracking-wider"
-												style="border-radius: 2px"
-												>Report</span
-											>
-										</div>
-										<div class="text-[11px] text-ink-500 mt-0.5 leading-snug">
-											{{ rt.desc }}
-										</div>
-									</div>
-								</div>
+								</span>
+								<span
+									class="text-sm font-medium truncate transition-colors"
+									:class="
+										rt.primary
+											? 'text-ink-900'
+											: 'text-ink-900 group-hover:text-brand-700'
+									"
+									>{{ rt.label }}</span
+								>
+								<span
+									v-if="rt.primary"
+									class="ml-auto text-brand-700 text-sm flex-shrink-0 group-hover:translate-x-0.5 transition-transform"
+									>→</span
+								>
 							</RouterLink>
+						</div>
+						<div class="border-t border-ink-100 mt-3 pt-2.5">
+							<button
+								type="button"
+								class="text-xs text-brand-700 hover:underline"
+								@click="reportsShowMore = !reportsShowMore"
+							>
+								{{ reportsShowMore ? "Show less ▴" : "Show more ▾" }}
+							</button>
 						</div>
 					</div>
 				</section>


### PR DESCRIPTION
## What

Implements the **project Progress Report** — a Daily / Weekly / Monthly report surface reached from the **Reports** list on the project Overview (S168), exportable to PDF via the browser print dialog.

## How

New whitelisted **`api.progress_report.get_progress_report(project, period, date)`** — one windowed aggregate read, scoped to the project + its sub-projects, mirroring the `project_dashboard` pattern. `period` = daily (the day) / weekly (7-day) / monthly (30-day rolling), ending on `date` (today if omitted). It rolls up, all server-side:

- **Task status snapshot** (completed / in-progress / not-started / delayed / blocked / overdue)
- **In-period KPIs** — tasks completed, progress entries filed, labour-days (skilled/unskilled from Task Progress Entry), deliveries, materials ordered (PO value + count), blockers, scope changes, attachments
- **Task activity** (tasks touched in the window), **stage status**, **materials** (MR/PO/Purchase-Receipt with a GRN table), **scope changes**, **issues/blockers**, and a **look-ahead** of tasks due next period

The Vue **`ProgressReportView.vue`** is a thin renderer with a period/date control bar; **Export PDF** calls `window.print()` and reuses the existing global `.report-root` / `.print:hidden` print rules (no new dependency).

## Wiring
- Route `projects/:id/progress-report`.
- Progress Report tile added at the **top** of `PROJECT_REPORTS`; `OverviewTab.reportLink()` routes that one tile to the project-scoped report (others stay generic stubs).

## ProjectDetailView alignment
The live ProjectDetailView already mirrors the prototype — identical tab set (Overview → Team) and the same Overview cards (About / Reports / Project Manager / Project details). The one concrete divergence was that the prototype surfaces the Progress Report inside the Reports section (S168); that's now added. No speculative rewrite of the mature view beyond that.

## Tests
`test_progress_report.py` — 3 pass (window math + payload shape, invalid-period fallback, missing-project throw). Verified live against `PROJ-0260` (weekly/monthly/daily). `vite build` clean.