### PR TITLE
fix: in-app report view honors filters passed in the URL

### DIFF
--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -10,6 +10,7 @@
 // values, seeded from the report's defaults. A client-side search filters the returned
 // rows, then pagination. Themed for light + dark.
 import { ref, reactive, computed, watch } from "vue";
+import { useRoute } from "vue-router";
 import { runReport, getReportFilters } from "@/data/reportApi";
 import { evalReportFilters } from "@/utils/reportFilters";
 import { useActiveCompany } from "@/composables/useActiveCompany";
@@ -23,10 +24,26 @@ const props = defineProps({
 });
 
 const activeCompany = useActiveCompany();
+const route = useRoute();
 const loading = ref(true);
 const error = ref("");
 const columns = ref([]);
 const rows = ref([]);
+
+// Filter values supplied via the URL query (a deep-linked report view). These override
+// the report's own computed defaults, so a shared link renders exactly what it encodes.
+// This also covers reports whose filters we can't evaluate client-side — e.g. ERPNext's
+// financial statements, whose script pulls filters from erpnext.financial_statements
+// (absent from our shim), so they'd otherwise run with no filters and error.
+const ROUTE_KEYS = new Set(["from", "fromLabel"]);
+const urlFilters = computed(() => {
+	const out = {};
+	for (const [k, v] of Object.entries(route.query || {})) {
+		if (ROUTE_KEYS.has(k)) continue;
+		out[k] = Array.isArray(v) ? v[v.length - 1] : v;
+	}
+	return out;
+});
 
 // --- filters (report-defined) ---
 const filterDefs = ref([]);
@@ -101,9 +118,12 @@ async function load() {
 		filterDefs.value = [];
 	}
 	seedFilters(filterDefs.value);
+	// URL query params win — makes deep-linked report URLs (with filters encoded) render
+	// as shared, and supplies filters for reports whose defs we can't evaluate here.
+	Object.assign(filterValues, urlFilters.value);
 	await runWith();
 }
-watch(() => props.report, load, { immediate: true });
+watch(() => [props.report, route.fullPath], load, { immediate: true });
 
 function applyFilters() {
 	page.value = 1;


### PR DESCRIPTION
## Symptom
Opening an ERPNext financial statement in the Vue report renderer, e.g.
`/core/reports/view/Profit and Loss Statement?company=…&filter_based_on=Fiscal Year&from_fiscal_year=2026&…`,
shows **"From Date and To Date are mandatory"** — even though the URL carries a complete Fiscal Year filter set.

## Root cause
`FrappeReport` seeded filter values **only** from the report's own client script, evaluated in a minimal `frappe` shim. ERPNext's financial statements (P&L, Balance Sheet, Cash Flow) build their filters from `erpnext.financial_statements` — which isn't in the shim — so the filter defs resolved to **empty**, the report ran with **no filters**, and with `filter_based_on` unset ERPNext's `get_period_list` took the *Date Range* branch and threw the mandatory-dates error. The renderer also **ignored the URL query entirely**, so the filters in the link never reached the report.

Confirmed on the site: `run_report("Profit and Loss Statement", <fiscal-year filters>)` returns 5 columns / 16 rows, while `get_report_filters` returns 0 child-table filters and a script that references `erpnext.financial_statements`.

## Fix
`FrappeReport` now merges the **URL query params** into the filter values (overriding the report's computed defaults). A deep-linked report URL renders exactly what it encodes, and financial statements run against the filters in the link. It re-runs when the report or the query changes.

## Verified
- Backend: the report runs correctly given the URL's fiscal-year filters (5 cols, 16 rows).
- `npx vite build` clean.

## Follow-up (not in this PR)
For these financial-statement reports the filter **bar** still doesn't render (their defs can't be evaluated client-side), so filters can be set via the URL but not yet edited in-app. Making the bar appear would mean shimming `erpnext.financial_statements` or synthesizing defs from the query — a larger, separate change.