### PR TITLE
feat: in-app report renderer — number cards, chart, tree + synthesized filter bar

### DIFF
--- a/buildsuite_core/api/report.py
+++ b/buildsuite_core/api/report.py
@@ -91,4 +91,10 @@ def run_report(report, filters=None):
 		"columns": res.get("columns") or [],
 		"result": res.get("result") or [],
 		"message": res.get("message"),
+		# Extra render payloads a Script Report's execute() can return, so the in-app
+		# renderer can match the Desk: number cards (report_summary), a frappe-charts
+		# spec (chart), and whether to append a totals row.
+		"report_summary": res.get("report_summary") or [],
+		"chart": res.get("chart") or None,
+		"skip_total_row": res.get("skip_total_row") or 0,
 	}

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -17,6 +17,7 @@ import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtINR, fmtDate } from "@/utils/format";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
+import ReportChart from "@/components/ReportChart.vue";
 
 const props = defineProps({
 	report: { type: String, required: true },
@@ -29,6 +30,9 @@ const loading = ref(true);
 const error = ref("");
 const columns = ref([]);
 const rows = ref([]);
+// Extra render payloads from the report's execute(), matching the Desk.
+const reportSummary = ref([]); // number cards
+const chart = ref(null); // frappe-charts spec
 
 // Filter values supplied via the URL query (a deep-linked report view). These override
 // the report's own computed defaults, so a shared link renders exactly what it encodes.
@@ -93,14 +97,48 @@ async function runWith() {
 				align: NUMERIC.has(c.fieldtype) ? "right" : "left",
 			}));
 		rows.value = res.result || [];
+		reportSummary.value = res.report_summary || [];
+		chart.value = res.chart || null;
+		collapsed.value = new Set();
 		page.value = 1;
 	} catch (err) {
 		error.value = err.message || "Failed to run report.";
 		columns.value = [];
 		rows.value = [];
+		reportSummary.value = [];
+		chart.value = null;
 	} finally {
 		loading.value = false;
 	}
+}
+
+// --- number cards (report_summary) ---
+function summaryValueText(card) {
+	const v = card.value;
+	switch (card.datatype) {
+		case "Currency":
+			return fmtINR(v);
+		case "Percent":
+			return `${Math.round((Number(v) || 0) * 100) / 100}%`;
+		case "Int":
+			return Number(v).toLocaleString("en-IN");
+		case "Float":
+			return Number(v).toLocaleString("en-IN", {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			});
+		default:
+			return v === null || v === undefined || v === "" ? "—" : String(v);
+	}
+}
+function summaryTone(card) {
+	const ind = (card.indicator || "").toLowerCase();
+	if (ind.includes("red") || ind.includes("danger")) return "text-danger-700";
+	if (ind.includes("green") || ind.includes("success")) return "text-success-700";
+	if (ind.includes("orange") || ind.includes("yellow") || ind.includes("warn"))
+		return "text-warning-700";
+	if (ind.includes("blue")) return "text-info-700";
+	return "text-ink-900";
 }
 
 async function load() {
@@ -175,11 +213,53 @@ const filtered = computed(() => {
 	);
 });
 const page = ref(1);
