### PR TITLE
feat: enrich workspace dashboards to prototype UI

### DIFF
--- a/frontend/src/views/finance/FinanceOverviewPanel.vue
+++ b/frontend/src/views/finance/FinanceOverviewPanel.vue
@@ -1,55 +1,497 @@
 <script setup>
+// Project Finance › Financial Overview. Mirrors the prototype's richer overview:
+// a clickable KPI strip (cash & bank · receivables · payables · retention · net
+// position), cash/bank accounts, a "needs attention" action queue, quick actions,
+// receivable/payable chase-lists and the latest money movements. Finance is
+// client-side dummy data for now (except Petty Cash, which is live) — everything
+// here derives from useFinanceMock; the KPI links jump to each section.
 import { computed } from "vue";
+import { useRouter } from "vue-router";
 import { useFinanceMock } from "@/data/financeMock";
 import DeskPage from "@/components/desk/DeskPage.vue";
+import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { fmtDate, fmtINR, fmtCompactINR } from "@/utils/format";
 
 const fin = useFinanceMock();
+const router = useRouter();
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Overview" }];
-const kpis = computed(() => [
-	{ label: "Cash & bank", value: fin.totalCashBank, color: "text-ink-900" },
-	{ label: "Receivable", value: fin.totalReceivable, color: "text-success-700" },
-	{ label: "Payable", value: fin.totalPayable, color: "text-danger-700" },
-	{ label: "Retention held", value: fin.retentionHeld, color: "text-warning-700" },
-	{ label: "Net position", value: fin.totalCashBank + fin.totalReceivable - fin.totalPayable, color: "text-brand-700" },
-]);
-const recent = computed(() => fin.allPayments.slice(0, 6));
+
+function go(section) {
+	router.push(`/project-finance/${section}`);
+}
+function daysOverdue(due) {
+	if (!due) return 0;
+	return Math.round((Date.now() - new Date(due).getTime()) / 86400000);
+}
+
+// ---- KPIs ----
+const accounts = computed(() => fin.sortedFinanceAccounts || []);
+const cashBankAccounts = computed(() => accounts.value.filter((a) => a.type !== "Petty Cash"));
+const totalCashBank = computed(() => fin.totalCashBank);
+const receivable = computed(() => fin.totalReceivable);
+const overdueCount = computed(
+	() => fin.openInvoices.filter((i) => daysOverdue(i.due_date) > 0).length
+);
+const payable = computed(() => fin.totalPayable);
+const retention = computed(() => fin.retentionHeld);
+const netPosition = computed(() => totalCashBank.value + receivable.value - payable.value);
+
+// ---- Needs attention (each row jumps to its queue) ----
+const draftInvoices = computed(
+	() => fin.invoices.filter((i) => (i.workflow_state || "Submitted") === "Draft").length
+);
+const attention = computed(() => {
+	const out = [];
+	const ex = fin.expensesToVerify.length;
+	if (ex > 0)
+		out.push({
+			text: `${ex} expense${ex === 1 ? "" : "s"} awaiting submit`,
+			section: "expenses",
+			tone: "warning",
+		});
+	if (draftInvoices.value > 0)
+		out.push({
+			text: `${draftInvoices.value} draft invoice${
+				draftInvoices.value === 1 ? "" : "s"
+			} not yet posted`,
+			section: "invoices",
+			tone: "info",
+		});
+	if (overdueCount.value > 0)
+		out.push({
+			text: `${overdueCount.value} invoice${
+				overdueCount.value === 1 ? "" : "s"
+			} overdue — chase receivables`,
+			section: "invoices",
+			tone: "danger",
+		});
+	return out;
+});
+
+// ---- Chase lists ----
+const topOverdue = computed(() =>
+	fin.openInvoices
+		.map((i) => ({
+			id: i.id,
+			party: fin.customerById(i.customer)?.name || i.customer,
+			amount: fin.invoiceOutstanding(i),
+			days: daysOverdue(i.due_date),
+		}))
+		.filter((r) => r.days > 0)
+		.sort((a, b) => b.days - a.days)
+		.slice(0, 4)
+);
+const topPayables = computed(() =>
+	fin.unifiedPayables
+		.filter((p) => p.outstanding > 0.01)
+		.sort((a, b) => (a.due_date || "").localeCompare(b.due_date || ""))
+		.slice(0, 4)
+);
+
+// ---- Recent movements (top 5 across all documents) ----
+const recentMovements = computed(() => fin.allPayments.slice(0, 5));
+
+const quickActions = [
+	{ key: "new-expense", section: "expenses", icon: "receipt", label: "New Expense" },
+	{ key: "req-petty", section: "petty-cash", icon: "hand-coins", label: "Request Petty Cash" },
+	{ key: "new-invoice", section: "invoices", icon: "file-text", label: "New Invoice" },
+	{ key: "new-bill", section: "bills", icon: "banknote", label: "New Bill" },
+];
+
+const toneDot = {
+	danger: "bg-danger-500",
+	warning: "bg-warning-500",
+	info: "bg-info-500",
+};
 </script>
 
 <template>
 	<DeskPage title="Finance Overview" :breadcrumbs="breadcrumbs">
