### PR TITLE
feat: Vue invoice/bill lifecycle defers to a Frappe Workflow when configured

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -365,8 +365,21 @@ def save_invoice(payload):
 	return {"name": si.name}
 
 
+def _guard_workflow():
+	"""Once a site configures an active workflow for Sales Invoice, submission and
+	cancellation must flow through it (buildsuite_core.api.workflow.apply_action), not
+	these direct docstatus endpoints — otherwise the workflow_state and docstatus drift
+	apart. The Vue detail view already routes to the workflow when one is active; this is
+	the server-side backstop."""
+	from buildsuite_core.api.workflow import workflow_active
+
+	if workflow_active(SI):
+		frappe.throw(_("Sales Invoice is governed by a workflow — use a workflow action."))
+
+
 @frappe.whitelist()
 def submit_invoice(name):
+	_guard_workflow()
 	si = frappe.get_doc(SI, name)
 	si.check_permission("submit")
 	si.flags.ignore_permissions = True
@@ -376,6 +389,7 @@ def submit_invoice(name):
 
 @frappe.whitelist()
 def cancel_invoice(name):
+	_guard_workflow()
 	si = frappe.get_doc(SI, name)
 	si.check_permission("cancel")
 	si.flags.ignore_permissions = True

--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -389,8 +389,20 @@ def save_bill(payload):
 	return _serialize(doc)
 
 
+def _guard_workflow():
+	"""When a site configures an active workflow for Subcontractor Bill, submission and
+	cancellation must flow through it (buildsuite_core.api.workflow.apply_action). The
+	workflow's submit transition still runs on_submit (Purchase Invoice generation); this
+	guard only stops the direct docstatus endpoints from bypassing the state machine."""
+	from buildsuite_core.api.workflow import workflow_active
+
+	if workflow_active(BILL):
+		frappe.throw(_("Subcontractor Bill is governed by a workflow — use a workflow action."))
+
+
 @frappe.whitelist()
 def submit_bill(name: str):
+	_guard_workflow()
 	doc = frappe.get_doc(BILL, name)
 	doc.check_permission("submit")
 	doc.submit()
@@ -399,6 +411,7 @@ def submit_bill(name: str):
 
 @frappe.whitelist()
 def cancel_bill(name: str):
+	_guard_workflow()
 	doc = frappe.get_doc(BILL, name)
 	doc.check_permission("cancel")
 	doc.cancel()

--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -513,8 +513,20 @@ def save_bill(payload):
 	return {"name": pi.name}
 
 
+def _guard_workflow():
+	"""When a site configures an active workflow for Purchase Invoice, submission and
+	cancellation must flow through it (buildsuite_core.api.workflow.apply_action), not these
+	direct docstatus endpoints — the Vue detail view already routes to the workflow when one
+	is active; this is the server-side backstop against drift."""
+	from buildsuite_core.api.workflow import workflow_active
+
+	if workflow_active(PI):
+		frappe.throw(_("Purchase Invoice is governed by a workflow — use a workflow action."))
+
+
 @frappe.whitelist()
 def submit_bill(name):
+	_guard_workflow()
 	pi = frappe.get_doc(PI, name)
 	pi.check_permission("submit")
 	pi.flags.ignore_permissions = True
@@ -524,6 +536,7 @@ def submit_bill(name):
 
 @frappe.whitelist()
 def cancel_bill(name):
+	_guard_workflow()
 	pi = frappe.get_doc(PI, name)
 	pi.check_permission("cancel")
 	pi.flags.ignore_permissions = True

