### PR TITLE
fix: scope the Home dashboard to the logged-in user's visible projects/tasks

### DIFF
--- a/buildsuite_core/api/home.py
+++ b/buildsuite_core/api/home.py
@@ -11,7 +11,11 @@ renderers (mirrors api/project_dashboard.py):
   · pending_scos      — Scope Change Orders awaiting approval (title + cost impact).
   · tasks_in_progress — the Working tasks, with their assignee.
 
-Derived numbers are computed server-side so the payload stays small. Single-company for now."""
+Scoped to the logged-in user: every project/task/SCO count goes through get_list, so the
+Project/Task permission query conditions apply — a team-scoped user (QS, Site Engineer, …)
+sees only their own projects + tasks, matching the Projects list; admins/PMs see the whole
+company. Derived numbers are computed server-side so the payload stays small. Single-company
+for now."""
 
 import json
 
@@ -84,11 +88,17 @@ def get_home_dashboard():
 	company = default_company()
 	today = getdate(nowdate())
 
-	project_ids = frappe.get_all("Project", filters={"company": company}, pluck="name") or ["__none__"]
+	# Use get_list (not get_all/db.count) so the Project/Task permission query conditions
+	# apply: a scoped user (QS, Site Engineer, …) sees only their team's projects + tasks,
+	# matching the Projects list. Admins/PMs are unscoped and still see the whole company.
+	# get_list defaults to a 20-row page, so limit_page_length=0 is required to count all.
+	project_ids = frappe.get_list(
+		"Project", filters={"company": company}, pluck="name", limit_page_length=0
+	) or ["__none__"]
 	proj_in = {"project": ["in", project_ids]}
 
-	# --- active root projects → the list + the order book ---
-	roots = frappe.get_all(
+	# --- active root projects → the list + the order book (team-scoped) ---
+	roots = frappe.get_list(
 		"Project",
 		filters={"company": company, "parent_project": ["in", ["", None]]},
 		fields=[
@@ -104,6 +114,7 @@ def get_home_dashboard():
 			"project_manager",
 		],
 		order_by="modified desc",
+		limit_page_length=0,
 	)
 	boq = _current_boq([p.name for p in roots])
 	customers = {p.customer for p in roots if p.customer}
@@ -149,7 +160,14 @@ def get_home_dashboard():
 		"Task",
 		{**proj_in, "status": ["not in", _OPEN_TASK], "exp_end_date": ["<", str(today)]},
 	)
-	progress_today = frappe.db.count("Task Progress Entry", {"entry_date": str(today)})
+	progress_today = len(
+		frappe.get_list(
+			"Task Progress Entry",
+			filters={"entry_date": str(today)},
+			pluck="name",
+			limit_page_length=0,
+		)
+	)
 	users = frappe.db.count("User", {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]})
 
 	scos = frappe.get_all(

--- a/buildsuite_core/tests/test_home.py
+++ b/buildsuite_core/tests/test_home.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Home dashboard — the KPIs are scoped to the logged-in user's visible projects/tasks."""
+
+import frappe
+
+from buildsuite_core.api.home import get_home_dashboard
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestHomeDashboard(BuildSuiteTestCase):
+	def _persona_user(self, persona, prefix):
+		email = f"{prefix}-{self._n}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": prefix.upper(),
+				"send_welcome_email": 0,
+				"user_type": "System User",
+				"persona": persona,
+				"company": self.company,
+			}
+		).insert(ignore_permissions=True)
+		return email
+
+	def _home_project(self, member=None, status="Ongoing"):
+		doc = {
+			"doctype": "Project",
+			"project_name": f"HOME {frappe.generate_hash(length=5)}",
+			"project_status": status,
+			"company": self.company,
+		}
+		if member:
+			doc["custom_team_members"] = [{"user": member}]
+		return frappe.get_doc(doc).insert(ignore_permissions=True)
+
+	def test_scoped_user_sees_only_their_projects(self):
+		# A team-scoped persona (Site Engineer) sees only the project they're teamed on —
+		# the home count must match the Projects list, not the whole company.
+		se = self._persona_user("Site Engineer", "se")
+		mine = self._home_project(member=se)
+		self._home_project()  # another active project the user is NOT on
+
+		frappe.set_user(se)
+		try:
+			dash = get_home_dashboard()
+			ids = [p["id"] for p in dash["projects"]]
+			self.assertIn(mine.name, ids)
+			# Exactly one visible active top-level project.
+			self.assertEqual(dash["kpis"]["active_projects"], 1)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_admin_unscoped_sees_more_than_scoped(self):
+		# Administrator is exempt from team scoping → counts both projects (plus any others);
+		# the scoped user counts only the one they're teamed on.
+		se = self._persona_user("Site Engineer", "se")
+		self._home_project(member=se)  # the user is on this one
+		self._home_project()  # …but not this one
+
+		frappe.set_user(se)
+		try:
+			scoped = get_home_dashboard()["kpis"]["active_projects"]
+		finally:
+			frappe.set_user("Administrator")
+		unscoped = get_home_dashboard()["kpis"]["active_projects"]
+
+		self.assertEqual(scoped, 1)
+		self.assertGreaterEqual(unscoped, 2)
+		self.assertGreater(unscoped, scoped)


### PR DESCRIPTION
## Bug
Logged in as a **Quantity Surveyor**, the Projects list showed **2** projects (team-scoped) but the **Home** showed **1399** — the home counts were company-wide.

## Cause
`get_home_dashboard` used `frappe.db.count` / `frappe.get_all`, which **bypass `permission_query_conditions`**. Those hooks (which scope Project/Task/TPE to the user's team) only fire through `frappe.get_list`.

## Fix
Route the project/task/SCO reads through **`frappe.get_list`** (with `limit_page_length=0`, since it defaults to a 20-row page). Scoped users (QS, Site Engineer, …) now see only their team's projects + tasks; **admins/PMs are exempt and keep the whole-company view**. Project count stays parent-only; task count stays cumulative.

Verified on `bs.local`: admin → 1399 active / 1443 tasks; QS → **2 active / 5 tasks**, matching the Projects list.

## Tests
`test_home` (new): scoped user sees only their project (count == 1); admin sees strictly more.