### PR TITLE
fix: QA batch — advance-adjusted helper, payment ref hover, WO terms spacing, cost-code approval scope, project id fallback

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -274,10 +274,13 @@ def subcontract_actual_by_cost_code(project: str):
 
 @frappe.whitelist()
 def get_project_cost_codes(project: str):
-	"""BOQ groups + items for a project, as pickable cost codes for SOV lines."""
+	"""BOQ groups + items for a project, as pickable cost codes for SOV lines.
+
+	Only APPROVED BOQs count — a Work Order must not be costed against a draft/submitted
+	(unapproved) BOQ line."""
 	if not project:
 		return []
-	boqs = frappe.get_all("BOQ", filters={"project": project}, pluck="name")
+	boqs = frappe.get_all("BOQ", filters={"project": project, "status": "Approved"}, pluck="name")
 	if not boqs:
 		return []
 

--- a/buildsuite_core/overrides/project.py
+++ b/buildsuite_core/overrides/project.py
@@ -52,12 +52,16 @@ class BuildSuiteProject(_ERPNextProject):
 			self.name = project_id
 			return
 
-		self.custom_project_id = None  # keep it NULL (not "") so the unique index holds
 		if not self.naming_series:
 			self.naming_series = default_project_series()
 		if self.naming_series:
 			set_name_by_naming_series(self)
+			# No ID was entered, so surface the series-generated name AS the Project ID —
+			# otherwise the field stays NULL and the Vue views show a blank ID. The name is
+			# the primary key (unique), so this keeps the unique index intact.
+			self.custom_project_id = self.name
 			return
+		self.custom_project_id = None  # keep it NULL (not "") so the unique index holds
 		frappe.throw(_("Enter a Project ID or configure a naming series."))
 
 

--- a/buildsuite_core/tests/test_project.py
+++ b/buildsuite_core/tests/test_project.py
@@ -110,7 +110,8 @@ class TestProject(BuildSuiteTestCase):
 		).insert(ignore_permissions=True)
 		self.assertEqual(with_id.name, f"NMID2-{self._n}")
 
-		# No Project ID → the record name comes from the series, and the id is NULL.
+		# No Project ID → the record name comes from the series, and that series name is
+		# surfaced AS the Project ID (so the field isn't left blank in the Vue views).
 		no_id = frappe.get_doc(
 			{
 				"doctype": "Project",
@@ -120,7 +121,7 @@ class TestProject(BuildSuiteTestCase):
 			}
 		).insert(ignore_permissions=True)
 		self.assertTrue(no_id.name.startswith("PROJ-"))
-		self.assertIsNone(no_id.custom_project_id)
+		self.assertEqual(no_id.custom_project_id, no_id.name)
 
 	def test_company_locked_after_create(self):
 		others = frappe.get_all("Company", filters={"name": ("!=", self.company)}, pluck="name")

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -209,6 +209,10 @@
   html.dark .hover\:bg-ink-50:hover  { background-color: #2E2E2E; }
   html.dark .hover\:bg-ink-100:hover { background-color: #333333; }
   html.dark .hover\:bg-brand-50:hover { background-color: rgba(22, 163, 74, 0.16); }
+  /* The /30 opacity variant (used by the Payments register + other tables) is its own
+     class, so the base rule above doesn't cover it. Without this it fell back to Tailwind's
+     bright brand-50, washing out the row on hover and hiding the mono Ref text. */
+  html.dark .hover\:bg-brand-50\/30:hover { background-color: rgba(22, 163, 74, 0.1); }
   html.dark .hover\:bg-brand-50\/40:hover { background-color: rgba(22, 163, 74, 0.1); }
   html.dark .hover\:border-ink-300:hover { border-color: #525252; }
   html.dark .hover\:text-ink-900:hover { color: #F5F5F5; }

--- a/frontend/src/views/NewSubcontractorWorkOrderView.vue
+++ b/frontend/src/views/NewSubcontractorWorkOrderView.vue
@@ -364,8 +364,9 @@ const saveLabel = computed(() =>
 				<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">{{ errors.lines }}</p>
 			</section>
 
-			<!-- Terms & conditions -->
-			<DeskSection title="Terms & conditions" :cols="1">
+			<!-- Terms & conditions — extra top margin so the header isn't cramped against
+					 the schedule-of-values table above. -->
+			<DeskSection title="Terms & conditions" :cols="1" class="mt-8">
 				<DeskField
 					label="Import from template"
 					hint="Pick a standard template to fill the box below. You can edit the text after importing."

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -1298,6 +1298,11 @@ const accountFilters = computed(() =>
 							>− {{ fmtINR(advanceAdjusted) }}</span
 						>
 					</div>
+					<div v-if="advanceAdjusted > 0" class="text-[10px] text-ink-400 -mt-0.5">
+						Settles the payable — advance payments linked below{{
+							isSubmitted ? "" : "; reflects in the outstanding"
+						}}.
+					</div>
 					<template v-if="isSubmitted && advanceAdjusted > 0">
 						<div class="flex justify-between py-1">
 							<span class="text-ink-500">Paid</span


### PR DESCRIPTION
Five QA fixes.

### 1. Subcontractor Bill — 'Advance adjusted' helper text
The right-side **Net payable** panel showed the *Advance adjusted* amount but not the prototype's helper line. Added **"Settles the payable — advance payments linked below"** (with "; reflects in the outstanding" while unsubmitted), beneath the amount — matching the prototype.

### 2. Project Finance › Payments — Ref invisible on hover
The register rows use `hover:bg-brand-50/30`, but the live stylesheet was **missing the dark-mode remap** for that `/30` variant (it had the base and `/40`). In dark mode the row fell back to Tailwind's bright brand-50, washing out and hiding the mono **Ref** text. Added the remap (subtle green), matching the prototype's `style.css`.

### 3. New Work Order — Terms & conditions spacing
The **Terms & conditions** header sat cramped against the schedule-of-values table. Added a top margin to that section.

### 4. Cost-code picker scoped to Approved BOQs
`get_project_cost_codes` returned codes from BOQs in **any** state (incl. drafts), so a Work Order could be costed against an unapproved BOQ line. Now filtered to **status = Approved** for the project. (Verified: a project whose only BOQ is a draft now returns 0 codes.)

### 5. Project ID null when created without an optional ID
The naming override set `custom_project_id = None` when no ID was entered, so the Vue views showed a **blank Project ID**. Now the series-generated record name is surfaced **as** `custom_project_id` (still unique — it's the primary key). Test updated.

## Tests
`test_project` — 21 pass (naming assertion updated). `test_work_order_submittable` green. `vite build` clean. Backend fixes verified live on `bs.local`.