-		<div class="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
-			<div v-for="k in kpis" :key="k.label" class="bg-white border border-ink-200 rounded-lg px-3 py-2.5">
-				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">{{ k.label }}</div>
-				<div class="text-base font-semibold tabular-nums mt-0.5" :class="k.color">{{ fmtCompactINR(k.value) }}</div>
+		<div class="space-y-5">
+			<!-- ===== KPI strip ===== -->
+			<div class="grid grid-cols-2 md:grid-cols-5 gap-2">
+				<button
+					type="button"
+					class="bg-white border border-ink-200 hover:border-brand-400 px-3 py-2.5 rounded-lg text-left transition-colors"
+					@click="go('payments')"
+				>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Cash &amp; bank
+					</div>
+					<div class="text-lg font-semibold text-ink-900 tabular-nums mt-0.5">
+						{{ fmtCompactINR(totalCashBank) }}
+					</div>
+					<div class="text-[10px] text-ink-500">
+						{{ cashBankAccounts.length }} account{{
+							cashBankAccounts.length === 1 ? "" : "s"
+						}}
+					</div>
+				</button>
+				<button
+					type="button"
+					class="bg-white border border-ink-200 hover:border-brand-400 px-3 py-2.5 rounded-lg text-left transition-colors"
+					@click="go('invoices')"
+				>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Receivables
+					</div>
+					<div class="text-lg font-semibold text-ink-900 tabular-nums mt-0.5">
+						{{ fmtCompactINR(receivable) }}
+					</div>
+					<div
+						class="text-[10px]"
+						:class="overdueCount > 0 ? 'text-danger-700 font-medium' : 'text-ink-500'"
+					>
+						{{ overdueCount > 0 ? `${overdueCount} overdue` : "none overdue" }}
+					</div>
+				</button>
+				<button
+					type="button"
+					class="bg-white border border-ink-200 hover:border-brand-400 px-3 py-2.5 rounded-lg text-left transition-colors"
+					@click="go('bills')"
+				>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Payables
+					</div>
+					<div class="text-lg font-semibold text-ink-900 tabular-nums mt-0.5">
+						{{ fmtCompactINR(payable) }}
+					</div>
+					<div class="text-[10px] text-ink-500">
+						retention {{ fmtCompactINR(retention) }}
+					</div>
+				</button>
+				<button
+					type="button"
+					class="bg-white border border-ink-200 hover:border-brand-400 px-3 py-2.5 rounded-lg text-left transition-colors"
+					@click="go('bills')"
+				>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Retention held
+					</div>
+					<div class="text-lg font-semibold text-warning-700 tabular-nums mt-0.5">
+						{{ fmtCompactINR(retention) }}
+					</div>
+					<div class="text-[10px] text-ink-500">withheld on sub-bills</div>
+				</button>
+				<button
+					type="button"
+					class="px-3 py-2.5 rounded-lg text-left transition-colors border"
+					:class="
+						netPosition >= 0
+							? 'bg-brand-50 border-brand-200 hover:border-brand-400'
+							: 'bg-danger-50 border-danger-200 hover:border-danger-400'
+					"
+					@click="router.push('/project-finance/report/position')"
+				>
+					<div
+						class="text-[10px] uppercase tracking-wider font-medium"
+						:class="netPosition >= 0 ? 'text-brand-700' : 'text-danger-700'"
+					>
+						Net position
+					</div>
+					<div class="text-lg font-semibold text-ink-900 tabular-nums mt-0.5">
+						{{ fmtCompactINR(netPosition) }}
+					</div>
+					<div class="text-[10px] text-ink-500">have − owe · report →</div>
+				</button>
 			</div>
