### PR TITLE
feat: Material Consumption in Procurement

### DIFF
--- a/buildsuite_core/api/material_consumption.py
+++ b/buildsuite_core/api/material_consumption.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Material Consumption — a Stock Entry of type "Material Issue".
+
+Draft only. Submitting is what moves the stock, and that is driven by a Frappe
+Workflow when a site configures one — see api/workflow.py.
+
+The store is derived from the project, never sent by the client: Warehouse
+carries a `project` link and `create_warehouse_for_project` builds one per
+project. Same rule the Desk client scripts follow.
+"""
+
+import frappe
+from frappe import _
+from frappe.utils import cint, flt
+
+from buildsuite_core.utils.project import default_company
+from buildsuite_core.utils.stock_entry import get_warehouse_from_project
+
+STOCK_ENTRY = "Stock Entry"
+MATERIAL_ISSUE = "Material Issue"
+
+_ITEM_FIELDS = ("item_code", "qty", "uom")
+
+
+@frappe.whitelist()
+def get_site_stock(project: str) -> dict:
+	"""Items on hand at a project's store.
+
+	`actual_qty`, not `projected_qty` — material on order cannot be issued.
+	"""
+	warehouse = get_warehouse_from_project(project) if project else None
+	if not warehouse:
+		# Projects predating the warehouse hook have none — the form explains it.
+		return {"warehouse": None, "rows": []}
+
+	# get_list for Warehouse user permissions; its page length defaults to 20.
+	rows = frappe.get_list(
+		"Bin",
+		filters={"warehouse": warehouse, "actual_qty": [">", 0]},
+		fields=["item_code", "item_code.item_name", "actual_qty as available", "stock_uom as uom"],
+		order_by="item_code asc",
+		limit_page_length=0,
+	)
+	return {"warehouse": warehouse, "rows": rows}
+
+
+@frappe.whitelist()
+def get_material_consumption(name: str) -> dict:
+	"""One entry with its items — a list read would not return child rows."""
+	doc = frappe.get_doc(STOCK_ENTRY, name)
+	doc.check_permission("read")  # get_doc does not check; only get_list does
+	return _serialize(doc)
+
+
+@frappe.whitelist()
+def list_material_consumption(start=0, page_length=10, search=None, project=None) -> dict:
+	"""One page of Material Issue entries + total_count for the pager."""
+	filters = {"stock_entry_type": MATERIAL_ISSUE}
+	if project:
+		filters["project"] = project
+	or_filters = [["name", "like", f"%{search}%"], ["remarks", "like", f"%{search}%"]] if search else None
+
+	rows = frappe.get_list(
+		STOCK_ENTRY,
+		filters=filters,
+		or_filters=or_filters,
+		fields=[
+			"name",
+			"posting_date",
+			"project",
+			"owner",
+			"docstatus",
+			"custom_cost_code_label as cost_code_label",
+		],
+		order_by="posting_date desc, name desc",
+		start=cint(start),
+		page_length=cint(page_length),
+	)
+	total_count = frappe.get_list(
+		STOCK_ENTRY,
+		filters=filters,
+		or_filters=or_filters,
+		fields=[{"COUNT": "name", "as": "count"}],
+	)[0].count
+
+	_attach_items(rows)
+	return {"rows": rows, "total_count": total_count}
+
+
+@frappe.whitelist(methods=["POST"])
+def save_material_consumption(project=None, items=None, cost_code=None, name=None) -> dict:
+	"""Create or update a draft Material Issue.
+
+	No posting date is accepted — Stock Entry defaults it to today.
+	"""
+	rows = _parse_items(items)
+	if not project:
+		frappe.throw(_("Project is required."))
+	if not rows:
+		frappe.throw(_("Add at least one item."))
+
+	warehouse = get_warehouse_from_project(project)
+	if not warehouse:
+		frappe.throw(_("This project has no store, so nothing can be issued from it."))
+
+	if name:
+		if not frappe.db.exists(STOCK_ENTRY, name):
+			# A stale id would otherwise create a second entry.
+			frappe.throw(_("Consumption {0} no longer exists.").format(name))
+		doc = frappe.get_doc(STOCK_ENTRY, name)
+		if doc.docstatus != 0:
+			frappe.throw(_("Only a draft can be edited."))
+	else:
+		doc = frappe.new_doc(STOCK_ENTRY)
+		doc.stock_entry_type = MATERIAL_ISSUE
+
+	doc.project = project
+	# The project's company, not the user's default — the store was created under
+	# the project's company, and a mismatch fails validation on a multi-company site.
+	doc.company = frappe.db.get_value("Project", project, "company") or default_company()
+	doc.from_warehouse = warehouse
+	_apply_cost_code(doc, cost_code)
+
+	doc.set("items", [])
+	for row in rows:
+		doc.append("items", {**{k: row.get(k) for k in _ITEM_FIELDS}, "s_warehouse": warehouse})
+
+	doc.save()  # checks write / create permission itself
+	return _serialize(doc)
+
+
+def _serialize(doc) -> dict:
+	return {
+		"name": doc.name,
+		"project": doc.project,
+		"project_name": frappe.db.get_value("Project", doc.project, "project_name"),
+		"posting_date": str(doc.posting_date) if doc.posting_date else None,
+		"purpose": doc.purpose,
+		"owner": doc.owner,
+		"docstatus": doc.docstatus,
+		"cost_code_type": doc.get("custom_cost_code_type"),
+		"cost_code_group": doc.get("custom_cost_code_group"),
+		"cost_code_item": doc.get("custom_cost_code_item"),
+		"cost_code_label": doc.get("custom_cost_code_label"),
+		"items": [
+			{"item_code": r.item_code, "item_name": r.item_name, "qty": r.qty, "uom": r.uom}
+			for r in doc.items
+		],
+	}
+
+
+def _parse_items(payload) -> list:
+	"""A JSON object parses to a truthy _dict and would iterate its keys."""
+	rows = frappe.parse_json(payload) or []
+	if not isinstance(rows, list):
+		frappe.throw(_("Expected a list of items."))
+
+	rows = [r for r in rows if r and r.get("item_code")]
+	if any(flt(r.get("qty")) <= 0 for r in rows):
+		frappe.throw(_("Every item needs a quantity above zero."))
+	return rows
+
+
+def _apply_cost_code(doc, payload) -> None:
+	"""Flatten the picker's selection. The group is kept even for an item pick,
+	so cost rolls up either way."""
+	cc = frappe.parse_json(payload) if payload else None
+	cc = cc if isinstance(cc, dict) else {}
+	doc.custom_cost_code_type = ("Item" if cc.get("type") == "item" else "Group") if cc else ""
+	doc.custom_cost_code_group = cc.get("group_code") or ""
+	doc.custom_cost_code_item = cc.get("item_code") or ""
+	doc.custom_cost_code_label = cc.get("label") or ""
+
+
+def _attach_items(rows: list) -> None:
+	"""Stamp each entry with its items — one query for the page.
+
+	`parent_doctype` is required; this Frappe version rejects `parent=`.
+	"""
+	if not rows:
+		return
+
+	lines = frappe.get_all(
+		"Stock Entry Detail",
+		filters={"parent": ["in", [r.name for r in rows]]},
+		fields=["parent", "item_name", "item_code", "qty", "uom"],
+		order_by="idx asc",
+		parent_doctype=STOCK_ENTRY,
+	)
+	by_parent: dict[str, list[dict]] = {}
+	for line in lines:
+		by_parent.setdefault(line.parent, []).append(
+			{"label": line.item_name or line.item_code, "qty": line.qty, "uom": line.uom}
+		)
+	for row in rows:
+		row.items = by_parent.get(row.name, [])

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -305,6 +305,42 @@ CUSTOM_FIELD = {
 			"depends_on": 'eval:doc.stock_entry_type&&doc.purpose!="Material Transfer"',
 			"read_only": 0,
 		},
+		# Which BOQ line a Material Issue is charged to. Same four fields as
+		# Subcontractor Work Order Line, so CostCodePicker.vue works unchanged.
+		{
+			"fieldname": "custom_cost_code_type",
+			"fieldtype": "Select",
+			"label": "Cost Code Type",
+			"options": "\nGroup\nItem",
+			"insert_after": "project",
+			"module": "BuildSuite Core",
+		},
+		{
+			"fieldname": "custom_cost_code_group",
+			"fieldtype": "Data",
+			"label": "Cost Code Group",
+			"insert_after": "custom_cost_code_type",
+			"depends_on": "eval:doc.custom_cost_code_type",
+			"module": "BuildSuite Core",
+		},
+		{
+			# Only an Item pick carries one; a Group pick leaves it empty.
+			"fieldname": "custom_cost_code_item",
+			"fieldtype": "Data",
+			"label": "Cost Code Item",
+			"insert_after": "custom_cost_code_group",
+			"depends_on": 'eval:doc.custom_cost_code_type=="Item"',
+			"module": "BuildSuite Core",
+		},
+		{
+			"fieldname": "custom_cost_code_label",
+			"fieldtype": "Data",
+			"label": "Cost Code",
+			"insert_after": "custom_cost_code_item",
+			"depends_on": "eval:doc.custom_cost_code_type",
+			"read_only": 1,
+			"module": "BuildSuite Core",
+		},
 	],
 	"Material Request": [
 		{

--- a/frontend/src/data/materialConsumptionApi.js
+++ b/frontend/src/data/materialConsumptionApi.js
@@ -1,0 +1,29 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Wrapper over buildsuite_core.api.material_consumption — the `items` child
+// table can't go through the generic adapter. Delete can, so it isn't here.
+
+async function call(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.material_consumption.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const getSiteStock = (project) => call("get_site_stock", { project });
+
+export const listMaterialConsumption = (params) => call("list_material_consumption", params);
+
+export const getMaterialConsumption = (name) => call("get_material_consumption", { name });
+
+export const saveMaterialConsumption = (payload) =>
+	call("save_material_consumption", {
+		...payload,
+		items: JSON.stringify(payload.items || []),
+		cost_code: payload.cost_code ? JSON.stringify(payload.cost_code) : null,
+	});

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -43,6 +43,10 @@ const PAGE_TITLES = {
 	procurement: "Procurement",
 	"procurement-dashboard": "Procurement Dashboard",
 	items: "Items",
+	"material-consumption": "Material Consumption",
+	"material-consumption-new": "Record Consumption",
+	"material-consumption-detail": "Material Consumption",
+	"material-consumption-edit": "Edit Consumption",
 	equipment: "Equipment",
 	"equipment-dashboard": "Equipment Dashboard",
 	machinery: "Machinery",
@@ -321,6 +325,29 @@ const routes = [
 				path: "items",
 				name: "items",
 				component: () => import("@/views/ItemsListView.vue"),
+			},
+			{
+				path: "material-consumption",
+				name: "material-consumption",
+				component: () => import("@/views/ConsumptionListView.vue"),
+			},
+			// `new` must stay above `:id`, or it is read as a record id.
+			{
+				path: "material-consumption/new",
+				name: "material-consumption-new",
+				component: () => import("@/views/NewConsumptionView.vue"),
+			},
+			{
+				path: "material-consumption/:id/edit",
+				name: "material-consumption-edit",
+				component: () => import("@/views/NewConsumptionView.vue"),
+				props: true,
+			},
+			{
+				path: "material-consumption/:id",
+				name: "material-consumption-detail",
+				component: () => import("@/views/ConsumptionDetailView.vue"),
+				props: true,
 			},
 			{
 				path: "equipment",

--- a/frontend/src/views/ConsumptionDetailView.vue
+++ b/frontend/src/views/ConsumptionDetailView.vue
@@ -1,0 +1,227 @@
+<script setup>
+// Material Consumption detail — view / edit / delete, draft only.
+// A posted entry is read-only. Submit comes from a Frappe Workflow, if a site
+// configures one: useWorkflow renders its transitions as buttons.
+
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useConfirm } from "@/composables/useConfirm";
+import { useWorkflow } from "@/composables/useWorkflow";
+import { useProjectOptions } from "@/composables/useProjectOptions";
+import { getMaterialConsumption } from "@/data/materialConsumptionApi";
+import { useDataStore } from "@/stores";
+import { createDataAdapter } from "@/data/adapters";
+import { showToast } from "@/utils/appToast";
+import { fmtDate } from "@/utils/format";
+import { isPermissionDenied } from "@/utils/frappeError";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import AccessDenied from "@/components/AccessDenied.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
+
+const props = defineProps({ id: String });
+const router = useRouter();
+const confirmDialog = useConfirm();
+const adapter = createDataAdapter(useDataStore());
+const { projectLabel } = useProjectOptions();
+const {
+	active: wfActive,
+	state: wfState,
+	transitions: wfTransitions,
+	refresh: refreshWorkflow,
+	applyAction: applyWorkflowAction,
+} = useWorkflow("Stock Entry");
+
+const DOCSTATUS_LABELS = { 0: "Draft", 1: "Submitted", 2: "Cancelled" };
+
+const doc = ref(null);
+const loading = ref(true);
+const loadError = ref(null);
+
+const accessDenied = computed(() => isPermissionDenied(loadError.value));
+const isDraft = computed(() => doc.value?.docstatus === 0);
+// A workflow owns the status label once active.
+const stateLabel = computed(() =>
+	wfActive.value
+		? wfState.value || DOCSTATUS_LABELS[doc.value?.docstatus]
+		: DOCSTATUS_LABELS[doc.value?.docstatus] || "Draft"
+);
+const busy = ref(false);
+
+// The API returns the child rows; a list read would not.
+async function load() {
+	loading.value = true;
+	loadError.value = null;
+	try {
+		doc.value = await getMaterialConsumption(props.id);
+		await refreshWorkflow(props.id);
+	} catch (err) {
+		doc.value = null;
+		loadError.value = err;
+	} finally {
+		loading.value = false;
+	}
+}
+// Not onMounted — the router reuses this component when only :id changes.
+watch(() => props.id, load, { immediate: true });
+
+async function onWorkflowAction(action) {
+	busy.value = true;
+	try {
+		await applyWorkflowAction(props.id, action);
+		await load();
+		showToast(`${action} done.`);
+	} catch (err) {
+		showToast(err.message || "Action failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onDelete() {
+	const ok = await confirmDialog({
+		title: "Delete consumption?",
+		message: `${props.id} will be removed permanently.`,
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await adapter.remove("Stock Entry", props.id);
+		showToast("Consumption deleted");
+		router.push("/material-consumption");
+	} catch (err) {
+		showToast(err.message || "Failed to delete", "error");
+	}
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Material Consumption", to: "/material-consumption" },
+	{ label: props.id },
+]);
+</script>
+
+<template>
+	<DeskPage
+		v-if="doc"
+		:title="doc.name"
+		:subtitle="`Recorded ${fmtDate(doc.posting_date)} · ${doc.purpose || 'Material Issue'}`"
+		:status="stateLabel"
+		:breadcrumbs="breadcrumbs"
+	>
+		<template #actions>
+			<button
+				v-if="!wfActive && isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="router.push(`/material-consumption/${doc.name}/edit`)"
+			>
+				Edit
+			</button>
+			<button
+				v-if="!wfActive && isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+				style="border-radius: 6px"
+				@click="onDelete"
+			>
+				Delete
+			</button>
+
+			<!-- One button per allowed transition. -->
+			<button
+				v-for="t in wfActive ? wfTransitions : []"
+				:key="t.action"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onWorkflowAction(t.action)"
+			>
+				{{ t.action }}
+			</button>
+		</template>
+
+		<div
+			class="mb-4 px-3 py-2 bg-ink-50 border border-ink-200 text-xs text-ink-600"
+			style="border-radius: 6px"
+		>
+			{{
+				isDraft
+					? "Draft — nothing has been deducted from site stock yet."
+					: `This entry is ${stateLabel.toLowerCase()} and can no longer be edited here.`
+			}}
+		</div>
+
+		<!-- Summary strip -->
+		<div class="grid grid-cols-2 md:grid-cols-3 gap-2 mb-4">
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Project
+				</div>
+				<DeskLink v-if="doc.project" :to="`/projects/${doc.project}`" class="text-sm">
+					{{ doc.project_name || projectLabel(doc.project) || doc.project }}
+				</DeskLink>
+				<div v-else class="text-sm text-ink-400 mt-0.5">—</div>
+			</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Cost code
+				</div>
+				<span
+					v-if="doc.cost_code_label"
+					class="inline-block mt-1 text-[11px] px-2 py-0.5 bg-info-50 text-info-700"
+					style="border-radius: 4px"
+					>{{ doc.cost_code_label }}</span
+				>
+				<div v-else class="text-sm text-ink-400 mt-0.5">Not cost-coded</div>
+			</div>
+			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+					Recorded by
+				</div>
+				<div class="mt-0.5">
+					<FrappeUserBadge v-if="doc.owner" :user-id="doc.owner" size="xs" />
+					<span v-else class="text-sm text-ink-400">—</span>
+				</div>
+			</div>
+		</div>
+
+		<div class="border border-ink-200 overflow-hidden" style="border-radius: 6px">
+			<div
+				class="grid grid-cols-[1fr_140px_120px] gap-2 bg-ink-50 border-b border-ink-200 px-3 py-2 text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+			>
+				<span>Item</span>
+				<span class="text-right">Qty consumed</span>
+				<span>UOM</span>
+			</div>
+			<div
+				v-for="row in doc.items"
+				:key="row.item_code"
+				class="grid grid-cols-[1fr_140px_120px] gap-2 px-3 py-2 border-b border-ink-100 last:border-0 text-sm"
+			>
+				<span class="text-ink-900">{{ row.item_name || row.item_code }}</span>
+				<span class="text-right tabular-nums font-medium text-ink-900">{{ row.qty }}</span>
+				<span class="text-ink-500 text-xs pt-0.5">{{ row.uom || "—" }}</span>
+			</div>
+			<div
+				v-if="!doc.items.length"
+				class="px-3 py-6 text-center text-xs text-ink-400 italic"
+			>
+				No items on this entry.
+			</div>
+		</div>
+	</DeskPage>
+
+	<AccessDenied v-else-if="accessDenied" />
+
+	<div v-else-if="!loading" class="desk-page">
+		<p class="text-sm text-ink-500">
+			Consumption record not found.
+			<DeskLink to="/material-consumption">Back to log →</DeskLink>
+		</p>
+	</div>
+</template>

--- a/frontend/src/views/ConsumptionListView.vue
+++ b/frontend/src/views/ConsumptionListView.vue
@@ -1,0 +1,185 @@
+<script setup>
+// Material Consumption — Stock Entries of type "Material Issue".
+// Its own API, not DocTypeListView: the consumed items are child rows.
+
+import { onMounted, ref, watch } from "vue";
+import { RouterLink, useRouter } from "vue-router";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
+import { useProjectOptions } from "@/composables/useProjectOptions";
+import { listMaterialConsumption } from "@/data/materialConsumptionApi";
+import { showToast } from "@/utils/appToast";
+import { fmtDate } from "@/utils/format";
+
+const router = useRouter();
+const { projectOptions, projectLabel } = useProjectOptions();
+
+const DOCSTATUS_LABELS = { 0: "Draft", 1: "Submitted", 2: "Cancelled" };
+
+const rows = ref([]);
+const totalCount = ref(0);
+const loading = ref(false);
+const page = ref(1);
+const pageSize = ref(10);
+const search = ref("");
+const projectFilter = ref("");
+
+// reqId: only the latest request wins.
+let reqId = 0;
+async function reload() {
+	const my = ++reqId;
+	loading.value = true;
+	try {
+		const res = await listMaterialConsumption({
+			start: (page.value - 1) * pageSize.value,
+			page_length: pageSize.value,
+			search: search.value.trim() || undefined,
+			project: projectFilter.value || undefined,
+		});
+		if (my !== reqId) return;
+		rows.value = res.rows || [];
+		totalCount.value = res.total_count || 0;
+	} catch (err) {
+		if (my === reqId) showToast(err.message || "Could not load consumption.", "error");
+	} finally {
+		if (my === reqId) loading.value = false;
+	}
+}
+
+let searchTimer;
+watch(search, () => {
+	clearTimeout(searchTimer);
+	searchTimer = setTimeout(() => {
+		page.value = 1;
+		reload();
+	}, 300);
+});
+watch(projectFilter, () => {
+	page.value = 1;
+	reload();
+});
+onMounted(reload);
+
+// Formatting is the view's job — the API returns data.
+function itemsSummary(row) {
+	return (row.items || []).map((i) => `${i.label} ×${i.qty} ${i.uom}`.trim()).join(" · ");
+}
+
+const columns = [
+	{ key: "name", label: "ID" },
+	{ key: "posting_date", label: "Date" },
+	{ key: "project", label: "Project" },
+	{ key: "items", label: "Items consumed" },
+	{ key: "cost_code_label", label: "Cost code" },
+	{ key: "owner", label: "By" },
+	{ key: "docstatus", label: "State" },
+];
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Material Consumption" },
+];
+</script>
+
+<template>
+	<DeskPage title="Material Consumption" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<RouterLink to="/material-consumption/new" class="desk-save-btn !text-xs">
+				+ Record consumption
+			</RouterLink>
+		</template>
+
+		<DeskList
+			v-model="search"
+			:rows="rows"
+			:columns="columns"
+			row-key="name"
+			search-placeholder="Search consumption…"
+			@row-click="(row) => router.push(`/material-consumption/${row.name}`)"
+			:server-paginated="true"
+			:total-rows="totalCount"
+			:current-page="page"
+			:page-size="pageSize"
+			@page-change="
+				(p) => {
+					if (p !== page) {
+						page = p;
+						reload();
+					}
+				}
+			"
+			@page-size-change="
+				(s) => {
+					pageSize = s;
+					page = 1;
+					reload();
+				}
+			"
+		>
+			<template #filter-chips>
+				<div class="w-56">
+					<DeskSearchableSelect
+						v-model="projectFilter"
+						:options="projectOptions"
+						placeholder="All projects"
+						search-placeholder="Search projects…"
+						allow-clear
+					/>
+				</div>
+			</template>
+
+			<template #cell-name="{ row }">
+				<DeskLink
+					:to="`/material-consumption/${row.name}`"
+					class="font-mono text-xs"
+					@click.stop
+				>
+					{{ row.name }}
+				</DeskLink>
+			</template>
+
+			<template #cell-posting_date="{ row }">
+				<span class="text-ink-700">{{ fmtDate(row.posting_date) || "—" }}</span>
+			</template>
+
+			<template #cell-project="{ row }">
+				<span class="text-ink-900 font-medium">{{
+					projectLabel(row.project) || "—"
+				}}</span>
+			</template>
+
+			<template #cell-items="{ row }">
+				<span class="text-ink-700">{{ itemsSummary(row) || "—" }}</span>
+			</template>
+
+			<template #cell-cost_code_label="{ row }">
+				<span
+					v-if="row.cost_code_label"
+					class="text-[11px] px-1.5 py-0.5 bg-info-50 text-info-700 whitespace-nowrap"
+					style="border-radius: 4px"
+					>{{ row.cost_code_label }}</span
+				>
+				<span v-else class="text-ink-400">—</span>
+			</template>
+
+			<template #cell-owner="{ row }">
+				<FrappeUserBadge :user-id="row.owner" size="xs" />
+			</template>
+
+			<template #cell-docstatus="{ row }">
+				<StatusBadge :status="DOCSTATUS_LABELS[row.docstatus] || 'Draft'" />
+			</template>
+
+			<template #empty>
+				<div class="text-sm text-ink-500">
+					{{ loading ? "Loading…" : "No material consumption recorded yet." }}
+				</div>
+			</template>
+		</DeskList>
+	</DeskPage>
+</template>

--- a/frontend/src/views/NewConsumptionView.vue
+++ b/frontend/src/views/NewConsumptionView.vue
@@ -1,0 +1,311 @@
+<script setup>
+// Record / edit a Material Consumption, draft only.
+// The store is derived from the project, never picked.
+
+import { computed, onMounted, reactive, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useProjectOptions } from "@/composables/useProjectOptions";
+import {
+	getMaterialConsumption,
+	getSiteStock,
+	saveMaterialConsumption,
+} from "@/data/materialConsumptionApi";
+import { showToast } from "@/utils/appToast";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import CostCodePicker from "@/components/CostCodePicker.vue";
+
+const props = defineProps({ id: { type: String, default: "" } });
+const router = useRouter();
+const { projectOptions } = useProjectOptions();
+
+const editing = computed(() => !!props.id);
+const form = reactive({ project: "", cost_code: null, lines: [] });
+const saving = ref(false);
+const warehouse = ref("");
+const stock = ref([]);
+const loadingStock = ref(false);
+const addPick = ref(null);
+
+// reqId: a slower reply for the old project must not land last.
+let stockReq = 0;
+async function loadStock(project) {
+	const my = ++stockReq;
+	warehouse.value = "";
+	stock.value = [];
+	if (!project) return;
+	loadingStock.value = true;
+	try {
+		const res = await getSiteStock(project);
+		if (my !== stockReq) return;
+		warehouse.value = res.warehouse || "";
+		stock.value = res.rows || [];
+	} catch (err) {
+		if (my === stockReq) showToast(err.message || "Could not load site stock", "error");
+	} finally {
+		if (my === stockReq) loadingStock.value = false;
+	}
+}
+
+// Cost code and stock both belong to one project, so both reset. Not while
+// editing — the project is locked, and this runs after onMounted fills the form.
+watch(
+	() => form.project,
+	(project) => {
+		if (!editing.value) {
+			form.cost_code = null;
+			form.lines = [];
+			addPick.value = null;
+		}
+		loadStock(project);
+	}
+);
+
+onMounted(async () => {
+	if (!editing.value) return;
+	try {
+		const doc = await getMaterialConsumption(props.id);
+		if (doc.docstatus !== 0) {
+			// A posted entry has moved stock — cancelled, never edited.
+			router.replace(`/material-consumption/${props.id}`);
+			return;
+		}
+		form.project = doc.project || "";
+		form.cost_code = doc.cost_code_label
+			? {
+					type: (doc.cost_code_type || "").toLowerCase(),
+					group_code: doc.cost_code_group || "",
+					item_code: doc.cost_code_item || null,
+					label: doc.cost_code_label,
+			  }
+			: null;
+		await loadStock(form.project);
+		// A draft deducts nothing, so availability still includes it.
+		form.lines = (doc.items || []).map((it) => {
+			const s = stock.value.find((r) => r.item_code === it.item_code);
+			return {
+				item_code: it.item_code,
+				item_name: it.item_name || it.item_code,
+				uom: it.uom || s?.uom || "",
+				available: s?.available ?? 0,
+				qty: it.qty,
+			};
+		});
+	} catch (err) {
+		showToast(err.message || "Could not load this entry", "error");
+	}
+});
+
+const added = computed(() => new Set(form.lines.map((l) => l.item_code)));
+
+const pickerOptions = computed(() =>
+	stock.value
+		.filter((r) => !added.value.has(r.item_code))
+		.map((r) => ({
+			value: r.item_code,
+			label: r.item_name,
+			// Code trails the qty so search matches either.
+			hint: `${r.available} ${r.uom} available · ${r.item_code}`,
+		}))
+);
+
+function addItem(code) {
+	const row = stock.value.find((r) => r.item_code === code);
+	if (row) form.lines.push({ ...row, qty: null });
+	addPick.value = null;
+}
+
+// `max` stops the spinner, not typing or pasting.
+function setQty(line, value) {
+	const n = Number(value);
+	line.qty = !Number.isFinite(n) || n <= 0 ? null : Math.min(n, line.available);
+}
+
+// Clamped: an old draft can hold more than the store still has.
+function leftAfter(line) {
+	const qty = Math.min(Number(line.qty) || 0, line.available);
+	return Math.max(0, line.available - qty);
+}
+
+const filledLines = computed(() => form.lines.filter((l) => Number(l.qty) > 0));
+const canSave = computed(() => !!form.project && filledLines.value.length > 0);
+
+async function onSave() {
+	saving.value = true;
+	try {
+		const res = await saveMaterialConsumption({
+			name: props.id || undefined,
+			project: form.project,
+			cost_code: form.cost_code,
+			items: filledLines.value.map((l) => ({
+				item_code: l.item_code,
+				qty: Number(l.qty),
+				uom: l.uom,
+			})),
+		});
+		showToast(editing.value ? "Consumption updated" : "Consumption recorded");
+		router.push(`/material-consumption/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Failed to save the consumption", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Material Consumption", to: "/material-consumption" },
+	{ label: editing.value ? props.id : "New" },
+]);
+</script>
+
+<template>
+	<DeskPage
+		:title="editing ? `Edit ${props.id}` : 'Record Consumption'"
+		subtitle="Issues site material out of stock. Cost-code it against the BOQ if you want it costed."
+		:breadcrumbs="breadcrumbs"
+	>
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="
+						saving ? 'Saving…' : editing ? 'Save changes' : 'Record consumption'
+					"
+					:can-save="canSave"
+					:saving="saving"
+					@save="onSave"
+					@cancel="router.back()"
+				/>
+			</template>
+
+			<DeskSection title="Booking" :cols="2">
+				<DeskField
+					label="Project"
+					required
+					:hint="
+						editing ? 'Locked while editing — the record stays on its project.' : ''
+					"
+				>
+					<DeskSearchableSelect
+						v-model="form.project"
+						:options="projectOptions"
+						:disabled="editing"
+						placeholder="— Select project —"
+						search-placeholder="Search projects…"
+					/>
+				</DeskField>
+
+				<DeskField
+					label="Cost code"
+					hint="Optional. Set it to book this material against a BOQ group or line; leave it blank to record the issue without cost-coding it."
+				>
+					<CostCodePicker
+						v-model="form.cost_code"
+						:project-id="form.project"
+						placeholder="— Not cost-coded —"
+					/>
+				</DeskField>
+			</DeskSection>
+
+			<DeskSection v-if="form.project" title="Items consumed" :cols="1">
+				<!-- No store: an empty picker would look like an empty store. -->
+				<p v-if="!warehouse && !loadingStock" class="text-sm text-danger-700">
+					This project has no store, so nothing can be issued from it.
+				</p>
+
+				<template v-else-if="stock.length">
+					<div class="w-96 max-w-full">
+						<DeskSearchableSelect
+							:model-value="addPick"
+							:options="pickerOptions"
+							placeholder="+ Add item — search name or code…"
+							search-placeholder="Search site stock…"
+							@update:model-value="addItem"
+						/>
+					</div>
+
+					<div
+						v-if="form.lines.length"
+						class="border border-ink-200 overflow-hidden mt-4"
+						style="border-radius: 8px"
+					>
+						<div
+							class="grid grid-cols-[1fr_110px_140px_110px_44px] gap-2 items-center px-3 py-2 bg-ink-50 border-b border-ink-200 text-[10px] uppercase tracking-wider text-ink-500 font-medium"
+						>
+							<span>Item</span>
+							<span class="text-right">In stock</span>
+							<span class="text-right">Issue now</span>
+							<span class="text-right">Left after</span>
+							<span></span>
+						</div>
+						<div
+							v-for="(line, i) in form.lines"
+							:key="line.item_code"
+							class="grid grid-cols-[1fr_110px_140px_110px_44px] gap-2 items-center px-3 py-2.5 border-b border-ink-100 last:border-0"
+						>
+							<div class="min-w-0">
+								<div class="text-sm text-ink-900 truncate">
+									{{ line.item_name }}
+								</div>
+								<div class="text-[11px] text-ink-400">{{ line.uom }}</div>
+							</div>
+							<div class="text-xs tabular-nums text-ink-600 text-right">
+								{{ line.available }}
+							</div>
+							<DeskInput
+								:model-value="line.qty"
+								type="number"
+								min="0"
+								:max="line.available"
+								placeholder="0"
+								class="!text-right"
+								@update:model-value="setQty(line, $event)"
+							/>
+							<div
+								class="text-xs tabular-nums text-right"
+								:class="
+									leftAfter(line) === 0
+										? 'text-warning-700 font-medium'
+										: 'text-ink-600'
+								"
+							>
+								{{ leftAfter(line) }}
+							</div>
+							<button
+								type="button"
+								class="text-ink-400 hover:text-danger-600 text-sm justify-self-end"
+								:aria-label="`Remove ${line.item_name}`"
+								@click="form.lines.splice(i, 1)"
+							>
+								✕
+							</button>
+						</div>
+					</div>
+
+					<p v-if="form.lines.length" class="text-[11px] text-ink-400 mt-2">
+						You can't issue more than is at site — quantities cap at receipts received
+						less what's already been consumed.
+					</p>
+					<div
+						v-else
+						class="border border-dashed border-ink-200 py-6 text-center text-sm text-ink-500 mt-4"
+						style="border-radius: 8px"
+					>
+						Nothing added yet. Use the picker above to choose what left the store.
+					</div>
+				</template>
+
+				<p v-else-if="!loadingStock" class="text-sm text-ink-500">
+					Nothing in site stock for this project — record deliveries first; received
+					material shows up here.
+				</p>
+			</DeskSection>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -17,11 +17,7 @@ const shortcuts = [
 	// Supplier bills (money out) — opens the Bills register, where direct supplier bills
 	// are listed and a new one can be raised. Matches the prototype's "Supplier Bills" tile.
 	{ label: "Supplier Bills", icon: "wallet", to: "/project-finance/bills" },
-	{
-		label: "Material Consumption",
-		icon: "stock",
-		href: "/app/stock-entry?stock_entry_type=Material Issue",
-	},
+	{ label: "Material Consumption", icon: "stock", to: "/material-consumption" },
 	{ label: "Suppliers", icon: "building-2", href: "/app/supplier" },
 	{ label: "Items", icon: "tag", to: "/items" },
 ];


### PR DESCRIPTION
Add list, record and detail screens, backed by Stock Entry of type Material Issue.

The store comes from the project, not the user. Items are limited to what is on hand. Cost code is optional, picked from the project's BOQ.

Draft only for now — submit is left to a Frappe Workflow.