### PR TITLE
fix: QA batch — WO/MB billed & entries, machinery button, petty-cash names + status filter

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -608,3 +608,22 @@ def update_subcontractor(
 	doc.save()
 	upsert_primary_contact("Supplier", doc.name, doc.supplier_name, contact_person, phone, email)
 	return _serialize_subcontractor(doc)
+
+
+@frappe.whitelist()
+def measurement_book_entry_counts():
+	"""Entry count per Measurement Book, for the list view's Entries column. Scoped to the
+	MBs the user can read (child rows aren't directly listable by non-admins)."""
+	mbs = frappe.get_list("Measurement Book", pluck="name", limit_page_length=0)
+	if not mbs:
+		return {}
+	rows = frappe.get_all(
+		"Measurement Book Entry",
+		filters={"parenttype": "Measurement Book", "parent": ["in", mbs]},
+		fields=["parent"],
+		limit_page_length=0,
+	)
+	out = {}
+	for r in rows:
+		out[r.parent] = out.get(r.parent, 0) + 1
+	return out

--- a/frontend/src/data/subcontractApi.js
+++ b/frontend/src/data/subcontractApi.js
@@ -30,6 +30,7 @@ export const getProjectCostCodes = (project) => call("get_project_cost_codes", {
 // Subcontractor master CRUD — a Supplier tagged supplier_type="Subcontractor", with its
 // contact person / phone / email joined from the native Contact server-side.
 export const listSubcontractors = () => call("list_subcontractors");
+export const getMeasurementBookEntryCounts = () => call("measurement_book_entry_counts");
 export const getSubcontractor = (name) => call("get_subcontractor", { name });
 export const createSubcontractor = (payload) => call("create_subcontractor", payload);
 export const updateSubcontractor = (name, payload) =>

--- a/frontend/src/views/MachineryDetailView.vue
+++ b/frontend/src/views/MachineryDetailView.vue
@@ -155,7 +155,7 @@ const breadcrumbs = computed(() => [
 			<RouterLink
 				v-if="!editing"
 				:to="`/machinery-usage/new?machine=${doc.name}`"
-				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				class="text-xs px-2.5 py-1 border border-info-200 bg-info-50 hover:bg-info-100 text-info-700 font-medium"
 				style="border-radius: 6px"
 			>
 				+ Log usage

--- a/frontend/src/views/MeasurementBookDetailView.vue
+++ b/frontend/src/views/MeasurementBookDetailView.vue
@@ -17,6 +17,7 @@ import {
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import UserAvatar from "@/components/UserAvatar.vue";
 import { fmtDate } from "@/utils/format";
 
 const props = defineProps({ id: String });
@@ -213,11 +214,26 @@ const breadcrumbs = computed(() => [
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
-					Measured / certified by
+					Measured by
 				</div>
-				<div class="text-sm text-ink-900 mt-0.5 truncate">{{ mb.measured_by || "—" }}</div>
-				<div class="text-[10px] text-ink-500 truncate">
-					Certified: {{ mb.certified_by || "—" }}
+				<div class="text-sm text-ink-900 mt-0.5">
+					<UserAvatar
+						v-if="mb.measured_by"
+						:user-id="mb.measured_by"
+						size="xs"
+						show-name
+					/>
+					<span v-else>—</span>
+				</div>
+				<div class="text-[10px] text-ink-500 mt-1 flex items-center gap-1">
+					<span>Certified by</span>
+					<UserAvatar
+						v-if="mb.certified_by"
+						:user-id="mb.certified_by"
+						size="xs"
+						show-name
+					/>
+					<span v-else>—</span>
 				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">

--- a/frontend/src/views/MeasurementBooksListView.vue
+++ b/frontend/src/views/MeasurementBooksListView.vue
@@ -3,9 +3,10 @@
 // project level; each MB carries a work_order link so you can see which
 // WO it feeds.
 
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { getMeasurementBookEntryCounts } from "@/data/subcontractApi";
 import { useProjectNames } from "@/composables/useProjectNames";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -32,6 +33,16 @@ const mbRes = useDocTypeList("Measurement Book", {
 		})),
 });
 
+// Entry count per MB (child rows aren't listable client-side by non-admins).
+const entryCounts = ref({});
+onMounted(async () => {
+	try {
+		entryCounts.value = (await getMeasurementBookEntryCounts()) || {};
+	} catch {
+		entryCounts.value = {};
+	}
+});
+
 const search = ref("");
 const rows = computed(() => {
 	let data = mbRes.data || [];
@@ -52,6 +63,7 @@ const columns = [
 	{ key: "project", label: "Project" },
 	{ key: "work_order", label: "Work Order" },
 	{ key: "date", label: "Date" },
+	{ key: "entries", label: "Entries", align: "right" },
 	{ key: "measured", label: "Measured", align: "right" },
 	{ key: "status", label: "Status" },
 ];
@@ -102,6 +114,11 @@ function onRowClick(row) {
 			</template>
 			<template #cell-date="{ row }">
 				<span class="text-xs text-ink-500">{{ fmtDate(row.date) }}</span>
+			</template>
+			<template #cell-entries="{ row }">
+				<span class="text-xs tabular-nums text-ink-700">{{
+					entryCounts[row.id] || 0
+				}}</span>
 			</template>
 			<template #cell-measured="{ row }">
 				<span class="text-xs tabular-nums text-info-700 font-medium">{{

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -60,7 +60,7 @@ const mbs = computed(() => measurements.value.books || []);
 
 // Bills raised against this WO (state derives from docstatus).
 const billsRes = useDocTypeList("Subcontractor Bill", {
-	fields: ["name", "ra_no", "date", "gross", "net_payable", "docstatus"],
+	fields: ["name", "ra_no", "date", "gross", "retention_amount", "net_payable", "docstatus"],
 	filters: [["work_order", "=", props.id]],
 	orderBy: "ra_no asc",
 	pageLength: 0,
@@ -72,6 +72,21 @@ const bills = computed(() =>
 		status: { 0: "Draft", 1: "Submitted", 2: "Cancelled" }[b.docstatus] || "Draft",
 	}))
 );
+// Billed-to-date + retention held across this WO's non-cancelled bills.
+const totalBilled = computed(() =>
+	(billsRes.data || []).reduce((a, b) => (b.docstatus === 2 ? a : a + (Number(b.gross) || 0)), 0)
+);
+const totalRetention = computed(() =>
+	(billsRes.data || []).reduce(
+		(a, b) => (b.docstatus === 2 ? a : a + (Number(b.retention_amount) || 0)),
+		0
+	)
+);
+const woPct = computed(() => {
+	const total = Number(wo.value?.total_value) || 0;
+	if (total <= 0) return 0;
+	return Math.min(100, Math.round((totalBilled.value / total) * 1000) / 10);
+});
 const measuredByLine = computed(() => measurements.value.measured_by_line || {});
 function lineMeasured(name) {
 	return Number(measuredByLine.value[name] || 0);
@@ -273,7 +288,7 @@ const tabs = computed(() => [
 		</template>
 
 		<!-- Summary strip -->
-		<div class="grid grid-cols-2 md:grid-cols-4 gap-2 mb-4">
+		<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 mb-4">
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
 					Subcontractor
@@ -299,6 +314,24 @@ const tabs = computed(() => [
 					{{ fmtINR(wo.total_value) }}
 				</div>
 				<div class="text-[10px] text-ink-500">Retention {{ wo.retention_percent }}%</div>
+			</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Billed to date
+				</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ fmtINR(totalBilled) }}
+				</div>
+				<div class="text-[10px] text-ink-700">{{ woPct }}%</div>
+			</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Retention held
+				</div>
+				<div class="text-base font-semibold text-warning-700 tabular-nums mt-0.5">
+					{{ fmtINR(totalRetention) }}
+				</div>
+				<div class="text-[10px] text-ink-500">Withheld</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -40,6 +40,27 @@ const wosRes = useDocTypeList("Subcontractor Work Order", {
 		})),
 });
 
+// Billed-to-date per work order (sum of non-cancelled Subcontractor Bill gross) → % billed.
+const billsRes = useDocTypeList("Subcontractor Bill", {
+	fields: ["name", "work_order", "gross", "docstatus"],
+	orderBy: "modified desc",
+	pageLength: 0,
+	cache: "buildsuite-subcontractor-bills-all",
+});
+const billedByWO = computed(() => {
+	const map = {};
+	for (const b of billsRes.data || []) {
+		if (b.docstatus === 2 || !b.work_order) continue; // skip cancelled
+		map[b.work_order] = (map[b.work_order] || 0) + (Number(b.gross) || 0);
+	}
+	return map;
+});
+function woPercentBilled(row) {
+	const total = Number(row.total_value) || 0;
+	if (total <= 0) return 0;
+	return Math.min(100, Math.round(((billedByWO.value[row.id] || 0) / total) * 1000) / 10);
+}
+
 const search = ref("");
 const rows = computed(() => {
 	let data = wosRes.data || [];
@@ -62,6 +83,7 @@ const columns = [
 	{ key: "date", label: "Date" },
 	{ key: "delivery_type", label: "Type" },
 	{ key: "total_value", label: "Value", align: "right" },
+	{ key: "percent", label: "% Billed", align: "right" },
 	{ key: "status", label: "Status" },
 ];
 
@@ -121,6 +143,9 @@ function onRowClick(row) {
 				<span class="text-xs tabular-nums text-ink-900 font-medium">{{
 					fmtCompactINR(row.total_value)
 				}}</span>
+			</template>
+			<template #cell-percent="{ row }">
+				<span class="text-xs tabular-nums text-ink-700">{{ woPercentBilled(row) }}%</span>
 			</template>
 			<template #cell-status="{ row }">
 				<StatusBadge :status="row.status" />

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -26,9 +26,11 @@ import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
+import { useUserNames } from "@/composables/useUserNames";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const session = useSessionStore();
+const { userName } = useUserNames();
 const confirmDialog = useConfirm();
 const router = useRouter();
 
@@ -64,6 +66,7 @@ const all = computed(() => res.data || []);
 
 const tab = ref("disburse");
 const search = ref("");
+const statusFilter = ref(""); // All Requests tab status dropdown
 const tabs = computed(() => [
 	...(canDisburse.value
 		? [{ id: "disburse", label: "To Disburse", count: requested.value.length }]
@@ -78,13 +81,16 @@ const requested = computed(() => all.value.filter((r) => r.status === "Requested
 const mine = computed(() => all.value.filter((r) => r.requested_by === session.user));
 const filteredAll = computed(() => {
 	const q = search.value.trim().toLowerCase();
-	if (!q) return all.value;
-	return all.value.filter(
-		(r) =>
+	return all.value.filter((r) => {
+		if (statusFilter.value && r.status !== statusFilter.value) return false;
+		if (!q) return true;
+		return (
 			(r.name || "").toLowerCase().includes(q) ||
 			(r.purpose || "").toLowerCase().includes(q) ||
-			(r.requested_by || "").toLowerCase().includes(q)
-	);
+			(r.requested_by || "").toLowerCase().includes(q) ||
+			userName(r.requested_by).toLowerCase().includes(q)
+		);
+	});
 });
 
 // Columns are tailored per tab (mirrors the prototype): the All Requests register
@@ -239,7 +245,7 @@ async function onWithdraw(row) {
 		title: `${verb} request?`,
 		message: mine
 			? `Cancel your petty cash request ${row.name}?`
-			: `Cancel petty cash request ${row.name} for ${row.requested_by}?`,
+			: `Cancel petty cash request ${row.name} for ${userName(row.requested_by)}?`,
 		confirmLabel: verb,
 		destructive: true,
 	});
@@ -386,6 +392,17 @@ const rowsForTab = computed(() => {
 			row-key="name"
 			:search-placeholder="tab === 'all' ? 'Search requests…' : ''"
 		>
+			<template v-if="tab === 'all'" #filter-chips>
+				<select
+					v-model="statusFilter"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				>
+					<option value="">All statuses</option>
+					<option value="Requested">Requested</option>
+					<option value="Disbursed">Disbursed</option>
+					<option value="Cancelled">Cancelled</option>
+				</select>
+			</template>
 			<template #cell-name="{ row }">
 				<span class="font-mono text-ink-400 text-[10px]">{{ row.name }}</span>
 			</template>
@@ -398,7 +415,7 @@ const rowsForTab = computed(() => {
 				<div class="flex items-center gap-1.5">
 					<UserAvatar :user-id="row.requested_by" size="xs" /><span
 						class="text-xs text-ink-900"
-						>{{ row.requested_by }}</span
+						>{{ userName(row.requested_by) }}</span
 					>
 				</div>
 			</template>
@@ -594,8 +611,8 @@ const rowsForTab = computed(() => {
 					Disburse {{ fmtINR(disb.row?.amount) }}
 				</h3>
 				<p class="text-xs text-ink-500 mb-4">
-					to {{ disb.row?.requested_by }} · posts a Journal Entry (Dr Petty Cash / Cr the
-					source account).
+					to {{ userName(disb.row?.requested_by) }} · posts a Journal Entry (Dr Petty
+					Cash / Cr the source account).
 				</p>
 				<DeskField label="Pay from" required>
 					<DeskSelect v-model="disb.paidFrom">


### PR DESCRIPTION
A batch of prototype-alignment fixes across Equipment, Subcontract and Petty Cash.

- **Machinery detail** — the "+ Log usage" button now uses the info (blue) button style, matching the prototype (was neutral grey).
- **Work Order list** — added a **% Billed** column (sum of non-cancelled Subcontractor Bill `gross` ÷ WO `total_value`, capped at 100).
- **Work Order detail** — added **Billed to date** and **Retention held** summary cards (from this WO's non-cancelled bills; Billed card also shows the % complete).
- **Measurement Book list** — added an **Entries** column. Child rows aren't listable client-side by non-admins, so the count comes from a new whitelisted `measurement_book_entry_counts` endpoint, scoped to the MBs the user can read.
- **Measurement Book detail** — **Measured by** / **Certified by** now render **avatar + name** via `UserAvatar` (was a raw email).
- **Petty Cash** — the **All Requests** tab gets an **All statuses** filter (Requested / Disbursed / Cancelled); list rows across all tabs now show the holder's **name** (via `useUserNames`) instead of the raw email. Search matches the resolved name too.

The Balances "Report →" link the report also mentioned already shipped in #160 (present on develop) — the note about it "missing in dev" is a stale build; a frontend rebuild shows it.

## Verified
- `measurement_book_entry_counts` returns correct per-MB counts; a non-admin can't list the child doctype directly (why the endpoint exists).
- `npx vite build` clean.