-		</div>
 
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Account balances</h3></div>
-				<table class="w-full text-xs">
-					<tbody>
-						<tr v-for="a in fin.sortedFinanceAccounts" :key="a.id" class="border-t border-ink-100">
-							<td class="px-4 py-2 text-ink-900">{{ a.name }} <span class="text-ink-400 text-[10px]">{{ a.type }}</span></td>
-							<td class="px-4 py-2 text-right tabular-nums font-medium">{{ fmtINR(fin.accountBalance(a.id)) }}</td>
-						</tr>
-					</tbody>
-				</table>
-			</section>
+			<!-- ===== Accounts + Needs attention + Quick actions ===== -->
+			<div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+				<!-- Cash & Bank accounts -->
+				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+					<div
+						class="px-4 py-2.5 bg-gradient-to-r from-brand-50 to-white border-b border-ink-100 flex items-center justify-between"
+					>
+						<h3
+							class="text-xs uppercase tracking-wider font-semibold text-ink-700 flex items-center gap-1.5"
+						>
+							<svg
+								class="w-3.5 h-3.5 text-ink-400"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="1.75"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								v-html="getWorkspaceIconPath('wallet')"
+							/>
+							Accounts
+						</h3>
+						<RouterLink
+							to="/settings/finance-accounts"
+							class="text-[11px] text-brand-700 hover:underline"
+							>Manage</RouterLink
+						>
+					</div>
+					<div class="divide-y divide-ink-100">
+						<div
+							v-for="acc in accounts"
+							:key="acc.id"
+							class="px-4 py-2.5 flex items-center justify-between"
+						>
+							<div class="flex items-center gap-2.5 min-w-0">
+								<div
+									class="w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0"
+									:class="
+										acc.type === 'Bank'
+											? 'bg-info-50 text-info-700'
+											: 'bg-success-50 text-success-700'
+									"
+								>
+									<svg
+										class="w-4 h-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="1.75"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+										v-html="
+											getWorkspaceIconPath(
+												acc.type === 'Bank' ? 'building-2' : 'hand-coins'
+											)
+										"
+									/>
+								</div>
+								<div class="min-w-0">
+									<div class="text-xs text-ink-900 font-medium truncate">
+										{{ acc.name }}
+									</div>
+									<div class="text-[10px] text-ink-500">{{ acc.type }}</div>
+								</div>
+							</div>
+							<div class="text-sm font-semibold text-ink-900 tabular-nums">
+								{{ fmtINR(fin.accountBalance(acc.id)) }}
+							</div>
+						</div>
+						<div
+							v-if="!accounts.length"
+							class="px-4 py-8 text-center text-xs text-ink-400 italic"
+						>
+							No accounts defined.
+						</div>
+					</div>
+				</section>
 
