### PR TITLE
fix: Payments list In/Out label-value spacing

### DIFF
--- a/frontend/src/views/finance/FinancePaymentsPanel.vue
+++ b/frontend/src/views/finance/FinancePaymentsPanel.vue
@@ -68,7 +68,7 @@ const hasFilters = computed(
 		from.value ||
 		to.value ||
 		amtMin.value !== "" ||
-		amtMax.value !== "",
+		amtMax.value !== ""
 );
 function clearFilters() {
 	search.value = "";
@@ -94,12 +94,12 @@ function inAmountRange(n) {
 // Distinct accounts + parties across the register — the filter pools.
 const accountOptions = computed(() =>
 	[...new Set(movements.value.map((m) => m.account).filter(Boolean))].sort((a, b) =>
-		a.localeCompare(b),
-	),
+		a.localeCompare(b)
+	)
 );
 const partyOptions = computed(() => {
 	const names = [...new Set(movements.value.map((m) => m.party).filter(Boolean))].sort((a, b) =>
-		a.localeCompare(b),
+		a.localeCompare(b)
 	);
 	return names.map((n) => ({ value: n, label: n }));
 });
@@ -118,14 +118,14 @@ const filtered = computed(() => {
 				m.type.toLowerCase().includes(term) ||
 				(m.party || "").toLowerCase().includes(term) ||
 				(m.account || "").toLowerCase().includes(term) ||
-				(m.ref || "").toLowerCase().includes(term)),
+				(m.ref || "").toLowerCase().includes(term))
 	);
 });
 const totalIn = computed(() =>
-	filtered.value.filter((m) => m.dir === "in").reduce((a, m) => a + m.amount, 0),
+	filtered.value.filter((m) => m.dir === "in").reduce((a, m) => a + m.amount, 0)
 );
 const totalOut = computed(() =>
-	filtered.value.filter((m) => m.dir === "out").reduce((a, m) => a + m.amount, 0),
+	filtered.value.filter((m) => m.dir === "out").reduce((a, m) => a + m.amount, 0)
 );
 
 const CANCEL_NOTE = {
@@ -241,14 +241,14 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 				>
 					Clear filters
 				</button>
-				<div class="ml-auto flex items-center gap-4 text-xs">
-					<div>
+				<div class="ml-auto flex items-center gap-5 text-xs">
+					<div class="flex items-center gap-1.5">
 						<span class="text-ink-500">In</span>
 						<span class="tabular-nums text-success-700 font-medium">{{
 							fmtINR(totalIn)
 						}}</span>
 					</div>
-					<div>
+					<div class="flex items-center gap-1.5">
 						<span class="text-ink-500">Out</span>
 						<span class="tabular-nums text-danger-700 font-medium">{{
 							fmtINR(totalOut)
@@ -327,8 +327,8 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 						loading
 							? "Loading payments…"
 							: hasFilters
-								? "No transactions match the filters."
-								: "No transactions recorded yet."
+							? "No transactions match the filters."
+							: "No transactions recorded yet."
 					}}
 				</div>
 			</section>


### PR DESCRIPTION
The **In** / **Out** totals in the Project Finance Payments list had no gap between the label and the number (e.g. `In78,000,000`). Wrapped each in `flex items-center gap-1.5` so the label is spaced from its value — same fix as the Invoices/Bills summary strips. `vite build` clean.