### PR TITLE
feat: direct petty-cash issue + Journal Entry Entry-Type gating (S273)

### DIFF
--- a/buildsuite_core/api/petty_cash.py
+++ b/buildsuite_core/api/petty_cash.py
@@ -34,6 +34,7 @@ def _serialize(doc):
 		"amount": doc.amount,
 		"purpose": doc.purpose,
 		"status": doc.status,
+		"is_direct": bool(doc.is_direct),
 		"company": doc.company,
 		"paid_from": doc.paid_from,
 		"disbursed_by": doc.disbursed_by,
@@ -95,12 +96,46 @@ def disburse(name, paid_from):
 
 
 @frappe.whitelist()
+def issue_direct(payload):
+	"""Issue petty-cash float straight to a holder, with no request behind it (S273). Only
+	the finance approvers may do this. It creates the Petty Cash Request already marked as a
+	direct issue and disburses it in one step — reusing the same account checks + Journal
+	Entry posting (Dr Petty Cash / Cr source) as the request→disburse path. No project: the
+	float is handed to a person; project-level spend attaches later on the Expense Entry."""
+	if not _can_disburse():
+		frappe.throw(_("You are not authorised to issue petty cash."), frappe.PermissionError)
+	data = frappe.parse_json(payload)
+	holder = data.get("requested_by")
+	paid_from = data.get("paid_from")
+	if not holder:
+		frappe.throw(_("Select who is receiving the float."))
+	if not paid_from:
+		frappe.throw(_("Select the cash/bank account the float comes from."))
+
+	doc = frappe.new_doc(DOCTYPE)
+	doc.requested_by = holder  # the holder; company is derived from their Employee in validate
+	doc.amount = flt(data.get("amount"))
+	doc.purpose = data.get("purpose")
+	doc.is_direct = 1
+	doc.flags.ignore_permissions = True
+	doc.insert()  # lands as a Requested record for this holder …
+	doc.disburse(paid_from)  # … then disburse immediately (posts the JE)
+	return _serialize(doc)
+
+
+@frappe.whitelist()
 def undisburse(name: str):
-	"""Reverse a disbursement (cancel the JE, revert to Requested)."""
+	"""Reverse a disbursement (cancel the JE). A request reverts to Requested and goes back
+	to the queue; a DIRECT issue has no request to fall back to, so the record is removed
+	entirely (the JE is reversed either way)."""
 	doc = frappe.get_doc(DOCTYPE, name)
 	if not _can_disburse():
 		frappe.throw(_("You are not authorised to reverse a disbursement."), frappe.PermissionError)
+	is_direct = bool(doc.is_direct)
 	doc.cancel_disbursement()
+	if is_direct:
+		frappe.delete_doc(DOCTYPE, name, ignore_permissions=True)
+		return {"deleted": True, "name": name}
 	return _serialize(doc)
 
 
@@ -167,12 +202,19 @@ def disbursement_prefill(request):
 	from buildsuite_core.utils.petty_cash import employee_for_user, resolve_petty_cash_account
 
 	r = frappe.db.get_value(
-		"Petty Cash Request", request, ["name", "status", "company", "amount", "requested_by", "purpose"], as_dict=True
+		"Petty Cash Request",
+		request,
+		["name", "status", "company", "amount", "requested_by", "purpose"],
+		as_dict=True,
 	)
 	if not r:
 		return None
 	if r.status != "Requested":