+				<!-- Needs attention -->
+				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+					<div class="px-4 py-2.5 bg-ink-50 border-b border-ink-200">
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+							Needs attention
+						</h3>
+					</div>
+					<div v-if="attention.length" class="divide-y divide-ink-100">
+						<button
+							v-for="(a, i) in attention"
+							:key="i"
+							type="button"
+							class="w-full text-left px-4 py-2.5 flex items-center gap-2 hover:bg-brand-50/40 transition-colors"
+							@click="go(a.section)"
+						>
+							<span
+								class="w-1.5 h-1.5 rounded-full flex-shrink-0"
+								:class="toneDot[a.tone]"
+							></span>
+							<span class="text-xs text-ink-800 flex-1">{{ a.text }}</span>
+							<span class="text-ink-400 text-xs">→</span>
+						</button>
+					</div>
+					<div
+						v-else
+						class="px-4 py-8 text-center text-xs text-success-700 flex items-center justify-center gap-1.5"
+					>
+						<svg
+							class="w-3.5 h-3.5"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.75"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							v-html="getWorkspaceIconPath('check-circle')"
+						/>
+						All clear — nothing pending.
+					</div>
+				</section>
+
+				<!-- Quick actions -->
+				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+					<div class="px-4 py-2.5 bg-ink-50 border-b border-ink-200">
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+							Quick actions
+						</h3>
+					</div>
+					<div class="p-3 grid grid-cols-2 gap-2">
+						<button
+							v-for="qa in quickActions"
+							:key="qa.key"
+							type="button"
+							class="border border-ink-200 hover:border-brand-400 hover:shadow-sm p-2.5 rounded-lg text-left transition-all group flex items-center gap-2"
+							@click="go(qa.section)"
+						>
+							<div
+								class="w-8 h-8 rounded-lg bg-ink-50 text-ink-600 group-hover:bg-brand-50 group-hover:text-brand-700 flex items-center justify-center flex-shrink-0 transition-colors"
+							>
+								<svg
+									class="w-4 h-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="1.75"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									v-html="getWorkspaceIconPath(qa.icon)"
+								/>
+							</div>
+							<span class="text-xs font-medium text-ink-900 leading-tight">{{
+								qa.label
+							}}</span>
+						</button>
+					</div>
+				</section>
+			</div>
+
+			<!-- ===== Chase lists ===== -->
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+				<!-- Overdue receivables -->
+				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+					<div
+						class="px-4 py-2.5 bg-ink-50 border-b border-ink-200 flex items-center justify-between"
+					>
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+							Overdue receivables
+						</h3>
+						<button
+							type="button"
+							class="text-[11px] text-brand-700 hover:underline"
+							@click="go('invoices')"
+						>
+							All invoices →
+						</button>
+					</div>
+					<div v-if="topOverdue.length" class="divide-y divide-ink-100">
+						<div
+							v-for="r in topOverdue"
+							:key="r.id"
+							class="px-4 py-2.5 flex items-center justify-between gap-2"
+						>
+							<div class="min-w-0">
+								<div class="text-xs text-ink-900 font-medium truncate">
+									{{ r.party }}
+								</div>
+								<div class="text-[10px] text-ink-400 font-mono">{{ r.id }}</div>
+							</div>
+							<div class="text-right flex-shrink-0">
+								<div class="text-xs font-semibold text-ink-900 tabular-nums">
+									{{ fmtINR(r.amount) }}
+								</div>
+								<div class="text-[10px] text-danger-700 font-medium">
+									{{ r.days }}d overdue
+								</div>
+							</div>
+						</div>
+					</div>
+					<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
+						Nothing overdue.
+					</div>
+				</section>
+
+				<!-- Payables due -->
+				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+					<div
+						class="px-4 py-2.5 bg-ink-50 border-b border-ink-200 flex items-center justify-between"
+					>
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+							Payables due
+						</h3>
+						<button
+							type="button"
+							class="text-[11px] text-brand-700 hover:underline"
+							@click="go('bills')"
+						>
+							All bills →
+						</button>
+					</div>
+					<div v-if="topPayables.length" class="divide-y divide-ink-100">
+						<div
+							v-for="p in topPayables"
+							:key="p.kind + p.id"
+							class="px-4 py-2.5 flex items-center justify-between gap-2"
+						>
+							<div class="min-w-0">
+								<div class="flex items-center gap-1.5">
+									<div class="text-xs text-ink-900 font-medium truncate">
+										{{ fin.supplierById(p.supplier)?.name || p.supplier }}
+									</div>
+									<span
+										v-if="p.kind === 'subcontractor'"
+										class="text-[9px] px-1.5 py-0.5 bg-info-50 text-info-700 rounded-full uppercase tracking-wider flex-shrink-0"
+										>Sub</span
+									>
+								</div>
+								<div class="text-[10px] text-ink-400">
+									due {{ fmtDate(p.due_date) }}
+								</div>
+							</div>
+							<div
+								class="text-xs font-semibold text-ink-900 tabular-nums flex-shrink-0"
+							>
+								{{ fmtINR(p.outstanding) }}
+							</div>
+						</div>
+					</div>
+					<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
+						Nothing payable.
+					</div>
+				</section>
+			</div>
+
+			<!-- ===== Recent movements ===== -->
 			<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-				<div class="bg-ink-50 px-4 py-2 border-b border-ink-200"><h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Recent movements</h3></div>
