### PR TITLE
feat: rework Site Execution reports to the prototype set (+ data-source docs)

### DIFF
--- a/buildsuite_core/api/workspace_setting.py
+++ b/buildsuite_core/api/workspace_setting.py
@@ -54,6 +54,10 @@ def _resolve(row):
 	if not route and report:
 		if not frappe.db.exists("Report", report):
 			return None
+		# Hide the tile if the user can't run the report (the Report's own roles gate it) —
+		# e.g. site roles don't see the finance-restricted Billing / Subcontractor reports.
+		if not frappe.get_cached_doc("Report", report).is_permitted():
+			return None
 		route = _report_route(report)
 		label = label or frappe.db.get_value("Report", report, "report_name") or report
 	if not route:

--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
@@ -18,78 +18,9 @@ _PROJECT = {"fieldname": "project", "label": "Project", "fieldtype": "Link", "op
 _FROM = {"fieldname": "from_date", "label": "From", "fieldtype": "Date"}
 _TO = {"fieldname": "to_date", "label": "To", "fieldtype": "Date"}
 
-# (report_name, ref_doctype, icon, description, query, filters) — the Site Execution reports.
-REPORTS = (
-	(
-		"Project Status Summary",
-		"Project",
-		"chart-line",
-		"Active projects · status · progress.",
-		'SELECT name AS "Project:Link/Project:220", project_name AS "Name:Data:220",'
-		' status AS "Status:Data:120", percent_complete AS "Progress:Percent:100",'
-		' expected_end_date AS "End Date:Date:110" FROM `tabProject`'
-		" WHERE is_group = 0 AND (%(project)s = '' OR name = %(project)s)"
-		" ORDER BY modified DESC",
-		(_PROJECT,),
-	),
-	(
-		"Completed Tasks",
-		"Task",
-		"chart-line",
-		"Tasks marked completed, most recent first.",
-		'SELECT name AS "Task:Link/Task:220", subject AS "Subject:Data:260",'
-		' project AS "Project:Link/Project:200", modified AS "Completed On:Datetime:160"'
-		" FROM `tabTask` WHERE task_status = 'Completed'"
-		" AND (%(project)s = '' OR project = %(project)s)"
-		" AND (%(from_date)s = '' OR DATE(modified) >= %(from_date)s)"
-		" AND (%(to_date)s = '' OR DATE(modified) <= %(to_date)s)"
-		" ORDER BY modified DESC",
-		(_PROJECT, _FROM, _TO),
-	),
-	(
-		"Pending Progress Entries",
-		"Task",
-		"file-text",
-		"Open tasks with no progress entry yet.",
-		'SELECT t.name AS "Task:Link/Task:220", t.subject AS "Subject:Data:260",'
-		' t.project AS "Project:Link/Project:200", t.task_status AS "Status:Data:120"'
-		" FROM `tabTask` t LEFT JOIN `tabTask Progress Entry` tpe ON tpe.task = t.name"
-		" WHERE t.task_status IN ('Yet To Start','In Progress','In Delay')"
-		" AND tpe.name IS NULL AND (%(project)s = '' OR t.project = %(project)s)"
-		" GROUP BY t.name ORDER BY t.modified DESC",
-		(_PROJECT,),
-	),
-	(
-		"Stage Plan vs Actual",
-		"Stage Planning",
-		"calendar",
-		"Planned vs actual tasks per stage.",
-		'SELECT name AS "Stage Planning:Link/Stage Planning:220", stage_name AS "Stage:Data:180",'
-		' project AS "Project:Link/Project:200", planned_task_count AS "Planned:Int:90",'
-		' task_count AS "Actual:Int:90", mean_progress AS "Progress:Percent:110"'
-		" FROM `tabStage Planning` WHERE (%(project)s = '' OR project = %(project)s)"
-		" ORDER BY modified DESC",
-		(_PROJECT,),
-	),
-	(
-		"Progress Entries",
-		"Task Progress Entry",
-		"workforce",
-		"Task progress entries logged on site.",
-		'SELECT tpe.name AS "Entry:Link/Task Progress Entry:200", tpe.task AS "Task:Link/Task:220",'
-		' tpe.entry_date AS "Date:Date:110", tpe.cumulative_progress AS "Progress:Percent:110"'
-		" FROM `tabTask Progress Entry` tpe"
-		" WHERE (%(project)s = '' OR tpe.task IN"
-		"   (SELECT name FROM `tabTask` WHERE project = %(project)s))"
-		" AND (%(from_date)s = '' OR tpe.entry_date >= %(from_date)s)"
-		" AND (%(to_date)s = '' OR tpe.entry_date <= %(to_date)s)"
-		" ORDER BY tpe.entry_date DESC",
-		(_PROJECT, _FROM, _TO),
-	),
-)
-
-# Roles that may run the workspace reports.
-REPORT_ROLES = (
+# Role sets for the Site Execution reports (who may RUN each). Restricted reports are
+# also hidden as tiles for users who can't run them — see workspace_setting._resolve.
+_SITE_ROLES = (
 	"System Manager",
 	"BuildSuite Administrator",
 	"BuildSuite Director",
@@ -97,6 +28,124 @@ REPORT_ROLES = (
 	"BuildSuite QS",
 	"BuildSuite Site Engineer",
 	"BuildSuite Foreman",
+)
+_FINANCE_ROLES = (
+	"System Manager",
+	"BuildSuite Administrator",
+	"BuildSuite Director",
+	"BuildSuite PM",
+	"BuildSuite QS",
+	"BuildSuite Accountant",
+)
+
+# --- SQL for the four Site Execution reports. Query Reports: columns are declared inline
+#     as `field AS "Label:Type:Width"`; filters are optional via the `%(x)s = '' OR …` guard. ---
+
+_DELAY_SQL = """
+SELECT name AS "Stage:Link/Stage Planning:200", stage_name AS "Stage Name:Data:180",
+	project AS "Project:Link/Project:180", planned_end AS "Planned End:Date:110",
+	mean_progress AS "Progress:Percent:100", DATEDIFF(CURDATE(), planned_end) AS "Days Late:Int:90"
+FROM `tabStage Planning`
+WHERE planned_end IS NOT NULL AND planned_end < CURDATE() AND IFNULL(mean_progress, 0) < 100
+	AND (%(project)s = '' OR project = %(project)s)
+ORDER BY DATEDIFF(CURDATE(), planned_end) DESC
+"""
+
+_BILLING_SQL = """
+SELECT si.project AS "Project:Link/Project:200",
+	SUM(si.grand_total) AS "Invoiced:Currency:120",
+	SUM(si.grand_total - si.outstanding_amount) AS "Received:Currency:120",
+	SUM(si.outstanding_amount) AS "Outstanding:Currency:120",
+	SUM(CASE WHEN si.due_date < CURDATE() THEN si.outstanding_amount ELSE 0 END) AS "Overdue:Currency:120",
+	(SELECT IFNULL(SUM(sb.retention_amount), 0) FROM `tabSubcontractor Bill` sb
+		WHERE sb.docstatus = 1 AND sb.project = si.project) AS "Retention Held:Currency:130"
+FROM `tabSales Invoice` si
+WHERE si.docstatus = 1 AND si.project IS NOT NULL AND si.project <> ''
+	AND (%(project)s = '' OR si.project = %(project)s)
+	AND (%(from_date)s = '' OR si.posting_date >= %(from_date)s)
+	AND (%(to_date)s = '' OR si.posting_date <= %(to_date)s)
+GROUP BY si.project ORDER BY SUM(si.outstanding_amount) DESC
+"""
+
+_SUBPOS_SQL = """
+SELECT subcontractor AS "Subcontractor:Link/Supplier:200", MAX(subcontractor_name) AS "Name:Data:200",
+	SUM(wo_value) AS "WO Value:Currency:110", SUM(measured) AS "Measured Qty:Float:110",
+	SUM(billed) AS "Billed:Currency:110", SUM(retention) AS "Retention:Currency:110",
+	SUM(paid) AS "Paid:Currency:110", SUM(billed) - SUM(paid) AS "Outstanding:Currency:110"
+FROM (
+	SELECT wo.subcontractor, wo.subcontractor_name, wo.total_value AS wo_value, 0 measured, 0 billed, 0 retention, 0 paid
+		FROM `tabSubcontractor Work Order` wo WHERE wo.docstatus = 1 AND (%(project)s = '' OR wo.project = %(project)s)
+	UNION ALL
+	SELECT wo.subcontractor, wo.subcontractor_name, 0, mb.measured_total, 0, 0, 0
+		FROM `tabMeasurement Book` mb JOIN `tabSubcontractor Work Order` wo ON wo.name = mb.work_order
+		WHERE mb.status = 'Certified' AND (%(project)s = '' OR mb.project = %(project)s)
+	UNION ALL
+	SELECT sb.subcontractor, sb.subcontractor_name, 0, 0, sb.gross, sb.retention_amount,
+		IFNULL((SELECT pi.grand_total - pi.outstanding_amount FROM `tabPurchase Invoice` pi WHERE pi.name = sb.purchase_invoice), 0)
+		FROM `tabSubcontractor Bill` sb WHERE sb.docstatus = 1 AND (%(project)s = '' OR sb.project = %(project)s)
+) x
+GROUP BY subcontractor HAVING SUM(wo_value) + SUM(billed) > 0 ORDER BY SUM(wo_value) DESC
+"""
+
+_MATERIAL_SQL = """
+SELECT item_code AS "Item:Link/Item:220",
+	SUM(ordered) AS "Ordered:Float:110", SUM(received) AS "Received:Float:110",
+	SUM(consumed) AS "Consumed:Float:110", SUM(received) - SUM(consumed) AS "At Site:Float:110"
+FROM (
+	SELECT poi.item_code, poi.qty AS ordered, 0 received, 0 consumed
+		FROM `tabPurchase Order Item` poi JOIN `tabPurchase Order` po ON po.name = poi.parent
+		WHERE po.docstatus = 1 AND (%(project)s = '' OR poi.project = %(project)s)
+	UNION ALL
+	SELECT pri.item_code, 0, pri.received_qty, 0
+		FROM `tabPurchase Receipt Item` pri JOIN `tabPurchase Receipt` pr ON pr.name = pri.parent
+		WHERE pr.docstatus = 1 AND (%(project)s = '' OR pri.project = %(project)s)
+	UNION ALL
+	SELECT sed.item_code, 0, 0, sed.qty
+		FROM `tabStock Entry Detail` sed JOIN `tabStock Entry` se ON se.name = sed.parent
+		WHERE se.docstatus = 1 AND se.stock_entry_type = 'Material Issue' AND (%(project)s = '' OR se.project = %(project)s)
+) x
+GROUP BY item_code HAVING SUM(ordered) + SUM(received) + SUM(consumed) > 0 ORDER BY item_code
+"""
+
+# (report_name, ref_doctype, icon, description, query, filters, roles) — the Site Execution
+# reports, reworked to match the prototype's Overview report set.
+REPORTS = (
+	(
+		"Delay Analysis",
+		"Stage Planning",
+		"calendar",
+		"Stages slipping, by how much, and current progress.",
+		_DELAY_SQL,
+		(_PROJECT,),
+		_SITE_ROLES,
+	),
+	(
+		"Billing and Collection",
+		"Sales Invoice",
+		"banknote",
+		"Invoiced, received, overdue and retention held, per project.",
+		_BILLING_SQL,
+		(_PROJECT, _FROM, _TO),
+		_FINANCE_ROLES,
+	),
+	(
+		"Subcontractor Position",
+		"Subcontractor Work Order",
+		"subcontract",
+		"WO value, measured, billed, paid, retention and outstanding, per subcontractor.",
+		_SUBPOS_SQL,
+		(_PROJECT,),
+		_FINANCE_ROLES,
+	),
+	(
+		"Material Status",
+		"Item",
+		"package",
+		"Ordered → received → consumed → at site, by item.",
+		_MATERIAL_SQL,
+		(_PROJECT,),
+		_SITE_ROLES,
+	),
 )
 
 # Former hardcoded workspace tiles (functional ones only — the "coming soon" placeholder
@@ -139,10 +188,9 @@ _SEED = {
 }
 
 
-def _ensure_report(report_name, ref_doctype, query, filters=()):
-	"""Create the report, or sync its query + filter defs if it already exists (so the
-	filter-aware queries + Report Filter rows reach sites seeded before filters existed).
-	Returns True when newly created."""
+def _ensure_report(report_name, ref_doctype, query, filters=(), roles=()):
+	"""Create the report, or sync its query, filter defs AND roles if it already exists (so
+	updated queries / role restrictions reach sites seeded earlier). Returns True on create."""
 	existing = frappe.db.exists("Report", report_name)
 	if existing:
 		doc = frappe.get_doc("Report", report_name)
@@ -157,9 +205,13 @@ def _ensure_report(report_name, ref_doctype, query, filters=()):
 				"module": "BuildSuite Core",
 			}
 		)
-		for role in REPORT_ROLES:
-			if frappe.db.exists("Role", role):
-				doc.append("roles", {"role": role})
+
+	# Reconcile the roles that may run this report (drives both execution and, via
+	# workspace_setting._resolve, whether the tile is shown to a user).
+	doc.set("roles", [])
+	for role in roles:
+		if frappe.db.exists("Role", role):
+			doc.append("roles", {"role": role})
 
 	doc.query = query
 	doc.set("filters", [])
@@ -200,8 +252,8 @@ def _legacy_site_execution_rows():
 
 def seed_workspace_reports():
 	created = []
-	for report_name, ref_doctype, _icon, _desc, query, filters in REPORTS:
-		if _ensure_report(report_name, ref_doctype, query, filters):
+	for report_name, ref_doctype, _icon, _desc, query, filters, roles in REPORTS:
+		if _ensure_report(report_name, ref_doctype, query, filters, roles):
 			created.append(report_name)
 
 	settings = frappe.get_single("Workspace Setting")
@@ -212,7 +264,8 @@ def seed_workspace_reports():
 	if "site-execution" not in existing:
 		legacy = _legacy_site_execution_rows()
 		rows = legacy or [
-			{"report": name, "icon": icon, "description": desc} for name, _ref, icon, desc, _q in REPORTS
+			{"report": name, "icon": icon, "description": desc}
+			for name, _ref, icon, desc, _q, _f, _r in REPORTS
 		]
 		for r in rows:
 			settings.append("reports", {"workspace": "site-execution", **r})

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -21,3 +21,5 @@ buildsuite_core.patches.set_default_rate_master_update_threshold
 buildsuite_core.patches.retire_site_execution_settings
 buildsuite_core.patches.recompute_stage_completed_counts # 2026-08-04
 buildsuite_core.patches.sync_report_filters # 2026-08-04
+
+buildsuite_core.patches.reseed_site_execution_reports # 2026-08-12

--- a/buildsuite_core/patches/reseed_site_execution_reports.py
+++ b/buildsuite_core/patches/reseed_site_execution_reports.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""The Site Execution report set was reworked to match the prototype's Overview reports:
+Delay Analysis, Billing and Collection, Subcontractor Position, Material Status. This
+replaces the old set (Project Status Summary, Completed Tasks, Pending Progress Entries,
+Stage Plan vs Actual, Progress Entries) on sites seeded before the change — creates the
+new Query Reports, repoints the Site Execution workspace tiles, and removes the retired
+reports."""
+
+import frappe
+
+from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import (
+	REPORTS,
+	_ensure_report,
+)
+
+RETIRED = (
+	"Project Status Summary",
+	"Completed Tasks",
+	"Pending Progress Entries",
+	"Stage Plan vs Actual",
+	"Progress Entries",
+)
+
+
+def execute():
+	# 1) Ensure the four new reports exist (query + filters + roles reconciled).
+	for report_name, ref_doctype, _icon, _desc, query, filters, roles in REPORTS:
+		_ensure_report(report_name, ref_doctype, query, filters, roles)
+
+	# 2) Reset the Site Execution workspace tiles to the new report set (keep other workspaces).
+	settings = frappe.get_single("Workspace Setting")
+	kept = [
+		{
+			"workspace": r.workspace,
+			"label": r.label,
+			"report": r.report,
+			"route": r.route,
+			"icon": r.icon,
+			"description": r.description,
+		}
+		for r in settings.reports
+		if r.workspace != "site-execution"
+	]
+	settings.set("reports", [])
+	for row in kept:
+		settings.append("reports", row)
+	for name, _ref, icon, desc, _q, _f, _r in REPORTS:
+		settings.append(
+			"reports",
+			{"workspace": "site-execution", "report": name, "icon": icon, "description": desc},
+		)
+	settings.flags.ignore_permissions = True
+	settings.save()
+
+	# 3) Remove the retired reports (app-owned, now superseded).
+	for name in RETIRED:
+		if frappe.db.exists("Report", name):
+			frappe.delete_doc("Report", name, ignore_permissions=True, force=True)

--- a/docs/site-execution-reports.md
+++ b/docs/site-execution-reports.md
@@ -1,0 +1,107 @@
+# Site Execution Reports — Data Sources
+
+The Site Execution workspace links four reports, reworked to match the prototype's Overview
+set. Each is a **Frappe Query Report** (SQL) that renders **in-app** through the generic
+report renderer at `/reports/view/<Report Name>` (`FrappeReport.vue`) — the same renderer used
+for ERPNext's financial statements, so it gets the filter bar, number formatting, and (where
+applicable) tree/cards/chart automatically.
+
+Definitions live in
+`buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py`
+(the `REPORTS` tuple); the workspace tiles are seeded/repointed by the same module and the
+`reseed_site_execution_reports` patch. Every report takes an optional **Project** filter (and
+Billing also takes **From/To Date**); an empty filter means "all".
+
+Only **submitted** documents count as real (docstatus = 1) — drafts and cancelled are excluded,
+consistent with the rest of the app (a draft WO/bill/invoice isn't a commitment/receivable yet).
+
+---
+
+## 1. Delay Analysis
+*Stages slipping, by how much, and current progress.* — **Roles:** all site roles (Director,
+PM, QS, Site Engineer, Foreman, Admin).
+
+| Column | Source | Notes |
+|---|---|---|
+| Stage / Stage Name / Project | `Stage Planning` (`name`, `stage_name`, `project`) | |
+| Planned End | `Stage Planning.planned_end` | the stage's planned finish |
+| Progress | `Stage Planning.mean_progress` | mean % across the stage's tasks |
+| Days Late | `DATEDIFF(today, planned_end)` | how far past the planned end |
+
+**A stage is "slipping"** when `planned_end < today` **and** `mean_progress < 100`. Sorted by
+most days late first.
+**Caveat:** shows *how late* and *how far along*; the "what sits downstream" dependency chain
+is not yet surfaced (a possible enhancement using `Stage Planning Dependency`).
+
+---
+
+## 2. Billing and Collection
+*Invoiced, received, overdue and retention held, per project.* — **Roles:** finance
+(Director, PM, QS, Accountant, Admin). **Filters:** Project, From/To Date (on `posting_date`).
+
+Grouped by **Project**, over submitted **Sales Invoice** rows (`grand_total`,
+`outstanding_amount`, `due_date`, `posting_date`, `project`):
+
+| Column | Formula |
+|---|---|
+| Invoiced | `SUM(grand_total)` |
+| Received | `SUM(grand_total − outstanding_amount)` |
+| Outstanding | `SUM(outstanding_amount)` |
+| Overdue | `SUM(outstanding_amount)` where `due_date < today` |
+| Retention Held | `SUM(Subcontractor Bill.retention_amount)` for that project (submitted bills) |
+
+Retention comes from the payable side (**Subcontractor Bill**), everything else from the
+receivable side (**Sales Invoice**).
+
+---
+
+## 3. Subcontractor Position
+*WO value, measured, billed, paid, retention and outstanding, per subcontractor.* —
+**Roles:** finance. Grouped by **Subcontractor** (Supplier).
+
+| Column | Source | Formula |
+|---|---|---|
+| WO Value | `Subcontractor Work Order.total_value` (submitted) | total committed to the subcontractor |
+| Measured Qty | `Measurement Book.measured_total` (status = Certified, via `work_order → WO.subcontractor`) | certified measured quantity |
+| Billed | `Subcontractor Bill.gross` (submitted) | gross billed |
+| Retention | `Subcontractor Bill.retention_amount` (submitted) | held back |
+| Paid | linked `Purchase Invoice.grand_total − outstanding_amount` (`Subcontractor Bill.purchase_invoice`) | actually paid |
+| Outstanding | `Billed − Paid` | still owed |
+
+The three sources (WOs, Measurement Books, Bills) are unioned and rolled up per subcontractor.
+**Caveat:** "Measured Qty" is a quantity total (from certified MBs), not a currency value.
+
+---
+
+## 4. Material Status
+*Ordered → received → consumed → at site, by item.* — **Roles:** all site roles. Grouped by
+**Item**.
+
+| Column | Source | Formula |
+|---|---|---|
+| Ordered | `Purchase Order Item.qty` (parent PO submitted) | quantity ordered |
+| Received | `Purchase Receipt Item.received_qty` (parent PR submitted) | quantity received |
+| Consumed | `Stock Entry Detail.qty` where parent `Stock Entry.stock_entry_type = 'Material Issue'` (submitted) | issued to site |
+| At Site | `Received − Consumed` | on-hand derived from the project's own movements |
+
+Project scoping uses the `project` field that Purchase Order Item, Purchase Receipt Item and
+Stock Entry all carry.
+**Caveat:** "At Site" is computed as *received − consumed* (project-accurate) rather than from
+`Bin.actual_qty`, because `Bin` is keyed by warehouse and has no project field. This is a close
+proxy for current on-site stock per project.
+
+---
+
+## Roles & visibility
+A report's roles are set on the **Report** doc itself (`REPORTS` → `_ensure_report`). The
+workspace tile is **hidden** for any user who can't run the report
+(`api/workspace_setting._resolve` checks `Report.is_permitted()`), so a Site Engineer sees only
+Delay Analysis and Material Status, while Billing and Subcontractor Position appear for finance
+roles. No per-tile role config is needed — the Report's own permissions drive both execution and
+tile visibility.
+
+## Adding or changing a report
+Edit the `REPORTS` tuple (name, ref doctype, icon, description, SQL, filters, roles).
+`_ensure_report` reconciles the query, filters and roles on every migrate, so changes reach
+existing sites; new workspace links are added by `seed_workspace_reports()` (fresh installs) or
+a small patch (existing installs).


### PR DESCRIPTION
Replaces the old Site Execution reports with the prototype's four, as **Frappe Query Reports** that render **in-app** via the generic renderer (`/reports/view/<name>` → `FrappeReport`).

## The four reports
| Report | Grain | Sources | Roles |
|---|---|---|---|
| **Delay Analysis** | Stage | `Stage Planning` — stages where `planned_end < today` and `mean_progress < 100`, with days-late | all site roles |
| **Billing and Collection** | Project | `Sales Invoice` (invoiced / received / outstanding / overdue) + `Subcontractor Bill.retention_amount` | finance |
| **Subcontractor Position** | Subcontractor | `Subcontractor Work Order` (WO value) + `Measurement Book` (measured) + `Subcontractor Bill` (billed/retention) + linked `Purchase Invoice` (paid) | finance |
| **Material Status** | Item | `Purchase Order Item` (ordered) + `Purchase Receipt Item` (received) + `Stock Entry Detail` Material Issue (consumed); at-site = received − consumed | all site roles |

Each takes an optional **Project** filter (Billing also **From/To Date**); only submitted docs count.

## Roles & tile visibility
Per-report roles are set on the Report doc; `_ensure_report` now reconciles roles on migrate. Tiles are **hidden** for users who can't run the report (`workspace_setting._resolve` checks `Report.is_permitted()`), so a Site Engineer sees only Delay Analysis + Material Status; Billing + Subcontractor Position show for finance roles — matching the prototype.

## Migration
`reseed_site_execution_reports` patch repoints existing sites' Site Execution tiles to the new set and deletes the five retired reports (Project Status Summary, Completed Tasks, Pending Progress Entries, Stage Plan vs Actual, Progress Entries).

## Docs
`docs/site-execution-reports.md` documents each report's exact source doctypes/fields, per-column formulas, filters, roles, and caveats (e.g. "At Site" derived as received − consumed because `Bin` has no project).

## Verified
On `bs.local` after migrate: all four Reports exist and run through `run_report` (Billing 1 row, Subcontractor Position 5, Material Status 10, Delay Analysis 0 — no currently-late stages); tiles resolve to `/reports/view/…` for admin; old reports deleted; role assignments correct.