### PR TITLE
feat: role-aware Home dashboard (per-role snapshot / CTA / alerts)

### DIFF
--- a/buildsuite_core/api/home.py
+++ b/buildsuite_core/api/home.py
@@ -11,7 +11,11 @@ renderers (mirrors api/project_dashboard.py):
   · pending_scos      — Scope Change Orders awaiting approval (title + cost impact).
   · tasks_in_progress — the Working tasks, with their assignee.
 
-Derived numbers are computed server-side so the payload stays small. Single-company for now."""
+Scoped to the logged-in user: every project/task/SCO count goes through get_list, so the
+Project/Task permission query conditions apply — a team-scoped user (QS, Site Engineer, …)
+sees only their own projects + tasks, matching the Projects list; admins/PMs see the whole
+company. Derived numbers are computed server-side so the payload stays small. Single-company
+for now."""
 
 import json
 
@@ -84,11 +88,17 @@ def get_home_dashboard():
 	company = default_company()
 	today = getdate(nowdate())
 
-	project_ids = frappe.get_all("Project", filters={"company": company}, pluck="name") or ["__none__"]
+	# Use get_list (not get_all/db.count) so the Project/Task permission query conditions
+	# apply: a scoped user (QS, Site Engineer, …) sees only their team's projects + tasks,
+	# matching the Projects list. Admins/PMs are unscoped and still see the whole company.
+	# get_list defaults to a 20-row page, so limit_page_length=0 is required to count all.
+	project_ids = frappe.get_list(
+		"Project", filters={"company": company}, pluck="name", limit_page_length=0
+	) or ["__none__"]
 	proj_in = {"project": ["in", project_ids]}
 
-	# --- active root projects → the list + the order book ---
-	roots = frappe.get_all(
+	# --- active root projects → the list + the order book (team-scoped) ---
+	roots = frappe.get_list(
 		"Project",
 		filters={"company": company, "parent_project": ["in", ["", None]]},
 		fields=[
@@ -104,6 +114,7 @@ def get_home_dashboard():
 			"project_manager",
 		],
 		order_by="modified desc",
+		limit_page_length=0,
 	)
 	boq = _current_boq([p.name for p in roots])
 	customers = {p.customer for p in roots if p.customer}
@@ -149,7 +160,14 @@ def get_home_dashboard():
 		"Task",
 		{**proj_in, "status": ["not in", _OPEN_TASK], "exp_end_date": ["<", str(today)]},
 	)