-				<table class="w-full text-xs">
-					<tbody>
-						<tr v-for="p in recent" :key="p.id" class="border-t border-ink-100">
-							<td class="px-4 py-2 text-ink-500">{{ fmtDate(p.date) }}</td>
-							<td class="px-4 py-2 text-ink-700">{{ p.type }}</td>
-							<td class="px-4 py-2 text-right tabular-nums font-medium" :class="p.dir === 'in' ? 'text-success-700' : 'text-danger-700'">{{ p.dir === "in" ? "+" : "−" }}{{ fmtINR(p.amount) }}</td>
-						</tr>
-						<tr v-if="!recent.length"><td colspan="3" class="px-4 py-3 text-center text-ink-400 italic">No movements yet.</td></tr>
-					</tbody>
-				</table>
+				<div
+					class="px-4 py-2.5 bg-ink-50 border-b border-ink-200 flex items-center justify-between"
+				>
+					<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+						Recent transactions
+					</h3>
+					<button
+						type="button"
+						class="text-[11px] text-brand-700 hover:underline"
+						@click="go('payments')"
+					>
+						All payments →
+					</button>
+				</div>
+				<div v-if="recentMovements.length" class="divide-y divide-ink-100">
+					<div
+						v-for="(m, i) in recentMovements"
+						:key="i"
+						class="px-4 py-2.5 flex items-center gap-3"
+					>
+						<span
+							class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap flex-shrink-0"
+							:class="
+								m.dir === 'in'
+									? 'bg-success-50 text-success-700'
+									: 'bg-warning-50 text-warning-700'
+							"
+							>{{ m.type }}</span
+						>
+						<span class="text-xs text-ink-900 flex-1 truncate">{{ m.party }}</span>
+						<span class="text-[10px] text-ink-400 flex-shrink-0">{{
+							fmtDate(m.date)
+						}}</span>
+						<span
+							class="text-xs font-semibold tabular-nums w-24 text-right flex-shrink-0"
+							:class="m.dir === 'in' ? 'text-success-700' : 'text-danger-700'"
+							>{{ m.dir === "in" ? "+" : "−" }}{{ fmtINR(m.amount) }}</span
+						>
+					</div>
+				</div>
+				<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
+					No transactions yet.
+				</div>
 			</section>
 		</div>
 	</DeskPage>

--- a/frontend/src/views/workspaces/EquipmentWorkspace.vue
+++ b/frontend/src/views/workspaces/EquipmentWorkspace.vue
@@ -22,16 +22,19 @@ const reports = [
 		label: "Machinery utilisation",
 		icon: "chart-bar",
 		description: "Plant usage + cost by project / task.",
+		to: "/machinery-usage",
 	},
 	{
 		label: "Equipment register",
 		icon: "wrench",
 		description: "Owned + hired plant with rates.",
+		to: "/machinery",
 	},
 	{
 		label: "Fuel & running cost",
 		icon: "chart-line",
 		description: "Fuel logged against usage entries.",
+		prevent: true,
 	},
 ];
 </script>