-		frappe.throw(_("Petty Cash Request {0} is {1} — only a Requested one can be disbursed.").format(request, r.status))
+		frappe.throw(
+			_("Petty Cash Request {0} is {1} — only a Requested one can be disbursed.").format(
+				request, r.status
+			)
+		)
 	return {
 		"company": r.company,
 		"amount": flt(r.amount),
@@ -264,7 +306,9 @@ def statement(employee):
 	pnames = (
 		{
 			p.name: p.project_name
-			for p in frappe.get_all("Project", filters={"name": ["in", pids]}, fields=["name", "project_name"])
+			for p in frappe.get_all(
+				"Project", filters={"name": ["in", pids]}, fields=["name", "project_name"]
+			)
 		}
 		if pids
 		else {}

--- a/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.json
+++ b/buildsuite_core/buildsuite_core/doctype/petty_cash_request/petty_cash_request.json
@@ -11,6 +11,7 @@
   "column_break_hdr",
   "amount",
   "status",
+  "is_direct",
   "company",
   "purpose_section",
   "purpose",
@@ -64,6 +65,14 @@
    "label": "Status",
    "options": "Requested\nDisbursed\nCancelled",
    "read_only": 1
+  },
+  {
+   "fieldname": "is_direct",
+   "fieldtype": "Check",
+   "label": "Direct Issue",
+   "default": "0",
+   "read_only": 1,
+   "description": "Set when the float was issued directly to a holder, with no request behind it."
   },
   {
    "fieldname": "company",

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -378,6 +378,7 @@ CUSTOM_FIELD = {
 			"options": "Petty Cash Request",
 			"insert_after": "voucher_type",
 			"no_copy": 1,
+			"depends_on": "eval:doc.voucher_type=='Petty Cash'",
 			"description": "Disburses the linked Requested petty cash request when this entry is submitted.",
 			"module": "BuildSuite Core",
 		},

--- a/buildsuite_core/custom_property_list/property_field.py
+++ b/buildsuite_core/custom_property_list/property_field.py
@@ -1,6 +1,22 @@
 def get_property_setters():
 	return [
 		{
+			# Add "Petty Cash" as a Journal Entry Entry Type. The petty-cash disbursement JE
+			# uses it, and the Petty Cash Request link field shows only for this type.
+			"doctype_or_field": "DocField",
+			"doctype": "Journal Entry",
+			"fieldname": "voucher_type",
+			"property": "options",
+			"value": (
+				"Journal Entry\nInter Company Journal Entry\nBank Entry\nCash Entry\n"
+				"Credit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\n"
+				"Write Off Entry\nOpening Entry\nDepreciation Entry\nAsset Disposal\n"
+				"Periodic Accounting Entry\nExchange Rate Revaluation\nExchange Gain Or Loss\n"
+				"Deferred Revenue\nDeferred Expense\nPetty Cash"
+			),
+			"property_type": "Text",
+		},
+		{
 			# Subcontractors are modelled as Suppliers tagged with this type. Extend the
 			# native supplier_type options so "Subcontractor" is selectable.
 			"doctype_or_field": "DocField",
@@ -62,346 +78,344 @@ def get_property_setters():
 			"value": "1",
 			"property_type": "Check",
 		},
-    {
-            "doctype": "Stock Entry",
-            "fieldname": "project",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype_or_field":"DocType",
-            "doctype": "Stock Entry",
-            "fieldname": None,
-            "property": "field_order",
-            "property_type": "Data",
-            "value": "[\"stock_entry_details_tab\", \"company\", \"naming_series\", \"stock_entry_type\", \"purpose\", \"col2\", \"set_posting_time\", \"posting_date\", \"posting_time\", \"reference_section\", \"add_to_transit\", \"apply_putaway_rule\", \"inspection_required\", \"column_break_jabv\", \"work_order\", \"subcontracting_order\", \"outgoing_stock_entry\", \"source_stock_entry\", \"custom_section_break_o8nvm\", \"project\", \"bom_info_section\", \"from_bom\", \"use_multi_level_bom\", \"bom_no\", \"cb1\", \"fg_completed_qty\", \"get_items\", \"section_break_7qsm\", \"process_loss_percentage\", \"column_break_e92r\", \"process_loss_qty\", \"section_break_jwgn\", \"from_warehouse\", \"source_warehouse_address\", \"source_address_display\", \"cb0\", \"to_warehouse\", \"target_warehouse_address\", \"target_address_display\", \"sb0\", \"scan_barcode\", \"column_break_menu\", \"last_scanned_warehouse\", \"items_section\", \"items\", \"get_stock_and_rate\", \"section_break_19\", \"total_outgoing_value\", \"column_break_22\", \"total_incoming_value\", \"value_difference\", \"additional_costs_section\", \"additional_costs\", \"total_additional_costs\", \"supplier_info_tab\", \"contact_section\", \"supplier\", \"supplier_name\", \"supplier_address\", \"address_display\", \"accounting_dimensions_section\", \"column_break_wgvc\", \"cost_center\", \"other_info_tab\", \"printing_settings\", \"select_print_heading\", \"print_settings_col_break\", \"letter_head\", \"reference_details_section\", \"delivery_note_no\", \"sales_invoice_no\", \"job_card\", \"pick_list\", \"column_break_qpvo\", \"asset_repair\", \"purchase_receipt_no\", \"purchase_order\", \"subcontracting_inward_order\", \"is_additional_transfer_entry\", \"more_info\", \"is_opening\", \"remarks\", \"col5\", \"per_transferred\", \"total_amount\", \"amended_from\", \"credit_note\", \"is_return\", \"tab_connections\"]"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "bom_info_section",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type&&doc.purpose== \"Material Receipt\""
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "section_break_jwgn",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "additional_costs_section",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "sb0",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "more_info",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "printing_settings",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "section_break_19",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "items_section",
-            "property": "depends_on",
-            "property_type": "Data",
-            "value": "eval:doc.stock_entry_type"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "accounting_dimensions_section",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "scan_barcode",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "add_to_transit",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Stock Entry",
-            "fieldname": "apply_putaway_rule",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-
-        {
-            "doctype": "Stock Entry Detail",
-            "fieldname": "uom",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Stock Entry Detail",
-            "fieldname": "t_warehouse",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": "0"
-        },
-        {
-            "doctype": "Stock Entry Detail",
-            "fieldname": "s_warehouse",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": "0"
-        },
-        {
-            "doctype": "Material Request",
-            "fieldname": "naming_series",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Material Request",
-            "fieldname": "naming_series",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": "0"
-        },
-        {
-            "doctype": "Material Request",
-            "fieldname": "set_from_warehouse",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Material Request",
-            "fieldname": "set_warehouse",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Material Request",
-            "fieldname": "set_warehouse",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": "0"
-        },
-        {
-            "doctype": "Material Request",
-            "fieldname": "scan_barcode",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-
-        {
-            "doctype": "Material Request Item",
-            "fieldname": "description",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": 0
-        },
-        {
-            "doctype": "Material Request Item",
-            "fieldname": "description",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": 1
-        },
 		{
-            "doctype_or_field":"DocType",
-            "doctype": "Purchase Order",
-            "fieldname": None,
-            "property": "field_order",
-            "property_type": "Data",
-            "value": "[\"supplier_section\", \"company\", \"naming_series\", \"supplier\", \"project\", \"supplier_name\", \"order_confirmation_no\", \"order_confirmation_date\", \"column_break_7\", \"transaction_date\", \"transaction_time\", \"schedule_date\", \"column_break1\", \"is_subcontracted\", \"has_unit_price_items\", \"supplier_warehouse\", \"accounting_dimensions_section\", \"cost_center\", \"dimension_col_break\", \"currency_and_price_list\", \"currency\", \"conversion_rate\", \"cb_price_list\", \"buying_price_list\", \"price_list_currency\", \"plc_conversion_rate\", \"ignore_pricing_rule\", \"before_items_section\", \"scan_barcode\", \"last_scanned_warehouse\", \"items_col_break\", \"set_from_warehouse\", \"set_warehouse\", \"items_section\", \"custom_rate_master_banner\", \"items\", \"sb_last_purchase\", \"total_qty\", \"total_net_weight\", \"column_break_40\", \"base_total\", \"base_net_total\", \"column_break_26\", \"total\", \"net_total\", \"section_break_48\", \"pricing_rules\", \"set_reserve_warehouse\", \"taxes_section\", \"tax_category\", \"taxes_and_charges\", \"column_break_53\", \"shipping_rule\", \"column_break_50\", \"incoterm\", \"named_place\", \"section_break_52\", \"taxes\", \"totals\", \"base_taxes_and_charges_added\", \"base_taxes_and_charges_deducted\", \"base_total_taxes_and_charges\", \"column_break_39\", \"taxes_and_charges_added\", \"taxes_and_charges_deducted\", \"total_taxes_and_charges\", \"totals_section\", \"grand_total\", \"in_words\", \"column_break4\", \"disable_rounded_total\", \"rounding_adjustment\", \"rounded_total\", \"base_totals_section\", \"base_grand_total\", \"base_in_words\", \"column_break_jkoz\", \"base_rounding_adjustment\", \"base_rounded_total\", \"section_break_tnkm\", \"advance_paid\", \"discount_section\", \"apply_discount_on\", \"base_discount_amount\", \"column_break_45\", \"additional_discount_percentage\", \"discount_amount\", \"sec_tax_breakup\", \"other_charges_calculation\", \"item_wise_tax_details\", \"address_and_contact_tab\", \"section_addresses\", \"supplier_address\", \"address_display\", \"supplier_group\", \"col_break_address\", \"contact_person\", \"contact_display\", \"contact_mobile\", \"contact_email\", \"shipping_address_section\", \"dispatch_address\", \"dispatch_address_display\", \"column_break_99\", \"shipping_address\", \"shipping_address_display\", \"company_billing_address_section\", \"billing_address\", \"column_break_103\", \"billing_address_display\", \"drop_ship\", \"customer\", \"customer_name\", \"column_break_19\", \"customer_contact_person\", \"customer_contact_display\", \"customer_contact_mobile\", \"customer_contact_email\", \"terms_tab\", \"payment_schedule_section\", \"payment_terms_template\", \"payment_schedule\", \"terms_section_break\", \"tc_name\", \"terms\", \"more_info_tab\", \"tracking_section\", \"status\", \"advance_payment_status\", \"column_break_75\", \"per_billed\", \"per_received\", \"column_break5\", \"letter_head\", \"group_same_items\", \"column_break_86\", \"select_print_heading\", \"language\", \"auto_repeat_section\", \"from_date\", \"to_date\", \"column_break_97\", \"auto_repeat\", \"update_auto_repeat_reference\", \"additional_info_section\", \"title\", \"party_account_currency\", \"represents_company\", \"ref_sq\", \"amended_from\", \"column_break_74\", \"mps\", \"is_internal_supplier\", \"inter_company_order_reference\", \"connections_tab\"]"
+			"doctype": "Stock Entry",
+			"fieldname": "project",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "1",
 		},
-        {
-            "doctype": "Purchase Order",
-            "fieldname": "project",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Order",
-            "fieldname": "naming_series",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Order",
-            "fieldname": "naming_series",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": "0"
-        },
-        {
-            "doctype": "Purchase Order",
-            "fieldname": "currency_and_price_list",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Invoice",
-            "fieldname": "naming_series",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Invoice",
-            "fieldname": "incoterm",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Invoice",
-            "fieldname": "shipping_rule",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Invoice",
-            "fieldname": "update_stock",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Invoice",
-            "fieldname": "currency_and_price_list",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Invoice",
-            "fieldname": "scan_barcode",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype_or_field":"DocType",
-            "doctype": "Purchase Invoice",
-            "fieldname": None,
-            "property": "field_order",
-            "property_type": "Data",
-            "value": "[\"naming_series\", \"supplier\", \"supplier_name\", \"tax_id\", \"company\", \"column_break_6\", \"posting_date\", \"posting_time\", \"set_posting_time\", \"due_date\", \"column_break1\", \"is_paid\", \"is_return\", \"return_against\", \"update_outstanding_for_self\", \"update_billed_amount_in_purchase_order\", \"update_billed_amount_in_purchase_receipt\", \"apply_tds\", \"amended_from\", \"supplier_invoice_details\", \"bill_no\", \"column_break_15\", \"bill_date\", \"accounting_dimensions_section\", \"cost_center\", \"dimension_col_break\", \"currency_and_price_list\", \"currency\", \"conversion_rate\", \"use_transaction_date_exchange_rate\", \"column_break2\", \"buying_price_list\", \"price_list_currency\", \"plc_conversion_rate\", \"ignore_pricing_rule\", \"sec_warehouse\", \"project\", \"scan_barcode\", \"last_scanned_warehouse\", \"col_break_warehouse\", \"update_stock\", \"set_warehouse\", \"set_from_warehouse\", \"is_subcontracted\", \"rejected_warehouse\", \"supplier_warehouse\", \"items_section\", \"items\", \"section_break_26\", \"total_qty\", \"total_net_weight\", \"column_break_50\", \"base_total\", \"base_net_total\", \"claimed_landed_cost_amount\", \"column_break_28\", \"total\", \"net_total\", \"taxes_section\", \"tax_category\", \"taxes_and_charges\", \"column_break_58\", \"shipping_rule\", \"column_break_49\", \"incoterm\", \"named_place\", \"section_break_51\", \"taxes\", \"totals\", \"base_taxes_and_charges_added\", \"base_taxes_and_charges_deducted\", \"base_total_taxes_and_charges\", \"column_break_40\", \"taxes_and_charges_added\", \"taxes_and_charges_deducted\", \"total_taxes_and_charges\", \"totals_section\", \"use_company_roundoff_cost_center\", \"grand_total\", \"in_words\", \"column_break8\", \"disable_rounded_total\", \"rounding_adjustment\", \"rounded_total\", \"base_totals_section\", \"base_grand_total\", \"base_in_words\", \"column_break_hcca\", \"base_rounding_adjustment\", \"base_rounded_total\", \"section_break_ttrv\", \"total_advance\", \"column_break_peap\", \"outstanding_amount\", \"section_tax_withholding_entry\", \"tax_withholding_group\", \"ignore_tax_withholding_threshold\", \"override_tax_withholding_entries\", \"tax_withholding_entries\", \"section_break_44\", \"apply_discount_on\", \"base_discount_amount\", \"column_break_46\", \"additional_discount_percentage\", \"discount_amount\", \"sec_tax_breakup\", \"other_charges_calculation\", \"item_wise_tax_details\", \"pricing_rule_details\", \"pricing_rules\", \"raw_materials_supplied\", \"supplied_items\", \"payments_tab\", \"payments_section\", \"mode_of_payment\", \"base_paid_amount\", \"clearance_date\", \"col_br_payments\", \"cash_bank_account\", \"paid_amount\", \"advances_section\", \"allocate_advances_automatically\", \"only_include_allocated_payments\", \"get_advances\", \"advances\", \"write_off\", \"write_off_amount\", \"base_write_off_amount\", \"column_break_61\", \"write_off_account\", \"write_off_cost_center\", \"address_and_contact_tab\", \"section_addresses\", \"supplier_address\", \"address_display\", \"col_break_address\", \"contact_person\", \"contact_display\", \"contact_mobile\", \"contact_email\", \"company_shipping_address_section\", \"dispatch_address\", \"dispatch_address_display\", \"column_break_126\", \"shipping_address\", \"shipping_address_display\", \"company_billing_address_section\", \"billing_address\", \"column_break_130\", \"billing_address_display\", \"terms_tab\", \"payment_schedule_section\", \"payment_terms_template\", \"ignore_default_payment_terms_template\", \"payment_schedule\", \"terms_section_break\", \"tc_name\", \"terms\", \"more_info_tab\", \"status_section\", \"status\", \"column_break_177\", \"per_received\", \"accounting_details_section\", \"credit_to\", \"party_account_currency\", \"is_opening\", \"against_expense_account\", \"column_break_63\", \"unrealized_profit_loss_account\", \"subscription_section\", \"subscription\", \"column_break_114\", \"from_date\", \"to_date\", \"automation_section\", \"auto_repeat\", \"update_auto_repeat_reference\", \"printing_settings\", \"letter_head\", \"group_same_items\", \"column_break_112\", \"select_print_heading\", \"language\", \"sb_14\", \"on_hold\", \"release_date\", \"cb_17\", \"hold_comment\", \"additional_info_section\", \"is_internal_supplier\", \"title\", \"represents_company\", \"supplier_group\", \"sender\", \"column_break_147\", \"inter_company_invoice_reference\", \"remarks\", \"connections_tab\"]"
-        },
-        {
-            "doctype": "Purchase Invoice Item",
-            "fieldname": "uom",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "project",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "naming_series",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "naming_series",
-            "property": "reqd",
-            "property_type": "Check",
-            "value": "0"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "incoterm",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "shipping_rule",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "currency_and_price_list",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "apply_putaway_rule",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype": "Purchase Receipt",
-            "fieldname": "scan_barcode",
-            "property": "hidden",
-            "property_type": "Check",
-            "value": "1"
-        },
-        {
-            "doctype_or_field":"DocType",
-            "doctype": "Purchase Receipt",
-            "fieldname": None,
-            "property": "field_order",
-            "property_type": "Data",
-            "value": "[\"supplier_section\", \"column_break0\", \"naming_series\", \"supplier\", \"supplier_name\", \"supplier_delivery_note\", \"subcontracting_receipt\", \"column_break1\", \"posting_date\", \"posting_time\", \"set_posting_time\", \"column_break_12\", \"company\", \"apply_putaway_rule\", \"is_return\", \"return_against\", \"accounting_dimensions_section\", \"cost_center\", \"dimension_col_break\", \"currency_and_price_list\", \"currency\", \"conversion_rate\", \"column_break2\", \"buying_price_list\", \"price_list_currency\", \"plc_conversion_rate\", \"ignore_pricing_rule\", \"sec_warehouse\", \"project\", \"scan_barcode\", \"last_scanned_warehouse\", \"column_break_31\", \"set_warehouse\", \"set_from_warehouse\", \"col_break_warehouse\", \"rejected_warehouse\", \"is_subcontracted\", \"supplier_warehouse\", \"items_section\", \"items\", \"section_break0\", \"total_qty\", \"total_net_weight\", \"column_break_43\", \"base_total\", \"base_net_total\", \"column_break_27\", \"total\", \"net_total\", \"taxes_charges_section\", \"tax_category\", \"taxes_and_charges\", \"shipping_col\", \"shipping_rule\", \"column_break_53\", \"incoterm\", \"named_place\", \"taxes_section\", \"taxes\", \"totals\", \"base_taxes_and_charges_added\", \"base_taxes_and_charges_deducted\", \"base_total_taxes_and_charges\", \"column_break3\", \"taxes_and_charges_added\", \"taxes_and_charges_deducted\", \"total_taxes_and_charges\", \"totals_section\", \"grand_total\", \"in_words\", \"column_break_50\", \"disable_rounded_total\", \"rounding_adjustment\", \"rounded_total\", \"base_totals_section\", \"base_grand_total\", \"base_in_words\", \"column_break_ugyv\", \"base_rounding_adjustment\", \"base_rounded_total\", \"section_break_42\", \"apply_discount_on\", \"base_discount_amount\", \"column_break_44\", \"additional_discount_percentage\", \"discount_amount\", \"sec_tax_breakup\", \"other_charges_calculation\", \"item_wise_tax_details\", \"pricing_rule_details\", \"pricing_rules\", \"raw_material_details\", \"get_current_stock\", \"supplied_items\", \"address_and_contact_tab\", \"section_addresses\", \"supplier_address\", \"address_display\", \"col_break_address\", \"contact_person\", \"contact_display\", \"contact_mobile\", \"contact_email\", \"section_break_98\", \"dispatch_address\", \"dispatch_address_display\", \"column_break_100\", \"shipping_address\", \"shipping_address_display\", \"billing_address_section\", \"billing_address\", \"column_break_104\", \"billing_address_display\", \"terms_tab\", \"tc_name\", \"terms\", \"more_info_tab\", \"status_section\", \"status\", \"column_break4\", \"per_billed\", \"per_returned\", \"subscription_detail\", \"auto_repeat\", \"printing_settings\", \"letter_head\", \"group_same_items\", \"column_break_97\", \"select_print_heading\", \"language\", \"transporter_info\", \"transporter_name\", \"column_break5\", \"lr_no\", \"lr_date\", \"additional_info_section\", \"instructions\", \"is_internal_supplier\", \"represents_company\", \"title\", \"inter_company_reference\", \"column_break_131\", \"remarks\", \"range\", \"amended_from\", \"other_details\", \"connections_tab\"]" 
-        },
-        {
-            "doctype": "Purchase Receipt Item",
-            "fieldname": "uom",
-            "property": "in_list_view",
-            "property_type": "Check",
-            "value": "1"
-        },
+		{
+			"doctype_or_field": "DocType",
+			"doctype": "Stock Entry",
+			"fieldname": None,
+			"property": "field_order",
+			"property_type": "Data",
+			"value": '["stock_entry_details_tab", "company", "naming_series", "stock_entry_type", "purpose", "col2", "set_posting_time", "posting_date", "posting_time", "reference_section", "add_to_transit", "apply_putaway_rule", "inspection_required", "column_break_jabv", "work_order", "subcontracting_order", "outgoing_stock_entry", "source_stock_entry", "custom_section_break_o8nvm", "project", "bom_info_section", "from_bom", "use_multi_level_bom", "bom_no", "cb1", "fg_completed_qty", "get_items", "section_break_7qsm", "process_loss_percentage", "column_break_e92r", "process_loss_qty", "section_break_jwgn", "from_warehouse", "source_warehouse_address", "source_address_display", "cb0", "to_warehouse", "target_warehouse_address", "target_address_display", "sb0", "scan_barcode", "column_break_menu", "last_scanned_warehouse", "items_section", "items", "get_stock_and_rate", "section_break_19", "total_outgoing_value", "column_break_22", "total_incoming_value", "value_difference", "additional_costs_section", "additional_costs", "total_additional_costs", "supplier_info_tab", "contact_section", "supplier", "supplier_name", "supplier_address", "address_display", "accounting_dimensions_section", "column_break_wgvc", "cost_center", "other_info_tab", "printing_settings", "select_print_heading", "print_settings_col_break", "letter_head", "reference_details_section", "delivery_note_no", "sales_invoice_no", "job_card", "pick_list", "column_break_qpvo", "asset_repair", "purchase_receipt_no", "purchase_order", "subcontracting_inward_order", "is_additional_transfer_entry", "more_info", "is_opening", "remarks", "col5", "per_transferred", "total_amount", "amended_from", "credit_note", "is_return", "tab_connections"]',
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "bom_info_section",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": 'eval:doc.stock_entry_type&&doc.purpose== "Material Receipt"',
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "section_break_jwgn",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "additional_costs_section",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "sb0",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "more_info",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "printing_settings",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "section_break_19",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "items_section",
+			"property": "depends_on",
+			"property_type": "Data",
+			"value": "eval:doc.stock_entry_type",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "accounting_dimensions_section",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "scan_barcode",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "add_to_transit",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Stock Entry",
+			"fieldname": "apply_putaway_rule",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Stock Entry Detail",
+			"fieldname": "uom",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Stock Entry Detail",
+			"fieldname": "t_warehouse",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
+			"doctype": "Stock Entry Detail",
+			"fieldname": "s_warehouse",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
+			"doctype": "Material Request",
+			"fieldname": "naming_series",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Material Request",
+			"fieldname": "naming_series",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
+			"doctype": "Material Request",
+			"fieldname": "set_from_warehouse",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Material Request",
+			"fieldname": "set_warehouse",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Material Request",
+			"fieldname": "set_warehouse",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
+			"doctype": "Material Request",
+			"fieldname": "scan_barcode",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Material Request Item",
+			"fieldname": "description",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": 0,
+		},
+		{
+			"doctype": "Material Request Item",
+			"fieldname": "description",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": 1,
+		},
+		{
+			"doctype_or_field": "DocType",
+			"doctype": "Purchase Order",
+			"fieldname": None,
+			"property": "field_order",
+			"property_type": "Data",
+			"value": '["supplier_section", "company", "naming_series", "supplier", "project", "supplier_name", "order_confirmation_no", "order_confirmation_date", "column_break_7", "transaction_date", "transaction_time", "schedule_date", "column_break1", "is_subcontracted", "has_unit_price_items", "supplier_warehouse", "accounting_dimensions_section", "cost_center", "dimension_col_break", "currency_and_price_list", "currency", "conversion_rate", "cb_price_list", "buying_price_list", "price_list_currency", "plc_conversion_rate", "ignore_pricing_rule", "before_items_section", "scan_barcode", "last_scanned_warehouse", "items_col_break", "set_from_warehouse", "set_warehouse", "items_section", "custom_rate_master_banner", "items", "sb_last_purchase", "total_qty", "total_net_weight", "column_break_40", "base_total", "base_net_total", "column_break_26", "total", "net_total", "section_break_48", "pricing_rules", "set_reserve_warehouse", "taxes_section", "tax_category", "taxes_and_charges", "column_break_53", "shipping_rule", "column_break_50", "incoterm", "named_place", "section_break_52", "taxes", "totals", "base_taxes_and_charges_added", "base_taxes_and_charges_deducted", "base_total_taxes_and_charges", "column_break_39", "taxes_and_charges_added", "taxes_and_charges_deducted", "total_taxes_and_charges", "totals_section", "grand_total", "in_words", "column_break4", "disable_rounded_total", "rounding_adjustment", "rounded_total", "base_totals_section", "base_grand_total", "base_in_words", "column_break_jkoz", "base_rounding_adjustment", "base_rounded_total", "section_break_tnkm", "advance_paid", "discount_section", "apply_discount_on", "base_discount_amount", "column_break_45", "additional_discount_percentage", "discount_amount", "sec_tax_breakup", "other_charges_calculation", "item_wise_tax_details", "address_and_contact_tab", "section_addresses", "supplier_address", "address_display", "supplier_group", "col_break_address", "contact_person", "contact_display", "contact_mobile", "contact_email", "shipping_address_section", "dispatch_address", "dispatch_address_display", "column_break_99", "shipping_address", "shipping_address_display", "company_billing_address_section", "billing_address", "column_break_103", "billing_address_display", "drop_ship", "customer", "customer_name", "column_break_19", "customer_contact_person", "customer_contact_display", "customer_contact_mobile", "customer_contact_email", "terms_tab", "payment_schedule_section", "payment_terms_template", "payment_schedule", "terms_section_break", "tc_name", "terms", "more_info_tab", "tracking_section", "status", "advance_payment_status", "column_break_75", "per_billed", "per_received", "column_break5", "letter_head", "group_same_items", "column_break_86", "select_print_heading", "language", "auto_repeat_section", "from_date", "to_date", "column_break_97", "auto_repeat", "update_auto_repeat_reference", "additional_info_section", "title", "party_account_currency", "represents_company", "ref_sq", "amended_from", "column_break_74", "mps", "is_internal_supplier", "inter_company_order_reference", "connections_tab"]',
+		},
+		{
+			"doctype": "Purchase Order",
+			"fieldname": "project",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Order",
+			"fieldname": "naming_series",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Order",
+			"fieldname": "naming_series",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
+			"doctype": "Purchase Order",
+			"fieldname": "currency_and_price_list",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Invoice",
+			"fieldname": "naming_series",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Invoice",
+			"fieldname": "incoterm",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Invoice",
+			"fieldname": "shipping_rule",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Invoice",
+			"fieldname": "update_stock",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Invoice",
+			"fieldname": "currency_and_price_list",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Invoice",
+			"fieldname": "scan_barcode",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype_or_field": "DocType",
+			"doctype": "Purchase Invoice",
+			"fieldname": None,
+			"property": "field_order",
+			"property_type": "Data",
+			"value": '["naming_series", "supplier", "supplier_name", "tax_id", "company", "column_break_6", "posting_date", "posting_time", "set_posting_time", "due_date", "column_break1", "is_paid", "is_return", "return_against", "update_outstanding_for_self", "update_billed_amount_in_purchase_order", "update_billed_amount_in_purchase_receipt", "apply_tds", "amended_from", "supplier_invoice_details", "bill_no", "column_break_15", "bill_date", "accounting_dimensions_section", "cost_center", "dimension_col_break", "currency_and_price_list", "currency", "conversion_rate", "use_transaction_date_exchange_rate", "column_break2", "buying_price_list", "price_list_currency", "plc_conversion_rate", "ignore_pricing_rule", "sec_warehouse", "project", "scan_barcode", "last_scanned_warehouse", "col_break_warehouse", "update_stock", "set_warehouse", "set_from_warehouse", "is_subcontracted", "rejected_warehouse", "supplier_warehouse", "items_section", "items", "section_break_26", "total_qty", "total_net_weight", "column_break_50", "base_total", "base_net_total", "claimed_landed_cost_amount", "column_break_28", "total", "net_total", "taxes_section", "tax_category", "taxes_and_charges", "column_break_58", "shipping_rule", "column_break_49", "incoterm", "named_place", "section_break_51", "taxes", "totals", "base_taxes_and_charges_added", "base_taxes_and_charges_deducted", "base_total_taxes_and_charges", "column_break_40", "taxes_and_charges_added", "taxes_and_charges_deducted", "total_taxes_and_charges", "totals_section", "use_company_roundoff_cost_center", "grand_total", "in_words", "column_break8", "disable_rounded_total", "rounding_adjustment", "rounded_total", "base_totals_section", "base_grand_total", "base_in_words", "column_break_hcca", "base_rounding_adjustment", "base_rounded_total", "section_break_ttrv", "total_advance", "column_break_peap", "outstanding_amount", "section_tax_withholding_entry", "tax_withholding_group", "ignore_tax_withholding_threshold", "override_tax_withholding_entries", "tax_withholding_entries", "section_break_44", "apply_discount_on", "base_discount_amount", "column_break_46", "additional_discount_percentage", "discount_amount", "sec_tax_breakup", "other_charges_calculation", "item_wise_tax_details", "pricing_rule_details", "pricing_rules", "raw_materials_supplied", "supplied_items", "payments_tab", "payments_section", "mode_of_payment", "base_paid_amount", "clearance_date", "col_br_payments", "cash_bank_account", "paid_amount", "advances_section", "allocate_advances_automatically", "only_include_allocated_payments", "get_advances", "advances", "write_off", "write_off_amount", "base_write_off_amount", "column_break_61", "write_off_account", "write_off_cost_center", "address_and_contact_tab", "section_addresses", "supplier_address", "address_display", "col_break_address", "contact_person", "contact_display", "contact_mobile", "contact_email", "company_shipping_address_section", "dispatch_address", "dispatch_address_display", "column_break_126", "shipping_address", "shipping_address_display", "company_billing_address_section", "billing_address", "column_break_130", "billing_address_display", "terms_tab", "payment_schedule_section", "payment_terms_template", "ignore_default_payment_terms_template", "payment_schedule", "terms_section_break", "tc_name", "terms", "more_info_tab", "status_section", "status", "column_break_177", "per_received", "accounting_details_section", "credit_to", "party_account_currency", "is_opening", "against_expense_account", "column_break_63", "unrealized_profit_loss_account", "subscription_section", "subscription", "column_break_114", "from_date", "to_date", "automation_section", "auto_repeat", "update_auto_repeat_reference", "printing_settings", "letter_head", "group_same_items", "column_break_112", "select_print_heading", "language", "sb_14", "on_hold", "release_date", "cb_17", "hold_comment", "additional_info_section", "is_internal_supplier", "title", "represents_company", "supplier_group", "sender", "column_break_147", "inter_company_invoice_reference", "remarks", "connections_tab"]',
+		},
+		{
+			"doctype": "Purchase Invoice Item",
+			"fieldname": "uom",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "project",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "naming_series",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "naming_series",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "incoterm",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "shipping_rule",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "currency_and_price_list",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "apply_putaway_rule",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype": "Purchase Receipt",
+			"fieldname": "scan_barcode",
+			"property": "hidden",
+			"property_type": "Check",
+			"value": "1",
+		},
+		{
+			"doctype_or_field": "DocType",
+			"doctype": "Purchase Receipt",
+			"fieldname": None,
+			"property": "field_order",
+			"property_type": "Data",
+			"value": '["supplier_section", "column_break0", "naming_series", "supplier", "supplier_name", "supplier_delivery_note", "subcontracting_receipt", "column_break1", "posting_date", "posting_time", "set_posting_time", "column_break_12", "company", "apply_putaway_rule", "is_return", "return_against", "accounting_dimensions_section", "cost_center", "dimension_col_break", "currency_and_price_list", "currency", "conversion_rate", "column_break2", "buying_price_list", "price_list_currency", "plc_conversion_rate", "ignore_pricing_rule", "sec_warehouse", "project", "scan_barcode", "last_scanned_warehouse", "column_break_31", "set_warehouse", "set_from_warehouse", "col_break_warehouse", "rejected_warehouse", "is_subcontracted", "supplier_warehouse", "items_section", "items", "section_break0", "total_qty", "total_net_weight", "column_break_43", "base_total", "base_net_total", "column_break_27", "total", "net_total", "taxes_charges_section", "tax_category", "taxes_and_charges", "shipping_col", "shipping_rule", "column_break_53", "incoterm", "named_place", "taxes_section", "taxes", "totals", "base_taxes_and_charges_added", "base_taxes_and_charges_deducted", "base_total_taxes_and_charges", "column_break3", "taxes_and_charges_added", "taxes_and_charges_deducted", "total_taxes_and_charges", "totals_section", "grand_total", "in_words", "column_break_50", "disable_rounded_total", "rounding_adjustment", "rounded_total", "base_totals_section", "base_grand_total", "base_in_words", "column_break_ugyv", "base_rounding_adjustment", "base_rounded_total", "section_break_42", "apply_discount_on", "base_discount_amount", "column_break_44", "additional_discount_percentage", "discount_amount", "sec_tax_breakup", "other_charges_calculation", "item_wise_tax_details", "pricing_rule_details", "pricing_rules", "raw_material_details", "get_current_stock", "supplied_items", "address_and_contact_tab", "section_addresses", "supplier_address", "address_display", "col_break_address", "contact_person", "contact_display", "contact_mobile", "contact_email", "section_break_98", "dispatch_address", "dispatch_address_display", "column_break_100", "shipping_address", "shipping_address_display", "billing_address_section", "billing_address", "column_break_104", "billing_address_display", "terms_tab", "tc_name", "terms", "more_info_tab", "status_section", "status", "column_break4", "per_billed", "per_returned", "subscription_detail", "auto_repeat", "printing_settings", "letter_head", "group_same_items", "column_break_97", "select_print_heading", "language", "transporter_info", "transporter_name", "column_break5", "lr_no", "lr_date", "additional_info_section", "instructions", "is_internal_supplier", "represents_company", "title", "inter_company_reference", "column_break_131", "remarks", "range", "amended_from", "other_details", "connections_tab"]',
+		},
+		{
+			"doctype": "Purchase Receipt Item",
+			"fieldname": "uom",
+			"property": "in_list_view",
+			"property_type": "Check",
+			"value": "1",
+		},
 	]

--- a/buildsuite_core/tests/test_petty_cash.py
+++ b/buildsuite_core/tests/test_petty_cash.py
@@ -15,7 +15,9 @@ class TestPettyCash(BuildSuiteTestCase):
 		self._ensure_employee("Administrator")
 		# Petty cash derives company from the requester's Employee, so anchor the whole
 		# test (project, disburse account) to that Employee's company.
-		self.company = frappe.db.get_value("Employee", {"user_id": "Administrator", "status": "Active"}, "company")
+		self.company = frappe.db.get_value(
+			"Employee", {"user_id": "Administrator", "status": "Active"}, "company"
+		)
 		self.project = self._make_project(company=self.company).name
 
 	def _ensure_employee(self, user_id, company=None):
@@ -69,15 +71,32 @@ class TestPettyCash(BuildSuiteTestCase):
 	def test_company_from_employee(self):
 		# Petty cash carries no project; company is anchored to the requester's Employee.
 		req = self._request()
-		emp_company = frappe.db.get_value("Employee", {"user_id": "Administrator", "status": "Active"}, "company")
+		emp_company = frappe.db.get_value(
+			"Employee", {"user_id": "Administrator", "status": "Active"}, "company"
+		)
 		self.assertEqual(req.company, emp_company)
 
 	def test_non_employee_cannot_request(self):
-		user = frappe.get_doc(
-			{"doctype": "User", "email": f"noemp-{self._n}@example.com", "first_name": "NoEmp", "send_welcome_email": 0}
-		).insert(ignore_permissions=True).name
+		user = (
+			frappe.get_doc(
+				{
+					"doctype": "User",
+					"email": f"noemp-{self._n}@example.com",
+					"first_name": "NoEmp",
+					"send_welcome_email": 0,
+				}
+			)
+			.insert(ignore_permissions=True)
+			.name
+		)
 		req = frappe.get_doc(
-			{"doctype": "Petty Cash Request", "request_date": "2026-07-20", "amount": 1000, "purpose": "x", "requested_by": user}
+			{
+				"doctype": "Petty Cash Request",
+				"request_date": "2026-07-20",
+				"amount": 1000,
+				"purpose": "x",
+				"requested_by": user,
+			}
 		)
 		self.assertRaises(frappe.ValidationError, req.insert, ignore_permissions=True)
 
@@ -97,7 +116,10 @@ class TestPettyCash(BuildSuiteTestCase):
 		credit = [a for a in je.accounts if flt(a.credit_in_account_currency) > 0]
 		# Imprest treatment: Dr Petty Cash 15000 (holder on the `employee` dimension) / Cr bank 15000.
 		self.assertEqual(flt(debit[0].debit_in_account_currency), 15000)
-		self.assertEqual(debit[0].employee, frappe.db.get_value("Employee", {"user_id": "Administrator", "status": "Active"}, "name"))
+		self.assertEqual(
+			debit[0].employee,
+			frappe.db.get_value("Employee", {"user_id": "Administrator", "status": "Active"}, "name"),
+		)
 		self.assertEqual(credit[0].account, bank)
 		self.assertEqual(flt(credit[0].credit_in_account_currency), 15000)
 
@@ -167,7 +189,9 @@ class TestPettyCash(BuildSuiteTestCase):
 		petty_line = next(a for a in je.accounts if a.account == petty)
 		self.assertEqual(petty_line.employee, holder)
 		self.assertEqual(
-			frappe.db.get_value("GL Entry", {"voucher_no": je.name, "account": petty, "is_cancelled": 0}, "employee"),
+			frappe.db.get_value(
+				"GL Entry", {"voucher_no": je.name, "account": petty, "is_cancelled": 0}, "employee"
+			),
 			holder,
 		)
 
@@ -197,3 +221,56 @@ class TestPettyCash(BuildSuiteTestCase):
 		# A disbursed request can't be prefilled for another disbursement.
 		req.disburse(self._cash_account())
 		self.assertRaises(frappe.ValidationError, disbursement_prefill, req.name)
+
+	def test_direct_issue_creates_disbursed_je(self):
+		# S273 — a direct issue creates the request already Disbursed, with no project, and
+		# posts a submitted "Petty Cash" Journal Entry linked back to it.
+		import json
+
+		from buildsuite_core.api import petty_cash as pc
+
+		bank = self._cash_account()
+		rec = pc.issue_direct(
+			json.dumps(
+				{
+					"requested_by": "Administrator",
+					"amount": 3000,
+					"paid_from": bank,
+					"purpose": "Direct float to a site holder",
+				}
+			)
+		)
+		self.assertEqual(rec["status"], "Disbursed")
+		self.assertTrue(rec["is_direct"])
+		self.assertFalse(rec["project"])
+		self.assertTrue(rec["journal_entry"])
+
+		je = frappe.db.get_value(
+			"Journal Entry",
+			rec["journal_entry"],
+			["docstatus", "voucher_type", "petty_cash_request"],
+			as_dict=True,
+		)
+		self.assertEqual(je.docstatus, 1)
+		self.assertEqual(je.voucher_type, "Petty Cash")
+		self.assertEqual(je.petty_cash_request, rec["name"])
+
+	def test_direct_issue_reversed_is_removed(self):
+		# A direct issue has no request to fall back to — reversing it removes the record.
+		import json
+
+		from buildsuite_core.api import petty_cash as pc
+
+		rec = pc.issue_direct(
+			json.dumps(
+				{
+					"requested_by": "Administrator",
+					"amount": 500,
+					"paid_from": self._cash_account(),
+					"purpose": "reverse me",
+				}
+			)
+		)
+		out = pc.undisburse(rec["name"])
+		self.assertTrue(out.get("deleted"))
+		self.assertFalse(frappe.db.exists("Petty Cash Request", rec["name"]))

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -86,10 +86,17 @@ def post_disbursement_journal_entry(doc):
 	# mandatory (spec PF-02 rule 1).
 	employee = employee_for_user(doc.requested_by)
 	if not employee:
-		frappe.throw(_("Only employees hold petty cash — no active Employee is linked to {0}.").format(doc.requested_by))
+		frappe.throw(
+			_("Only employees hold petty cash — no active Employee is linked to {0}.").format(
+				doc.requested_by
+			)
+		)
 
 	je = frappe.new_doc("Journal Entry")
-	je.voucher_type = "Journal Entry"
+	# Categorise as a Petty Cash entry (Entry Type). This is the JE's own voucher_type
+	# Select — NOT GL Entry.voucher_type (which stays the doctype name "Journal Entry"), so
+	# the petty-cash reconciliation that filters GL on "Journal Entry" is unaffected.
+	je.voucher_type = "Petty Cash"
 	je.company = doc.company
 	je.posting_date = str(doc.request_date) if doc.request_date else None
 	je.user_remark = f"Petty cash {doc.name}: {doc.purpose or ''}"[:140]
@@ -127,6 +134,9 @@ def cancel_disbursement_journal_entry(doc):
 	je.flags.ignore_permissions = True
 	je.flags.ignore_petty_cash_sync = True  # cancel_disbursement() reverts the request itself
 	je.cancel()
+	# Drop the JE→request back-link so a reversed direct issue (which is then deleted) isn't
+	# blocked by the cancelled JE still referencing it.
+	je.db_set("petty_cash_request", None)
 
 
 # ---------------------------------------------------------------------------
@@ -190,7 +200,9 @@ def sync_petty_cash_request_on_je_submit(doc, method=None):
 		return
 	if status != "Requested":
 		frappe.throw(
-			_("Petty Cash Request {0} is {1} — only a Requested one can be disbursed.").format(request, status)
+			_("Petty Cash Request {0} is {1} — only a Requested one can be disbursed.").format(
+				request, status
+			)
 		)
 
 	frappe.db.set_value(
@@ -222,7 +234,13 @@ def revert_petty_cash_request_on_je_cancel(doc, method=None):
 	frappe.db.set_value(
 		"Petty Cash Request",
 		request,
-		{"status": "Requested", "journal_entry": None, "paid_from": None, "disbursed_by": None, "disbursed_on": None},
+		{
+			"status": "Requested",
+			"journal_entry": None,
+			"paid_from": None,
+			"disbursed_by": None,
+			"disbursed_on": None,
+		},
 	)
 	frappe.get_doc("Petty Cash Request", request).add_comment(
 		"Comment", _("Disbursement reversed — Journal Entry {0} cancelled").format(doc.name)
@@ -420,9 +438,7 @@ def _resolve_voucher_targets(gl_entries):
 				if row.reference_doctype and row.reference_docname:
 					references[row.name] = (row.reference_doctype, row.reference_docname)
 
-	return {
-		e.name: references.get(e.voucher_no, (e.voucher_type, e.voucher_no)) for e in gl_entries
-	}
+	return {e.name: references.get(e.voucher_no, (e.voucher_type, e.voucher_no)) for e in gl_entries}
 
 
 def _fetch_display_fields(targets):
@@ -449,9 +465,7 @@ def _fetch_display_fields(targets):
 
 
 @frappe.whitelist()
-def get_transaction_list(
-	employee, transaction_type=None, project=None, from_date=None, to_date=None
-):
+def get_transaction_list(employee, transaction_type=None, project=None, from_date=None, to_date=None):
 	"""Petty cash ledger for an employee, newest first, with a running balance.
 
 	The running balance is accumulated across the employee's full history before the
@@ -551,9 +565,7 @@ def create_account(doc, method=None):
 	Not whitelisted: this is a document event, and exposing it would let any user
 	trigger account creation.
 	"""
-	if frappe.db.exists(
-		"Account", {"account_name": PETTY_CASH_ACCOUNT_NAME, "company": doc.name}
-	):
+	if frappe.db.exists("Account", {"account_name": PETTY_CASH_ACCOUNT_NAME, "company": doc.name}):
 		return
 
 	parent = frappe.db.get_value(

--- a/frontend/src/data/pettyCashApi.js
+++ b/frontend/src/data/pettyCashApi.js
@@ -16,8 +16,12 @@ async function call(method, args) {
 
 export const pettyCashCanDisburse = () => call("can_disburse", {});
 export const getPettyCash = (name) => call("get_request", { name });
-export const savePettyCash = (payload) => call("save_request", { payload: JSON.stringify(payload) });
-export const disbursePettyCash = (name, paidFrom) => call("disburse", { name, paid_from: paidFrom });
+export const savePettyCash = (payload) =>
+	call("save_request", { payload: JSON.stringify(payload) });
+export const disbursePettyCash = (name, paidFrom) =>
+	call("disburse", { name, paid_from: paidFrom });
+export const issueDirectPettyCash = (payload) =>
+	call("issue_direct", { payload: JSON.stringify(payload) });
 export const undisbursePettyCash = (name) => call("undisburse", { name });
 export const cancelPettyCash = (name) => call("cancel_request", { name });
 export const deletePettyCash = (name) => call("delete_request", { name });

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -74,7 +74,7 @@ const filteredAll = computed(() => {
 		(r) =>
 			(r.name || "").toLowerCase().includes(q) ||
 			(r.purpose || "").toLowerCase().includes(q) ||
-			(r.requested_by || "").toLowerCase().includes(q)
+			(r.requested_by || "").toLowerCase().includes(q),
 	);
 });
 
@@ -237,10 +237,11 @@ const rowsForTab = computed(() => {
 				<button
 					v-if="canDisburse"
 					type="button"
-					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md whitespace-nowrap"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 whitespace-nowrap"
+					style="border-radius: 6px"
 					@click="openDirect"
 				>
-					Direct issue
+					+ Issue directly
 				</button>
 				<button
 					type="button"

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -22,6 +22,7 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
@@ -145,6 +146,9 @@ async function openDirect() {
 		showToast(err.message || "Failed to load accounts", "error");
 	}
 }
+const accountOptions = computed(() =>
+	(direct.accounts || []).map((a) => ({ value: a.name, label: a.name, hint: a.account_type })),
+);
 async function submitDirect() {
 	if (!direct.holder) return showToast("Pick who is receiving the float.", "error");
 	if (!(Number(direct.amount) > 0)) return showToast("Enter an amount.", "error");
@@ -428,49 +432,102 @@ const rowsForTab = computed(() => {
 		<!-- direct issue modal (S273) -->
 		<div
 			v-if="direct.open"
-			class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6"
 			@click.self="direct.open = false"
 		>
-			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
-				<h3 class="text-sm font-semibold text-ink-900 mb-1">Direct petty cash issue</h3>
-				<p class="text-xs text-ink-500 mb-4">
-					Hands float straight to a holder — no request. Posts a Journal Entry (Dr Petty
-					Cash / Cr the source). No project; project-level spend attaches on the expense.
-				</p>
-				<div class="space-y-3">
-					<DeskField label="Holder" required>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-md shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h2 class="text-sm font-semibold text-ink-900">Issue petty cash directly</h2>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900"
+						@click="direct.open = false"
+					>
+						✕
+					</button>
+				</header>
+				<div class="px-4 py-4 space-y-3">
+					<p
+						class="text-[11px] text-warning-700 bg-warning-50 border border-warning-200 rounded-md px-2.5 py-2"
+					>
+						No request precedes this — the record you create here is the only trail.
+						Use it when cash genuinely moved before anyone could raise a request.
+					</p>
+					<div>
+						<label
+							class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+							>Issue to <span class="text-danger-600">*</span></label
+						>
 						<DeskLinkPicker
 							v-model="direct.holder"
 							doctype="User"
 							label-field="full_name"
 							value-field="name"
-							placeholder="Who is receiving the float?"
+							placeholder="Pick the holder…"
 						/>
-					</DeskField>
-					<DeskField label="Amount" required>
-						<DeskInput v-model.number="direct.amount" type="number" min="0" />
-					</DeskField>
-					<DeskField label="Pay from" required>
-						<DeskSelect v-model="direct.paidFrom">
-							<option value="" disabled>Bank / Cash account…</option>
-							<option v-for="a in direct.accounts" :key="a.name" :value="a.name">
-								{{ a.name }}
-							</option>
-						</DeskSelect>
-					</DeskField>
-					<DeskField label="Reason" required>
-						<DeskInput
+					</div>
+					<div>
+						<label
+							class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+							>Amount <span class="text-danger-600">*</span></label
+						>
+						<input
+							v-model.number="direct.amount"
+							type="number"
+							min="0"
+							placeholder="0"
+							class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
+						/>
+					</div>
+					<div>
+						<label
+							class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+							>From account <span class="text-danger-600">*</span></label
+						>
+						<DeskSearchableSelect
+							v-model="direct.paidFrom"
+							:options="accountOptions"
+							placeholder="Pick an account…"
+							search-placeholder="Search accounts…"
+						/>
+					</div>
+					<div>
+						<label
+							class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
+							>Reason <span class="text-danger-600">*</span></label
+						>
+						<input
 							v-model="direct.purpose"
-							placeholder="This record is the only trail"
+							type="text"
+							placeholder="What's it for?"
+							class="w-full text-sm px-2.5 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
 						/>
-					</DeskField>
+					</div>
 				</div>
-				<div class="flex justify-end gap-2 mt-5">
-					<button class="desk-btn" @click="direct.open = false">Cancel</button>
-					<button class="desk-save-btn" :disabled="direct.saving" @click="submitDirect">
+				<footer
+					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+				>
+					<button
+						type="button"
+						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+						@click="direct.open = false"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						class="text-xs desk-save-btn"
+						:disabled="direct.saving"
+						@click="submitDirect"
+					>
 						{{ direct.saving ? "Issuing…" : "Issue float" }}
 					</button>
-				</div>
+				</footer>
 			</div>
 		</div>
 

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -11,6 +11,7 @@ import {
 	pettyCashCanDisburse,
 	savePettyCash,
 	disbursePettyCash,
+	issueDirectPettyCash,
 	cancelPettyCash,
 	pettyCashHolderBalances,
 	listCashBankAccounts,
@@ -20,6 +21,7 @@ import DeskList from "@/components/desk/DeskList.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
@@ -40,6 +42,7 @@ const res = useDocTypeList("Petty Cash Request", {
 		"amount",
 		"purpose",
 		"status",
+		"is_direct",
 		"company",
 		"paid_from",
 		"disbursed_by",
@@ -53,7 +56,9 @@ const all = computed(() => res.data || []);
 const tab = ref("disburse");
 const search = ref("");
 const tabs = computed(() => [
-	...(canDisburse.value ? [{ id: "disburse", label: "To Disburse", count: requested.value.length }] : []),
+	...(canDisburse.value
+		? [{ id: "disburse", label: "To Disburse", count: requested.value.length }]
+		: []),
 	{ id: "all", label: "All Requests", count: all.value.length },
 	{ id: "balances", label: "Balances", count: null },
 	{ id: "mine", label: "My Requests", count: mine.value.length },
@@ -69,7 +74,7 @@ const filteredAll = computed(() => {
 		(r) =>
 			(r.name || "").toLowerCase().includes(q) ||
 			(r.purpose || "").toLowerCase().includes(q) ||
-			(r.requested_by || "").toLowerCase().includes(q),
+			(r.requested_by || "").toLowerCase().includes(q)
 	);
 });
 
@@ -111,6 +116,56 @@ async function submitRequest() {
 		showToast(err.message || "Failed to save", "error");
 	} finally {
 		reqForm.saving = false;
+	}
+}
+
+// --- direct issue modal (S273) — float straight to a holder, no request ---
+const direct = reactive({
+	open: false,
+	holder: "",
+	amount: 0,
+	paidFrom: "",
+	purpose: "",
+	accounts: [],
+	saving: false,
+});
+async function openDirect() {
+	Object.assign(direct, {
+		open: true,
+		holder: "",
+		amount: 0,
+		paidFrom: "",
+		purpose: "",
+		accounts: [],
+		saving: false,
+	});
+	try {
+		direct.accounts = await listCashBankAccounts();
+	} catch (err) {
+		showToast(err.message || "Failed to load accounts", "error");
+	}
+}
+async function submitDirect() {
+	if (!direct.holder) return showToast("Pick who is receiving the float.", "error");
+	if (!(Number(direct.amount) > 0)) return showToast("Enter an amount.", "error");
+	if (!direct.paidFrom) return showToast("Pick the account to pay from.", "error");
+	if (!direct.purpose.trim()) return showToast("A short reason is required.", "error");
+	direct.saving = true;
+	try {
+		await issueDirectPettyCash({
+			requested_by: direct.holder,
+			amount: direct.amount,
+			paid_from: direct.paidFrom,
+			purpose: direct.purpose,
+		});
+		direct.open = false;
+		res.reload?.();
+		loadBalances();
+		showToast("Petty cash issued — Journal Entry posted.");
+	} catch (err) {
+		showToast(err.message || "Issue failed", "error");
+	} finally {
+		direct.saving = false;
 	}
 }
 
@@ -174,8 +229,27 @@ const rowsForTab = computed(() => {
 <template>
 	<DeskPage title="Petty Cash" :breadcrumbs="breadcrumbs">
 		<div class="flex items-center justify-between gap-3 mb-4">
-			<div class="text-sm text-ink-600">Advances to site holders. Spend is logged separately under <span class="font-medium">Expenses</span>.</div>
-			<button type="button" class="text-xs desk-save-btn whitespace-nowrap" @click="openRequest">+ Request petty cash</button>
+			<div class="text-sm text-ink-600">
+				Advances to site holders. Spend is logged separately under
+				<span class="font-medium">Expenses</span>.
+			</div>
+			<div class="flex items-center gap-2 flex-shrink-0">
+				<button
+					v-if="canDisburse"
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md whitespace-nowrap"
+					@click="openDirect"
+				>
+					Direct issue
+				</button>
+				<button
+					type="button"
+					class="text-xs desk-save-btn whitespace-nowrap"
+					@click="openRequest"
+				>
+					+ Request petty cash
+				</button>
+			</div>
 		</div>
 
 		<!-- tabs -->
@@ -186,15 +260,25 @@ const rowsForTab = computed(() => {
 				type="button"
 				class="px-3 py-2 text-xs font-medium whitespace-nowrap"
 				:class="tab === t.id ? 'text-brand-600' : 'text-ink-600 hover:text-ink-900'"
-				:style="tab === t.id ? 'border-bottom: 2px solid currentColor; margin-bottom: -1px;' : 'border-bottom: 2px solid transparent; margin-bottom: -1px;'"
+				:style="
+					tab === t.id
+						? 'border-bottom: 2px solid currentColor; margin-bottom: -1px;'
+						: 'border-bottom: 2px solid transparent; margin-bottom: -1px;'
+				"
 				@click="tab = t.id"
 			>
-				{{ t.label }}<span v-if="t.count !== null" class="ml-1 text-ink-500 tabular-nums">({{ t.count }})</span>
+				{{ t.label
+				}}<span v-if="t.count !== null" class="ml-1 text-ink-500 tabular-nums"
+					>({{ t.count }})</span
+				>
 			</button>
 		</div>
 
 		<!-- balances — reconciled: disbursed float in − verified spend out = in hand -->
-		<div v-if="tab === 'balances'" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+		<div
+			v-if="tab === 'balances'"
+			class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+		>
 			<table class="w-full text-xs">
 				<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
 					<tr>
@@ -205,23 +289,45 @@ const rowsForTab = computed(() => {
 					</tr>
 				</thead>
 				<tbody>
-					<tr v-for="b in balances" :key="b.employee || b.holder" class="border-t border-ink-100">
-						<td class="px-3 py-2 text-ink-900"><div class="flex items-center gap-1.5"><UserAvatar :name="b.holder" size="xs" /><span>{{ b.holder }}</span></div></td>
-						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.disbursed) }}</td>
-						<td class="px-3 py-2 text-right tabular-nums text-ink-700">{{ fmtINR(b.spent) }}</td>
-						<td class="px-3 py-2 text-right tabular-nums font-semibold" :class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'">
-							<template v-if="b.balance < 0">{{ fmtINR(-b.balance) }} owed to holder</template>
+					<tr
+						v-for="b in balances"
+						:key="b.employee || b.holder"
+						class="border-t border-ink-100"
+					>
+						<td class="px-3 py-2 text-ink-900">
+							<div class="flex items-center gap-1.5">
+								<UserAvatar :name="b.holder" size="xs" /><span>{{
+									b.holder
+								}}</span>
+							</div>
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ fmtINR(b.disbursed) }}
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ fmtINR(b.spent) }}
+						</td>
+						<td
+							class="px-3 py-2 text-right tabular-nums font-semibold"
+							:class="b.balance < 0 ? 'text-danger-700' : 'text-ink-900'"
+						>
+							<template v-if="b.balance < 0"
+								>{{ fmtINR(-b.balance) }} owed to holder</template
+							>
 							<template v-else>{{ fmtINR(b.balance) }}</template>
 						</td>
 					</tr>
 					<tr v-if="!balances.length">
-						<td colspan="4" class="px-3 py-4 text-center text-ink-400 italic">No petty-cash activity yet.</td>
+						<td colspan="4" class="px-3 py-4 text-center text-ink-400 italic">
+							No petty-cash activity yet.
+						</td>
 					</tr>
 				</tbody>
 			</table>
 			<p class="px-3 py-2 text-[11px] text-ink-400 border-t border-ink-100">
-				Balance in hand = disbursed float − approved expenses (from the Expenses tab).
-				A negative balance means the holder fronted their own money — it's owed back to them and cleared on the next disbursement.
+				Balance in hand = disbursed float − approved expenses (from the Expenses tab). A
+				negative balance means the holder fronted their own money — it's owed back to them
+				and cleared on the next disbursement.
 			</p>
 		</div>
 
@@ -235,7 +341,12 @@ const rowsForTab = computed(() => {
 			:search-placeholder="tab === 'all' ? 'Search requests…' : ''"
 		>
 			<template #cell-requested_by="{ row }">
-				<div class="flex items-center gap-1.5"><UserAvatar :user-id="row.requested_by" size="xs" /><span class="text-xs text-ink-900">{{ row.requested_by }}</span></div>
+				<div class="flex items-center gap-1.5">
+					<UserAvatar :user-id="row.requested_by" size="xs" /><span
+						class="text-xs text-ink-900"
+						>{{ row.requested_by }}</span
+					>
+				</div>
 			</template>
 			<template #cell-purpose="{ row }">
 				<span class="text-xs text-ink-700">{{ (row.purpose || "").slice(0, 60) }}</span>
@@ -247,7 +358,15 @@ const rowsForTab = computed(() => {
 				<span class="text-xs tabular-nums font-medium">{{ fmtINR(row.amount) }}</span>
 			</template>
 			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" />
+				<div class="flex items-center gap-1.5">
+					<StatusBadge :status="row.status" />
+					<span
+						v-if="row.is_direct"
+						class="text-[9px] px-1 py-0.5 rounded bg-info-50 text-info-700 font-medium uppercase tracking-wider"
+						title="Issued directly to the holder, no request behind it"
+						>Direct</span
+					>
+				</div>
 			</template>
 			<template #cell-actions="{ row }">
 				<div class="flex justify-end gap-2">
@@ -270,39 +389,117 @@ const rowsForTab = computed(() => {
 				</div>
 			</template>
 			<template #empty>
-				<div class="text-sm text-ink-500">{{ res.loading ? "Loading…" : "Nothing here." }}</div>
+				<div class="text-sm text-ink-500">
+					{{ res.loading ? "Loading…" : "Nothing here." }}
+				</div>
 			</template>
 		</DeskList>
 
 		<!-- request modal -->
-		<div v-if="reqForm.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="reqForm.open = false">
+		<div
+			v-if="reqForm.open"
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+			@click.self="reqForm.open = false"
+		>
 			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
 				<h3 class="text-sm font-semibold text-ink-900 mb-4">Request petty cash</h3>
 				<div class="space-y-3">
-					<DeskField label="Amount" required><DeskInput v-model.number="reqForm.amount" type="number" min="0" /></DeskField>
-					<DeskField label="Purpose" required><DeskInput v-model="reqForm.purpose" placeholder="What is it for?" /></DeskField>
+					<DeskField label="Amount" required
+						><DeskInput v-model.number="reqForm.amount" type="number" min="0"
+					/></DeskField>
+					<DeskField label="Purpose" required
+						><DeskInput v-model="reqForm.purpose" placeholder="What is it for?"
+					/></DeskField>
 				</div>
 				<div class="flex justify-end gap-2 mt-5">
 					<button class="desk-btn" @click="reqForm.open = false">Cancel</button>
-					<button class="desk-save-btn" :disabled="reqForm.saving" @click="submitRequest">{{ reqForm.saving ? "Saving…" : "Request" }}</button>
+					<button
+						class="desk-save-btn"
+						:disabled="reqForm.saving"
+						@click="submitRequest"
+					>
+						{{ reqForm.saving ? "Saving…" : "Request" }}
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- direct issue modal (S273) -->
+		<div
+			v-if="direct.open"
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+			@click.self="direct.open = false"
+		>
+			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
+				<h3 class="text-sm font-semibold text-ink-900 mb-1">Direct petty cash issue</h3>
+				<p class="text-xs text-ink-500 mb-4">
+					Hands float straight to a holder — no request. Posts a Journal Entry (Dr Petty
+					Cash / Cr the source). No project; project-level spend attaches on the expense.
+				</p>
+				<div class="space-y-3">
+					<DeskField label="Holder" required>
+						<DeskLinkPicker
+							v-model="direct.holder"
+							doctype="User"
+							label-field="full_name"
+							value-field="name"
+							placeholder="Who is receiving the float?"
+						/>
+					</DeskField>
+					<DeskField label="Amount" required>
+						<DeskInput v-model.number="direct.amount" type="number" min="0" />
+					</DeskField>
+					<DeskField label="Pay from" required>
+						<DeskSelect v-model="direct.paidFrom">
+							<option value="" disabled>Bank / Cash account…</option>
+							<option v-for="a in direct.accounts" :key="a.name" :value="a.name">
+								{{ a.name }}
+							</option>
+						</DeskSelect>
+					</DeskField>
+					<DeskField label="Reason" required>
+						<DeskInput
+							v-model="direct.purpose"
+							placeholder="This record is the only trail"
+						/>
+					</DeskField>
+				</div>
+				<div class="flex justify-end gap-2 mt-5">
+					<button class="desk-btn" @click="direct.open = false">Cancel</button>
+					<button class="desk-save-btn" :disabled="direct.saving" @click="submitDirect">
+						{{ direct.saving ? "Issuing…" : "Issue float" }}
+					</button>
 				</div>
 			</div>
 		</div>
 
 		<!-- disburse modal -->
-		<div v-if="disb.open" class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4" @click.self="disb.open = false">
+		<div
+			v-if="disb.open"
+			class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+			@click.self="disb.open = false"
+		>
 			<div class="bg-white rounded-lg shadow-xl w-full max-w-md p-5">
-				<h3 class="text-sm font-semibold text-ink-900 mb-1">Disburse {{ fmtINR(disb.row?.amount) }}</h3>
-				<p class="text-xs text-ink-500 mb-4">to {{ disb.row?.requested_by }} · posts a Journal Entry (Dr Petty Cash / Cr the source account).</p>
+				<h3 class="text-sm font-semibold text-ink-900 mb-1">
+					Disburse {{ fmtINR(disb.row?.amount) }}
+				</h3>
+				<p class="text-xs text-ink-500 mb-4">
+					to {{ disb.row?.requested_by }} · posts a Journal Entry (Dr Petty Cash / Cr the
+					source account).
+				</p>
 				<DeskField label="Pay from" required>
 					<DeskSelect v-model="disb.paidFrom">
 						<option value="" disabled>Bank / Cash account…</option>
-						<option v-for="a in disb.accounts" :key="a.name" :value="a.name">{{ a.name }}</option>
+						<option v-for="a in disb.accounts" :key="a.name" :value="a.name">
+							{{ a.name }}
+						</option>
 					</DeskSelect>
 				</DeskField>
 				<div class="flex justify-end gap-2 mt-5">
 					<button class="desk-btn" @click="disb.open = false">Cancel</button>
-					<button class="desk-save-btn" :disabled="disb.saving" @click="confirmDisburse">{{ disb.saving ? "Posting…" : "Disburse" }}</button>
+					<button class="desk-save-btn" :disabled="disb.saving" @click="confirmDisburse">
+						{{ disb.saving ? "Posting…" : "Disburse" }}
+					</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## What

Two related changes to petty cash, per the prototype (S273/S274) and the Journal Entry request.

### 1. Direct petty-cash issue
Accountant / admin-tier users can now hand petty-cash float **straight to a holder with no request behind it**.

**Reuses the same `Petty Cash Request` doctype** (recommended over a new doctype) — the doctype is already a general per-holder float (project optional, company anchored to the holder's Employee), which is exactly the direct-issue model. A new `is_direct` flag marks these. The endpoint creates the record and disburses it in one step, **reusing the existing account validation + Journal Entry posting** (Dr Petty Cash / Cr source, holder stamped on the `employee` dimension). No project — the float goes to a person; project-level spend attaches later on the Expense Entry.

Reversing a direct issue **removes the record** (there's no request to fall back to); a normal request still reverts to Requested.

- `api.petty_cash.issue_direct` — gated to `PETTY_CASH_DISBURSE_ROLES`.
- Vue: a **Direct issue** button + modal (holder / amount / account / reason) on the Petty Cash panel, and a **Direct** badge on those rows.

### 2. Journal Entry — Entry Type gating
- Added **"Petty Cash"** as a Journal Entry `voucher_type` (Entry Type) option (property setter).
- The disbursement JE now posts as `voucher_type = "Petty Cash"`.
- The **Petty Cash Request** link field now shows **only when Entry Type is Petty Cash** (`depends_on`).
- **Safe:** `GL Entry.voucher_type` stays the doctype name "Journal Entry", so the petty-cash GL reconciliation is unaffected (verified — the ledger suite stays green).

## Tests
`test_petty_cash` — 2 new (direct issue creates a Disbursed record + submitted "Petty Cash" JE linked back; reversal removes the record). All 11 petty-cash + 12 ledger tests pass. `vite build` clean.

## Migration
`is_direct` field, the `depends_on` on the JE field, and the "Petty Cash" voucher-type option all land on `bench migrate` (already applied locally).