-	progress_today = frappe.db.count("Task Progress Entry", {"entry_date": str(today)})
+	progress_today = len(
+		frappe.get_list(
+			"Task Progress Entry",
+			filters={"entry_date": str(today)},
+			pluck="name",
+			limit_page_length=0,
+		)
+	)
 	users = frappe.db.count("User", {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]})
 
 	scos = frappe.get_all(

--- a/buildsuite_core/api/home.py
+++ b/buildsuite_core/api/home.py
@@ -1,26 +1,19 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
 
-"""Home dashboard — the app-wide snapshot backing AppHomeView (`/home`) and the denser
-Desk overview DashboardView (`/dashboard`). One aggregate read so both views are thin
-renderers (mirrors api/project_dashboard.py):
+"""Home dashboard — the role-aware snapshot backing AppHomeView (`/home`), plus the legacy
+fields the denser Desk overview (`/dashboard`) still renders.
 
-  · kpis     — active projects, open + overdue tasks, pending SCOs, progress filed today,
-               users, and the total order book (BOQ contract value of active projects).
-  · projects — active root projects with progress + a schedule tone (for the bar colour).
-  · pending_scos      — Scope Change Orders awaiting approval (title + cost impact).
-  · tasks_in_progress — the Working tasks, with their assignee.
-
-Scoped to the logged-in user: every project/task/SCO count goes through get_list, so the
-Project/Task permission query conditions apply — a team-scoped user (QS, Site Engineer, …)
-sees only their own projects + tasks, matching the Projects list; admins/PMs see the whole
-company. Derived numbers are computed server-side so the payload stays small. Single-company
-for now."""
+One aggregate read. It resolves the logged-in user's role (their Persona) and returns that
+role's four snapshot tiles, a primary CTA, and three alert cards — the same per-role content
+as the prototype's HomeWorkspaceView. All project/task/SCO reads go through get_list, so the
+permission query conditions apply: a team-scoped user (QS, Site Engineer, …) sees only their
+own projects/tasks; admins/PMs see the whole company. Single-company for now."""
 
 import json
 
 import frappe
-from frappe.utils import date_diff, flt, getdate, nowdate
+from frappe.utils import add_days, date_diff, flt, getdate, nowdate
 
 from buildsuite_core.utils.project import default_company
 
@@ -31,9 +24,30 @@ _TASK_LIMIT = 6
 _SCO_LIMIT = 8
 _OPEN_TASK = ("Completed", "Cancelled", "Template")
 
+# Roles that see the whole company (no team scoping) — mirrors permissions._is_scoped.
+_ADMIN_ROLES = ("admin", "bsa")
+
+
+# --------------------------------------------------------------------------- #
+# small helpers
+# --------------------------------------------------------------------------- #
+def _count(doctype, filters):
+	"""Company/project-scoped count that never raises (a missing doctype/field → 0)."""
+	try:
+		return frappe.db.count(doctype, filters)
+	except Exception:
+		return 0
+
+
+def _sum(doctype, filters, field):
+	try:
+		rows = frappe.get_all(doctype, filters=filters, fields=[f"sum(`{field}`) as t"])
+		return flt(rows[0].t) if rows else 0.0
+	except Exception:
+		return 0.0
+
 
 def _current_boq(project_names):
-	"""The best current BOQ per project (Approved > Submitted > latest) → planned amount."""
 	if not project_names:
 		return {}
 	rows = frappe.get_all(
@@ -51,7 +65,6 @@ def _current_boq(project_names):
 
 
 def _expected_pct(today, start, end):
-	"""Schedule-expected % complete for `today` given the planned window (0 if undated)."""
 	if not start or not end:
 		return 0.0
 	span = date_diff(end, start)
@@ -61,7 +74,6 @@ def _expected_pct(today, start, end):
 
 
 def _tone(expected, progress):
-	"""Schedule-variance tone for the progress bar, same convention as the Projects list."""
 	if expected <= 0:
 		return "success"
 	variance = (expected - progress) / expected * 100.0
@@ -73,7 +85,6 @@ def _tone(expected, progress):
 
 
 def _first_assignee(assign):
-	"""ERPNext stores assignments as a JSON list in `_assign`; take the first."""
 	if not assign:
 		return None
 	try:
@@ -83,21 +94,172 @@ def _first_assignee(assign):
 		return None
 
 
+def _resolve_role(user):
+	"""The user's BuildSuite role id (Persona.slug), e.g. 'qs'. Falls back to 'admin' for a
+	System Manager / no persona so they get the org-wide snapshot."""
+	persona = frappe.db.get_value("User", user, "persona") if user else None
+	role = frappe.db.get_value("Persona", persona, "slug") if persona else None
+	if role:
+		return role
+	roles = set(frappe.get_roles(user))
+	if user == "Administrator" or "System Manager" in roles:
+		return "admin"
+	return "site-engineer"
+
+
+def _cash_and_bank(company):
+	from erpnext.accounts.utils import get_balance_on
+
+	total = 0.0
+	for a in frappe.get_all(
+		"Account",
+		filters={"company": company, "is_group": 0, "account_type": ["in", ["Bank", "Cash"]]},
+		pluck="name",
+	):
+		try:
+			total += flt(get_balance_on(account=a, company=company))
+		except Exception:
+			pass
+	return total
+
+
+# --------------------------------------------------------------------------- #
+# snapshot / CTA / alerts — per role
+# --------------------------------------------------------------------------- #
+def _tile(label, value, slug, tone="brand", fmt="int"):
+	return {"label": label, "value": value, "slug": slug, "tone": tone, "format": fmt}
+
+
+def _alert(key, title, value, sub, slug, to, active, tone="warning"):
+	return {
+		"key": key,
+		"title": title,
+		"value": value,
+		"sub": sub,
+		"slug": slug,
+		"to": to,
+		"tone": tone if active else "muted",
+	}
+
+
+_GREETINGS = {
+	"admin": "Here is a snapshot of system activity today.",
+	"bsa": "Here is a snapshot of system activity today.",
+	"director": "Here is where your portfolio stands today.",
+	"pm": "Here is what needs your attention across your projects.",
+	"accountant": "Here is the money position and today's queues.",
+	"estimator": "Here is a summary of your estimation work today.",
+	"qs": "Here is a summary of your estimation and measurement work today.",
+	"site-engineer": "Here is your work on site today.",
+	"foreman": "Here is your crew and work on site today.",
+	"procurement": "Here is the buying pipeline today.",
+	"store-keeper": "Here is the store and deliveries today.",
+	"hr-manager": "Here is the workforce position today.",
+}
+
+# CTA per role — (title, sub, cta-label, route, icon slug).
+_CTAS = {
+	"admin": (
+		"Settings",
+		"Manage workspaces, users, project types, and data.",
+		"Open Settings",
+		"/settings",
+		"settings",
+	),
+	"bsa": (
+		"Settings",
+		"Manage workspaces, users, project types, and data.",
+		"Open Settings",
+		"/settings",
+		"settings",
+	),
+	"director": (
+		"Project Dashboard",
+		"Portfolio health, risks, and high-value approvals.",
+		"Open",
+		"/project-dashboard",
+		"chart-bar",
+	),
+	"pm": (
+		"Project Dashboard",
+		"Portfolio health, risks, and high-value approvals.",
+		"Open",
+		"/project-dashboard",
+		"chart-bar",
+	),
+	"accountant": (
+		"Project Finance",
+		"Cash position, receivables, payables and the day's queues.",
+		"Open",
+		"/project-finance",
+		"wallet",
+	),
+	"estimator": (
+		"BOQ Workbench",
+		"Bill of quantities register, templates and revision compare.",
+		"Open",
+		"/boq",
+		"estimation",
+	),
+	"qs": (
+		"Measurement Books",
+		"Certify site measurements — certified MBs drive subcontractor bills.",
+		"Open",
+		"/measurement-books",
+		"clipboard-list",
+	),
+	"site-engineer": (
+		"File progress entry",
+		"Report today's progress, labour and any blockers.",
+		"Open",
+		"/progress-entries/new",
+		"file-text",
+	),
+	"foreman": (
+		"Mark attendance",
+		"Log the crew for today — wages and labour cost derive from it.",
+		"Open",
+		"/workforce",
+		"users",
+	),
+	"procurement": (
+		"Procurement Dashboard",
+		"Open requests, on-order value, receipts and rate variances.",
+		"Open",
+		"/procurement-dashboard",
+		"chart-bar",
+	),
+	"store-keeper": (
+		"Procurement",
+		"Confirm deliveries against their purchase orders.",
+		"Open",
+		"/procurement",
+		"stock",
+	),
+	"hr-manager": (
+		"Workforce",
+		"Man-days, labour cost and attendance across projects.",
+		"Open",
+		"/workforce",
+		"workforce",
+	),
+}
+
+
 @frappe.whitelist()
 def get_home_dashboard():
+	user = frappe.session.user
 	company = default_company()
+	role = _resolve_role(user)
 	today = getdate(nowdate())
+	week_ago = str(add_days(today, -7))
 
-	# Use get_list (not get_all/db.count) so the Project/Task permission query conditions
-	# apply: a scoped user (QS, Site Engineer, …) sees only their team's projects + tasks,
-	# matching the Projects list. Admins/PMs are unscoped and still see the whole company.
-	# get_list defaults to a 20-row page, so limit_page_length=0 is required to count all.
+	# --- scoped project set (permission query conditions apply via get_list) ---
 	project_ids = frappe.get_list(
 		"Project", filters={"company": company}, pluck="name", limit_page_length=0
 	) or ["__none__"]
 	proj_in = {"project": ["in", project_ids]}
 
-	# --- active root projects → the list + the order book (team-scoped) ---
 	roots = frappe.get_list(
 		"Project",
 		filters={"company": company, "parent_project": ["in", ["", None]]},
@@ -131,7 +293,7 @@ def get_home_dashboard():
 		else {}
 	)
 
-	projects, order_book, active_ct = [], 0.0, 0
+	projects, order_book, active_ct, at_risk = [], 0.0, 0, 0
 	for p in roots:
 		if not (p.project_status in _ACTIVE and p.status != "Cancelled"):
 			continue
@@ -140,6 +302,8 @@ def get_home_dashboard():
 		order_book += flt(planned)
 		progress = flt(p.percent_complete)
 		expected = _expected_pct(today, p.expected_start_date, p.expected_end_date)
+		if _tone(expected, progress) == "danger":
+			at_risk += 1
 		if len(projects) < _PROJECT_LIMIT:
 			projects.append(
 				{
@@ -154,21 +318,19 @@ def get_home_dashboard():
 				}
 			)
 
-	# --- task + SCO counts (company-scoped via project) ---
-	open_tasks = frappe.db.count("Task", {**proj_in, "status": ["not in", _OPEN_TASK]})
-	overdue_tasks = frappe.db.count(
-		"Task",
-		{**proj_in, "status": ["not in", _OPEN_TASK], "exp_end_date": ["<", str(today)]},
+	# --- common counts (scoped) ---
+	open_tasks = _count("Task", {**proj_in, "status": ["not in", _OPEN_TASK]})
+	overdue_tasks = _count(
+		"Task", {**proj_in, "status": ["not in", _OPEN_TASK], "exp_end_date": ["<", str(today)]}
 	)
 	progress_today = len(
 		frappe.get_list(
-			"Task Progress Entry",
-			filters={"entry_date": str(today)},
-			pluck="name",
-			limit_page_length=0,
+			"Task Progress Entry", filters={"entry_date": str(today)}, pluck="name", limit_page_length=0
 		)
 	)
-	users = frappe.db.count("User", {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]})
+	users = _count("User", {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]})
+	stage_pending = _count("Stage Planning", {**proj_in, "workflow_state": "Pending Approval"})
+	pending_scos_ct = _count("Scope Change Order", {**proj_in, "status": "Pending Approval"})
 
 	scos = frappe.get_all(
 		"Scope Change Order",
@@ -177,9 +339,6 @@ def get_home_dashboard():
 		order_by="modified desc",
 		limit=_SCO_LIMIT,
 	)
-	pending_scos_ct = frappe.db.count("Scope Change Order", {**proj_in, "status": "Pending Approval"})
-
-	# --- tasks in progress (Working), with assignee ---
 	working = frappe.get_all(
 		"Task",
 		filters={**proj_in, "status": "Working"},
@@ -197,7 +356,510 @@ def get_home_dashboard():
 		for t in working
 	]
 
+	# --- my-task metrics (field roles) ---
+	def _my(extra=None):
+		f = {**proj_in, "status": ["not in", _OPEN_TASK], "_assign": ["like", f"%{user}%"]}
+		if extra:
+			f.update(extra)
+		return _count("Task", f)
+
+	my_open = _my()
+	my_overdue = _my({"exp_end_date": ["<", str(today)]})
+	my_due_week = _my({"exp_end_date": ["between", [str(today), str(add_days(today, 7))]]})
+	my_progress_today = len(
+		frappe.get_list(
+			"Task Progress Entry",
+			filters={"entry_date": str(today), "owner": user},
+			pluck="name",
+			limit_page_length=0,
+		)
+	)
+
+	# --- lazily-computed heavier metrics (only used by some roles) ---
+	def boqs():
+		return _count("BOQ", {**proj_in, "status": "Draft"}), _count("BOQ", {**proj_in, "status": "Approved"})
+
+	def finance():
+		recv = _sum("Sales Invoice", {"company": company, "docstatus": 1}, "outstanding_amount")
+		pay = _sum("Purchase Invoice", {"company": company, "docstatus": 1}, "outstanding_amount")
+		overdue_recv = _count(
+			"Sales Invoice",
+			{
+				"company": company,
+				"docstatus": 1,
+				"outstanding_amount": [">", 0],
+				"due_date": ["<", str(today)],
+			},
+		)
+		return recv, pay, overdue_recv
+
+	def procurement():
+		on_order = _sum(
+			"Purchase Order",
+			{
+				**proj_in,
+				"docstatus": 1,
+				"status": ["not in", ["Closed", "Cancelled"]],
+				"per_received": ["<", 100],
+			},
+			"grand_total",
+		)
+		on_order_ct = _count(
+			"Purchase Order",
+			{
+				**proj_in,
+				"docstatus": 1,
+				"status": ["not in", ["Closed", "Cancelled"]],
+				"per_received": ["<", 100],
+			},
+		)
+		overdue_del = _count(
+			"Purchase Order",
+			{**proj_in, "docstatus": 1, "per_received": ["<", 100], "schedule_date": ["<", str(today)]},
+		)
+		mrs_pending = _count("Material Request", {**proj_in, "docstatus": 0})
+		received_week = _count(
+			"Purchase Receipt", {**proj_in, "docstatus": 1, "posting_date": [">=", week_ago]}
+		)
+		return on_order, on_order_ct, overdue_del, mrs_pending, received_week
+
+	# --- role → snapshot + alerts ---
+	stage_alert = _alert(
+		"stages",
+		"Stage approvals pending",
+		stage_pending,
+		f"{stage_pending} awaiting your approval" if stage_pending else "No stages waiting",
+		"check-circle",
+		"/stage-plannings?status=Pending Approval",
+		stage_pending > 0,
+	)
+	sco_alert = _alert(
+		"sco",
+		"Pending SCOs",
+		pending_scos_ct,
+		f"{pending_scos_ct} awaiting approval" if pending_scos_ct else "No scope changes waiting",
+		"refresh-ccw",
+		"/sco",
+		pending_scos_ct > 0,
+	)
+
+	if role in _ADMIN_ROLES:
+		snapshot = [
+			_tile("Active projects", active_ct, "clipboard-list"),
+			_tile("Open tasks", open_tasks, "check-circle", "info"),
+			_tile("Users", users, "users", "success"),
+			_tile(
+				"Pending stage approvals",
+				stage_pending,
+				"check-circle",
+				"warning" if stage_pending else "brand",
+			),
+		]
+		alerts = [
+			stage_alert,
+			sco_alert,
+			_alert(
+				"overdue",
+				"Overdue tasks",
+				overdue_tasks,
+				f"{overdue_tasks} past their end date" if overdue_tasks else "Nothing overdue",
+				"refresh-ccw",
+				"/tasks?status=overdue",
+				overdue_tasks > 0,
+				"danger",
+			),
+		]
+	elif role == "director":
+		recv, pay, overdue_recv = finance()
+		snapshot = [
+			_tile("Active projects", active_ct, "clipboard-list"),
+			_tile("Projects at risk", at_risk, "chart-line", "danger" if at_risk else "success"),
+			_tile("Receivables", recv, "banknote", "info", "currency"),
+			_tile("Payables", pay, "receipt", "warning", "currency"),
+		]
+		alerts = [
+			stage_alert,
+			sco_alert,
+			_alert(
+				"recv",
+				"Overdue receivables",
+				overdue_recv,
+				f"{overdue_recv} invoice(s) past due" if overdue_recv else "No customer invoices past due",
+				"banknote",
+				"/project-finance",
+				overdue_recv > 0,
+				"danger",
+			),
+		]
+	elif role == "pm":
+		on_order, on_order_ct, overdue_del, mrs_pending, _rw = procurement()
+		snapshot = [
+			_tile("Active projects", active_ct, "clipboard-list"),
+			_tile("Open tasks", open_tasks, "check-circle", "info"),
+			_tile(
+				"Stage approvals", stage_pending, "check-circle", "warning" if stage_pending else "success"
+			),
+			_tile("MRs awaiting approval", mrs_pending, "procurement", "warning" if mrs_pending else "muted"),
+		]
+		alerts = [
+			stage_alert,
+			_alert(
+				"mrs",
+				"MRs awaiting approval",
+				mrs_pending,
+				f"{mrs_pending} request(s) to review" if mrs_pending else "No requests waiting",
+				"procurement",
+				"/procurement/material-requests",
+				mrs_pending > 0,
+			),
+			_alert(
+				"overdue-del",
+				"Overdue deliveries",
+				overdue_del,
+				f"{overdue_del} PO(s) past required-by" if overdue_del else "Supply is on schedule",
+				"refresh-ccw",
+				"/procurement/purchase-orders",
+				overdue_del > 0,
+				"danger",
+			),
+		]
+	elif role == "accountant":
+		recv, pay, overdue_recv = finance()
+		cash = _cash_and_bank(company)
+		to_verify = _count("Expense Entry", {"company": company, "docstatus": 0})
+		petty = _count("Petty Cash Request", {"company": company, "status": "Requested"})
+		snapshot = [
+			_tile("Cash & bank", cash, "wallet", "brand", "currency"),
+			_tile("Receivables", recv, "banknote", "info", "currency"),
+			_tile("Payables", pay, "receipt", "warning", "currency"),
+			_tile("Expenses to verify", to_verify, "file-text", "danger" if to_verify else "success"),
+		]
+		alerts = [
+			_alert(
+				"exp",
+				"Expenses to verify",
+				to_verify,
+				f"{to_verify} draft expense(s) to submit" if to_verify else "Verification queue is clear",
+				"file-text",
+				"/project-finance/expenses",
+				to_verify > 0,
+				"danger",
+			),
+			_alert(
+				"petty",
+				"Petty cash to disburse",
+				petty,
+				f"{petty} request(s) to disburse" if petty else "No requests waiting",
+				"wallet",
+				"/project-finance/petty-cash",
+				petty > 0,
+			),
+			_alert(
+				"recv",
+				"Overdue receivables",
+				overdue_recv,
+				f"{overdue_recv} invoice(s) past due" if overdue_recv else "No customer invoices past due",
+				"banknote",
+				"/project-finance",
+				overdue_recv > 0,
+				"danger",
+			),
+		]
+	elif role == "estimator":
+		draft_boqs, approved_boqs = boqs()
+		templates = _count("Estimate Template", {})
+		assemblies = _count("Assembly", {})
+		snapshot = [
+			_tile("Draft BOQs", draft_boqs, "file-text", "warning"),
+			_tile("Approved BOQs", approved_boqs, "check-circle", "success"),
+			_tile("Estimate templates", templates, "layout-grid", "info"),
+			_tile("Assemblies", assemblies, "chart-bar"),
+		]
+		alerts = [
+			_alert(
+				"drafts",
+				"Draft BOQs",
+				draft_boqs,
+				f"{draft_boqs} open" if draft_boqs else "No drafts in flight",
+				"file-text",
+				"/boq",
+				draft_boqs > 0,
+				"info",
+			),
+			_alert(
+				"templates",
+				"Estimate templates",
+				templates,
+				f"{templates} configured",
+				"layout-grid",
+				"/estimation",
+				templates > 0,
+				"info",
+			),
+			_alert(
+				"assemblies",
+				"Assemblies",
+				assemblies,
+				f"{assemblies} in the library",
+				"chart-bar",
+				"/assembly",
+				assemblies > 0,
+				"info",
+			),
+		]
+	elif role == "qs":
+		draft_boqs, approved_boqs = boqs()
+		mbs = _count("Measurement Book", {"company": company, "status": "Draft"})
+		snapshot = [
+			_tile("Draft BOQs", draft_boqs, "file-text", "warning"),
+			_tile("Approved BOQs", approved_boqs, "check-circle", "success"),
+			_tile("MBs to certify", mbs, "clipboard-list", "danger" if mbs else "muted"),
+			_tile("Active projects", active_ct, "building-2"),
+		]
+		alerts = [
+			_alert(
+				"mbs",
+				"MBs to certify",
+				mbs,
+				f"{mbs} awaiting certification" if mbs else "No draft measurement books",
+				"clipboard-list",
+				"/measurement-books",
+				mbs > 0,
+				"danger",
+			),
+			_alert(
+				"drafts",
+				"Draft BOQs",
+				draft_boqs,
+				f"{draft_boqs} open" if draft_boqs else "No drafts in flight",
+				"file-text",
+				"/boq",
+				draft_boqs > 0,
+				"info",
+			),
+			sco_alert,
+		]
+	elif role == "procurement":
+		on_order, on_order_ct, overdue_del, mrs_pending, received_week = procurement()
+		snapshot = [
+			_tile("MRs to approve", mrs_pending, "clipboard-list", "warning" if mrs_pending else "muted"),
+			_tile("Received this week", received_week, "check-circle", "success"),
+			_tile("On order", on_order, "procurement", "brand", "currency"),
+			_tile("Overdue deliveries", overdue_del, "refresh-ccw", "danger" if overdue_del else "success"),
+		]
+		alerts = [
+			_alert(
+				"overdue-del",
+				"Overdue deliveries",
+				overdue_del,
+				f"{overdue_del} PO(s) past required-by" if overdue_del else "Supply is on schedule",
+				"refresh-ccw",
+				"/procurement/purchase-orders",
+				overdue_del > 0,
+				"danger",
+			),
+			_alert(
+				"mrs",
+				"MRs to approve",
+				mrs_pending,
+				f"{mrs_pending} request(s) to review" if mrs_pending else "No requests waiting",
+				"clipboard-list",
+				"/procurement/material-requests",
+				mrs_pending > 0,
+			),
+			_alert(
+				"on-order",
+				"On order",
+				on_order_ct,
+				f"{on_order_ct} PO(s) awaiting delivery" if on_order_ct else "Nothing on order",
+				"procurement",
+				"/procurement/purchase-orders",
+				on_order_ct > 0,
+				"info",
+			),
+		]
+	elif role == "store-keeper":
+		on_order, on_order_ct, overdue_del, _mp, received_week = procurement()
+		snapshot = [
+			_tile("Deliveries open", on_order_ct, "procurement"),
+			_tile("Received this week", received_week, "stock", "success"),
+			_tile("Overdue deliveries", overdue_del, "refresh-ccw", "danger" if overdue_del else "muted"),
+			_tile("Active projects", active_ct, "building-2", "info"),
+		]
+		alerts = [
+			_alert(
+				"overdue-del",
+				"Overdue deliveries",
+				overdue_del,
+				f"{overdue_del} PO(s) past required-by" if overdue_del else "Nothing overdue on the way",
+				"refresh-ccw",
+				"/procurement/purchase-orders",
+				overdue_del > 0,
+				"danger",
+			),
+			_alert(
+				"open-del",
+				"Deliveries open",
+				on_order_ct,
+				f"{on_order_ct} awaiting receipt" if on_order_ct else "No open deliveries",
+				"procurement",
+				"/procurement/purchase-orders",
+				on_order_ct > 0,
+			),
+			_alert(
+				"received",
+				"Received this week",
+				received_week,
+				f"{received_week} receipt(s) booked" if received_week else "Nothing received yet",
+				"stock",
+				"/procurement/receipts",
+				received_week > 0,
+				"success",
+			),
+		]
+	elif role == "foreman":
+		att_today = _count(
+			"Field Attendance", {"company": company, "date": str(today), "docstatus": ["<", 2]}
+		)
+		snapshot = [
+			_tile("Attendance today", att_today, "users", "success" if att_today else "warning"),
+			_tile("My open tasks", my_open, "check-circle"),
+			_tile("Overdue", my_overdue, "refresh-ccw", "danger" if my_overdue else "muted"),
+			_tile(
+				"Progress today",
+				my_progress_today,
+				"file-text",
+				"success" if my_progress_today else "warning",
+			),
+		]
+		alerts = [
+			_alert(
+				"att",
+				"Attendance today",
+				att_today,
+				f"{att_today} sheet(s) marked" if att_today else "Not marked yet — mark it before noon",
+				"users",
+				"/workforce",
+				att_today > 0,
+				"success",
+			),
+			_alert(
+				"overdue",
+				"My overdue tasks",
+				my_overdue,
+				f"{my_overdue} past their end date" if my_overdue else "On track — nothing past due",
+				"refresh-ccw",
+				"/tasks",
+				my_overdue > 0,
+				"danger",
+			),
+			_alert(
+				"progress",
+				"Progress today",
+				my_progress_today,
+				f"{my_progress_today} filed today" if my_progress_today else "No entries filed yet",
+				"file-text",
+				"/progress-entries",
+				my_progress_today > 0,
+				"success",
+			),
+		]
+	elif role == "hr-manager":
+		att_week = _count("Field Attendance", {"company": company, "docstatus": 1, "date": [">=", week_ago]})
+		ot_hours = _sum("Overtime Attendance Register", {"company": company}, "overtime_hours")
+		workers = _count("Employee", {"status": "Active"})
+		snapshot = [
+			_tile("Active workers", workers, "users", "brand"),
+			_tile("Attendance this week", att_week, "check-circle", "success" if att_week else "muted"),
+			_tile("Overtime (hrs) this week", round(ot_hours), "calendar", "info"),
+			_tile("Active projects", active_ct, "building-2"),
+		]
+		alerts = [
+			_alert(
+				"att-week",
+				"Attendance this week",
+				att_week,
+				f"{att_week} sheet(s) submitted" if att_week else "No sheets submitted yet",
+				"check-circle",
+				"/workforce",
+				att_week > 0,
+				"success",
+			),
+			_alert(
+				"ot",
+				"Overtime this week",
+				round(ot_hours),
+				f"{round(ot_hours)} hrs across the crews" if ot_hours else "No overtime recorded",
+				"calendar",
+				"/workforce",
+				ot_hours > 0,
+			),
+			_alert(
+				"workers",
+				"Active workers",
+				workers,
+				f"{workers} on the books",
+				"users",
+				"/workforce",
+				workers > 0,
+				"info",
+			),
+		]
+	else:  # site-engineer + any unmapped role
+		snapshot = [
+			_tile("My open tasks", my_open, "check-circle"),
+			_tile("Due this week", my_due_week, "calendar", "info"),
+			_tile("Overdue", my_overdue, "refresh-ccw", "danger" if my_overdue else "muted"),
+			_tile(
+				"Progress today",
+				my_progress_today,
+				"file-text",
+				"success" if my_progress_today else "warning",
+			),
+		]
+		on_order, on_order_ct, overdue_del, _mp, _rw = procurement()
+		alerts = [
+			_alert(
+				"overdue",
+				"My overdue tasks",
+				my_overdue,
+				f"{my_overdue} past their end date" if my_overdue else "On track — nothing past due",
+				"refresh-ccw",
+				"/tasks",
+				my_overdue > 0,
+				"danger",
+			),
+			_alert(
+				"deliveries",
+				"Deliveries expected",
+				overdue_del,
+				f"{overdue_del} PO(s) past required-by" if overdue_del else "Nothing overdue on the way",
+				"procurement",
+				"/procurement/purchase-orders",
+				overdue_del > 0,
+			),
+			_alert(
+				"progress",
+				"Progress today",
+				my_progress_today,
+				f"{my_progress_today} filed today" if my_progress_today else "No entries filed yet",
+				"file-text",
+				"/progress-entries",
+				my_progress_today > 0,
+				"success",
+			),
+		]
+
+	title, sub, cta_label, to, cta_slug = _CTAS.get(role, _CTAS["site-engineer"])
+	cta = {"title": title, "sub": sub, "cta": cta_label, "to": to, "slug": cta_slug}
+
 	return {
+		"role": role,
+		"greeting_sub": _GREETINGS.get(role, "Here is a snapshot of your work today."),
+		"snapshot": snapshot,
+		"cta": cta,
+		"alerts": alerts,
+		# --- legacy fields still rendered by DashboardView (/dashboard) ---
 		"kpis": {
 			"active_projects": active_ct,
 			"open_tasks": open_tasks,

--- a/buildsuite_core/tests/test_home.py
+++ b/buildsuite_core/tests/test_home.py
@@ -70,3 +70,26 @@ class TestHomeDashboard(BuildSuiteTestCase):
 		self.assertEqual(scoped, 1)
 		self.assertGreaterEqual(unscoped, 2)
 		self.assertGreater(unscoped, scoped)
+
+	def test_role_aware_snapshot(self):
+		# A QS gets estimation/measurement tiles; the payload carries a snapshot (4), a CTA,
+		# and three alert cards.
+		qs = self._persona_user("Quantity Surveyor", "qs")
+		frappe.set_user(qs)
+		try:
+			dash = get_home_dashboard()
+			self.assertEqual(dash["role"], "qs")
+			labels = [t["label"] for t in dash["snapshot"]]
+			self.assertEqual(len(dash["snapshot"]), 4)
+			for expected in ("Draft BOQs", "Approved BOQs", "MBs to certify"):
+				self.assertIn(expected, labels)
+			self.assertTrue(dash["cta"]["title"])
+			self.assertEqual(len(dash["alerts"]), 3)
+		finally:
+			frappe.set_user("Administrator")
+
+		# Administrator resolves to the org-wide 'admin' snapshot.
+		frappe.set_user("Administrator")
+		admin = get_home_dashboard()
+		self.assertEqual(admin["role"], "admin")
+		self.assertIn("Users", [t["label"] for t in admin["snapshot"]])

--- a/buildsuite_core/tests/test_home.py
+++ b/buildsuite_core/tests/test_home.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Home dashboard — the KPIs are scoped to the logged-in user's visible projects/tasks."""
+
+import frappe
+
+from buildsuite_core.api.home import get_home_dashboard
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestHomeDashboard(BuildSuiteTestCase):
+	def _persona_user(self, persona, prefix):
+		email = f"{prefix}-{self._n}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": prefix.upper(),
+				"send_welcome_email": 0,
+				"user_type": "System User",
+				"persona": persona,
+				"company": self.company,
+			}
+		).insert(ignore_permissions=True)
+		return email
+
+	def _home_project(self, member=None, status="Ongoing"):
+		doc = {
+			"doctype": "Project",
+			"project_name": f"HOME {frappe.generate_hash(length=5)}",
+			"project_status": status,
+			"company": self.company,
+		}
+		if member:
+			doc["custom_team_members"] = [{"user": member}]
+		return frappe.get_doc(doc).insert(ignore_permissions=True)
+
+	def test_scoped_user_sees_only_their_projects(self):
+		# A team-scoped persona (Site Engineer) sees only the project they're teamed on —
+		# the home count must match the Projects list, not the whole company.
+		se = self._persona_user("Site Engineer", "se")
+		mine = self._home_project(member=se)
+		self._home_project()  # another active project the user is NOT on
+
+		frappe.set_user(se)
+		try:
+			dash = get_home_dashboard()
+			ids = [p["id"] for p in dash["projects"]]
+			self.assertIn(mine.name, ids)
+			# Exactly one visible active top-level project.
+			self.assertEqual(dash["kpis"]["active_projects"], 1)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_admin_unscoped_sees_more_than_scoped(self):
+		# Administrator is exempt from team scoping → counts both projects (plus any others);
+		# the scoped user counts only the one they're teamed on.
+		se = self._persona_user("Site Engineer", "se")
+		self._home_project(member=se)  # the user is on this one
+		self._home_project()  # …but not this one
+
+		frappe.set_user(se)
+		try:
+			scoped = get_home_dashboard()["kpis"]["active_projects"]
+		finally:
+			frappe.set_user("Administrator")
+		unscoped = get_home_dashboard()["kpis"]["active_projects"]
+
+		self.assertEqual(scoped, 1)
+		self.assertGreaterEqual(unscoped, 2)
+		self.assertGreater(unscoped, scoped)

--- a/frontend/src/views/AppHomeView.vue
+++ b/frontend/src/views/AppHomeView.vue
@@ -1,44 +1,50 @@
 <script setup>
+// Role-aware Home. One live aggregate read (api.home.get_home_dashboard) returns the
+// logged-in user's snapshot tiles, primary CTA and alert cards — the same per-role content
+// as the prototype's HomeWorkspaceView. This view is a thin renderer of that payload.
 import { computed, onMounted, ref } from "vue";
 import { RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useSessionStore } from "@/stores/session";
 import { useUserNames } from "@/composables/useUserNames";
+import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
+import { fmtCompactINR } from "@/utils/format";
 import { getHomeDashboard } from "@/data/homeDashboardApi";
 
 const store = useDataStore();
 const session = useSessionStore();
 const { userName: resolveUserName } = useUserNames();
 
-// One live aggregate read backs every metric below (api.home.get_home_dashboard).
 const dash = ref(null);
 onMounted(async () => {
 	try {
 		dash.value = await getHomeDashboard();
 	} catch {
-		dash.value = null; // fall through to the fallback numbers
+		dash.value = null;
 	}
 });
-const kpis = computed(() => dash.value?.kpis || {});
+
+const snapshot = computed(() => dash.value?.snapshot || []);
+const alerts = computed(() => dash.value?.alerts || []);
+const cta = computed(() => dash.value?.cta || null);
 
 const now = new Date();
-
 const greeting = computed(() => {
 	const hour = now.getHours();
 	if (hour < 12) return "Good morning";
 	if (hour < 18) return "Good afternoon";
 	return "Good evening";
 });
-
 const userName = computed(() => {
 	const id = session.user && session.user !== "Guest" ? session.user : null;
 	return (id && resolveUserName(id)) || store.user?.name || "Admin User";
 });
-
 const roleLabel = computed(() =>
 	store.isAdmin ? "System Manager (Admin)" : store.currentRole?.name || "User"
 );
-
+const greetingSub = computed(
+	() => dash.value?.greeting_sub || "Here is a snapshot of your work today."
+);
 const dateLabel = computed(() =>
 	new Intl.DateTimeFormat("en-GB", {
 		weekday: "long",
@@ -47,7 +53,6 @@ const dateLabel = computed(() =>
 		year: "numeric",
 	}).format(now)
 );
-
 const initials = computed(() => {
 	const name = userName.value || "A D";
 	const parts = name.split(" ").filter(Boolean);
@@ -56,35 +61,35 @@ const initials = computed(() => {
 	return `${parts[0][0] || ""}${parts[1][0] || ""}`.toUpperCase();
 });
 
-const activeProjectsCount = computed(() => kpis.value.active_projects);
-const openTasksCount = computed(() => kpis.value.open_tasks);
-const usersCount = computed(() => kpis.value.users);
-const workspacesCount = computed(() => (store.visibleWorkspaces || []).length);
-
-const pendingScosCount = computed(() => kpis.value.pending_scos);
-const overdueTasksCount = computed(() => kpis.value.overdue_tasks);
-const progressTodayCount = computed(() => kpis.value.progress_today);
+// tone → icon chip classes (shared by snapshot tiles + alert cards).
+const TONE = {
+	brand: "bg-brand-50 text-brand-700",
+	info: "bg-info-50 text-info-700",
+	success: "bg-success-50 text-success-700",
+	warning: "bg-warning-50 text-warning-700",
+	danger: "bg-danger-50 text-danger-700",
+	muted: "bg-ink-50 text-ink-400",
+};
+function toneClass(t) {
+	return TONE[t] || TONE.brand;
+}
+function tileValue(m) {
+	return m.format === "currency" ? fmtCompactINR(m.value) : m.value;
+}
 
 const quickActions = [
 	{ label: "Users", to: "/settings/users", icon: "users" },
-	{ label: "Companies", to: "/settings/companies", icon: "companies" },
-	{ label: "Project Categories", to: "/settings/project-categories", icon: "project-types" },
-	{
-		label: "Workspace Structure",
-		to: "/settings/workspace-structure",
-		icon: "workspace-structure",
-	},
-	{ label: "All Projects", to: "/projects", icon: "projects" },
-	{ label: "Data Tools", to: "/settings/data", icon: "data-tools" },
+	{ label: "Companies", to: "/settings/companies", icon: "building-2" },
+	{ label: "Project Categories", to: "/settings/project-categories", icon: "tag" },
+	{ label: "Workspace Structure", to: "/settings/workspace-structure", icon: "layout-grid" },
+	{ label: "All Projects", to: "/projects", icon: "clipboard-list" },
+	{ label: "Data Tools", to: "/settings/data", icon: "database" },
 ];
-
-function showCount(value, fallback) {
-	return Number.isFinite(value) ? value : fallback;
-}
 </script>
 
 <template>
 	<div class="px-6 py-8 max-w-6xl mx-auto">
+		<!-- Greeting -->
 		<div class="flex items-start gap-4 mb-6">
 			<div class="inline-flex items-center gap-2">
 				<div
@@ -96,9 +101,7 @@ function showCount(value, fallback) {
 			<div class="flex-1 min-w-0">
 				<div class="text-sm text-ink-500">{{ greeting }},</div>
 				<h1 class="text-2xl font-semibold text-ink-900 mt-0.5">{{ userName }}</h1>
-				<p class="text-sm text-ink-500 mt-1.5">
-					Here is a snapshot of system activity today.
-				</p>
+				<p class="text-sm text-ink-500 mt-1.5">{{ greetingSub }}</p>
 				<div class="text-[11px] text-ink-400 mt-1 flex flex-wrap items-center gap-x-2">
 					<span>{{ roleLabel }}</span>
 					<span class="text-ink-300">·</span>
@@ -107,6 +110,7 @@ function showCount(value, fallback) {
 			</div>
 		</div>
 
+		<!-- Snapshot + CTA -->
 		<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
 			<section
 				class="lg:col-span-2 bg-white border border-ink-200 rounded-lg overflow-hidden"
@@ -124,9 +128,10 @@ function showCount(value, fallback) {
 				</header>
 				<div class="p-5">
 					<div class="grid grid-cols-2 sm:grid-cols-4 gap-5">
-						<div>
+						<div v-for="m in snapshot" :key="m.label">
 							<div
-								class="w-11 h-11 rounded-lg flex items-center justify-center mb-3 bg-brand-50 text-brand-700"
+								class="w-11 h-11 rounded-lg flex items-center justify-center mb-3"
+								:class="toneClass(m.tone)"
 							>
 								<svg
 									width="22"
@@ -138,119 +143,19 @@ function showCount(value, fallback) {
 									stroke-linecap="round"
 									stroke-linejoin="round"
 									aria-hidden="true"
-								>
-									<rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-									<path
-										d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-									></path>
-									<path d="M12 11h4"></path>
-									<path d="M12 16h4"></path>
-									<path d="M8 11h.01"></path>
-									<path d="M8 16h.01"></path>
-								</svg>
+									v-html="getWorkspaceIconPath(m.slug)"
+								/>
 							</div>
 							<div
-								class="text-3xl font-semibold text-ink-900 tabular-nums leading-none"
+								class="font-semibold text-ink-900 tabular-nums leading-none"
+								:class="m.format === 'currency' ? 'text-2xl' : 'text-3xl'"
 							>
-								{{ showCount(activeProjectsCount, 4) }}
+								{{ tileValue(m) }}
 							</div>
 							<div
 								class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-2"
 							>
-								Active projects
-							</div>
-						</div>
-						<div>
-							<div
-								class="w-11 h-11 rounded-lg flex items-center justify-center mb-3 bg-info-50 text-info-700"
-							>
-								<svg
-									width="22"
-									height="22"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.75"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-								>
-									<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-									<polyline points="22 4 12 14.01 9 11.01"></polyline>
-								</svg>
-							</div>
-							<div
-								class="text-3xl font-semibold text-ink-900 tabular-nums leading-none"
-							>
-								{{ showCount(openTasksCount, 9) }}
-							</div>
-							<div
-								class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-2"
-							>
-								Open tasks
-							</div>
-						</div>
-						<div>
-							<div
-								class="w-11 h-11 rounded-lg flex items-center justify-center mb-3 bg-success-50 text-success-700"
-							>
-								<svg
-									width="22"
-									height="22"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.75"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-								>
-									<path d="M14 19a6 6 0 0 0-12 0"></path>
-									<circle cx="8" cy="9" r="4"></circle>
-									<path d="M22 19a6 6 0 0 0-6-6 4 4 0 1 0 0-8"></path>
-								</svg>
-							</div>
-							<div
-								class="text-3xl font-semibold text-ink-900 tabular-nums leading-none"
-							>
-								{{ showCount(usersCount, 7) }}
-							</div>
-							<div
-								class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-2"
-							>
-								Users
-							</div>
-						</div>
-						<div>
-							<div
-								class="w-11 h-11 rounded-lg flex items-center justify-center mb-3 bg-warning-50 text-warning-700"
-							>
-								<svg
-									width="22"
-									height="22"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="1.75"
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									aria-hidden="true"
-								>
-									<rect width="7" height="7" x="3" y="3" rx="1"></rect>
-									<rect width="7" height="7" x="14" y="3" rx="1"></rect>
-									<rect width="7" height="7" x="14" y="14" rx="1"></rect>
-									<rect width="7" height="7" x="3" y="14" rx="1"></rect>
-								</svg>
-							</div>
-							<div
-								class="text-3xl font-semibold text-ink-900 tabular-nums leading-none"
-							>
-								{{ showCount(workspacesCount, 11) }}
-							</div>
-							<div
-								class="text-[10px] uppercase tracking-wider text-ink-500 font-medium mt-2"
-							>
-								Workspaces
+								{{ m.label }}
 							</div>
 						</div>
 					</div>
@@ -258,7 +163,8 @@ function showCount(value, fallback) {
 			</section>
 
 			<RouterLink
-				to="/settings"
+				v-if="cta"
+				:to="cta.to"
 				class="bg-brand-50 hover:bg-brand-100 rounded-lg p-5 flex flex-col justify-between transition-colors group"
 			>
 				<div class="flex items-start gap-3">
@@ -275,37 +181,35 @@ function showCount(value, fallback) {
 							stroke-linecap="round"
 							stroke-linejoin="round"
 							aria-hidden="true"
-						>
-							<path
-								d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"
-							></path>
-							<circle cx="12" cy="12" r="3"></circle>
-						</svg>
+							v-html="getWorkspaceIconPath(cta.slug)"
+						/>
 					</div>
 					<div class="min-w-0">
 						<h2 class="text-base font-semibold text-ink-900 leading-tight">
-							Settings
+							{{ cta.title }}
 						</h2>
-						<p class="text-xs text-ink-600 mt-1.5 leading-snug">
-							Manage workspaces, users, project types, and data.
-						</p>
+						<p class="text-xs text-ink-600 mt-1.5 leading-snug">{{ cta.sub }}</p>
 					</div>
 				</div>
 				<div
 					class="mt-4 inline-flex items-center gap-1.5 bg-brand-600 group-hover:bg-brand-700 text-white text-xs font-medium px-2.5 py-1.5 rounded-md self-start transition-colors"
 				>
-					Open Settings <span aria-hidden="true">→</span>
+					{{ cta.cta }} <span aria-hidden="true">→</span>
 				</div>
 			</RouterLink>
 		</div>
 
+		<!-- Alert cards -->
 		<div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6">
 			<RouterLink
-				to="/sco"
+				v-for="a in alerts"
+				:key="a.key"
+				:to="a.to"
 				class="bg-white border border-ink-200 hover:border-brand-400 rounded-lg p-4 flex items-center gap-3 transition-colors group"
 			>
 				<div
-					class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-warning-50 text-warning-700"
+					class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0"
+					:class="toneClass(a.tone)"
 				>
 					<svg
 						width="18"
@@ -317,97 +221,12 @@ function showCount(value, fallback) {
 						stroke-linecap="round"
 						stroke-linejoin="round"
 						aria-hidden="true"
-					>
-						<path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path>
-						<path d="M3 3v5h5"></path>
-						<path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16"></path>
-						<path d="M16 16h5v5"></path>
-					</svg>
+						v-html="getWorkspaceIconPath(a.slug)"
+					/>
 				</div>
 				<div class="flex-1 min-w-0">
-					<div class="text-sm font-semibold text-ink-900">Pending SCOs</div>
-					<div class="text-xs text-ink-500 mt-0.5 truncate">
-						{{ showCount(pendingScosCount, 2) }} awaiting approval
-					</div>
-				</div>
-				<div
-					class="text-xs text-brand-700 group-hover:text-brand-800 font-medium flex-shrink-0"
-				>
-					View →
-				</div>
-			</RouterLink>
-
-			<RouterLink
-				to="/tasks"
-				class="bg-white border border-ink-200 hover:border-brand-400 rounded-lg p-4 flex items-center gap-3 transition-colors group"
-			>
-				<div
-					class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-danger-50 text-danger-700"
-				>
-					<svg
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.75"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
-					>
-						<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
-						<polyline points="22 4 12 14.01 9 11.01"></polyline>
-					</svg>
-				</div>
-				<div class="flex-1 min-w-0">
-					<div class="text-sm font-semibold text-ink-900">Overdue tasks</div>
-					<div class="text-xs text-ink-500 mt-0.5 truncate">
-						{{ showCount(overdueTasksCount, 4) }} past their end date
-					</div>
-				</div>
-				<div
-					class="text-xs text-brand-700 group-hover:text-brand-800 font-medium flex-shrink-0"
-				>
-					View →
-				</div>
-			</RouterLink>
-
-			<RouterLink
-				to="/progress-entries"
-				class="bg-white border border-ink-200 hover:border-brand-400 rounded-lg p-4 flex items-center gap-3 transition-colors group"
-			>
-				<div
-					class="w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 bg-ink-50 text-ink-400"
-				>
-					<svg
-						width="18"
-						height="18"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.75"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
-					>
-						<path
-							d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
-						></path>
-						<polyline points="14 2 14 8 20 8"></polyline>
-						<line x1="16" x2="8" y1="13" y2="13"></line>
-						<line x1="16" x2="8" y1="17" y2="17"></line>
-						<line x1="10" x2="8" y1="9" y2="9"></line>
-					</svg>
-				</div>
-				<div class="flex-1 min-w-0">
-					<div class="text-sm font-semibold text-ink-900">Progress today</div>
-					<div class="text-xs text-ink-500 mt-0.5 truncate">
-						{{
-							progressTodayCount
-								? `${progressTodayCount} entries filed`
-								: "No entries filed yet"
-						}}
-					</div>
+					<div class="text-sm font-semibold text-ink-900">{{ a.title }}</div>
+					<div class="text-xs text-ink-500 mt-0.5 truncate">{{ a.sub }}</div>
 				</div>
 				<div
 					class="text-xs text-brand-700 group-hover:text-brand-800 font-medium flex-shrink-0"
@@ -417,6 +236,7 @@ function showCount(value, fallback) {
 			</RouterLink>
 		</div>
 
+		<!-- Quick actions -->
 		<div class="mb-6">
 			<h2 class="text-sm font-semibold text-ink-900 mb-3">Quick actions</h2>
 			<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -430,7 +250,6 @@ function showCount(value, fallback) {
 						class="w-10 h-10 rounded-lg bg-ink-50 group-hover:bg-brand-50 text-ink-600 group-hover:text-brand-700 flex items-center justify-center flex-shrink-0 transition-colors"
 					>
 						<svg
-							v-if="action.icon === 'users'"
 							width="20"
 							height="20"
 							viewBox="0 0 24 24"
@@ -440,105 +259,8 @@ function showCount(value, fallback) {
 							stroke-linecap="round"
 							stroke-linejoin="round"
 							aria-hidden="true"
-						>
-							<path d="M14 19a6 6 0 0 0-12 0"></path>
-							<circle cx="8" cy="9" r="4"></circle>
-							<path d="M22 19a6 6 0 0 0-6-6 4 4 0 1 0 0-8"></path>
-						</svg>
-						<svg
-							v-else-if="action.icon === 'companies'"
-							width="20"
-							height="20"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.75"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-						>
-							<path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z"></path>
-							<path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2"></path>
-							<path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2"></path>
-							<path d="M10 6h4"></path>
-							<path d="M10 10h4"></path>
-							<path d="M10 14h4"></path>
-							<path d="M10 18h4"></path>
-						</svg>
-						<svg
-							v-else-if="action.icon === 'project-types'"
-							width="20"
-							height="20"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.75"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-						>
-							<circle cx="12" cy="12" r="10"></circle>
-							<path d="M12 16v-4"></path>
-							<path d="M12 8h.01"></path>
-						</svg>
-						<svg
-							v-else-if="action.icon === 'workspace-structure'"
-							width="20"
-							height="20"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.75"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-						>
-							<rect width="7" height="7" x="3" y="3" rx="1"></rect>
-							<rect width="7" height="7" x="14" y="3" rx="1"></rect>
-							<rect width="7" height="7" x="14" y="14" rx="1"></rect>
-							<rect width="7" height="7" x="3" y="14" rx="1"></rect>
-						</svg>
-						<svg
-							v-else-if="action.icon === 'projects'"
-							width="20"
-							height="20"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.75"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-						>
-							<rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-							<path
-								d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
-							></path>
-							<path d="M12 11h4"></path>
-							<path d="M12 16h4"></path>
-							<path d="M8 11h.01"></path>
-							<path d="M8 16h.01"></path>
-						</svg>
-						<svg
-							v-else
-							width="20"
-							height="20"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.75"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							aria-hidden="true"
-						>
-							<path
-								d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
-							></path>
-							<polyline points="14 2 14 8 20 8"></polyline>
-							<line x1="16" x2="8" y1="13" y2="13"></line>
-							<line x1="16" x2="8" y1="17" y2="17"></line>
-							<line x1="10" x2="8" y1="9" y2="9"></line>
-						</svg>
+							v-html="getWorkspaceIconPath(action.icon)"
+						/>
 					</div>
 					<div class="flex-1 min-w-0">
 						<div


### PR DESCRIPTION
## What
The Home (`/home`) now **adapts to the logged-in user's role** (their Persona), matching the prototype's `HomeWorkspaceView`. Previously every user saw the same generic tiles (Active projects / Open tasks / Users / Workspaces).

`get_home_dashboard` resolves the role and returns that role's **four snapshot tiles + a primary CTA + three alert cards**. `AppHomeView` is a thin renderer of that payload (tone → chip colour, currency vs count formatting, icon per slug).

| Role | Snapshot tiles |
|---|---|
| **QS** | Draft BOQs · Approved BOQs · **MBs to certify** · Active projects |
| Estimator | Draft/Approved BOQs · Estimate templates · Assemblies |
| Director | Active projects · at risk · Receivables · Payables |
| Accountant | Cash & bank · Receivables · Payables · Expenses to verify |
| PM | Active projects · Open tasks · Stage approvals · MRs to approve |
| Site Engineer / Foreman | my open/overdue/due tasks · progress · attendance |
| Procurement / Store Keeper | MRs · on-order · received · overdue deliveries |
| HR | active workers · attendance · overtime |
| Admin / BSA | the org-wide snapshot |

Each role also gets its own CTA (QS → Measurement Books, Accountant → Project Finance, …) and three live alert cards.

## Scoping
All project/task/SCO reads go through **`get_list`**, so the permission query conditions apply — a scoped user (QS, Site Engineer) sees only their own projects/tasks; admins/PMs/Director are company-wide. Verified: QS → Draft BOQs 3 / Approved 0 / MBs 5 / Active 2 (its 2 team projects), vs Admin whole-company.

## Notes
- **Supersedes #150** — it includes that get_list scoping fix and rewrites the endpoint on top of it.
- Legacy `kpis`/`projects`/`pending_scos`/`tasks_in_progress` fields are kept so `DashboardView` (`/dashboard`) still works.
- Metrics with **no live source yet** (unmatched receipts, above-rate-master, consumption, workers-unallocated) are omitted rather than faked; workforce figures (attendance, OT) read the live registers and stay 0 until data exists.

## Tests
`test_home` — role-aware snapshot (QS tiles + CTA + 3 alerts), scoped-user count, admin-unscoped. `vite build` clean; all home icon slugs verified present.