### PR TITLE
fix: QA batch — project ID fallback, subcontractor contacts, MB→bill, petty-cash cancel

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -515,3 +515,96 @@ def get_wo_measurements(work_order: str):
 		b["entries_count"] = entry_counts.get(b.name, 0)
 
 	return {"books": books, "measured_by_line": measured_by_line}
+
+
+# ---------------------------------------------------------------------------
+# Subcontractor master CRUD — a subcontractor is a native ERPNext Supplier tagged
+# supplier_type="Subcontractor". Trade + tax id live on the Supplier; contact person /
+# phone / email live on its native Contact (via utils.party). These endpoints own the
+# join so the Vue master screens read/write all of it in one call.
+# ---------------------------------------------------------------------------
+from buildsuite_core.utils.party import primary_contact, upsert_primary_contact  # noqa: E402
+
+SUBCONTRACTOR_TYPE = "Subcontractor"
+
+
+def _serialize_subcontractor(sup):
+	contact = primary_contact("Supplier", sup.name)
+	return {
+		"name": sup.name,
+		"subcontractor_name": sup.supplier_name,
+		"trade": sup.get("custom_trade") or "",
+		"tax_id": sup.get("tax_id") or "",
+		"status": "Inactive" if sup.get("disabled") else "Active",
+		"contact_person": contact["contact_person"],
+		"phone": contact["phone"],
+		"email": contact["email"],
+	}
+
+
+@frappe.whitelist()
+def list_subcontractors():
+	"""All subcontractor Suppliers with their trade, tax id and primary-contact details."""
+	rows = frappe.get_all(
+		"Supplier",
+		filters={"supplier_type": SUBCONTRACTOR_TYPE},
+		fields=["name", "supplier_name", "custom_trade", "tax_id", "disabled"],
+		order_by="supplier_name asc",
+		limit_page_length=0,
+	)
+	return [_serialize_subcontractor(frappe._dict(r)) for r in rows]
+
+
+@frappe.whitelist()
+def get_subcontractor(name: str):
+	sup = frappe.get_doc("Supplier", name)
+	sup.check_permission("read")
+	return _serialize_subcontractor(sup)
+
+
+@frappe.whitelist()
+def create_subcontractor(
+	subcontractor_name: str,
+	trade: str | None = None,
+	tax_id: str | None = None,
+	status: str = "Active",
+	contact_person: str | None = None,
+	phone: str | None = None,
+	email: str | None = None,
+):
+	doc = frappe.new_doc("Supplier")
+	doc.supplier_name = (subcontractor_name or "").strip()
+	doc.supplier_type = SUBCONTRACTOR_TYPE
+	doc.supplier_group = SUBCONTRACTOR_TYPE
+	doc.custom_trade = trade
+	doc.tax_id = tax_id
+	doc.disabled = 1 if status == "Inactive" else 0
+	doc.insert()
+	upsert_primary_contact("Supplier", doc.name, doc.supplier_name, contact_person, phone, email)
+	return _serialize_subcontractor(doc)
+
+
+@frappe.whitelist()
+def update_subcontractor(
+	name: str,
+	subcontractor_name: str | None = None,
+	trade: str | None = None,
+	tax_id: str | None = None,
+	status: str | None = None,
+	contact_person: str | None = None,
+	phone: str | None = None,
+	email: str | None = None,
+):
+	doc = frappe.get_doc("Supplier", name)
+	doc.check_permission("write")
+	if subcontractor_name is not None:
+		doc.supplier_name = subcontractor_name.strip()
+	if trade is not None:
+		doc.custom_trade = trade
+	if tax_id is not None:
+		doc.tax_id = tax_id
+	if status is not None:
+		doc.disabled = 1 if status == "Inactive" else 0
+	doc.save()
+	upsert_primary_contact("Supplier", doc.name, doc.supplier_name, contact_person, phone, email)
+	return _serialize_subcontractor(doc)

--- a/buildsuite_core/overrides/project.py
+++ b/buildsuite_core/overrides/project.py
@@ -26,6 +26,11 @@ PROJECT_ID_MODE = "Project ID"
 NAME_SERIES_MODE = "Name Series"
 SETTINGS = "BuildSuite Core Settings"
 
