### PR TITLE
fix: Procurement workspace links to Supplier Bills register

### DIFF
--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -14,9 +14,9 @@ const shortcuts = [
 	{ label: "Material Requests", icon: "clipboard-list", href: "/app/material-request" },
 	{ label: "Purchase Orders", icon: "file-text", href: "/app/purchase-order" },
 	{ label: "Purchase Receipts", icon: "check-circle", href: "/app/purchase-receipt" },
-	// Direct supplier bill (money out) — distinct from the subcontractor bill flow. Routes
-	// to the in-app create form (against a PO or a direct Item-line bill).
-	{ label: "Create Supplier Bill", icon: "wallet", to: "/project-finance/supplier-bills/new" },
+	// Supplier bills (money out) — opens the Bills register, where direct supplier bills
+	// are listed and a new one can be raised. Matches the prototype's "Supplier Bills" tile.
+	{ label: "Supplier Bills", icon: "wallet", to: "/project-finance/bills" },
 	{
 		label: "Material Consumption",
 		icon: "stock",


### PR DESCRIPTION
The Procurement workspace tile was **"Create Supplier Bill"**, routing straight to the new-bill form. The prototype's Procurement workspace instead has a **"Supplier Bills"** tile that opens the bills *register* (from which a new one can still be raised via the panel's "+ New bill" action).

Relabels the tile to **Supplier Bills** and points it at `/project-finance/bills` (the `FinanceBillsPanel` register — the live equivalent of the prototype's supplier-bills list; live has no supplier-only list route). No create capability is lost.