-const pageCount = computed(() => Math.max(1, Math.ceil(filtered.value.length / props.pageSize)));
-const paged = computed(() => {
+
+// --- tree (hierarchical reports carry `indent` + `is_group` per row) ---
+const isTree = computed(() =>
+	rows.value.some((r) => r && typeof r === "object" && r.indent != null)
+);
+const collapsed = ref(new Set());
+function rowIndent(r) {
+	return Math.max(0, Math.round(Number(r?.indent) || 0));
+}
+function isGroupRow(r) {
+	return !!(r && typeof r === "object" && r.is_group);
+}
+function toggleCollapse(key) {
+	const s = new Set(collapsed.value);
+	s.has(key) ? s.delete(key) : s.add(key);
+	collapsed.value = s;
+}
+
+// Rows to render: the full tree (collapse applied, no pagination) when hierarchical,
+// else the current page. Each entry carries display depth + group/collapsed state.
+const bodyRows = computed(() => {
+	if (isTree.value) {
+		const src = filtered.value;
+		const searching = !!search.value.trim();
+		const out = [];
+		let hideBelow = Infinity; // skip rows deeper than a collapsed group
+		for (let i = 0; i < src.length; i++) {
+			const r = src[i];
+			const depth = rowIndent(r);
+			if (!searching && depth > hideBelow) continue;
+			if (!searching) hideBelow = Infinity;
+			const group = isGroupRow(r);
+			const isCollapsed = group && collapsed.value.has(i);
+			out.push({ row: r, depth, group, key: i, collapsed: isCollapsed });
+			if (!searching && isCollapsed) hideBelow = depth;
+		}
+		return out;
+	}
 	const start = (page.value - 1) * props.pageSize;
-	return filtered.value.slice(start, start + props.pageSize);
+	return filtered.value
+		.slice(start, start + props.pageSize)
+		.map((row) => ({ row, depth: 0, group: false, key: null, collapsed: false }));
 });
+
+const pageCount = computed(() =>
+	isTree.value ? 1 : Math.max(1, Math.ceil(filtered.value.length / props.pageSize))
+);
 watch(search, () => (page.value = 1));
 function go(delta) {
 	page.value = Math.min(pageCount.value, Math.max(1, page.value + delta));
@@ -275,6 +355,28 @@ const inputClass =
 			</div>
 		</div>
 
+		<!-- Number cards (report_summary) -->
+		<div
+			v-if="!loading && !error && reportSummary.length"
+			class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 mb-3"
+		>
+			<div
+				v-for="(card, i) in reportSummary"
+				:key="i"
+				class="bg-white border border-ink-200 rounded-lg px-3 py-2.5"
+			>
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					{{ card.label }}
+				</div>
+				<div class="text-lg font-semibold tabular-nums mt-0.5" :class="summaryTone(card)">
+					{{ summaryValueText(card) }}
+				</div>
+			</div>
+		</div>
+
+		<!-- Chart -->
+		<ReportChart v-if="!loading && !error && chart" :chart="chart" />
+
 		<!-- Search + count -->
 		<div class="flex items-center gap-3 mb-3 flex-wrap">
 			<input
@@ -317,27 +419,47 @@ const inputClass =
 					</thead>
 					<tbody>
 						<tr
-							v-for="(row, i) in paged"
+							v-for="(item, i) in bodyRows"
 							:key="i"
 							class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30"
+							:class="item.group ? 'bg-ink-50/40' : ''"
 						>
 							<td
-								v-for="col in columns"
+								v-for="(col, ci) in columns"
 								:key="col.fieldname"
 								class="px-3 py-2 whitespace-nowrap"
 								:class="[
 									col.align === 'right'
 										? 'text-right tabular-nums'
 										: 'text-left',
-									col.fieldtype === 'Link'
+									col.fieldtype === 'Link' && !(ci === 0 && isTree)
 										? 'font-mono text-ink-600'
 										: 'text-ink-800',
 								]"
 							>
-								{{ cellText(row, col) }}
+								<!-- Tree label column: indent by depth + collapse toggle for groups -->
+								<span
+									v-if="ci === 0 && isTree"
+									class="inline-flex items-center gap-1"
+									:style="{ paddingLeft: item.depth * 16 + 'px' }"
+								>
+									<button
+										v-if="item.group"
+										type="button"
+										class="w-3 text-ink-400 hover:text-ink-700 leading-none"
+										@click="toggleCollapse(item.key)"
+									>
+										{{ item.collapsed ? "▸" : "▾" }}
+									</button>
+									<span v-else class="inline-block w-3"></span>
+									<span :class="item.group ? 'font-medium text-ink-900' : ''">{{
+										cellText(item.row, col)
+									}}</span>
+								</span>
+								<template v-else>{{ cellText(item.row, col) }}</template>
 							</td>
 						</tr>
-						<tr v-if="!paged.length">
+						<tr v-if="!bodyRows.length">
 							<td
 								:colspan="columns.length || 1"
 								class="px-3 py-12 text-center text-xs text-ink-400 italic"

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -141,6 +141,48 @@ function summaryTone(card) {
 	return "text-ink-900";
 }
 
+// Some reports (e.g. ERPNext's financial statements) build their filters from a shared
+// JS module we can't evaluate in the shim, so no defs come back — but the deep link
+// carries the filter values. Synthesize editable controls from the URL keys so those
+// reports still get a filter bar. Types are inferred; a handful of well-known keys map
+// to proper Link / Select pickers.
+const KNOWN_LINKS = {
+	company: "Company",
+	cost_center: "Cost Center",
+	project: "Project",
+	warehouse: "Warehouse",
+	customer: "Customer",
+	supplier: "Supplier",
+	item_code: "Item",
+	account: "Account",
+	finance_book: "Finance Book",
+	from_fiscal_year: "Fiscal Year",
+	to_fiscal_year: "Fiscal Year",
+	fiscal_year: "Fiscal Year",
+};
+const KNOWN_SELECTS = {
+	filter_based_on: "Fiscal Year\nDate Range",
+	periodicity: "Monthly\nQuarterly\nHalf-Yearly\nYearly",
+};
+function humanize(k) {
+	return k.replaceAll("_", " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+function synthFiltersFromParams(params) {
+	return Object.entries(params).map(([k, v]) => {
+		let fieldtype = "Data";
+		let options = "";
+		if (v === "0" || v === "1") fieldtype = "Check";
+		else if (KNOWN_LINKS[k]) {
+			fieldtype = "Link";
+			options = KNOWN_LINKS[k];
+		} else if (KNOWN_SELECTS[k]) {
+			fieldtype = "Select";
+			options = KNOWN_SELECTS[k];
+		} else if (k.endsWith("_date")) fieldtype = "Date";
+		return { fieldname: k, label: humanize(k), fieldtype, options, mandatory: 0, default: v };
+	});
+}
+
 async function load() {
 	loading.value = true;
 	error.value = "";
@@ -155,10 +197,19 @@ async function load() {
 	} catch {
 		filterDefs.value = [];
 	}
+	// No evaluable defs but the URL carries filters → build editable controls from them.
+	if (!filterDefs.value.length && Object.keys(urlFilters.value).length) {
+		filterDefs.value = synthFiltersFromParams(urlFilters.value);
+	}
 	seedFilters(filterDefs.value);
-	// URL query params win — makes deep-linked report URLs (with filters encoded) render
-	// as shared, and supplies filters for reports whose defs we can't evaluate here.
-	Object.assign(filterValues, urlFilters.value);
+	// URL query params win — deep-linked report URLs render as shared. Coerce to the
+	// control's type so checkboxes/numbers bind cleanly.
+	for (const [k, v] of Object.entries(urlFilters.value)) {
+		const def = filterDefs.value.find((f) => f.fieldname === k);
+		if (def?.fieldtype === "Check") filterValues[k] = v === "1" || v === 1 ? 1 : 0;
+		else if (def && NUMERIC.has(def.fieldtype)) filterValues[k] = Number(v);
+		else filterValues[k] = v;
+	}
 	await runWith();
 }
 watch(() => [props.report, route.fullPath], load, { immediate: true });

--- a/frontend/src/components/ReportChart.vue
+++ b/frontend/src/components/ReportChart.vue
@@ -1,0 +1,174 @@
+<script setup>
+// Minimal SVG renderer for a frappe-charts spec ({ type, data: { labels, datasets } })
+// as returned by a Script Report's execute(). Supports bar (default) and line, multiple
+// datasets, and negative values (bars grow from a zero baseline). No external chart lib —
+// keeps the SPA bundle lean. Theme-aware via currentColor for axes/labels.
+import { computed } from "vue";
+
+const props = defineProps({
+	chart: { type: Object, required: true },
+});
+
+// Distinct, colour-blind-friendly palette; cycles if there are more datasets.
+const PALETTE = ["#6366f1", "#ef4444", "#f59e0b", "#10b981", "#3b82f6", "#ec4899", "#14b8a6"];
+
+const W = 640;
+const H = 240;
+const PAD = { top: 12, right: 12, bottom: 26, left: 12 };
+
+const labels = computed(() => props.chart?.data?.labels || []);
+const datasets = computed(() =>
+	(props.chart?.data?.datasets || []).map((d, i) => ({
+		name: d.name || `Series ${i + 1}`,
+		values: (d.values || []).map((v) => Number(v) || 0),
+		color: PALETTE[i % PALETTE.length],
+	}))
+);
+const type = computed(() => props.chart?.type || "bar");
+const hasData = computed(() => labels.value.length && datasets.value.length);
+
+const allValues = computed(() => datasets.value.flatMap((d) => d.values));
+const yMax = computed(() => Math.max(0, ...allValues.value));
+const yMin = computed(() => Math.min(0, ...allValues.value));
+const span = computed(() => yMax.value - yMin.value || 1);
+
+const plot = computed(() => ({
+	left: PAD.left,
+	right: W - PAD.right,
+	top: PAD.top,
+	bottom: H - PAD.bottom,
+}));
+function yFor(v) {
+	const p = plot.value;
+	return p.top + ((yMax.value - v) / span.value) * (p.bottom - p.top);
+}
+const zeroY = computed(() => yFor(0));
+
+// Compact number label (K / L / Cr for the Indian scale the reports use).
+function compact(v) {
+	const n = Number(v) || 0;
+	const a = Math.abs(n);
+	const sign = n < 0 ? "-" : "";
+	if (a >= 1e7) return `${sign}${(a / 1e7).toFixed(2)}Cr`;
+	if (a >= 1e5) return `${sign}${(a / 1e5).toFixed(2)}L`;
+	if (a >= 1e3) return `${sign}${(a / 1e3).toFixed(1)}K`;
+	return `${sign}${a}`;
+}
+
+const groupWidth = computed(
+	() => (plot.value.right - plot.value.left) / (labels.value.length || 1)
+);
+
+// Bar geometry: bars sit side-by-side within each label group.
+const bars = computed(() => {
+	if (type.value === "line") return [];
+	const out = [];
+	const gw = groupWidth.value;
+	const n = datasets.value.length;
+	const inner = gw * 0.7;
+	const bw = inner / n;
+	const showLabels = allValues.value.length <= 12;
+	labels.value.forEach((_, li) => {
+		const gx = plot.value.left + li * gw + (gw - inner) / 2;
+		datasets.value.forEach((d, di) => {
+			const v = d.values[li] ?? 0;
+			const y = yFor(v);
+			const x = gx + di * bw;
+			out.push({
+				x: x + 1,
+				y: Math.min(y, zeroY.value),
+				w: Math.max(bw - 2, 1),
+				h: Math.max(Math.abs(y - zeroY.value), 0.5),
+				color: d.color,
+				label: showLabels ? compact(v) : "",
+				labelY:
+					(v >= 0 ? Math.min(y, zeroY.value) : Math.max(y, zeroY.value)) +
+					(v >= 0 ? -3 : 11),
+				labelX: x + bw / 2,
+			});
+		});
+	});
+	return out;
+});
+
+// Line geometry: one polyline per dataset.
+const lines = computed(() => {
+	if (type.value !== "line") return [];
+	const gw = groupWidth.value;
+	return datasets.value.map((d) => ({
+		color: d.color,
+		points: labels.value
+			.map((_, li) => `${plot.value.left + li * gw + gw / 2},${yFor(d.values[li] ?? 0)}`)
+			.join(" "),
+	}));
+});
+
+const xTicks = computed(() => {
+	const gw = groupWidth.value;
+	return labels.value.map((l, i) => ({ label: l, x: plot.value.left + i * gw + gw / 2 }));
+});
+</script>
+
+<template>
+	<div v-if="hasData" class="bg-white border border-ink-200 rounded-lg p-3 mb-3">
+		<svg :viewBox="`0 0 ${W} ${H}`" class="w-full" style="max-height: 240px" role="img">
+			<!-- zero baseline -->
+			<line
+				:x1="plot.left"
+				:x2="plot.right"
+				:y1="zeroY"
+				:y2="zeroY"
+				stroke="currentColor"
+				class="text-ink-300"
+				stroke-width="1"
+			/>
+			<!-- bars -->
+			<template v-for="(b, i) in bars" :key="`b${i}`">
+				<rect :x="b.x" :y="b.y" :width="b.w" :height="b.h" :fill="b.color" rx="1.5" />
+				<text
+					v-if="b.label"
+					:x="b.labelX"
+					:y="b.labelY"
+					text-anchor="middle"
+					class="fill-ink-600"
+					style="font-size: 9px"
+				>
+					{{ b.label }}
+				</text>
+			</template>
+			<!-- lines -->
+			<polyline
+				v-for="(ln, i) in lines"
+				:key="`l${i}`"
+				:points="ln.points"
+				fill="none"
+				:stroke="ln.color"
+				stroke-width="2"
+				stroke-linejoin="round"
+				stroke-linecap="round"
+			/>
+			<!-- x-axis labels -->
+			<text
+				v-for="(t, i) in xTicks"
+				:key="`x${i}`"
+				:x="t.x"
+				:y="H - 8"
+				text-anchor="middle"
+				class="fill-ink-500"
+				style="font-size: 10px"
+			>
+				{{ t.label }}
+			</text>
+		</svg>
+		<!-- legend -->
+		<div class="flex flex-wrap items-center gap-x-4 gap-y-1 mt-1 px-1">
+			<div v-for="d in datasets" :key="d.name" class="flex items-center gap-1.5">
+				<span
+					class="inline-block w-2.5 h-2.5 rounded-sm"
+					:style="{ backgroundColor: d.color }"
+				></span>
+				<span class="text-[11px] text-ink-600">{{ d.name }}</span>
+			</div>
+		</div>
+	</div>
+</template>


### PR DESCRIPTION
Builds on the merged URL-filters fix (#161) to bring the in-app report renderer (`/reports/view/:report` → `FrappeReport`) to full parity with the ERPNext Desk for Script/Query reports.

## Number cards + chart + tree
A report's `execute()` returns up to `columns, data, message, chart, report_summary, skip_total_row`; the Desk renders the extras above the table.
- **Backend** — `run_report` now forwards `report_summary`, `chart`, and `skip_total_row` (it was dropping them).
- **Number cards** — `report_summary` rendered as labelled cards, formatted by `datatype`, coloured by `indicator` (e.g. P&L's Total Income / Total Expense / Profit, the loss in red).
- **Chart** — a dependency-free SVG `ReportChart` renders the frappe-charts spec (bar/line, multiple datasets, negative values from a zero baseline) with a legend. No new bundle deps.
- **Tree** — hierarchical reports carry `indent` + `is_group` per row; the label column indents by depth with collapsible group rows (expanded by default, no pagination in tree mode). P&L / Balance Sheet / Cash Flow read like the Desk.

## Synthesized filter bar
Reports whose filters live in a shared JS module we can't evaluate client-side (ERPNext's financial statements) returned no filter defs, so their filter bar never rendered. When a report yields no evaluable defs but the URL carries filters, `FrappeReport` now builds editable controls from those keys: `0`/`1` → checkbox, `*_date` → date, well-known keys → proper Link/Select pickers (company, fiscal years, filter_based_on, periodicity, …), the rest → text.

## Verified
- `run_report("Profit and Loss Statement", …)` forwards 3 summary cards + a bar chart; the tree rows carry `indent`/`is_group`.
- `npx vite build` clean.