--- a/buildsuite_core/api/workflow.py
+++ b/buildsuite_core/api/workflow.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Generic Frappe-Workflow bridge for the Vue app.
+
+The finance documents (Sales Invoice, Purchase Invoice, Subcontractor Bill) ship with a
+plain docstatus lifecycle: the detail views drive Submit / Cancel directly. If a site
+later configures an *active* Frappe Workflow for one of those doctypes, the UI should
+defer to the workflow instead — showing exactly the transitions the signed-in user may
+take from the document's current state, and applying them through Frappe's engine.
+
+This module is the seam. It exposes two thin, doctype-agnostic endpoints:
+
+  · get_workflow_info(doctype[, name]) — is an active workflow configured, and (given a
+    doc) what state is it in + which transitions can THIS user take. Frappe already filters
+    transitions by the user's roles and each transition's condition, so persona-derived
+    roles (see utils/user.sync_persona_roles) gate the buttons natively — no persona field
+    on Workflow is needed.
+  · apply_action(doctype, name, action) — run one workflow action via Frappe, return the
+    resulting lifecycle snapshot.
+
+When no workflow is configured, get_workflow_info reports active=False and callers keep
+their existing docstatus buttons; nothing else changes.
+"""
+
+import frappe
+from frappe.model.workflow import apply_workflow, get_transitions, get_workflow, get_workflow_name
+
+
+def _state_field(doctype):
+	"""The workflow_state field name for `doctype`'s active workflow, or None."""
+	name = get_workflow_name(doctype)
+	if not name:
+		return None
+	return get_workflow(doctype).workflow_state_field
+
+
+@frappe.whitelist()
+def get_workflow_info(doctype, name=None):
+	"""Whether an active workflow governs `doctype`; with `name`, also the doc's current
+	state and the transitions available to the calling user (role + condition filtered)."""
+	wf_name = get_workflow_name(doctype)
+	info = {
+		"active": bool(wf_name),
+		"workflow": wf_name or None,
+		"state_field": None,
+		"state": None,
+		"transitions": [],
+	}
+	if not wf_name:
+		return info
+
+	workflow = get_workflow(doctype)
+	info["state_field"] = workflow.workflow_state_field
+
+	if name:
+		doc = frappe.get_doc(doctype, name)
+		doc.check_permission("read")
+		info["state"] = doc.get(workflow.workflow_state_field)
+		info["transitions"] = [
+			{
+				"action": t.get("action"),
+				"next_state": t.get("next_state"),
+				"allowed": t.get("allowed"),
+			}
+			for t in get_transitions(doc, workflow)
+		]
+	return info
+
+
+@frappe.whitelist()
+def apply_action(doctype, name, action):
+	"""Apply a workflow `action` to (doctype, name) through Frappe's engine, then return
+	the new lifecycle snapshot. Frappe enforces the transition's role, condition and
+	self-approval rules, and drives docstatus when the target state is submitted/cancelled."""
+	doc = frappe.get_doc(doctype, name)
+	updated = apply_workflow(doc.as_dict(), action)
+	state_field = _state_field(doctype)
+	return {
+		"name": updated.name,
+		"state": updated.get(state_field) if state_field else None,
+		"docstatus": updated.docstatus,
+	}
+
+
+def workflow_active(doctype):
+	"""Helper for server-side guards: True when an active workflow governs `doctype`."""
+	return bool(get_workflow_name(doctype))

--- a/frontend/src/composables/useWorkflow.js
+++ b/frontend/src/composables/useWorkflow.js
@@ -1,0 +1,46 @@
+import { ref } from "vue";
+import { getWorkflowInfo, applyWorkflowAction } from "@/data/workflowApi";
+
+/**
+ * Workflow-awareness for a doctype's detail view.
+ *
+ * When an active Frappe Workflow governs `doctype`, `active` becomes true and
+ * `transitions` holds the actions the signed-in user may take from the doc's current
+ * state — Frappe filters these by the user's roles (which personas grant, see
+ * utils/user.sync_persona_roles) and each transition's condition, so the buttons
+ * are already permission-correct. When no workflow is configured, `active` stays
+ * false and the caller keeps its existing docstatus (Submit / Cancel) buttons.
+ *
+ * Refs are returned individually so callers destructure them (`const { active } =
+ * useWorkflow(...)`) and get template auto-unwrapping.
+ *
+ * @param {string} doctype
+ */
+export function useWorkflow(doctype) {
+	const active = ref(false);
+	const stateField = ref(null);
+	const state = ref(null);
+	const transitions = ref([]);
+	const loading = ref(false);
+
+	async function refresh(name) {
+		loading.value = true;
+		try {
+			const info = await getWorkflowInfo(doctype, name);
+			active.value = !!info.active;
+			stateField.value = info.state_field;
+			state.value = info.state;
+			transitions.value = info.transitions || [];
+		} finally {
+			loading.value = false;
+		}
+	}
+
+	// Apply an action, then hand the fresh snapshot back to the caller (which usually
+	// reloads the whole doc anyway).
+	async function applyAction(name, action) {
+		return await applyWorkflowAction(doctype, name, action);
+	}
+
+	return { active, stateField, state, transitions, loading, refresh, applyAction };
+}

