### PR TITLE
feat: Create Supplier Bill shortcut on the Procurement workspace

### DIFF
--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -14,6 +14,9 @@ const shortcuts = [
 	{ label: "Material Requests", icon: "clipboard-list", href: "/app/material-request" },
 	{ label: "Purchase Orders", icon: "file-text", href: "/app/purchase-order" },
 	{ label: "Purchase Receipts", icon: "check-circle", href: "/app/purchase-receipt" },
+	// Direct supplier bill (money out) — distinct from the subcontractor bill flow. Routes
+	// to the in-app create form (against a PO or a direct Item-line bill).
+	{ label: "Create Supplier Bill", icon: "wallet", to: "/project-finance/supplier-bills/new" },
 	{
 		label: "Material Consumption",
 		icon: "stock",


### PR DESCRIPTION
## What

Adds a **Create Supplier Bill** tile to the Procurement workspace shortcuts, routing to the in-app supplier-bill create form (`/project-finance/supplier-bills/new`).

This is the **supplier bill (money out)** flow — a bill against a Purchase Order, or a direct Item-line bill — **distinct from the subcontractor bill**, as requested. Placed after Purchase Receipts, mirroring the order → receipt → bill flow.

## Notes
- Uses the existing `WorkspaceShortcut` (renders a RouterLink for the in-app `to` target).
- Frontend-only; `vite build` clean.