### PR TITLE
fix: petty-cash status colours + reverse-disbursement (Cancel) action

### DIFF
--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -39,6 +39,9 @@ const classes = computed(() => {
 		"Pending Approval": "bg-warning-50 text-warning-700",
 		Approved: "bg-success-50 text-success-700",
 		Rejected: "bg-danger-50 text-danger-700",
+		// Petty Cash Request lifecycle.
+		Requested: "bg-warning-50 text-warning-700",
+		Disbursed: "bg-success-50 text-success-700",
 		// Subcontractor Work Order lifecycle + Subcontractor status.
 		Awarded: "bg-info-50 text-info-700",
 		Closed: "bg-ink-100 text-ink-500",

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -14,6 +14,7 @@ import {
 	disbursePettyCash,
 	issueDirectPettyCash,
 	cancelPettyCash,
+	undisbursePettyCash,
 	pettyCashHolderBalances,
 	listCashBankAccounts,
 } from "@/data/pettyCashApi";
@@ -259,6 +260,34 @@ async function onWithdraw(row) {
 	}
 }
 
+// Reverse a disbursement (cancel the JE and drop the holder's float). A direct issue has no
+// request behind it, so reversing removes the record; a disbursed request goes back to the
+// queue. Only petty-cash managers (canDisburse) see this.
+async function onUndisburse(row) {
+	const ok = await confirmDialog({
+		title: "Cancel disbursement?",
+		message: row.is_direct
+			? `Reverse the ${fmtINR(row.amount)} issued to ${userName(
+					row.requested_by
+			  )}? It was issued directly, so the record is removed and their float drops.`
+			: `Reverse the ${fmtINR(row.amount)} disbursed to ${userName(
+					row.requested_by
+			  )}? The request returns to the disburse queue and their float drops.`,
+		confirmLabel: "Cancel disbursement",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await undisbursePettyCash(row.name);
+		res.reload?.();
+		loadBalances();
+		showToast("Disbursement reversed.");
+	} catch (err) {
+		showToast(err.message || "Reversal failed", "error");
+	}
+}
+
 const breadcrumbs = [
 	{ label: "BuildSuite Core", to: "/" },
 	{ label: "Project Finance", to: "/project-finance" },
@@ -459,6 +488,14 @@ const rowsForTab = computed(() => {
 						@click.stop="onWithdraw(row)"
 					>
 						{{ row.requested_by === session.user ? "Withdraw" : "Cancel" }}
+					</button>
+					<button
+						v-if="row.status === 'Disbursed' && canDisburse"
+						type="button"
+						class="text-[11px] px-2 py-1 text-danger-600 hover:text-danger-700 hover:underline"
+						@click.stop="onUndisburse(row)"
+					>
+						Cancel
 					</button>
 				</div>
 			</template>


### PR DESCRIPTION
Two petty-cash gaps against the prototype.

## Status tag colours
The Petty Cash Request statuses fell through to grey because `StatusBadge` had no entry for them. Now coloured like the prototype:
- **Requested** → amber (`warning`)
- **Disbursed** → green (`success`)

## Reverse-disbursement action (the missing red Cancel)
Disbursed rows had **no action** — the actions column was effectively empty for them. The `undisburse` API existed but was never wired to a button. Now a **Disbursed** row shows a red **Cancel** that reverses the disbursement: it cancels the Journal Entry and drops the holder's float, returning the request to the disburse queue (or removing the record if it was a direct issue). Gated to petty-cash managers (`canDisburse`).

Requested rows keep the green **Disburse** / **Withdraw** actions (green comes from the brand palette, which is `#16A34A`).

## Verified
`npx vite build` clean.