--- a/frontend/src/data/workflowApi.js
+++ b/frontend/src/data/workflowApi.js
@@ -1,0 +1,22 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Generic Frappe-Workflow bridge (buildsuite_core.api.workflow.*). Lets any detail view
+// ask whether an active workflow governs its doctype and, if so, drive the transitions
+// the signed-in user may take. When no workflow is configured, `active` is false and the
+// caller keeps its plain docstatus (Submit / Cancel) buttons.
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.workflow.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+// name is optional — omit it to just probe whether the doctype has an active workflow.
+export const getWorkflowInfo = (doctype, name) => call("get_workflow_info", { doctype, name });
+export const applyWorkflowAction = (doctype, name, action) =>
+	call("apply_action", { doctype, name, action });

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -32,12 +32,24 @@ import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
+import { useWorkflow } from "@/composables/useWorkflow";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+
+// Defer to an active Frappe Workflow on Subcontractor Bill when configured; the
+// transition's submit still runs on_submit (which generates the Purchase Invoice),
+// so the side effects are preserved. With no workflow, the plain Submit/Cancel show.
+const {
+	active: wfActive,
+	state: wfState,
+	transitions: wfTransitions,
+	refresh: refreshWorkflow,
+	applyAction: applyWorkflowAction,
+} = useWorkflow("Subcontractor Bill");
 
 const bill = ref(null);
 const busy = ref(false);
@@ -58,6 +70,7 @@ async function load() {
 			discType.value = "%";
 			discValue.value = Number(bill.value.additional_discount_percentage) || 0;
 		}
+		await refreshWorkflow(props.id);
 	} catch (err) {
 		showToast(err.message || "Failed to load bill", "error");
 	}
@@ -76,9 +89,14 @@ const taxRatePct = computed(() =>
 	(bill.value?.taxes || []).reduce((a, t) => a + (Number(t.rate) || 0), 0)
 );
 
+const lifecycleLabel = computed(() =>
+	wfActive.value ? wfState.value || bill.value?.status : bill.value?.status
+);
 const statusPills = computed(() => {
 	if (!bill.value) return [];
-	return isSubmitted.value ? [bill.value.status, payment.value.status] : [bill.value.status];
+	return isSubmitted.value
+		? [lifecycleLabel.value, payment.value.status]
+		: [lifecycleLabel.value];
 });
 
 // --- live waterfall (server is authoritative on save) ---