@@ -108,7 +111,8 @@ const reports = [
 						:icon="r.icon"
 						:label="r.label"
 						:description="r.description"
-						:prevent="true"
+						:to="r.prevent ? null : r.to"
+						:prevent="r.prevent"
 					>
 						<template #badge>
 							<span

--- a/frontend/src/views/workspaces/SubcontractorDashboardView.vue
+++ b/frontend/src/views/workspaces/SubcontractorDashboardView.vue
@@ -1,8 +1,9 @@
 <script setup>
-// Subcontractor Dashboard — rolls the Work Order, Subcontractor and
-// Measurement Book slices into KPI cards + recent-activity panels. Mirrors
-// the prototype's SubcontractorDashboardView; the RA-bill panels land in a
-// later pass, so retention + billed KPIs are omitted rather than faked.
+// Subcontractor Dashboard — rolls the Work Order, Subcontractor, Measurement
+// Book and Subcontractor Bill slices into KPI cards + recent-activity panels.
+// Mirrors the prototype's SubcontractorDashboardView. All lists come through
+// useDocTypeList (get_list), so counts + totals are permission-scoped to the
+// projects the signed-in user can see.
 
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
@@ -10,7 +11,7 @@ import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import StatusBadge from "@/components/StatusBadge.vue";
-import { fmtDate, fmtCompactINR } from "@/utils/format";
+import { fmtDate, fmtINR, fmtCompactINR } from "@/utils/format";
 
 const today = computed(() => {
 	const d = new Date();
@@ -47,10 +48,31 @@ const mbsRes = useDocTypeList("Measurement Book", {
 	pageLength: 0,
 	cache: "buildsuite-measurement-book-dashboard",
 });
+const billsRes = useDocTypeList("Subcontractor Bill", {
+	fields: [
+		"name",
+		"ra_no",
+		"subcontractor_name",
+		"project",
+		"work_order",
+		"date",
+		"status",
+		"gross",
+		"retention_amount",
+		"net_payable",
+		"modified",
+	],
+	orderBy: "modified desc",
+	pageLength: 0,
+	cache: "buildsuite-subcontractor-bill-dashboard",
+});
 
 const wos = computed(() => wosRes.data || []);
 const subs = computed(() => subsRes.data || []);
+const bills = computed(() => billsRes.data || []);
 const recentMBs = computed(() => (mbsRes.data || []).slice(0, 5));
+const recentWorkOrders = computed(() => wos.value.slice(0, 6));
+const recentBills = computed(() => bills.value.slice(0, 6));
 
 const openWos = computed(() =>
 	wos.value.filter((w) => w.status === "Awarded" || w.status === "In Progress")
@@ -58,12 +80,32 @@ const openWos = computed(() =>
 const openWosValue = computed(() =>
 	openWos.value.reduce((a, w) => a + (Number(w.total_value) || 0), 0)
 );
-const totalWoValue = computed(() =>
-	wos.value.reduce((a, w) => a + (Number(w.total_value) || 0), 0)
-);
 const activeSubs = computed(() => subs.value.filter((s) => !s.disabled).length);
 
-const recentWorkOrders = computed(() => wos.value.slice(0, 6));
+const totalBilledToDate = computed(() =>
+	bills.value.reduce((a, b) => a + (Number(b.gross) || 0), 0)
+);
+const totalRetentionHeld = computed(() =>
+	bills.value.reduce((a, b) => a + (Number(b.retention_amount) || 0), 0)
+);
+
+// Billed-to-date rolled up per work order, so each WO row can show progress.
+const billedByWorkOrder = computed(() => {
+	const map = {};
+	for (const b of bills.value) {
+		if (!b.work_order) continue;
+		map[b.work_order] = (map[b.work_order] || 0) + (Number(b.gross) || 0);
+	}
+	return map;
+});
+function woBilled(name) {
+	return billedByWorkOrder.value[name] || 0;
+}
+function woPercent(wo) {
+	const total = Number(wo.total_value) || 0;
+	if (total <= 0) return 0;
+	return Math.round((woBilled(wo.name) / total) * 100);
+}
 </script>
 
 <template>
@@ -82,7 +124,7 @@ const recentWorkOrders = computed(() => wos.value.slice(0, 6));
 				</div>
 				<h1 class="text-2xl font-semibold text-ink-900">Subcontractor Dashboard</h1>
 				<p class="text-xs text-ink-500 mt-1">
-					Open commitments, work order momentum and active subcontractors at a glance.
+					Open commitments, billing momentum, and certified measurements at a glance.
 				</p>
 			</div>
 
@@ -104,13 +146,22 @@ const recentWorkOrders = computed(() => wos.value.slice(0, 6));
 				</div>
 				<div class="p-4 bg-white border border-ink-200 rounded-lg">
 					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
-						Total WO value
+						Billed to date
 					</div>
 					<div class="text-2xl font-semibold text-ink-900 tabular-nums mt-1.5">
-						{{ fmtCompactINR(totalWoValue) }}
+						{{ fmtCompactINR(totalBilledToDate) }}
+					</div>
+					<div class="text-[10px] text-ink-400 mt-1">Sum across all bills</div>
+				</div>
+				<div class="p-4 bg-white border border-ink-200 rounded-lg">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						Retention held
+					</div>
+					<div class="text-2xl font-semibold text-warning-700 tabular-nums mt-1.5">
+						{{ fmtCompactINR(totalRetentionHeld) }}
 					</div>
 					<div class="text-[10px] text-ink-400 mt-1">
-						Across {{ wos.length }} work order{{ wos.length === 1 ? "" : "s" }}
+						Withheld pending defect-liability period
 					</div>
 				</div>
 				<div class="p-4 bg-white border border-ink-200 rounded-lg">
@@ -122,66 +173,130 @@ const recentWorkOrders = computed(() => wos.value.slice(0, 6));
 					</div>
 					<div class="text-[10px] text-ink-400 mt-1">In the master</div>
 				</div>
-				<div class="p-4 bg-white border border-ink-200 rounded-lg">
-					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
-						Total subcontractors
-					</div>
-					<div class="text-2xl font-semibold text-ink-900 tabular-nums mt-1.5">
-						{{ subs.length }}
-					</div>
-					<div class="text-[10px] text-ink-400 mt-1">Registered vendors</div>
-				</div>
 			</div>
 
-			<!-- Recent work orders -->
-			<div class="bg-white border border-ink-200 overflow-hidden rounded-xl mb-6">
-				<div
-					class="px-4 py-3 border-b border-ink-100 bg-gradient-to-r from-brand-50 to-white flex items-center gap-2"
-				>
-					<svg
-						class="w-4 h-4 text-brand-700"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="1.75"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						v-html="getWorkspaceIconPath('clipboard-list')"
-					/>
-					<h2 class="text-sm font-semibold text-ink-900">Recent work orders</h2>
-					<RouterLink
-						to="/subcontractor-work-orders"
-						class="ml-auto text-xs text-brand-700 hover:underline"
-						>View all →</RouterLink
+			<!-- Recent work orders + Recent bills -->
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+				<!-- Recent work orders -->
+				<div class="bg-white border border-ink-200 overflow-hidden rounded-xl">
+					<div
+						class="px-4 py-3 border-b border-ink-100 bg-gradient-to-r from-brand-50 to-white flex items-center gap-2"
 					>
-				</div>
-				<ul v-if="recentWorkOrders.length" class="divide-y divide-ink-100">
-					<li v-for="wo in recentWorkOrders" :key="wo.name" class="px-4 py-3">
-						<div class="flex items-baseline justify-between gap-2">
-							<RouterLink
-								:to="`/subcontractor-work-orders/${wo.name}`"
-								class="text-sm text-ink-900 font-medium hover:text-brand-700 truncate"
-							>
-								{{ wo.subcontractor_name || wo.name }}
-							</RouterLink>
-							<span class="text-xs tabular-nums text-ink-700">{{
-								fmtCompactINR(wo.total_value)
-							}}</span>
-						</div>
-						<div
-							class="text-[11px] text-ink-500 mt-0.5 truncate flex items-center gap-1.5 flex-wrap"
+						<svg
+							class="w-4 h-4 text-brand-700"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.75"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							v-html="getWorkspaceIconPath('clipboard-list')"
+						/>
+						<h2 class="text-sm font-semibold text-ink-900">Recent work orders</h2>
+						<RouterLink
+							to="/subcontractor-work-orders"
+							class="ml-auto text-xs text-brand-700 hover:underline"
+							>View all →</RouterLink
 						>
-							<StatusBadge :status="wo.status" size="xs" />
-							<span>· {{ projectName(wo.project) }}</span>
-							<span class="text-ink-400">· {{ fmtDate(wo.date) }}</span>
-							<span v-if="wo.delivery_type" class="text-ink-400"
-								>· {{ wo.delivery_type }}</span
+					</div>
+					<ul v-if="recentWorkOrders.length" class="divide-y divide-ink-100">
+						<li v-for="wo in recentWorkOrders" :key="wo.name" class="px-4 py-3">
+							<div class="flex items-baseline justify-between gap-2">
+								<RouterLink
+									:to="`/subcontractor-work-orders/${wo.name}`"
+									class="text-sm text-ink-900 font-medium hover:text-brand-700 truncate"
+								>
+									{{ wo.subcontractor_name || wo.name }}
+								</RouterLink>
+								<span class="text-xs tabular-nums text-ink-700">{{
+									fmtCompactINR(wo.total_value)
+								}}</span>
+							</div>
+							<div
+								class="text-[11px] text-ink-500 mt-0.5 truncate flex items-center gap-1.5 flex-wrap"
 							>
-						</div>
-					</li>
-				</ul>
-				<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
-					{{ wosRes.loading ? "Loading work orders…" : "No work orders raised yet." }}
+								<StatusBadge :status="wo.status" size="xs" />
+								<span>· {{ projectName(wo.project) }}</span>
+								<span class="text-ink-400">· {{ fmtDate(wo.date) }}</span>
+								<span v-if="wo.delivery_type" class="text-ink-400"
+									>· {{ wo.delivery_type }}</span
+								>
+							</div>
+							<div class="text-[11px] text-ink-500 mt-0.5">
+								<span class="text-ink-700 tabular-nums">{{ woPercent(wo) }}%</span>
+								billed ·
+								<span class="tabular-nums">{{
+									fmtCompactINR(woBilled(wo.name))
+								}}</span>
+							</div>
+						</li>
+					</ul>
+					<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
+						{{
+							wosRes.loading ? "Loading work orders…" : "No work orders raised yet."
+						}}
+					</div>
+				</div>
+
+				<!-- Recent bills -->
+				<div class="bg-white border border-ink-200 overflow-hidden rounded-xl">
+					<div
+						class="px-4 py-3 border-b border-ink-100 bg-gradient-to-r from-warning-50 to-white flex items-center gap-2"
+					>
+						<svg
+							class="w-4 h-4 text-warning-700"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.75"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							v-html="getWorkspaceIconPath('file-text')"
+						/>
+						<h2 class="text-sm font-semibold text-ink-900">
+							Recent subcontractor bills
+						</h2>
+						<RouterLink
+							to="/subcontractor-bills"
+							class="ml-auto text-xs text-brand-700 hover:underline"
+							>View all →</RouterLink
+						>
+					</div>
+					<ul v-if="recentBills.length" class="divide-y divide-ink-100">
+						<li v-for="b in recentBills" :key="b.name" class="px-4 py-3">
+							<div class="flex items-baseline justify-between gap-2">
+								<RouterLink
+									:to="`/subcontractor-bills/${b.name}`"
+									class="text-sm text-ink-900 font-medium hover:text-brand-700 truncate"
+								>
+									RA {{ b.ra_no }} · {{ b.subcontractor_name || b.name }}
+								</RouterLink>
+								<span class="text-xs tabular-nums text-ink-700">{{
+									fmtCompactINR(b.gross)
+								}}</span>
+							</div>
+							<div
+								class="text-[11px] text-ink-500 mt-0.5 truncate flex items-center gap-1.5 flex-wrap"
+							>
+								<StatusBadge :status="b.status" size="xs" />
+								<span>· {{ projectName(b.project) }}</span>
+								<span class="text-ink-400">· {{ fmtDate(b.date) }}</span>
+							</div>
+							<div class="text-[11px] text-ink-500 mt-0.5 tabular-nums">
+								Retention
+								<span class="text-warning-700 font-medium">{{
+									fmtINR(b.retention_amount)
+								}}</span>
+								· Net payable
+								<span class="text-ink-900 font-medium">{{
+									fmtINR(b.net_payable)
+								}}</span>
+							</div>
+						</li>
+					</ul>
+					<div v-else class="px-4 py-8 text-center text-xs text-ink-400 italic">
+						{{ billsRes.loading ? "Loading bills…" : "No bills raised yet." }}
+					</div>
 				</div>
 			</div>
 


### PR DESCRIPTION
Aligns the workspace **dashboards** with the fresh prototype. The workspace *landings* were already ported in prior PRs; this pass covers the dashboard views the landings link to. All counts/totals come through permission-honoring `get_list` (or the finance mock), so figures stay scoped to what the signed-in user can see.

## Subcontractor Dashboard
- Add **Billed to date** and **Retention held** KPIs, and a **Recent subcontractor bills** panel (2-col with work orders).
- Show **billed % / billed amount per work order** on each WO row.
- All from real `Subcontractor Bill` data via `useDocTypeList` — previously these RA-bill KPIs and the bills panel were stubbed out (the visible gap that prompted this).

## Finance Overview
- Replace the flat two-table mock view with the prototype's richer layout: clickable **KPI strip** (cash & bank / receivables / payables / retention / net position), **cash-and-bank accounts**, a **needs-attention** queue, **quick actions**, receivable/payable **chase-lists**, and **recent transactions**.
- Still driven by `useFinanceMock` (finance remains dummy data except Petty Cash).

## Equipment workspace
- Report tiles (Machinery utilisation / Equipment register) now navigate to their views instead of being inert stubs.

## Verified already matching the prototype (no change needed)
Equipment, Procurement and Project dashboards already carry the full prototype layout (KPIs + all panels), wired to their live APIs.