+# Last-resort naming series: used only when no Project ID was entered and no series is
+# configured (neither a per-project pick nor a doctype default). Guarantees a Project can
+# always be created without a manual ID — the generated name doubles as the display ID.
+FALLBACK_SERIES = "PROJ-.#####"
+
 
 def project_naming_mode():
 	return frappe.db.get_single_value(SETTINGS, "project_naming") or PROJECT_ID_MODE
@@ -52,17 +57,15 @@ class BuildSuiteProject(_ERPNextProject):
 			self.name = project_id
 			return
 
-		if not self.naming_series:
-			self.naming_series = default_project_series()
-		if self.naming_series:
-			set_name_by_naming_series(self)
-			# No ID was entered, so surface the series-generated name AS the Project ID —
-			# otherwise the field stays NULL and the Vue views show a blank ID. The name is
-			# the primary key (unique), so this keeps the unique index intact.
-			self.custom_project_id = self.name
-			return
-		self.custom_project_id = None  # keep it NULL (not "") so the unique index holds
-		frappe.throw(_("Enter a Project ID or configure a naming series."))
+		# No ID entered → generate from a series. Prefer the per-project pick, then the
+		# doctype default, then a last-resort fallback so a Project can ALWAYS be created
+		# without a manual ID.
+		self.naming_series = self.naming_series or default_project_series() or FALLBACK_SERIES
+		set_name_by_naming_series(self)
+		# Surface the series-generated name AS the Project ID — otherwise the field stays
+		# NULL and the Vue views show a blank ID. The name is the primary key (unique), so
+		# this keeps the Frappe id and the display Project ID identical.
+		self.custom_project_id = self.name
 
 
 def reject_duplicate_project_id(doc, method=None):

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -26,6 +26,14 @@ export const submitWorkOrder = (name) => call("submit_work_order", { name });
 export const cancelWorkOrder = (name) => call("cancel_work_order", { name });
 export const amendWorkOrder = (name) => call("amend_work_order", { name });
 export const getProjectCostCodes = (project) => call("get_project_cost_codes", { project });
+
+// Subcontractor master CRUD — a Supplier tagged supplier_type="Subcontractor", with its
+// contact person / phone / email joined from the native Contact server-side.
+export const listSubcontractors = () => call("list_subcontractors");
+export const getSubcontractor = (name) => call("get_subcontractor", { name });
+export const createSubcontractor = (payload) => call("create_subcontractor", payload);
+export const updateSubcontractor = (name, payload) =>
+	call("update_subcontractor", { name, ...payload });
 export const getCommittedByCostCode = (project) => call("committed_by_cost_code", { project });
 // Subcontract actual (submitted bill this-period amounts) by cost-code group — added to the
 // BOQ's task-progress actuals.

--- a/frontend/src/views/MeasurementBookDetailView.vue
+++ b/frontend/src/views/MeasurementBookDetailView.vue
@@ -90,6 +90,14 @@ async function onRevert() {
 	}
 }
 