@@ -212,6 +230,23 @@ async function onSubmit() {
 		submitMsg.value = `Purchase Invoice ${bill.value.purchase_invoice} generated — bill submitted.`;
 	} catch (err) {
 		showToast(err.message || "Submit failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+// Workflow-driven transition (only rendered when an active workflow governs the doctype).
+// The transition that submits the doc runs on_submit, so the Purchase Invoice is still generated.
+async function onWorkflowAction(action) {
+	busy.value = true;
+	try {
+		await applyWorkflowAction(bill.value.name, action);
+		await load();
+		if (bill.value?.purchase_invoice) {
+			submitMsg.value = `Purchase Invoice ${bill.value.purchase_invoice} generated.`;
+		}
+		showToast(`${action} done.`);
+	} catch (err) {
+		showToast(err.message || "Action failed", "error");
 	} finally {
 		busy.value = false;
 	}
@@ -553,8 +588,9 @@ const accountFilters = computed(() =>
 			>
 				Edit
 			</button>
+			<!-- Plain docstatus lifecycle (no workflow configured) -->
 			<button
-				v-if="isDraft"
+				v-if="!wfActive && isDraft"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -563,26 +599,37 @@ const accountFilters = computed(() =>
 			>
 				Submit
 			</button>
-			<template v-if="isSubmitted">
-				<button
-					v-if="payment.status !== 'Paid'"
-					type="button"
-					class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
-					style="border-radius: 6px"
-					@click="onMakePayment"
-				>
-					Make Payment
-				</button>
-				<button
-					type="button"
-					class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
-					style="border-radius: 6px"
-					:disabled="busy"
-					@click="onCancel"
-				>
-					Cancel
-				</button>
-			</template>
+			<button
+				v-if="isSubmitted && payment.status !== 'Paid'"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				@click="onMakePayment"
+			>
+				Make Payment
+			</button>
+			<button
+				v-if="!wfActive && isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onCancel"
+			>
+				Cancel
+			</button>
+			<!-- Workflow transitions (active workflow) -->
+			<button
+				v-for="t in wfActive ? wfTransitions : []"
+				:key="t.action"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onWorkflowAction(t.action)"
+			>
+				{{ t.action }}
+			</button>
 			<button
 				v-if="isCancelled"
 				type="button"

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -25,11 +25,24 @@ import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { useWorkflow } from "@/composables/useWorkflow";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, required: true } });
 const router = useRouter();
 const confirmDialog = useConfirm();
+
+// If a site configures an active Frappe Workflow for Sales Invoice, the lifecycle
+// buttons below defer to it: Submit/Cancel are replaced by the workflow's allowed
+// transitions for this user + state. With no workflow, `wfActive` stays false and
+// the plain docstatus buttons render as before.
+const {
+	active: wfActive,
+	state: wfState,
+	transitions: wfTransitions,
+	refresh: refreshWorkflow,
+	applyAction: applyWorkflowAction,
+} = useWorkflow("Sales Invoice");
 
 const inv = ref(null);
 const receipts = ref([]);
@@ -43,6 +56,8 @@ async function load() {
 		// On-account advances from this customer that can still be adjusted (draft or submitted).
 		availableAdvances.value =
 			inv.value.docstatus === 2 ? [] : await availableInvoiceAdvances(props.id);
+		// Probe for a workflow + refresh the available transitions for this state/user.
+		await refreshWorkflow(props.id);
 	} catch (err) {
 		showToast(err.message || "Failed to load invoice", "error");
 	} finally {
@@ -62,9 +77,16 @@ const state = computed(() => {
 const payment = computed(
 	() => inv.value?.payment || { invoiced: 0, received: 0, outstanding: 0, status: "Draft" }
 );
+// Lifecycle label: the workflow state when a workflow governs the doc, else the
+// docstatus-derived label. The payment pill is independent of the workflow.
+const lifecycleLabel = computed(() =>
+	wfActive.value ? wfState.value || state.value : state.value
+);
 const statusPills = computed(() => {
 	if (!inv.value) return [];
-	return isSubmitted.value ? [state.value, payment.value.status] : [state.value];
+	return isSubmitted.value
+		? [lifecycleLabel.value, payment.value.status]
+		: [lifecycleLabel.value];
 });
 
 const breadcrumbs = [
@@ -111,6 +133,19 @@ async function onCancel() {
 		showToast("Cancelled.");
 	} catch (err) {
 		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+// Workflow-driven transition (only rendered when an active workflow governs the doctype).
+async function onWorkflowAction(action) {
+	busy.value = true;
+	try {
+		await applyWorkflowAction(inv.value.name, action);
+		await load();
+		showToast(`${action} done.`);
+	} catch (err) {
+		showToast(err.message || "Action failed", "error");
 	} finally {
 		busy.value = false;
 	}
@@ -324,8 +359,9 @@ async function unlinkAdvance(row) {
 				>
 					Edit
 				</button>
+				<!-- Plain docstatus lifecycle (no workflow configured) -->
 				<button
-					v-if="isDraft"
+					v-if="!wfActive && isDraft"
 					type="button"
 					class="text-xs desk-save-btn"
 					:disabled="busy"
@@ -343,13 +379,25 @@ async function unlinkAdvance(row) {
 					Receive payment
 				</button>
 				<button
-					v-if="isSubmitted"
+					v-if="!wfActive && isSubmitted"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md"
 					:disabled="busy"
 					@click="onCancel"
 				>
 					Cancel
+				</button>
+				<!-- Workflow transitions (active workflow) — one button per action the
+				     signed-in user may take from the current state -->
+				<button
+					v-for="t in wfActive ? wfTransitions : []"
+					:key="t.action"
+					type="button"
+					class="text-xs desk-save-btn"
+					:disabled="busy"
+					@click="onWorkflowAction(t.action)"
+				>
+					{{ t.action }}
 				</button>
 			</div>
 		</template>

--- a/frontend/src/views/finance/FinanceSupplierBillDetailView.vue
+++ b/frontend/src/views/finance/FinanceSupplierBillDetailView.vue
@@ -26,11 +26,22 @@ import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { useWorkflow } from "@/composables/useWorkflow";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, required: true } });
 const router = useRouter();
 const confirmDialog = useConfirm();
+
+// Defer to an active Frappe Workflow on Purchase Invoice when one is configured;
+// otherwise the plain docstatus Submit/Cancel buttons render as before.
+const {
+	active: wfActive,
+	state: wfState,
+	transitions: wfTransitions,
+	refresh: refreshWorkflow,
+	applyAction: applyWorkflowAction,
+} = useWorkflow("Purchase Invoice");
 
 const bill = ref(null);
 const payments = ref([]);
@@ -45,6 +56,7 @@ async function load() {
 		// On-account advances to this supplier that can still be adjusted (draft or submitted).
 		availableAdvances.value =
 			bill.value.docstatus === 2 ? [] : await availableSupplierBillAdvances(props.id);
+		await refreshWorkflow(props.id);
 	} catch (err) {
 		showToast(err.message || "Failed to load bill", "error");
 	} finally {
@@ -64,9 +76,14 @@ const state = computed(() => {
 const payment = computed(
 	() => bill.value?.payment || { invoiced: 0, paid: 0, outstanding: 0, status: "Draft" }
 );
+const lifecycleLabel = computed(() =>
+	wfActive.value ? wfState.value || state.value : state.value
+);
 const statusPills = computed(() => {
 	if (!bill.value) return [];
-	return isSubmitted.value ? [state.value, payment.value.status] : [state.value];
+	return isSubmitted.value
+		? [lifecycleLabel.value, payment.value.status]
+		: [lifecycleLabel.value];
 });
 
 const breadcrumbs = [
@@ -113,6 +130,19 @@ async function onCancel() {
 		showToast("Cancelled.");
 	} catch (err) {
 		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+// Workflow-driven transition (only rendered when an active workflow governs the doctype).
+async function onWorkflowAction(action) {
+	busy.value = true;
+	try {
+		await applyWorkflowAction(bill.value.name, action);
+		await load();
+		showToast(`${action} done.`);
+	} catch (err) {
+		showToast(err.message || "Action failed", "error");
 	} finally {
 		busy.value = false;
 	}
@@ -329,8 +359,9 @@ async function unlinkAdvance(row) {
 				>
 					Edit
 				</button>
+				<!-- Plain docstatus lifecycle (no workflow configured) -->
 				<button
-					v-if="isDraft"
+					v-if="!wfActive && isDraft"
 					type="button"
 					class="text-xs desk-save-btn"
 					:disabled="busy"
@@ -348,13 +379,24 @@ async function unlinkAdvance(row) {
 					Pay
 				</button>
 				<button
-					v-if="isSubmitted"
+					v-if="!wfActive && isSubmitted"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md"
 					:disabled="busy"
 					@click="onCancel"
 				>
 					Cancel
+				</button>
+				<!-- Workflow transitions (active workflow) -->
+				<button
+					v-for="t in wfActive ? wfTransitions : []"
+					:key="t.action"
+					type="button"
+					class="text-xs desk-save-btn"
+					:disabled="busy"
+					@click="onWorkflowAction(t.action)"
+				>
+					{{ t.action }}
 				</button>
 			</div>
 		</template>


### PR DESCRIPTION
Makes the Project Finance detail views **workflow-aware**. Today Sales Invoice, Purchase Invoice (supplier bill) and Subcontractor Bill run on a plain docstatus lifecycle (Submit / Cancel). This adds an **opt-in seam**: configure an active Frappe Workflow for one of those doctypes and the UI defers to it — states, allowed transitions, role gating. With no workflow configured, behaviour is unchanged.

## Persona vs roles
Roles are sufficient — no Workflow extension needed. Personas already grant their Frappe roles to users via `utils.user.sync_persona_roles` (a `User.validate` hook), and Frappe Workflow transitions are role-gated. So transitions configured against the BuildSuite roles are filtered per user natively.

## Backend — `buildsuite_core.api.workflow`
- `get_workflow_info(doctype[, name])` — whether an active workflow governs the doctype, plus (given a doc) its current `workflow_state` and the transitions this user may take (Frappe filters by role + condition).
- `apply_action(doctype, name, action)` — apply a transition through Frappe's engine; it drives docstatus and runs `on_submit`, so side effects (e.g. the Subcontractor Bill's generated Purchase Invoice) still fire.
- The existing `submit_*` / `cancel_*` endpoints now refuse when a workflow is active, so they can't bypass the state machine.

## Frontend
- `useWorkflow(doctype)` composable + `workflowApi` bridge.
- Invoice / Supplier Bill / Subcontractor Bill detail views: when a workflow is active, the Submit/Cancel buttons are replaced by the workflow's allowed transitions and the lifecycle badge shows `workflow_state`; otherwise the docstatus buttons render as before. Delete/Edit (draft) and Pay/Receive stay available in both modes.

## Verification
- No-workflow path: `get_workflow_info` returns `active: false`; existing submit/cancel unchanged. `test_invoice` (10) and `test_supplier_bill` (4) green.
- With a live test workflow on Sales Invoice: detection flips on save (the `workflow` cache key is in Frappe's `doctype_cache_keys`, cleared by the Workflow controller); Admin (Director role) saw both role-gated transitions from *Pending Review*; the old `submit_invoice` endpoint correctly refused.
- `test_subcontractor_bill`: 19/21 pass; the 2 errors ("Reference No … mandatory for Bank transaction" in `make_payment_entry`/`record_payment`) are **pre-existing** — they fail identically without this change (verified by stashing it).