### PR TITLE
fix: usage-log task/project integrity + readable list names; invoice/bill filters + pagination

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/machinery_usage/machinery_usage.py
+++ b/buildsuite_core/buildsuite_core/doctype/machinery_usage/machinery_usage.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -24,4 +25,10 @@ class MachineryUsage(Document):
 		unit: DF.Literal["Days", "Hours"]
 	# end: auto-generated types
 
-	pass
+	def validate(self):
+		# The task is optional, but if set it must belong to the selected project —
+		# a usage log must never be booked against a task from another project.
+		if self.task and self.project:
+			task_project = frappe.db.get_value("Task", self.task, "project")
+			if task_project != self.project:
+				frappe.throw(_("Task {0} does not belong to project {1}.").format(self.task, self.project))

--- a/frontend/src/views/MachineryUsageDetailView.vue
+++ b/frontend/src/views/MachineryUsageDetailView.vue
@@ -78,6 +78,14 @@ watch(
 	},
 	{ immediate: true }
 );
+// In edit mode, changing the project clears the task (the picker is scoped to the project,
+// and the server rejects a cross-project task).
+watch(
+	() => form.value.project,
+	(_new, _old) => {
+		if (editing.value) form.value.task = "";
+	}
+);
 
 function totalOf(o) {
 	return (Number(o.quantity) || 0) * (Number(o.rate) || 0) + (Number(o.fuel_cost) || 0);

--- a/frontend/src/views/MachineryUsageListView.vue
+++ b/frontend/src/views/MachineryUsageListView.vue
@@ -31,6 +31,31 @@ const usageRes = useDocTypeList("Machinery Usage", {
 	transform: (data) => data.map((u) => ({ id: u.name, ...u })),
 });
 
+// The usage log stores machine + task ids; resolve them to readable names for display.
+const machineryRes = useDocTypeList("Machinery", {
+	fields: ["name", "machinery_name"],
+	pageLength: 0,
+	cache: "buildsuite-machinery-names",
+});
+const machineNameById = computed(() => {
+	const map = {};
+	for (const m of machineryRes.data || []) map[m.name] = m.machinery_name;
+	return map;
+});
+const machineName = (id) => machineNameById.value[id] || id;
+
+const taskRes = useDocTypeList("Task", {
+	fields: ["name", "subject"],
+	pageLength: 0,
+	cache: "buildsuite-task-subjects",
+});
+const taskSubjectById = computed(() => {
+	const map = {};
+	for (const t of taskRes.data || []) map[t.name] = t.subject;
+	return map;
+});
+const taskSubject = (id) => taskSubjectById.value[id] || id;
+
 function totalFor(row) {
 	return (Number(row.quantity) || 0) * (Number(row.rate) || 0) + (Number(row.fuel_cost) || 0);
 }
@@ -42,7 +67,8 @@ const rows = computed(() => {
 	if (q)
 		data = data.filter(
 			(u) =>
-				(u.machine || "").toLowerCase().includes(q) ||
+				machineName(u.machine).toLowerCase().includes(q) ||
+				taskSubject(u.task).toLowerCase().includes(q) ||
 				(u.project || "").toLowerCase().includes(q) ||
 				projectName(u.project).toLowerCase().includes(q)
 		);
@@ -85,14 +111,14 @@ function onRowClick(row) {
 		>
 			<template #cell-machine="{ row }">
 				<DeskLink :to="`/machinery/${row.machine}`" @click.stop>{{
-					row.machine
+					machineName(row.machine)
 				}}</DeskLink>
 			</template>
 			<template #cell-project="{ row }">
 				<span class="text-ink-700">{{ projectName(row.project) || "—" }}</span>
 			</template>
 			<template #cell-task="{ row }">
-				<span class="text-ink-500">{{ row.task || "—" }}</span>
+				<span class="text-ink-500">{{ row.task ? taskSubject(row.task) : "—" }}</span>
 			</template>
 			<template #cell-date="{ row }">
 				<span class="text-ink-500">{{ fmtDate(row.date) }}</span>

--- a/frontend/src/views/NewMachineryUsageView.vue
+++ b/frontend/src/views/NewMachineryUsageView.vue
@@ -34,7 +34,7 @@ const machineryOptions = computed(() =>
 		value: m.name,
 		label: m.machinery_name,
 		hint: [m.machinery_type, m.ownership].filter(Boolean).join(" · "),
-	})),
+	}))
 );
 const projectRes = useDocTypeList("Project", {
 	fields: ["name", "project_name"],
@@ -43,7 +43,7 @@ const projectRes = useDocTypeList("Project", {
 	cache: "buildsuite-project-options",
 });
 const projectOptions = computed(() =>
-	(projectRes.data || []).map((p) => ({ value: p.name, label: p.project_name, hint: p.name })),
+	(projectRes.data || []).map((p) => ({ value: p.name, label: p.project_name, hint: p.name }))
 );
 
 const today = new Date().toISOString().slice(0, 10);
@@ -65,7 +65,7 @@ const saving = ref(false);
 
 // Auto-fill rate + unit from the picked machine (also on ?machine= prefill).
 const selectedMachine = computed(() =>
-	(machineryRes.data || []).find((m) => m.name === form.machine),
+	(machineryRes.data || []).find((m) => m.name === form.machine)
 );
 watch(
 	selectedMachine,
@@ -75,11 +75,20 @@ watch(
 			form.unit = m.rate_unit === "Hour" ? "Hours" : "Days";
 		}
 	},
-	{ immediate: true },
+	{ immediate: true }
+);
+
+// Changing the project clears the task — the task picker is scoped to the project, so a
+// stale cross-project task must never linger (the server rejects it too).
+watch(
+	() => form.project,
+	() => {
+		form.task = "";
+	}
 );
 
 const total = computed(
-	() => (Number(form.quantity) || 0) * (Number(form.rate) || 0) + (Number(form.fuel_cost) || 0),
+	() => (Number(form.quantity) || 0) * (Number(form.rate) || 0) + (Number(form.fuel_cost) || 0)
 );
 
 function validate() {

--- a/frontend/src/views/finance/FinanceBillsPanel.vue
+++ b/frontend/src/views/finance/FinanceBillsPanel.vue
@@ -4,7 +4,7 @@
 // right create screen (supplier bill form here, or the Subcontract module); a row opens the
 // matching detail screen. Rendering differs by kind. The list merges two doctypes, so it's a
 // custom endpoint + table rather than DocTypeListView (which is single-doctype).
-import { computed, reactive, ref } from "vue";
+import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import {
@@ -56,11 +56,25 @@ load();
 const search = ref("");
 const typeFilter = ref("");
 const statusFilter = ref("");
-const hasFilters = computed(() => search.value || typeFilter.value || statusFilter.value);
+const projectFilter = ref("");
+const fromDate = ref("");
+const toDate = ref("");
+const hasFilters = computed(
+	() =>
+		search.value ||
+		typeFilter.value ||
+		statusFilter.value ||
+		projectFilter.value ||
+		fromDate.value ||
+		toDate.value
+);
 function clearFilters() {
 	search.value = "";
 	typeFilter.value = "";
 	statusFilter.value = "";
+	projectFilter.value = "";
+	fromDate.value = "";
+	toDate.value = "";
 }
 const rows = computed(() => {
 	const term = search.value.trim().toLowerCase();
@@ -68,11 +82,27 @@ const rows = computed(() => {
 		(r) =>
 			(!typeFilter.value || r.kind === typeFilter.value) &&
 			(!statusFilter.value || r.status === statusFilter.value) &&
+			(!projectFilter.value || r.project === projectFilter.value) &&
+			(!fromDate.value || (r.date && r.date >= fromDate.value)) &&
+			(!toDate.value || (r.date && r.date <= toDate.value)) &&
 			(!term ||
 				r.name.toLowerCase().includes(term) ||
 				(r.party || "").toLowerCase().includes(term) ||
 				(r.project || "").toLowerCase().includes(term))
 	);
+});
+
+// Client-side pagination over the filtered rows (the list merges two doctypes, so it
+// can't use the single-doctype DocTypeListView).
+const page = ref(1);
+const pageSize = ref(10);
+const totalPages = computed(() => Math.max(1, Math.ceil(rows.value.length / pageSize.value)));
+const pagedRows = computed(() => {
+	const start = (page.value - 1) * pageSize.value;
+	return rows.value.slice(start, start + pageSize.value);
+});
+watch([rows, pageSize], () => {
+	if (page.value > totalPages.value) page.value = 1;
 });
 
 function aging(row) {
@@ -241,20 +271,20 @@ async function saveAdvance() {
 		</template>
 
 		<div class="space-y-4">
-			<div class="flex items-center gap-4 text-sm">
-				<div>
+			<div class="flex items-center gap-6 text-sm">
+				<div class="flex items-center gap-1.5">
 					<span class="text-ink-500">Payable</span>
 					<span class="font-semibold text-ink-900 tabular-nums">{{
 						fmtINR(summary.outstanding)
 					}}</span>
 				</div>
-				<div v-if="summary.retention > 0">
+				<div v-if="summary.retention > 0" class="flex items-center gap-1.5">
 					<span class="text-ink-500">Retention held</span>
 					<span class="font-semibold text-warning-700 tabular-nums">{{
 						fmtINR(summary.retention)
 					}}</span>
 				</div>
-				<div v-if="summary.advances > 0">
+				<div v-if="summary.advances > 0" class="flex items-center gap-1.5">
 					<span class="text-ink-500">Advances paid</span>
 					<span class="font-semibold text-info-700 tabular-nums">{{
 						fmtINR(summary.advances)
@@ -286,6 +316,27 @@ async function saveAdvance() {
 					<option>Partly Paid</option>
 					<option>Paid</option>
 				</select>
+				<div class="w-44">
+					<DeskLinkPicker
+						v-model="projectFilter"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						placeholder="All projects"
+					/>
+				</div>
+				<input
+					v-model="fromDate"
+					type="date"
+					title="From date"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+				<input
+					v-model="toDate"
+					type="date"
+					title="To date"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
 				<button
 					v-if="hasFilters"
 					type="button"
@@ -319,7 +370,7 @@ async function saveAdvance() {
 					</thead>
 					<tbody>
 						<tr
-							v-for="r in rows"
+							v-for="r in pagedRows"
 							:key="r.kind + r.name"
 							class="border-t border-ink-100 hover:bg-brand-50/40 cursor-pointer"
 							@click="openDetail(r)"
@@ -381,6 +432,38 @@ async function saveAdvance() {
 					{{ loading ? "Loading…" : "No bills yet." }}
 				</div>
 			</section>
+
+			<!-- Pagination -->
+			<div
+				v-if="totalPages > 1"
+				class="flex items-center justify-between text-xs text-ink-500"
+			>
+				<span
+					>Showing {{ (page - 1) * pageSize + 1 }}–{{
+						Math.min(page * pageSize, rows.length)
+					}}
+					of {{ rows.length }}</span
+				>
+				<div class="flex items-center gap-2">
+					<button
+						type="button"
+						class="px-2 py-1 border border-ink-200 rounded-md disabled:opacity-40 hover:bg-ink-50"
+						:disabled="page <= 1"
+						@click="page--"
+					>
+						← Prev
+					</button>
+					<span>Page {{ page }} / {{ totalPages }}</span>
+					<button
+						type="button"
+						class="px-2 py-1 border border-ink-200 rounded-md disabled:opacity-40 hover:bg-ink-50"
+						:disabled="page >= totalPages"
+						@click="page++"
+					>
+						Next →
+					</button>
+				</div>
+			</div>
 		</div>
 
 		<!-- New bill type chooser -->

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -78,7 +78,22 @@ function aging(row) {
 }
 
 const statusFilter = ref("");
-const filterValues = computed(() => ({ status: statusFilter.value }));
+const projectFilter = ref("");
+const fromDate = ref("");
+const toDate = ref("");
+const filterValues = computed(() => ({
+	status: statusFilter.value,
+	project: projectFilter.value,
+	fromDate: fromDate.value,
+	toDate: toDate.value,
+}));
+// Map filter keys → Sales Invoice fields; the two dates bracket posting_date.
+const filterFieldMap = {
+	status: "status",
+	project: "project",
+	fromDate: { field: "posting_date", op: ">=" },
+	toDate: { field: "posting_date", op: "<=" },
+};
 
 function openDetail(row) {
 	router.push(`/project-finance/invoices/${row.name}`);
@@ -225,14 +240,14 @@ async function saveAdvance() {
 		</template>
 
 		<div class="space-y-4">
-			<div class="flex items-center gap-4 text-sm">
-				<div>
+			<div class="flex items-center gap-6 text-sm">
+				<div class="flex items-center gap-1.5">
 					<span class="text-ink-500">Outstanding</span>
 					<span class="font-semibold text-ink-900 tabular-nums">{{
 						fmtINR(summary.outstanding)
 					}}</span>
 				</div>
-				<div v-if="summary.advances > 0">
+				<div v-if="summary.advances > 0" class="flex items-center gap-1.5">
 					<span class="text-ink-500">Advances held</span>
 					<span class="font-semibold text-info-700 tabular-nums">{{
 						fmtINR(summary.advances)
@@ -272,7 +287,7 @@ async function saveAdvance() {
 				:search-fields="['name', 'customer_name']"
 				:base-filters="baseFilters"
 				:filter-values="filterValues"
-				:filter-field-map="{ status: 'status' }"
+				:filter-field-map="filterFieldMap"
 				cache-key="buildsuite-invoice-list"
 				row-key="name"
 				initial-order-by="posting_date desc"
@@ -290,6 +305,27 @@ async function saveAdvance() {
 						<option>Paid</option>
 						<option>Cancelled</option>
 					</DeskSelect>
+					<div class="w-48">
+						<DeskLinkPicker
+							v-model="projectFilter"
+							doctype="Project"
+							label-field="project_name"
+							value-field="name"
+							placeholder="All projects"
+						/>
+					</div>
+					<input
+						v-model="fromDate"
+						type="date"
+						title="From date (posting date)"
+						class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+					/>
+					<input
+						v-model="toDate"
+						type="date"
+						title="To date (posting date)"
+						class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+					/>
 				</template>
 
 				<template #cell-name="{ row }"


### PR DESCRIPTION
## Machinery Usage (Equipment Usage Log)
- **Task must belong to the project.** Server-side `validate()` on Machinery Usage rejects a task whose project ≠ the log's project — verified: cross-project → *"Task … does not belong to project …"*, same-project → OK. The Task field is optional but never cross-project.
- **Clear task on project change.** In both the New form and the detail/edit view, changing the Project clears the Task (the Task picker was already scoped to the selected project via `filters`, so it refreshes to that project's tasks).
- **List columns showed IDs.** The MACHINE and TASK columns rendered the Frappe `name`; they now resolve to `machinery_name` and the task `subject` (cached lookups, also searchable).

## Project Finance lists
- **Padding** — the summary strip labels butted against their numbers (Outstanding/Advances held on Invoices; Payable/Retention/Advances on Bills). Labels are now spaced from their values.
- **Invoices** — added **Project**, **From Date**, **To Date** filters (bracketing `posting_date`) through `DocTypeListView`'s filter map. Pagination / sort / search were already provided by `DocTypeListView`.
- **Bills** — this list **merges** two doctypes (Purchase Invoice + Subcontractor Bill), so it can't use the single-doctype `DocTypeListView`. Added **Project + From/To Date** filters and **client-side pagination** (10/page) to the existing custom table.

## Verified
- Backend validation exercised directly (cross-project rejected, same-project passes).
- `npx vite build` clean.