+// Once the MB is certified, its measured quantities can be billed — jump to the new
+// Subcontractor Bill form seeded from this MB's Work Order (it derives the this-period
+// lines from the WO's certified MBs).
+function onCreateBill() {
+	if (!mb.value?.work_order) return;
+	router.push(`/subcontractor-bills/new?work_order=${mb.value.work_order}`);
+}
+
 async function onDelete() {
 	const ok = await confirmDialog({
 		title: `Delete ${mb.value.name}?`,
@@ -152,6 +160,16 @@ const breadcrumbs = computed(() => [
 				@click="onRevert"
 			>
 				Revert to Draft
+			</button>
+			<button
+				v-if="!isDraft && mb.work_order"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				title="Open the new Subcontractor Bill form pre-filled to this Work Order"
+				@click="onCreateBill"
+			>
+				+ Create Subcontractor bill
 			</button>
 			<button
 				type="button"

--- a/frontend/src/views/NewSubcontractorView.vue
+++ b/frontend/src/views/NewSubcontractorView.vue
@@ -5,10 +5,9 @@
 
 import { reactive, ref } from "vue";
 import { useRouter } from "vue-router";
-import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
-import { createDataAdapter } from "@/data/adapters";
+import { createSubcontractor } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
 import DeskActionBar from "@/components/desk/DeskActionBar.vue";
@@ -19,13 +18,15 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import TradePicker from "@/components/TradePicker.vue";
 
 const router = useRouter();
-const adapter = createDataAdapter(useDataStore());
 
 const form = reactive({
 	subcontractor_name: "",
 	trade: "",
 	status: "Active",
 	tax_id: "",
+	contact_person: "",
+	phone: "",
+	email: "",
 });
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	supplier_name: "subcontractor_name",
@@ -49,13 +50,14 @@ async function onSave() {
 	if (!validate()) return;
 	saving.value = true;
 	try {
-		const res = await adapter.create("Supplier", {
-			supplier_name: form.subcontractor_name.trim(),
-			supplier_type: "Subcontractor",
-			supplier_group: "Subcontractor",
-			custom_trade: form.trade,
+		const res = await createSubcontractor({
+			subcontractor_name: form.subcontractor_name.trim(),
+			trade: form.trade,
 			tax_id: form.tax_id,
-			disabled: form.status === "Inactive" ? 1 : 0,
+			status: form.status,
+			contact_person: form.contact_person,
+			phone: form.phone,
+			email: form.email,
 		});
 		router.push(`/subcontractors/${res.name}`);
 	} catch (err) {
@@ -102,10 +104,18 @@ const breadcrumbs = [
 					><DeskInput v-model="form.tax_id"
 				/></DeskField>
 			</DeskSection>
-			<p class="text-xs text-ink-400 mt-3">
-				Contact person, phone and email are managed on the subcontractor's Supplier record
-				in the accounting desk.
-			</p>
+
+			<DeskSection title="Contact" :cols="3">
+				<DeskField label="Contact person">
+					<DeskInput v-model="form.contact_person" />
+				</DeskField>
+				<DeskField label="Phone number">
+					<DeskInput v-model="form.phone" />
+				</DeskField>
+				<DeskField label="Email id">
+					<DeskInput v-model="form.email" type="email" />
+				</DeskField>
+			</DeskSection>
 		</DeskForm>
 	</DeskPage>
 </template>

--- a/frontend/src/views/SubcontractorDetailView.vue
+++ b/frontend/src/views/SubcontractorDetailView.vue
@@ -1,6 +1,8 @@
 <script setup>
 // Subcontractor master detail — view / edit / delete + linked Work Orders.
-// Mirrors the prototype's inline view↔edit toggle.
+// Mirrors the prototype's inline view↔edit toggle. Reads/writes through the
+// subcontract API so contact person / phone / email (which live on the native
+// Contact) travel with the trade / tax-id in one call.
 
 import { computed, ref, watch } from "vue";
 import { useRouter, RouterLink } from "vue-router";
@@ -11,6 +13,7 @@ import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
+import { getSubcontractor, updateSubcontractor } from "@/data/subcontractApi";
 import { fmtCompactINR, fmtDate } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSection from "@/components/desk/DeskSection.vue";
@@ -24,16 +27,28 @@ import StatusBadge from "@/components/StatusBadge.vue";
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
-const adapter = createDataAdapter(useDataStore());
+const adapter = createDataAdapter(useDataStore()); // delete only
 const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	subcontractor_name: "subcontractor_name",
 	trade: "trade",
 });
 
-// A subcontractor is a Supplier (supplier_type="Subcontractor").
-const resource = adapter.read("Supplier", props.id, { fields: ["*"] });
-const doc = computed(() => resource?.doc || null);
+// A subcontractor is a Supplier (supplier_type="Subcontractor"); the API joins its
+// primary Contact so { contact_person, phone, email } come back with it.
+const sub = ref(null);
+const loading = ref(true);
+async function load() {
+	loading.value = true;
+	try {
+		sub.value = await getSubcontractor(props.id);
+	} catch (err) {
+		showToast(err.message || "Failed to load subcontractor", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
 
 // Linked Work Orders for this subcontractor.
 const wosRes = useDocTypeList("Subcontractor Work Order", {
@@ -45,22 +60,47 @@ const wosRes = useDocTypeList("Subcontractor Work Order", {
 });
 const linkedWOs = computed(() => wosRes.data || []);
 
+// This subcontractor's bills → billed-to-date per work order for the "% Billed" column.
+const billsRes = useDocTypeList("Subcontractor Bill", {
+	fields: ["name", "work_order", "gross", "docstatus"],
+	filters: [["subcontractor", "=", props.id]],
+	orderBy: "modified desc",
+	pageLength: 0,
+	cache: `buildsuite-subcontractor-bills-${props.id}`,
+});
+const billedByWO = computed(() => {
+	const map = {};
+	for (const b of billsRes.data || []) {
+		if (b.docstatus === 2 || !b.work_order) continue; // skip cancelled
+		map[b.work_order] = (map[b.work_order] || 0) + (Number(b.gross) || 0);
+	}
+	return map;
+});
+function woPercentBilled(wo) {
+	const total = Number(wo.total_value) || 0;
+	if (total <= 0) return 0;
+	return Math.min(100, Math.round(((billedByWO.value[wo.name] || 0) / total) * 1000) / 10);
+}
+
 const editing = ref(false);
 const saving = ref(false);
 const form = ref({});
 
 function snapshot() {
-	const d = doc.value;
+	const d = sub.value;
 	if (!d) return {};
 	return {
-		subcontractor_name: d.supplier_name || "",
-		trade: d.custom_trade || "",
-		status: d.disabled ? "Inactive" : "Active",
+		subcontractor_name: d.subcontractor_name || "",
+		trade: d.trade || "",
+		status: d.status || "Active",
 		tax_id: d.tax_id || "",
+		contact_person: d.contact_person || "",
+		phone: d.phone || "",
+		email: d.email || "",
 	};
 }
 watch(
-	doc,
+	sub,
 	(v) => {
 		if (v && !editing.value) form.value = snapshot();
 	},
@@ -86,13 +126,16 @@ async function saveEdit() {
 	if (!validate()) return;
 	saving.value = true;
 	try {
-		await adapter.update("Supplier", props.id, {
-			supplier_name: form.value.subcontractor_name.trim(),
-			custom_trade: form.value.trade,
+		await updateSubcontractor(props.id, {
+			subcontractor_name: form.value.subcontractor_name.trim(),
+			trade: form.value.trade,
 			tax_id: form.value.tax_id,
-			disabled: form.value.status === "Inactive" ? 1 : 0,
+			status: form.value.status,
+			contact_person: form.value.contact_person,
+			phone: form.value.phone,
+			email: form.value.email,
 		});
-		await resource?.reload?.();
+		await load();
 		editing.value = false;
 	} catch (err) {
 		showToast(applyServerErrors(err) ?? "Failed to update subcontractor", "error");
@@ -104,7 +147,7 @@ async function saveEdit() {
 async function onDelete() {
 	const n = linkedWOs.value.length;
 	const ok = await confirmDialog({
-		title: `Delete ${doc.value?.supplier_name}?`,
+		title: `Delete ${sub.value?.subcontractor_name}?`,
 		message: n
 			? `${n} work order${
 					n === 1 ? "" : "s"
@@ -126,17 +169,17 @@ const breadcrumbs = computed(() => [
 	{ label: "BuildSuite Core", to: "/" },
 	{ label: "Subcontract", to: "/subcontract" },
 	{ label: "Subcontractors", to: "/subcontractors" },
-	{ label: doc.value?.subcontractor_name || props.id },
+	{ label: sub.value?.subcontractor_name || props.id },
 ]);
 </script>
 
 <template>
 	<DeskPage
-		v-if="doc"
-		:title="doc.supplier_name"
-		:subtitle="`${doc.name} · ${doc.custom_trade || '—'}`"
+		v-if="sub"
+		:title="sub.subcontractor_name"
+		:subtitle="`${sub.name} · ${sub.trade || '—'}`"
 		:breadcrumbs="breadcrumbs"
-		:status="doc.disabled ? 'Inactive' : 'Active'"
+		:status="sub.status"
 	>
 		<template #actions>
 			<button
@@ -182,27 +225,39 @@ const breadcrumbs = computed(() => [
 			<DeskSection title="Details" :cols="3">
 				<DeskField label="Name"
 					><div class="text-sm text-ink-900">
-						{{ doc.supplier_name }}
+						{{ sub.subcontractor_name }}
 					</div></DeskField
 				>
 				<DeskField label="Trade"
 					><div class="text-sm text-ink-700">
-						{{ doc.custom_trade || "—" }}
+						{{ sub.trade || "—" }}
 					</div></DeskField
 				>
-				<DeskField label="Status"
-					><StatusBadge :status="doc.disabled ? 'Inactive' : 'Active'"
-				/></DeskField>
+				<DeskField label="Status"><StatusBadge :status="sub.status" /></DeskField>
 				<DeskField label="Tax ID"
 					><div class="text-sm font-mono text-ink-700">
-						{{ doc.tax_id || "—" }}
+						{{ sub.tax_id || "—" }}
 					</div></DeskField
 				>
 			</DeskSection>
-			<p class="text-xs text-ink-400 mt-2">
-				Contact person, phone and email live on this subcontractor's Supplier record in the
-				accounting desk.
-			</p>
+
+			<DeskSection title="Contact" :cols="3">
+				<DeskField label="Contact person"
+					><div class="text-sm text-ink-900">
+						{{ sub.contact_person || "—" }}
+					</div></DeskField
+				>
+				<DeskField label="Phone number"
+					><div class="text-sm text-ink-700">
+						{{ sub.phone || "—" }}
+					</div></DeskField
+				>
+				<DeskField label="Email id"
+					><div class="text-sm text-ink-700">
+						{{ sub.email || "—" }}
+					</div></DeskField
+				>
+			</DeskSection>
 
 			<!-- Linked Work Orders -->
 			<section class="mt-6">
@@ -211,7 +266,7 @@ const breadcrumbs = computed(() => [
 						Work orders ({{ linkedWOs.length }})
 					</h3>
 					<RouterLink
-						:to="`/subcontractor-work-orders/new?subcontractor=${doc.name}`"
+						:to="`/subcontractor-work-orders/new?subcontractor=${sub.name}`"
 						class="text-xs text-brand-700 hover:underline"
 						>+ Raise new work order</RouterLink
 					>
@@ -227,6 +282,7 @@ const breadcrumbs = computed(() => [
 								<th class="text-left px-3 py-2">Project</th>
 								<th class="text-left px-3 py-2">Date</th>
 								<th class="text-right px-3 py-2">Value</th>
+								<th class="text-right px-3 py-2">% Billed</th>
 								<th class="text-left px-3 py-2">Status</th>
 							</tr>
 						</thead>
@@ -252,6 +308,9 @@ const breadcrumbs = computed(() => [
 									class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium"
 								>
 									{{ fmtCompactINR(wo.total_value) }}
+								</td>
+								<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+									{{ woPercentBilled(wo) }}%
 								</td>
 								<td class="px-3 py-2">
 									<StatusBadge
@@ -291,6 +350,18 @@ const breadcrumbs = computed(() => [
 				<DeskField label="Tax ID" hint="e.g. GSTIN (India), VAT No, TIN"
 					><DeskInput v-model="form.tax_id"
 				/></DeskField>
+			</DeskSection>
+
+			<DeskSection title="Contact" :cols="3">
+				<DeskField label="Contact person">
+					<DeskInput v-model="form.contact_person" />
+				</DeskField>
+				<DeskField label="Phone number">
+					<DeskInput v-model="form.phone" />
+				</DeskField>
+				<DeskField label="Email id">
+					<DeskInput v-model="form.email" type="email" />
+				</DeskField>
 			</DeskSection>
 		</div>
 	</DeskPage>

--- a/frontend/src/views/SubcontractorsListView.vue
+++ b/frontend/src/views/SubcontractorsListView.vue
@@ -1,9 +1,10 @@
 <script setup>
 // Subcontractors master list — Desk-styled, mirrors the prototype.
 
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { listSubcontractors } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -11,22 +12,27 @@ import StatusBadge from "@/components/StatusBadge.vue";
 
 const router = useRouter();
 
-// Subcontractors are Suppliers of type "Subcontractor".
-const subsRes = useDocTypeList("Supplier", {
-	fields: ["name", "supplier_name", "custom_trade", "tax_id", "disabled"],
-	filters: [["supplier_type", "=", "Subcontractor"]],
-	orderBy: "supplier_name asc",
-	pageLength: 0,
-	cache: "buildsuite-subcontractor-list",
-	transform: (data) =>
-		data.map((s) => ({
+// Subcontractors are Suppliers of type "Subcontractor"; the API joins each one's
+// primary Contact so contact person + phone come back for the list columns.
+const subs = ref([]);
+const loading = ref(true);
+async function loadSubs() {
+	loading.value = true;
+	try {
+		subs.value = (await listSubcontractors()).map((s) => ({
 			id: s.name,
-			name: s.supplier_name,
-			trade: s.custom_trade,
+			name: s.subcontractor_name,
+			trade: s.trade,
 			tax_id: s.tax_id,
-			status: s.disabled ? "Inactive" : "Active",
-		})),
-});
+			status: s.status,
+			contact: s.contact_person,
+			phone: s.phone,
+		}));
+	} finally {
+		loading.value = false;
+	}
+}
+onMounted(loadSubs);
 
 // Trade filter — the Construction Trade master drives the dropdown.
 const tradesRes = useDocTypeList("Construction Trade", {
@@ -40,7 +46,7 @@ const tradeFilter = ref("");
 
 const search = ref("");
 const rows = computed(() => {
-	let data = subsRes.data || [];
+	let data = subs.value;
 	if (tradeFilter.value) data = data.filter((s) => s.trade === tradeFilter.value);
 	const q = search.value.trim().toLowerCase();
 	if (q)
@@ -48,7 +54,9 @@ const rows = computed(() => {
 			(s) =>
 				(s.name || "").toLowerCase().includes(q) ||
 				(s.trade || "").toLowerCase().includes(q) ||
-				(s.tax_id || "").toLowerCase().includes(q)
+				(s.tax_id || "").toLowerCase().includes(q) ||
+				(s.contact || "").toLowerCase().includes(q) ||
+				(s.phone || "").toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -57,6 +65,8 @@ const columns = [
 	{ key: "id", label: "ID" },
 	{ key: "name", label: "Name" },
 	{ key: "trade", label: "Trade" },
+	{ key: "contact", label: "Contact" },
+	{ key: "phone", label: "Phone" },
 	{ key: "tax_id", label: "Tax ID" },
 	{ key: "status", label: "Status" },
 ];
@@ -113,6 +123,16 @@ function onRowClick(row) {
 				>
 				<span v-else class="text-ink-300">—</span>
 			</template>
+			<template #cell-contact="{ row }">
+				<span v-if="row.contact" class="text-xs text-ink-700">{{ row.contact }}</span>
+				<span v-else class="text-ink-300">—</span>
+			</template>
+			<template #cell-phone="{ row }">
+				<span v-if="row.phone" class="text-xs font-mono text-ink-700">{{
+					row.phone
+				}}</span>
+				<span v-else class="text-ink-300">—</span>
+			</template>
 			<template #cell-tax_id="{ row }">
 				<span class="text-xs font-mono text-ink-500">{{ row.tax_id || "—" }}</span>
 			</template>
@@ -122,8 +142,8 @@ function onRowClick(row) {
 
 			<template #empty>
 				<div class="text-sm text-ink-500">
-					{{ subsRes.loading ? "Loading subcontractors…" : "No subcontractors yet." }}
-					<RouterLink v-if="!subsRes.loading" to="/subcontractors/new" class="desk-link"
+					{{ loading ? "Loading subcontractors…" : "No subcontractors yet." }}
+					<RouterLink v-if="!loading" to="/subcontractors/new" class="desk-link"
 						>Add one →</RouterLink
 					>
 				</div>

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -75,7 +75,7 @@ const filteredAll = computed(() => {
 		(r) =>
 			(r.name || "").toLowerCase().includes(q) ||
 			(r.purpose || "").toLowerCase().includes(q) ||
-			(r.requested_by || "").toLowerCase().includes(q),
+			(r.requested_by || "").toLowerCase().includes(q)
 	);
 });
 
@@ -147,7 +147,7 @@ async function openDirect() {
 	}
 }
 const accountOptions = computed(() =>
-	(direct.accounts || []).map((a) => ({ value: a.name, label: a.name, hint: a.account_type })),
+	(direct.accounts || []).map((a) => ({ value: a.name, label: a.name, hint: a.account_type }))
 );
 async function submitDirect() {
 	if (!direct.holder) return showToast("Pick who is receiving the float.", "error");
@@ -202,19 +202,23 @@ async function confirmDisburse() {
 }
 
 async function onWithdraw(row) {
+	const mine = row.requested_by === session.user;
+	const verb = mine ? "Withdraw" : "Cancel";
 	const ok = await confirmDialog({
-		title: "Withdraw request?",
-		message: `Cancel your petty cash request ${row.name}?`,
-		confirmLabel: "Withdraw",
+		title: `${verb} request?`,
+		message: mine
+			? `Cancel your petty cash request ${row.name}?`
+			: `Cancel petty cash request ${row.name} for ${row.requested_by}?`,
+		confirmLabel: verb,
 		destructive: true,
 	});
 	if (!ok) return;
 	try {
 		await cancelPettyCash(row.name);
 		res.reload?.();
-		showToast("Request withdrawn.");
+		showToast(mine ? "Request withdrawn." : "Request cancelled.");
 	} catch (err) {
-		showToast(err.message || "Withdraw failed", "error");
+		showToast(err.message || `${verb} failed`, "error");
 	}
 }
 
@@ -384,12 +388,15 @@ const rowsForTab = computed(() => {
 						Disburse
 					</button>
 					<button
-						v-if="row.status === 'Requested' && row.requested_by === session.user"
+						v-if="
+							row.status === 'Requested' &&
+							(row.requested_by === session.user || canDisburse)
+						"
 						type="button"
 						class="text-[11px] px-2 py-0.5 border border-ink-200 text-ink-600 rounded"
 						@click.stop="onWithdraw(row)"
 					>
-						Withdraw
+						{{ row.requested_by === session.user ? "Withdraw" : "Cancel" }}
 					</button>
 				</div>
 			</template>


### PR DESCRIPTION
A batch of fixes across Projects, Subcontractors, Measurement Books and Petty Cash.

## 1. Project always gets an ID
`Project.autoname` no longer throws when there's **no entered Project ID and no naming series** configured. It falls back to a `PROJ-.#####` series, so a Project can always be created without a manual ID. The generated name is surfaced as `custom_project_id`, so the **Frappe id and the Vue-displayed Project ID stay identical**. (Typed ID still wins and is uniqueness-checked; blank + configured series still uses that series — unchanged.)

## 2. Subcontractor contact details
Added **Contact person / Phone number / Email id** to the subcontractor master — on the **New**, **Detail** and **Edit** views. These live on the Supplier's native Contact, so new whitelisted endpoints (`create_subcontractor` / `get_subcontractor` / `update_subcontractor` / `list_subcontractors`) join the Contact via `utils.party`, and the views read+write through them instead of the generic adapter (which can't persist a Contact).

## 3. Subcontractor detail: "% Billed" WO column
The Work Orders table on the subcontractor detail page now has a **% Billed** column — sum of that WO's non-cancelled Subcontractor Bill `gross` ÷ WO value (1-dp, capped at 100).

## 4. Subcontractor list: Contact + Phone columns
Added **Contact** and **Phone** columns (and made them searchable) to the subcontractor list.

## 5. Measurement Book → Subcontractor bill
A **certified** Measurement Book's detail view now shows a **"+ Create Subcontractor bill"** button (next to Delete) that opens the new-bill form seeded from the MB's Work Order. Matches the prototype.

## 6. Petty cash: managers can cancel
The withdraw/cancel action was gated to the request owner, so a BS Administrator (and other petty-cash managers) couldn't cancel others' requests in **All Requests**. Now managers (can-disburse) get a **Cancel** action on any Requested request; owners still see **Withdraw**. The backend already permitted it.

## Note — cost-code picker (reported separately)
The report that the WO cost-code picker lists draft BOQs is **already fixed on `develop`** (`get_project_cost_codes` filters `status = "Approved"` scoped to the project — commit `7985ca0`). No change needed; the environment showing drafts is running a stale build.

## Verification
- Backend smoke test: project with no ID + no series → `PROJ-1646`, `name == custom_project_id`. Subcontractor create/get/update/list round-trips contact person/phone/email. `test_project` (21) green.
- `npx vite build` clean.