### PR TITLE
fix: Purchase Invoice naming_series hidden-but-mandatory blocks adding custom fields (workflows)

### DIFF
--- a/buildsuite_core/custom_property_list/property_field.py
+++ b/buildsuite_core/custom_property_list/property_field.py
@@ -298,6 +298,18 @@ def get_property_setters():
 			"value": "1",
 		},
 		{
+			# Hiding a mandatory field with no default trips Frappe's
+			# HiddenAndMandatoryWithoutDefaultError whenever the doctype's fields are
+			# re-validated (e.g. when a Workflow adds its workflow_state custom field).
+			# Match the sibling doctypes (Material Request / Purchase Order / Receipt):
+			# drop the mandatory flag since the series auto-generates the name anyway.
+			"doctype": "Purchase Invoice",
+			"fieldname": "naming_series",
+			"property": "reqd",
+			"property_type": "Check",
+			"value": "0",
+		},
+		{
 			"doctype": "Purchase Invoice",
 			"fieldname": "incoterm",
 			"property": "hidden",


### PR DESCRIPTION
## Symptom
Creating a **Workflow** on Purchase Invoice fails server-side with a 417:

```
Purchase Invoice: Field Series in row 2 cannot be hidden and mandatory without default
(HiddenAndMandatoryWithoutDefaultError)
```

The traceback is entirely inside Frappe: `Workflow.on_update → create_custom_field_for_workflow_state → CustomField.on_update → validate_fields_for_doctype`. **Not related to any recent app/frontend change** — it reproduces on a clean checkout the moment you add any custom field to Purchase Invoice.

## Root cause
`custom_property_list/property_field.py` hides `naming_series` on Material Request, Purchase Order, Purchase Receipt **and** Purchase Invoice. For MR/PO/PR it also sets `reqd = 0`. For **Purchase Invoice it set `hidden = 1` but not `reqd = 0`** — so the Series field is hidden + mandatory + no default. That's a latent invalid meta state; it only surfaces when the doctype's fields get re-validated, which is exactly what happens when a Workflow creates its `workflow_state` custom field.

## Fix
Add the missing `reqd = 0` property setter for Purchase Invoice `naming_series`, matching the sibling doctypes. The series still auto-generates the name; custom fields (and therefore workflows) can now be added. Applied on `after_migrate` via `make_property_setters()`.

## Verify
On a site in the bad state, after applying the setter: `naming_series → hidden: 1, reqd: 0`, and creating the Purchase Invoice workflow succeeds with **no** default-value workaround.

## Deploying to an already-migrated site
`bench --site <site> migrate` re-runs `make_property_setters()` and applies it. For immediate relief before a deploy, run in `bench console`:
```python
from frappe.custom.doctype.property_setter.property_setter import make_property_setter
make_property_setter("Purchase Invoice", "naming_series", "reqd", "0", "Check", validate_fields_for_doctype=False)
frappe.db.commit()
```