### PR TITLE
feat: full in-app Procurement — Material Requests / POs / Receipts (list + form + detail) + report filter names

### DIFF
--- a/buildsuite_core/api/procurement_docs.py
+++ b/buildsuite_core/api/procurement_docs.py
@@ -1,0 +1,591 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Whitelisted CRUD + lifecycle for the three in-app procurement documents —
+Material Request, Purchase Order and Purchase Receipt. Each carries a child
+`items` table that can't go through the generic data adapter, so the Vue
+procurement surface reads/writes them here. All three are natively submittable:
+state IS the docstatus — Draft (0) → Submitted (1) → Cancelled (2), plus Amend.
+
+Company is anchored to the project (never the user default); a Material Request
+has no parent project in ERPNext, so we treat the request as single-project and
+stamp that project on every item line, deriving the request's project back from
+its lines for display."""
+
+import frappe
+from frappe import _
+from frappe.utils import flt, nowdate
+
+from buildsuite_core.utils.project import default_company
+
+MATERIAL_REQUEST = "Material Request"
+PURCHASE_ORDER = "Purchase Order"
+PURCHASE_RECEIPT = "Purchase Receipt"
+
+# docstatus → the lifecycle label the Vue screens show.
+_DOCSTATE = {0: "Draft", 1: "Submitted", 2: "Cancelled"}
+
+
+def _state(doc):
+	return _DOCSTATE.get(doc.docstatus, "Draft")
+
+
+def _company_for(project=None):
+	"""Company anchored to the project; fall back to the single default company."""
+	if project:
+		return frappe.db.get_value("Project", project, "company") or default_company()
+	return default_company()
+
+
+def _project_name(project):
+	return frappe.db.get_value("Project", project, "project_name") if project else None
+
+
+def _company_currency(company):
+	return frappe.get_cached_value("Company", company, "default_currency") if company else None
+
+
+# ==========================================================================
+# Material Request
+# ==========================================================================
+
+
+def _mr_project(doc):
+	"""The request's project. This app adds a mandatory parent `project` custom field
+	to Material Request; fall back to a line's project for any legacy row without it."""
+	if doc.get("project"):
+		return doc.project
+	return next((it.project for it in doc.items if it.project), None)
+
+
+def _serialize_mr(doc):
+	project = _mr_project(doc)
+	return {
+		"name": doc.name,
+		"project": project,
+		"project_name": _project_name(project),
+		"material_request_type": doc.material_request_type,
+		"transaction_date": str(doc.transaction_date) if doc.transaction_date else None,
+		"schedule_date": str(doc.schedule_date) if doc.schedule_date else None,
+		"requested_by": doc.owner,
+		"docstatus": doc.docstatus,
+		"state": _state(doc),
+		"status": doc.status,
+		"amended_from": doc.get("amended_from"),
+		"per_ordered": flt(doc.per_ordered),
+		"company": doc.company,
+		"total": sum(flt(it.qty) * flt(it.rate) for it in doc.items),
+		"items": [
+			{
+				"name": it.name,
+				"item_code": it.item_code,
+				"item_name": it.item_name,
+				"description": it.description,
+				"qty": flt(it.qty),
+				"uom": it.uom,
+				"rate": flt(it.rate),
+				"amount": flt(it.qty) * flt(it.rate),
+				"project": it.project,
+				"ordered_qty": flt(it.ordered_qty),
+			}
+			for it in doc.items
+		],
+	}
+
+
+def _mr_actions(doc):
+	if doc.docstatus == 0:
+		return ["edit", "submit", "delete"]
+	if doc.docstatus == 1:
+		actions = ["cancel"]
+		if flt(doc.per_ordered) < 100:
+			actions.insert(0, "create_po")
+		return actions
+	return ["amend", "delete"]
+
+
+@frappe.whitelist()
+def get_material_request(name):
+	doc = frappe.get_doc(MATERIAL_REQUEST, name)
+	doc.check_permission("read")
+	out = _serialize_mr(doc)
+	out["actions"] = _mr_actions(doc)
+	return out
+
+
+@frappe.whitelist()
+def save_material_request(name=None, project=None, schedule_date=None, items=None):
+	"""Create / update a draft Material Request (Purchase type). One project for the
+	whole request, stamped on every line + used to anchor the company."""
+	items = frappe.parse_json(items) or []
+	if not project:
+		frappe.throw(_("Pick a project for the request."))
+
+	if name and frappe.db.exists(MATERIAL_REQUEST, name):
+		doc = frappe.get_doc(MATERIAL_REQUEST, name)
+		doc.check_permission("write")
+	else:
+		doc = frappe.new_doc(MATERIAL_REQUEST)
+		doc.material_request_type = "Purchase"
+
+	doc.company = _company_for(project)
+	doc.project = project  # mandatory parent custom field on Material Request in this app
+	doc.transaction_date = doc.transaction_date or nowdate()
+	doc.schedule_date = schedule_date or doc.schedule_date
+
+	# ERPNext requires a target warehouse on stock lines; the prototype has no
+	# warehouse UI, so default to the company/project warehouse (harmless on services).
+	default_wh = _default_warehouse(doc.company)
+	doc.set("items", [])
+	for row in items:
+		if not row.get("item_code") or flt(row.get("qty")) <= 0:
+			continue
+		doc.append(
+			"items",
+			{
+				"item_code": row.get("item_code"),
+				"qty": flt(row.get("qty")),
+				"uom": row.get("uom") or None,
+				"rate": flt(row.get("rate")),
+				"description": row.get("description") or None,
+				"schedule_date": row.get("schedule_date") or schedule_date or nowdate(),
+				"warehouse": default_wh,
+				"project": project,
+			},
+		)
+	if not doc.get("items"):
+		frappe.throw(_("Add at least one item with a quantity."))
+
+	doc.save()
+	return _serialize_mr(doc)
+
+
+@frappe.whitelist()
+def submit_material_request(name):
+	doc = frappe.get_doc(MATERIAL_REQUEST, name)
+	doc.check_permission("submit")
+	doc.submit()
+	return get_material_request(name)
+
+
+@frappe.whitelist()
+def cancel_material_request(name):
+	doc = frappe.get_doc(MATERIAL_REQUEST, name)
+	doc.check_permission("cancel")
+	doc.cancel()
+	return get_material_request(name)
+
+
+@frappe.whitelist()
+def amend_material_request(name):
+	src = frappe.get_doc(MATERIAL_REQUEST, name)
+	src.check_permission("amend")
+	if src.docstatus != 2:
+		frappe.throw(_("Only a cancelled request can be amended."))
+	amended = frappe.copy_doc(src)
+	amended.amended_from = name
+	amended.docstatus = 0
+	amended.insert()
+	return get_material_request(amended.name)
+
+
+@frappe.whitelist()
+def delete_material_request(name):
+	frappe.delete_doc(MATERIAL_REQUEST, name)
+	return {"ok": True}
+
+
+# ==========================================================================
+# Purchase Order
+# ==========================================================================
+
+
+def _serialize_po(doc):
+	return {
+		"name": doc.name,
+		"supplier": doc.supplier,
+		"supplier_name": doc.supplier_name,
+		"project": doc.project,
+		"project_name": _project_name(doc.project),
+		"transaction_date": str(doc.transaction_date) if doc.transaction_date else None,
+		"schedule_date": str(doc.schedule_date) if doc.schedule_date else None,
+		"currency": doc.currency,
+		"grand_total": flt(doc.grand_total),
+		"total": flt(doc.total),
+		"per_received": flt(doc.per_received),
+		"per_billed": flt(doc.per_billed),
+		"docstatus": doc.docstatus,
+		"state": _state(doc),
+		"status": doc.status,
+		"amended_from": doc.get("amended_from"),
+		"terms": doc.terms,
+		"tc_name": doc.tc_name,
+		"company": doc.company,
+		"items": [
+			{
+				"name": it.name,
+				"item_code": it.item_code,
+				"item_name": it.item_name,
+				"description": it.description,
+				"qty": flt(it.qty),
+				"uom": it.uom,
+				"rate": flt(it.rate),
+				"amount": flt(it.amount),
+				"received_qty": flt(it.received_qty),
+				"warehouse": it.warehouse,
+				"project": it.project,
+			}
+			for it in doc.items
+		],
+	}
+
+
+def _po_actions(doc):
+	if doc.docstatus == 0:
+		return ["edit", "submit", "delete"]
+	if doc.docstatus == 1:
+		actions = ["cancel"]
+		if flt(doc.per_received) < 100:
+			actions.insert(0, "create_receipt")
+		return actions
+	return ["amend", "delete"]
+
+
+@frappe.whitelist()
+def get_purchase_order(name):
+	doc = frappe.get_doc(PURCHASE_ORDER, name)
+	doc.check_permission("read")
+	out = _serialize_po(doc)
+	out["actions"] = _po_actions(doc)
+	return out
+
+
+@frappe.whitelist()
+def get_mr_for_po(material_request):
+	"""Prefill payload for a PO raised from an approved Material Request — the
+	request's project and its still-to-order lines (qty net of already-ordered)."""
+	doc = frappe.get_doc(MATERIAL_REQUEST, material_request)
+	doc.check_permission("read")
+	project = _mr_project(doc)
+	lines = []
+	for it in doc.items:
+		remaining = flt(it.qty) - flt(it.ordered_qty)
+		if remaining <= 0:
+			continue
+		lines.append(
+			{
+				"item_code": it.item_code,
+				"item_name": it.item_name,
+				"description": it.description,
+				"qty": remaining,
+				"uom": it.uom,
+				"rate": flt(it.rate),
+			}
+		)
+	return {
+		"material_request": doc.name,
+		"project": project,
+		"project_name": _project_name(project),
+		"lines": lines,
+	}
+
+
+@frappe.whitelist()
+def save_purchase_order(
+	name=None,
+	supplier=None,
+	project=None,
+	transaction_date=None,
+	schedule_date=None,
+	items=None,
+	terms=None,
+	material_request=None,
+):
+	"""Create / update a draft Purchase Order. Rate is entered by hand (single
+	company currency, conversion 1); line amounts are computed by the controller."""
+	items = frappe.parse_json(items) or []
+	if not supplier:
+		frappe.throw(_("Pick a supplier."))
+	if not project:
+		frappe.throw(_("Pick a project."))
+
+	if name and frappe.db.exists(PURCHASE_ORDER, name):
+		doc = frappe.get_doc(PURCHASE_ORDER, name)
+		doc.check_permission("write")
+	else:
+		doc = frappe.new_doc(PURCHASE_ORDER)
+
+	company = _company_for(project)
+	doc.supplier = supplier
+	doc.company = company
+	doc.currency = _company_currency(company)
+	doc.conversion_rate = 1
+	doc.project = project
+	doc.transaction_date = transaction_date or doc.transaction_date or nowdate()
+	doc.schedule_date = schedule_date or doc.schedule_date
+	doc.terms = terms
+
+	# Stock lines need a delivery warehouse (see save_material_request); default it.
+	default_wh = _default_warehouse(company)
+	doc.set("items", [])
+	for row in items:
+		if not row.get("item_code") or flt(row.get("qty")) <= 0:
+			continue
+		doc.append(
+			"items",
+			{
+				"item_code": row.get("item_code"),
+				"qty": flt(row.get("qty")),
+				"uom": row.get("uom") or None,
+				"rate": flt(row.get("rate")),
+				"description": row.get("description") or None,
+				"schedule_date": row.get("schedule_date") or schedule_date or nowdate(),
+				"warehouse": default_wh,
+				"project": project,
+				"material_request": material_request or None,
+			},
+		)
+	if not doc.get("items"):
+		frappe.throw(_("Add at least one item with a quantity."))
+
+	doc.save()
+	return _serialize_po(doc)
+
+
+@frappe.whitelist()
+def submit_purchase_order(name):
+	doc = frappe.get_doc(PURCHASE_ORDER, name)
+	doc.check_permission("submit")
+	doc.submit()
+	return get_purchase_order(name)
+
+
+@frappe.whitelist()
+def cancel_purchase_order(name):
+	doc = frappe.get_doc(PURCHASE_ORDER, name)
+	doc.check_permission("cancel")
+	doc.cancel()
+	return get_purchase_order(name)
+
+
+@frappe.whitelist()
+def amend_purchase_order(name):
+	src = frappe.get_doc(PURCHASE_ORDER, name)
+	src.check_permission("amend")
+	if src.docstatus != 2:
+		frappe.throw(_("Only a cancelled order can be amended."))
+	amended = frappe.copy_doc(src)
+	amended.amended_from = name
+	amended.docstatus = 0
+	amended.insert()
+	return get_purchase_order(amended.name)
+
+
+@frappe.whitelist()
+def delete_purchase_order(name):
+	frappe.delete_doc(PURCHASE_ORDER, name)
+	return {"ok": True}
+
+
+# ==========================================================================
+# Purchase Receipt — derived from a submitted Purchase Order
+# ==========================================================================
+
+
+def _make_purchase_receipt(source_po):
+	"""ERPNext's PO → Purchase Receipt mapper. Its module moved in newer ERPNext
+	(deployed prod may still carry the old location), so import defensively."""
+	try:
+		from erpnext.buying.doctype.purchase_order.mapper import make_purchase_receipt
+	except ImportError:
+		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
+	return make_purchase_receipt(source_po)
+
+
+def _default_warehouse(company=None):
+	"""A receiving warehouse for the goods — ERPNext requires one on every stock line.
+	Prefer Stock Settings' default, else the company's first non-group warehouse."""
+	wh = frappe.db.get_single_value("Stock Settings", "default_warehouse")
+	if wh and (not company or frappe.db.get_value("Warehouse", wh, "company") == company):
+		return wh
+	filters = {"is_group": 0, "disabled": 0}
+	if company:
+		filters["company"] = company
+	return frappe.db.get_value("Warehouse", filters, "name")
+
+
+def _serialize_pr(doc, ordered_by_poi=None):
+	ordered_by_poi = ordered_by_poi or {}
+	return {
+		"name": doc.get("name"),
+		"supplier": doc.supplier,
+		"supplier_name": doc.supplier_name,
+		"project": doc.project,
+		"project_name": _project_name(doc.project),
+		"posting_date": str(doc.posting_date) if doc.posting_date else None,
+		"currency": doc.currency,
+		"grand_total": flt(doc.grand_total),
+		"per_billed": flt(doc.per_billed),
+		"docstatus": doc.docstatus or 0,
+		"state": _state(doc),
+		"status": doc.get("status") or "Draft",
+		"amended_from": doc.get("amended_from"),
+		"purchase_order": next((it.purchase_order for it in doc.items if it.purchase_order), None),
+		"warehouse": doc.get("set_warehouse")
+		or next((it.warehouse for it in doc.items if it.warehouse), None),
+		"company": doc.company,
+		"items": [
+			{
+				"name": it.get("name"),
+				"item_code": it.item_code,
+				"item_name": it.item_name,
+				"uom": it.uom,
+				"rate": flt(it.rate),
+				"received_qty": flt(it.received_qty),
+				"ordered_qty": flt(ordered_by_poi.get(it.purchase_order_item, 0)),
+				"amount": flt(it.amount),
+				"warehouse": it.warehouse,
+				"purchase_order": it.purchase_order,
+				"purchase_order_item": it.purchase_order_item,
+			}
+			for it in doc.items
+		],
+	}
+
+
+def _ordered_map(items):
+	"""PO-item name → its ordered qty, for the 'ordered' column on the receipt form."""
+	poi_names = [it.purchase_order_item for it in items if it.purchase_order_item]
+	if not poi_names:
+		return {}
+	rows = frappe.get_all("Purchase Order Item", filters={"name": ["in", poi_names]}, fields=["name", "qty"])
+	return {r.name: flt(r.qty) for r in rows}
+
+
+@frappe.whitelist()
+def get_open_purchase_orders():
+	"""Submitted POs still awaiting delivery — the pick-list for a new receipt."""
+	rows = frappe.get_list(
+		PURCHASE_ORDER,
+		filters=[
+			["docstatus", "=", 1],
+			["per_received", "<", 100],
+			["status", "not in", ["Closed", "On Hold"]],
+		],
+		fields=["name", "supplier", "supplier_name", "project", "schedule_date", "grand_total"],
+		order_by="transaction_date desc",
+	)
+	for r in rows:
+		r["project_name"] = _project_name(r.project)
+	return rows
+
+
+@frappe.whitelist()
+def get_receipt_draft(purchase_order):
+	"""Build (unsaved) a receipt from a PO so the form shows the remaining-to-receive
+	lines, pre-filled with warehouse + PO rate. Nothing is persisted until save."""
+	try:
+		target = _make_purchase_receipt(purchase_order)
+	except Exception as e:  # fully received / closed / permission
+		frappe.throw(_("Can't receive against {0}: {1}").format(purchase_order, str(e)))
+	fallback = _default_warehouse(target.company)
+	for it in target.items:
+		it.warehouse = it.warehouse or fallback
+		# Default the editable received qty to the still-outstanding quantity.
+		it.received_qty = flt(it.received_qty) or flt(it.qty)
+	return _serialize_pr(target, _ordered_map(target.items))
+
+
+def _apply_receipt_lines(doc, lines, warehouse=None):
+	"""Set each line's received qty from the payload; stamp a warehouse (chosen, else
+	the line's own, else the company default) since stock lines require one; drop lines
+	left at zero."""
+	by_poi = {l.get("purchase_order_item"): l for l in lines if l.get("purchase_order_item")}
+	by_item = {}
+	for l in lines:
+		by_item.setdefault(l.get("item_code"), l)
+	fallback = warehouse or _default_warehouse(doc.company)
+	for it in doc.items:
+		match = by_poi.get(it.purchase_order_item) or by_item.get(it.item_code)
+		qty = flt(match.get("received_qty")) if match else 0
+		it.received_qty = qty
+		it.qty = qty
+		it.rejected_qty = 0
+		it.warehouse = warehouse or it.warehouse or fallback
+	doc.set("items", [it for it in doc.items if flt(it.received_qty) > 0])
+
+
+@frappe.whitelist()
+def save_purchase_receipt(name=None, purchase_order=None, posting_date=None, warehouse=None, items=None):
+	"""Create / update a draft Purchase Receipt against a PO. New receipts are seeded
+	from the PO mapper (warehouse, rate, links); the entered received quantities and
+	the chosen receiving warehouse are applied and zero lines dropped."""
+	lines = frappe.parse_json(items) or []
+
+	if name and frappe.db.exists(PURCHASE_RECEIPT, name):
+		doc = frappe.get_doc(PURCHASE_RECEIPT, name)
+		doc.check_permission("write")
+	elif purchase_order:
+		doc = _make_purchase_receipt(purchase_order)
+	else:
+		frappe.throw(_("Pick a purchase order to receive against."))
+
+	if warehouse:
+		doc.set_warehouse = warehouse
+	_apply_receipt_lines(doc, lines, warehouse)
+	if not doc.get("items"):
+		frappe.throw(_("Enter at least one received quantity."))
+	doc.posting_date = posting_date or doc.get("posting_date") or nowdate()
+	doc.set_posting_time = 1
+
+	doc.save()
+	return _serialize_pr(doc, _ordered_map(doc.items))
+
+
+@frappe.whitelist()
+def get_purchase_receipt(name):
+	doc = frappe.get_doc(PURCHASE_RECEIPT, name)
+	doc.check_permission("read")
+	out = _serialize_pr(doc, _ordered_map(doc.items))
+	if doc.docstatus == 0:
+		out["actions"] = ["edit", "submit", "delete"]
+	elif doc.docstatus == 1:
+		out["actions"] = ["cancel"]
+	else:
+		out["actions"] = ["amend", "delete"]
+	return out
+
+
+@frappe.whitelist()
+def submit_purchase_receipt(name):
+	doc = frappe.get_doc(PURCHASE_RECEIPT, name)
+	doc.check_permission("submit")
+	doc.submit()
+	return get_purchase_receipt(name)
+
+
+@frappe.whitelist()
+def cancel_purchase_receipt(name):
+	doc = frappe.get_doc(PURCHASE_RECEIPT, name)
+	doc.check_permission("cancel")
+	doc.cancel()
+	return get_purchase_receipt(name)
+
+
+@frappe.whitelist()
+def amend_purchase_receipt(name):
+	src = frappe.get_doc(PURCHASE_RECEIPT, name)
+	src.check_permission("amend")
+	if src.docstatus != 2:
+		frappe.throw(_("Only a cancelled receipt can be amended."))
+	amended = frappe.copy_doc(src)
+	amended.amended_from = name
+	amended.docstatus = 0
+	amended.insert()
+	return get_purchase_receipt(amended.name)
+
+
+@frappe.whitelist()
+def delete_purchase_receipt(name):
+	frappe.delete_doc(PURCHASE_RECEIPT, name)
+	return {"ok": True}

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -61,6 +61,21 @@ function seedFilters(defs) {
 			f.fieldtype === "Check" ? Number(f.default) || 0 : f.default ?? "";
 	}
 }
+// Link filters should show a readable title, not the record id. Map the common report
+// filter doctypes to their title field; unknown doctypes fall back to `name`.
+const TITLE_FIELDS = {
+	Project: "project_name",
+	Customer: "customer_name",
+	Supplier: "supplier_name",
+	Item: "item_name",
+	Employee: "employee_name",
+	"Cost Center": "cost_center_name",
+	Warehouse: "warehouse_name",
+	Task: "subject",
+};
+function labelFieldFor(doctype) {
+	return TITLE_FIELDS[doctype] || "name";
+}
 function selectOptions(f) {
 	return (f.options || "")
 		.split("\n")
@@ -337,7 +352,7 @@ const inputClass =
 					<DeskLinkPicker
 						v-model="filterValues[f.fieldname]"
 						:doctype="f.options || 'DocType'"
-						label-field="name"
+						:label-field="labelFieldFor(f.options)"
 						value-field="name"
 						:placeholder="`All ${f.label.toLowerCase()}`"
 					/>

--- a/frontend/src/components/procurement/ProcurementStatusPill.vue
+++ b/frontend/src/components/procurement/ProcurementStatusPill.vue
@@ -1,0 +1,45 @@
+<script setup>
+// Status pill for the procurement documents (Material Request / Purchase Order /
+// Purchase Receipt), matching the prototype's exact PILL colour maps. The shared
+// StatusBadge can't be reused here because the same status word (e.g. "Completed")
+// carries a different colour in other modules (Task Completed is brand, a completed
+// PO is success), so these business statuses live in their own map.
+defineProps({
+	status: { type: String, default: "" },
+});
+
+const PILL = {
+	// Shared
+	Draft: "bg-ink-100 text-ink-700",
+	Cancelled: "bg-ink-100 text-ink-500",
+	Closed: "bg-ink-100 text-ink-500",
+	// Material Request
+	Pending: "bg-warning-50 text-warning-700",
+	"Partially Ordered": "bg-info-50 text-info-700",
+	Ordered: "bg-success-50 text-success-700",
+	Received: "bg-success-50 text-success-700",
+	"Partially Received": "bg-info-50 text-info-700",
+	Issued: "bg-success-50 text-success-700",
+	Transferred: "bg-success-50 text-success-700",
+	Stopped: "bg-ink-100 text-ink-500",
+	// Purchase Order
+	"To Receive and Bill": "bg-warning-50 text-warning-700",
+	"To Receive": "bg-info-50 text-info-700",
+	"To Bill": "bg-info-50 text-info-700",
+	Completed: "bg-success-50 text-success-700",
+	"On Hold": "bg-warning-50 text-warning-700",
+	Delivered: "bg-success-50 text-success-700",
+	// Purchase Receipt
+	"Partly Billed": "bg-info-50 text-info-700",
+	Return: "bg-danger-50 text-danger-700",
+	"Return Issued": "bg-warning-50 text-warning-700",
+};
+</script>
+
+<template>
+	<span
+		class="text-[11px] px-2 py-0.5 rounded-full whitespace-nowrap"
+		:class="PILL[status] || 'bg-ink-100 text-ink-700'"
+		>{{ status }}</span
+	>
+</template>

--- a/frontend/src/data/procurementApi.js
+++ b/frontend/src/data/procurementApi.js
@@ -12,3 +12,49 @@ async function call(method) {
 }
 
 export const getProcurementDashboard = () => call("get_dashboard");
+
+// --- In-app procurement documents (Material Request / Purchase Order / Purchase
+// Receipt) — read/save their child `items` tables + the native submittable
+// lifecycle (Draft → Submit → Cancel → Amend). Backed by api.procurement_docs.*.
+async function docCall(method, args) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.procurement_docs.${method}`,
+			params: args || {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+// Material Request
+export const getMaterialRequest = (name) => docCall("get_material_request", { name });
+export const saveMaterialRequest = (payload) =>
+	docCall("save_material_request", { ...payload, items: JSON.stringify(payload.items || []) });
+export const submitMaterialRequest = (name) => docCall("submit_material_request", { name });
+export const cancelMaterialRequest = (name) => docCall("cancel_material_request", { name });
+export const amendMaterialRequest = (name) => docCall("amend_material_request", { name });
+export const deleteMaterialRequest = (name) => docCall("delete_material_request", { name });
+
+// Purchase Order
+export const getPurchaseOrder = (name) => docCall("get_purchase_order", { name });
+export const getMrForPo = (materialRequest) =>
+	docCall("get_mr_for_po", { material_request: materialRequest });
+export const savePurchaseOrder = (payload) =>
+	docCall("save_purchase_order", { ...payload, items: JSON.stringify(payload.items || []) });
+export const submitPurchaseOrder = (name) => docCall("submit_purchase_order", { name });
+export const cancelPurchaseOrder = (name) => docCall("cancel_purchase_order", { name });
+export const amendPurchaseOrder = (name) => docCall("amend_purchase_order", { name });
+export const deletePurchaseOrder = (name) => docCall("delete_purchase_order", { name });
+
+// Purchase Receipt (derived from a submitted PO)
+export const getOpenPurchaseOrders = () => docCall("get_open_purchase_orders");
+export const getReceiptDraft = (purchaseOrder) =>
+	docCall("get_receipt_draft", { purchase_order: purchaseOrder });
+export const getPurchaseReceipt = (name) => docCall("get_purchase_receipt", { name });
+export const savePurchaseReceipt = (payload) =>
+	docCall("save_purchase_receipt", { ...payload, items: JSON.stringify(payload.items || []) });
+export const submitPurchaseReceipt = (name) => docCall("submit_purchase_receipt", { name });
+export const cancelPurchaseReceipt = (name) => docCall("cancel_purchase_receipt", { name });
+export const amendPurchaseReceipt = (name) => docCall("amend_purchase_receipt", { name });
+export const deletePurchaseReceipt = (name) => docCall("delete_purchase_receipt", { name });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -323,14 +323,62 @@ const routes = [
 				component: () => import("@/views/procurement/MaterialRequestsListView.vue"),
 			},
 			{
+				path: "procurement/material-requests/new",
+				name: "material-request-new",
+				component: () => import("@/views/procurement/NewMaterialRequestView.vue"),
+			},
+			{
+				path: "procurement/material-requests/:id",
+				name: "material-request-detail",
+				component: () => import("@/views/procurement/MaterialRequestDetailView.vue"),
+				props: true,
+			},
+			{
+				path: "procurement/material-requests/:id/edit",
+				name: "material-request-edit",
+				component: () => import("@/views/procurement/NewMaterialRequestView.vue"),
+			},
+			{
 				path: "procurement/purchase-orders",
 				name: "purchase-orders",
 				component: () => import("@/views/procurement/PurchaseOrdersListView.vue"),
 			},
 			{
+				path: "procurement/purchase-orders/new",
+				name: "purchase-order-new",
+				component: () => import("@/views/procurement/NewPurchaseOrderView.vue"),
+			},
+			{
+				path: "procurement/purchase-orders/:id",
+				name: "purchase-order-detail",
+				component: () => import("@/views/procurement/PurchaseOrderDetailView.vue"),
+				props: true,
+			},
+			{
+				path: "procurement/purchase-orders/:id/edit",
+				name: "purchase-order-edit",
+				component: () => import("@/views/procurement/NewPurchaseOrderView.vue"),
+			},
+			{
 				path: "procurement/receipts",
 				name: "purchase-receipts",
 				component: () => import("@/views/procurement/PurchaseReceiptsListView.vue"),
+			},
+			{
+				path: "procurement/receipts/new",
+				name: "purchase-receipt-new",
+				component: () => import("@/views/procurement/NewPurchaseReceiptView.vue"),
+			},
+			{
+				path: "procurement/receipts/:id",
+				name: "purchase-receipt-detail",
+				component: () => import("@/views/procurement/PurchaseReceiptDetailView.vue"),
+				props: true,
+			},
+			{
+				path: "procurement/receipts/:id/edit",
+				name: "purchase-receipt-edit",
+				component: () => import("@/views/procurement/NewPurchaseReceiptView.vue"),
 			},
 			{
 				path: "items",

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -318,6 +318,21 @@ const routes = [
 				component: () => import("@/views/workspaces/ProcurementDashboardView.vue"),
 			},
 			{
+				path: "procurement/material-requests",
+				name: "material-requests",
+				component: () => import("@/views/procurement/MaterialRequestsListView.vue"),
+			},
+			{
+				path: "procurement/purchase-orders",
+				name: "purchase-orders",
+				component: () => import("@/views/procurement/PurchaseOrdersListView.vue"),
+			},
+			{
+				path: "procurement/receipts",
+				name: "purchase-receipts",
+				component: () => import("@/views/procurement/PurchaseReceiptsListView.vue"),
+			},
+			{
 				path: "items",
 				name: "items",
 				component: () => import("@/views/ItemsListView.vue"),

--- a/frontend/src/views/procurement/MaterialRequestDetailView.vue
+++ b/frontend/src/views/procurement/MaterialRequestDetailView.vue
@@ -1,0 +1,302 @@
+<script setup>
+// Material Request detail — summary strip, read-only item lines, and the native
+// submittable lifecycle: Draft → Edit / Submit / Delete; Submitted → Create
+// Purchase Order / Cancel; Cancelled → Amend / Delete. State IS the docstatus.
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import {
+	getMaterialRequest,
+	submitMaterialRequest,
+	cancelMaterialRequest,
+	amendMaterialRequest,
+	deleteMaterialRequest,
+} from "@/data/procurementApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import UserAvatar from "@/components/UserAvatar.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const props = defineProps({ id: String });
+const router = useRouter();
+const confirmDialog = useConfirm();
+
+const mr = ref(null);
+const loading = ref(true);
+const busy = ref(false);
+
+async function load() {
+	loading.value = true;
+	try {
+		mr.value = await getMaterialRequest(props.id);
+	} catch (err) {
+		showToast(err.message || "Failed to load request", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
+
+const isDraft = computed(() => mr.value?.state === "Draft");
+const isSubmitted = computed(() => mr.value?.state === "Submitted");
+const isCancelled = computed(() => mr.value?.state === "Cancelled");
+const canOrder = computed(() => isSubmitted.value && (mr.value?.per_ordered || 0) < 100);
+
+function onEdit() {
+	router.push(`/procurement/material-requests/${mr.value.name}/edit`);
+}
+function onCreatePo() {
+	router.push(`/procurement/purchase-orders/new?mr=${mr.value.name}`);
+}
+
+async function onSubmit() {
+	const ok = await confirmDialog({
+		title: `Submit ${mr.value.name}?`,
+		message: `Submit this request (${fmtINR(
+			mr.value.total
+		)})? It enters the procurement queue; a submitted request is cancelled, not edited.`,
+		confirmLabel: "Submit",
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		mr.value = await submitMaterialRequest(mr.value.name);
+		showToast("Request submitted.");
+	} catch (err) {
+		showToast(err.message || "Submit failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onCancel() {
+	const ok = await confirmDialog({
+		title: `Cancel ${mr.value.name}?`,
+		message:
+			"Cancelling withdraws the request — it drops out of the procurement queue. Amend later to raise a corrected copy.",
+		confirmLabel: "Cancel request",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		mr.value = await cancelMaterialRequest(mr.value.name);
+		showToast("Request cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onAmend() {
+	busy.value = true;
+	try {
+		const res = await amendMaterialRequest(mr.value.name);
+		showToast("Amended — a fresh draft was created.");
+		router.push(`/procurement/material-requests/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Amend failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onDelete() {
+	const ok = await confirmDialog({
+		title: `Delete ${mr.value.name}?`,
+		message: "This request and its items will be removed permanently.",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await deleteMaterialRequest(mr.value.name);
+		router.push("/procurement/material-requests");
+	} catch (err) {
+		showToast(err.message || "Failed to delete request", "error");
+	}
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Material Requests", to: "/procurement/material-requests" },
+	{ label: mr.value?.name || props.id },
+]);
+</script>
+
+<template>
+	<DeskPage
+		v-if="mr"
+		:title="mr.name"
+		:subtitle="`${mr.project_name || mr.project} · requested ${fmtDate(mr.transaction_date)}`"
+		:breadcrumbs="breadcrumbs"
+		:status="mr.state"
+	>
+		<template #actions>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="onEdit"
+			>
+				Edit
+			</button>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onSubmit"
+			>
+				Submit
+			</button>
+			<button
+				v-if="canOrder"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				title="Raise a Purchase Order from this request"
+				@click="onCreatePo"
+			>
+				+ Create Purchase Order
+			</button>
+			<button
+				v-if="isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onCancel"
+			>
+				Cancel
+			</button>
+			<button
+				v-if="isCancelled"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				title="Create a fresh editable draft copy (the original stays cancelled)"
+				@click="onAmend"
+			>
+				Amend
+			</button>
+			<button
+				v-if="!isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+				style="border-radius: 6px"
+				@click="onDelete"
+			>
+				Delete
+			</button>
+		</template>
+
+		<div
+			v-if="isDraft"
+			class="mb-4 px-4 py-2.5 bg-ink-50 border border-ink-200 rounded-md text-xs text-ink-600"
+		>
+			Draft — not sent to the office yet. Submit it to enter the procurement queue.
+		</div>
+		<div
+			v-if="isCancelled"
+			class="mb-4 px-4 py-2.5 bg-ink-100 border border-ink-200 rounded-md text-xs text-ink-600"
+		>
+			This request is <span class="font-semibold">cancelled</span> — it's out of the
+			procurement queue. Click <span class="font-medium">Amend</span> to raise a corrected
+			draft.
+		</div>
+
+		<!-- Summary strip -->
+		<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Project</div>
+				<DeskLink :to="`/projects/${mr.project}`" class="text-sm">{{
+					mr.project_name || mr.project
+				}}</DeskLink>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Requested by</div>
+				<div class="flex items-center gap-1.5 mt-0.5">
+					<UserAvatar :user-id="mr.requested_by" size="xs" show-name />
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Needed by</div>
+				<div class="text-sm text-ink-900 mt-0.5">
+					{{ mr.schedule_date ? fmtDate(mr.schedule_date) : "—" }}
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">
+					Estimated value
+				</div>
+				<div class="text-sm font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ fmtINR(mr.total) }}
+				</div>
+			</div>
+		</div>
+
+		<!-- Item lines -->
+		<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<div
+				class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between"
+			>
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Items</h3>
+				<span class="text-[10px] text-ink-500"
+					>Ordered {{ Math.round(mr.per_ordered || 0) }}%</span
+				>
+			</div>
+			<table class="w-full text-xs" style="min-width: 640px">
+				<thead class="bg-white text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr>
+						<th class="text-left px-3 py-2">Item</th>
+						<th class="text-right px-3 py-2">Qty</th>
+						<th class="text-left px-3 py-2">UOM</th>
+						<th class="text-right px-3 py-2">Est. rate</th>
+						<th class="text-right px-3 py-2">Amount</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="(it, i) in mr.items"
+						:key="i"
+						class="border-t border-ink-100 align-top"
+					>
+						<td class="px-3 py-2">
+							<span class="text-ink-900">{{ it.item_name || it.item_code }}</span>
+							<span
+								v-if="it.item_name && it.item_code !== it.item_name"
+								class="text-[10px] font-mono text-ink-400 ml-1.5"
+								>{{ it.item_code }}</span
+							>
+							<span
+								v-if="it.description"
+								class="block text-[11px] text-ink-500 mt-0.5"
+								>{{ it.description }}</span
+							>
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ it.qty }}
+						</td>
+						<td class="px-3 py-2 text-ink-500">{{ it.uom || "—" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ it.rate ? fmtINR(it.rate) : "—" }}
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+							{{ it.amount ? fmtINR(it.amount) : "—" }}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
+	</DeskPage>
+
+	<div v-else class="px-3 py-2 text-sm text-ink-500">
+		{{ loading ? "Loading request…" : "Material request not found." }}
+	</div>
+</template>

--- a/frontend/src/views/procurement/MaterialRequestDetailView.vue
+++ b/frontend/src/views/procurement/MaterialRequestDetailView.vue
@@ -15,7 +15,7 @@ import {
 } from "@/data/procurementApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
-import StatusBadge from "@/components/StatusBadge.vue";
+import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
@@ -132,9 +132,9 @@ const breadcrumbs = computed(() => [
 		:title="mr.name"
 		:subtitle="`${mr.project_name || mr.project} · requested ${fmtDate(mr.transaction_date)}`"
 		:breadcrumbs="breadcrumbs"
-		:status="mr.state"
 	>
 		<template #actions>
+			<ProcurementStatusPill :status="mr.status" class="self-center mr-1" />
 			<button
 				v-if="isDraft"
 				type="button"

--- a/frontend/src/views/procurement/MaterialRequestsListView.vue
+++ b/frontend/src/views/procurement/MaterialRequestsListView.vue
@@ -8,7 +8,7 @@ import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
-import StatusBadge from "@/components/StatusBadge.vue";
+import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { useProjectNames } from "@/composables/useProjectNames";
@@ -158,7 +158,7 @@ const breadcrumbs = [
 				>
 			</template>
 			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" size="xs" />
+				<ProcurementStatusPill :status="row.status" />
 			</template>
 		</DocTypeListView>
 	</DeskPage>

--- a/frontend/src/views/procurement/MaterialRequestsListView.vue
+++ b/frontend/src/views/procurement/MaterialRequestsListView.vue
@@ -1,17 +1,22 @@
 <script setup>
 // Material Requests — ERPNext Material Request master, in-app list via DocTypeListView.
-// Requested-by resolves from the doc owner to a name (not the email). Note: Material
-// Request carries no parent `project` (it lives on the line items), so this list has no
-// project column/filter — unlike PO / Purchase Receipt. Row / New open the Desk form.
+// This app adds a mandatory parent `project` custom field, so the list carries a project
+// column + filter (like PO / Receipt). Requested-by resolves from the doc owner to a name.
+// Row click / New open the in-app detail + form (full CRUD lives in the Vue app now).
 import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
+import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate } from "@/utils/format";
 
+const router = useRouter();
+const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
 	activeCompany.value ? [["company", "=", activeCompany.value]] : []
@@ -19,6 +24,7 @@ const baseFilters = computed(() =>
 
 const FIELDS = [
 	"name",
+	"project",
 	"material_request_type",
 	"transaction_date",
 	"schedule_date",
@@ -28,7 +34,7 @@ const FIELDS = [
 ];
 const columns = [
 	{ key: "name", label: "MR" },
-	{ key: "material_request_type", label: "Type" },
+	{ key: "project", label: "Project" },
 	{ key: "transaction_date", label: "Date" },
 	{ key: "schedule_date", label: "Required by" },
 	{ key: "owner", label: "Requested by" },
@@ -37,24 +43,27 @@ const columns = [
 ];
 
 const statusFilter = ref("");
+const projectFilter = ref("");
 const fromDate = ref("");
 const toDate = ref("");
 const filterValues = computed(() => ({
 	status: statusFilter.value,
+	project: projectFilter.value,
 	fromDate: fromDate.value,
 	toDate: toDate.value,
 }));
 const filterFieldMap = {
 	status: "status",
+	project: "project",
 	fromDate: { field: "transaction_date", op: ">=" },
 	toDate: { field: "transaction_date", op: "<=" },
 };
 
-function openDesk(row) {
-	window.open(`/app/material-request/${encodeURIComponent(row.name)}`, "_blank", "noopener");
+function openDetail(row) {
+	router.push(`/procurement/material-requests/${row.name}`);
 }
 function openNew() {
-	window.open("/app/material-request/new", "_blank", "noopener");
+	router.push("/procurement/material-requests/new");
 }
 
 const breadcrumbs = [
@@ -86,7 +95,7 @@ const breadcrumbs = [
 			initial-order-by="transaction_date desc"
 			search-placeholder="Search material request…"
 			empty-message="No material requests yet."
-			@row-click="openDesk"
+			@row-click="openDetail"
 		>
 			<template #filter-chips>
 				<DeskSelect v-model="statusFilter" class="!w-44">
@@ -99,6 +108,15 @@ const breadcrumbs = [
 					<option>Stopped</option>
 					<option>Cancelled</option>
 				</DeskSelect>
+				<div class="w-48">
+					<DeskLinkPicker
+						v-model="projectFilter"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						placeholder="All projects"
+					/>
+				</div>
 				<input
 					v-model="fromDate"
 					type="date"
@@ -116,8 +134,8 @@ const breadcrumbs = [
 			<template #cell-name="{ row }">
 				<span class="font-mono text-[11px] text-ink-600">{{ row.name }}</span>
 			</template>
-			<template #cell-material_request_type="{ row }">
-				<span class="text-ink-700">{{ row.material_request_type || "—" }}</span>
+			<template #cell-project="{ row }">
+				<span class="text-ink-700">{{ projectName(row.project) || "—" }}</span>
 			</template>
 			<template #cell-transaction_date="{ row }">
 				<span class="text-ink-500 whitespace-nowrap">{{

--- a/frontend/src/views/procurement/MaterialRequestsListView.vue
+++ b/frontend/src/views/procurement/MaterialRequestsListView.vue
@@ -1,0 +1,147 @@
+<script setup>
+// Material Requests — ERPNext Material Request master, in-app list via DocTypeListView.
+// Requested-by resolves from the doc owner to a name (not the email). Note: Material
+// Request carries no parent `project` (it lives on the line items), so this list has no
+// project column/filter — unlike PO / Purchase Receipt. Row / New open the Desk form.
+import { computed, ref } from "vue";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
+import UserAvatar from "@/components/UserAvatar.vue";
+import { useActiveCompany } from "@/composables/useActiveCompany";
+import { fmtDate } from "@/utils/format";
+
+const activeCompany = useActiveCompany();
+const baseFilters = computed(() =>
+	activeCompany.value ? [["company", "=", activeCompany.value]] : []
+);
+
+const FIELDS = [
+	"name",
+	"material_request_type",
+	"transaction_date",
+	"schedule_date",
+	"owner",
+	"per_ordered",
+	"status",
+];
+const columns = [
+	{ key: "name", label: "MR" },
+	{ key: "material_request_type", label: "Type" },
+	{ key: "transaction_date", label: "Date" },
+	{ key: "schedule_date", label: "Required by" },
+	{ key: "owner", label: "Requested by" },
+	{ key: "per_ordered", label: "Ordered", align: "right" },
+	{ key: "status", label: "Status" },
+];
+
+const statusFilter = ref("");
+const fromDate = ref("");
+const toDate = ref("");
+const filterValues = computed(() => ({
+	status: statusFilter.value,
+	fromDate: fromDate.value,
+	toDate: toDate.value,
+}));
+const filterFieldMap = {
+	status: "status",
+	fromDate: { field: "transaction_date", op: ">=" },
+	toDate: { field: "transaction_date", op: "<=" },
+};
+
+function openDesk(row) {
+	window.open(`/app/material-request/${encodeURIComponent(row.name)}`, "_blank", "noopener");
+}
+function openNew() {
+	window.open("/app/material-request/new", "_blank", "noopener");
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Material Requests" },
+];
+</script>
+
+<template>
+	<DeskPage title="Material Requests" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button type="button" class="desk-save-btn !text-xs" @click="openNew">
+				+ New Request
+			</button>
+		</template>
+
+		<DocTypeListView
+			v-if="activeCompany"
+			doctype="Material Request"
+			:field-order="FIELDS"
+			:columns="columns"
+			:search-fields="['name']"
+			:base-filters="baseFilters"
+			:filter-values="filterValues"
+			:filter-field-map="filterFieldMap"
+			cache-key="buildsuite-material-requests"
+			row-key="name"
+			initial-order-by="transaction_date desc"
+			search-placeholder="Search material request…"
+			empty-message="No material requests yet."
+			@row-click="openDesk"
+		>
+			<template #filter-chips>
+				<DeskSelect v-model="statusFilter" class="!w-44">
+					<option value="">Status: Any</option>
+					<option>Draft</option>
+					<option>Pending</option>
+					<option>Partially Ordered</option>
+					<option>Ordered</option>
+					<option>Received</option>
+					<option>Stopped</option>
+					<option>Cancelled</option>
+				</DeskSelect>
+				<input
+					v-model="fromDate"
+					type="date"
+					title="From (request date)"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+				<input
+					v-model="toDate"
+					type="date"
+					title="To (request date)"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+			</template>
+
+			<template #cell-name="{ row }">
+				<span class="font-mono text-[11px] text-ink-600">{{ row.name }}</span>
+			</template>
+			<template #cell-material_request_type="{ row }">
+				<span class="text-ink-700">{{ row.material_request_type || "—" }}</span>
+			</template>
+			<template #cell-transaction_date="{ row }">
+				<span class="text-ink-500 whitespace-nowrap">{{
+					fmtDate(row.transaction_date)
+				}}</span>
+			</template>
+			<template #cell-schedule_date="{ row }">
+				<span class="text-ink-500 whitespace-nowrap">{{
+					row.schedule_date ? fmtDate(row.schedule_date) : "—"
+				}}</span>
+			</template>
+			<template #cell-owner="{ row }">
+				<div class="flex items-center gap-1.5">
+					<UserAvatar :user-id="row.owner" size="xs" show-name />
+				</div>
+			</template>
+			<template #cell-per_ordered="{ row }">
+				<span class="tabular-nums text-ink-700"
+					>{{ Math.round(row.per_ordered || 0) }}%</span
+				>
+			</template>
+			<template #cell-status="{ row }">
+				<StatusBadge :status="row.status" size="xs" />
+			</template>
+		</DocTypeListView>
+	</DeskPage>
+</template>

--- a/frontend/src/views/procurement/NewMaterialRequestView.vue
+++ b/frontend/src/views/procurement/NewMaterialRequestView.vue
@@ -1,0 +1,286 @@
+<script setup>
+// Material Request form — create + edit (draft only). One project for the whole
+// request (locked while editing — the request stays on its project) plus an
+// editable list of item lines. Saved via the whitelisted save_material_request
+// (the child items table can't go through the generic adapter). Status is
+// workflow-driven, so it is never set from this form.
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { showToast } from "@/utils/appToast";
+import { getMaterialRequest, saveMaterialRequest } from "@/data/procurementApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { fmtINR } from "@/utils/format";
+
+const route = useRoute();
+const router = useRouter();
+
+const editingId = computed(() => route.params.id || null);
+const isEdit = computed(() => !!editingId.value);
+
+function emptyLine() {
+	return { item_code: "", description: "", qty: null, uom: "", rate: null };
+}
+function inDays(n) {
+	return new Date(Date.now() + n * 86400000).toISOString().slice(0, 10);
+}
+
+const form = ref({
+	project: route.query.project || "",
+	schedule_date: inDays(7),
+	lines: [emptyLine()],
+});
+const errors = ref({});
+const saving = ref(false);
+
+watch(
+	editingId,
+	async (id) => {
+		if (!id) return;
+		try {
+			const mr = await getMaterialRequest(id);
+			if (mr.state !== "Draft") {
+				showToast("Only a draft request can be edited.", "error");
+				router.replace(`/procurement/material-requests/${id}`);
+				return;
+			}
+			form.value = {
+				project: mr.project || "",
+				schedule_date: mr.schedule_date || inDays(7),
+				lines: (mr.items || []).map((it) => ({
+					item_code: it.item_code || "",
+					description: it.description || "",
+					qty: it.qty,
+					uom: it.uom || "",
+					rate: it.rate ?? null,
+				})),
+			};
+			if (!form.value.lines.length) form.value.lines = [emptyLine()];
+		} catch (err) {
+			showToast(err.message || "Failed to load request", "error");
+		}
+	},
+	{ immediate: true }
+);
+
+const validLines = computed(() =>
+	form.value.lines.filter((l) => l.item_code && Number(l.qty) > 0)
+);
+const total = computed(() =>
+	validLines.value.reduce((a, l) => a + Number(l.qty) * (Number(l.rate) || 0), 0)
+);
+
+function addLine() {
+	form.value.lines.push(emptyLine());
+}
+function removeLine(idx) {
+	form.value.lines.splice(idx, 1);
+	if (!form.value.lines.length) addLine();
+}
+
+function validate() {
+	const e = {};
+	if (!form.value.project) e.project = "Pick a project for the request.";
+	if (!validLines.value.length) e.lines = "Add at least one item with a quantity.";
+	errors.value = e;
+	return Object.keys(e).length === 0;
+}
+
+async function onSave() {
+	if (!validate()) return;
+	saving.value = true;
+	try {
+		const mr = await saveMaterialRequest({
+			name: editingId.value || undefined,
+			project: form.value.project,
+			schedule_date: form.value.schedule_date,
+			items: validLines.value.map((l) => ({
+				item_code: l.item_code,
+				description: l.description,
+				qty: Number(l.qty),
+				uom: l.uom || null,
+				rate: Number(l.rate) || 0,
+			})),
+		});
+		showToast(isEdit.value ? "Request saved." : "Request raised.");
+		router.push(`/procurement/material-requests/${mr.name}`);
+	} catch (err) {
+		showToast(err.message || "Failed to save request", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+function onCancel() {
+	router.back();
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Material Requests", to: "/procurement/material-requests" },
+	isEdit.value
+		? { label: editingId.value, to: `/procurement/material-requests/${editingId.value}` }
+		: { label: "New" },
+	...(isEdit.value ? [{ label: "Edit" }] : []),
+]);
+const pageTitle = computed(() =>
+	isEdit.value ? `Edit ${editingId.value}` : "New Material Request"
+);
+const saveLabel = computed(() =>
+	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Raise request"
+);
+</script>
+
+<template>
+	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="saveLabel"
+					:saving="saving"
+					@save="onSave"
+					@cancel="onCancel"
+				/>
+			</template>
+
+			<DeskSection title="Request" :cols="2">
+				<DeskField
+					label="Project"
+					required
+					:error="errors.project"
+					:hint="
+						isEdit ? 'Locked while editing — the request stays on its project.' : ''
+					"
+				>
+					<DeskLinkPicker
+						v-model="form.project"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						:search-fields="['project_name', 'name']"
+						:disabled="isEdit"
+						placeholder="— Select project —"
+					/>
+				</DeskField>
+				<DeskField label="Needed by">
+					<DeskInput v-model="form.schedule_date" type="date" />
+				</DeskField>
+			</DeskSection>
+
+			<!-- Item lines -->
+			<section class="mt-6">
+				<div class="flex items-center justify-between mb-2 gap-3">
+					<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+						Items
+					</h3>
+					<button
+						type="button"
+						class="text-xs text-brand-700 hover:underline"
+						@click="addLine"
+					>
+						+ Add item
+					</button>
+				</div>
+				<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+					<table class="w-full text-xs" style="min-width: 720px">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2" style="min-width: 200px">Item</th>
+								<th class="text-left px-3 py-2">Notes</th>
+								<th class="text-right px-3 py-2 w-24">Qty</th>
+								<th class="text-left px-3 py-2 w-32">UOM</th>
+								<th class="text-right px-3 py-2 w-28">Est. rate</th>
+								<th class="text-center px-2 py-2 w-8"></th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(line, idx) in form.lines"
+								:key="idx"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2" style="min-width: 200px">
+									<DeskLinkPicker
+										v-model="line.item_code"
+										doctype="Item"
+										label-field="item_name"
+										value-field="name"
+										:search-fields="['item_name', 'item_code', 'name']"
+										placeholder="— Item —"
+									/>
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model="line.description"
+										class="w-full bg-transparent text-xs py-1.5 focus:outline-none"
+										placeholder="Brand, spec, where it's needed…"
+									/>
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model.number="line.qty"
+										type="number"
+										min="0"
+										class="w-full bg-transparent text-xs text-right tabular-nums py-1.5 focus:outline-none"
+										placeholder="Qty"
+									/>
+								</td>
+								<td class="px-3 py-2" style="min-width: 120px">
+									<DeskLinkPicker
+										v-model="line.uom"
+										doctype="UOM"
+										label-field="name"
+										value-field="name"
+										placeholder="—"
+									/>
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model.number="line.rate"
+										type="number"
+										min="0"
+										step="0.01"
+										class="w-full bg-transparent text-xs text-right tabular-nums py-1.5 focus:outline-none"
+										placeholder="—"
+									/>
+								</td>
+								<td class="px-2 py-2 text-center">
+									<button
+										type="button"
+										class="text-ink-400 hover:text-danger-600"
+										title="Remove"
+										@click="removeLine(idx)"
+									>
+										✕
+									</button>
+								</td>
+							</tr>
+						</tbody>
+						<tfoot>
+							<tr class="border-t-2 border-ink-200 bg-ink-50">
+								<td
+									colspan="4"
+									class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider"
+								>
+									Estimated value
+								</td>
+								<td
+									class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+								>
+									{{ fmtINR(total) }}
+								</td>
+								<td></td>
+							</tr>
+						</tfoot>
+					</table>
+				</div>
+				<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">{{ errors.lines }}</p>
+			</section>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/procurement/NewPurchaseOrderView.vue
+++ b/frontend/src/views/procurement/NewPurchaseOrderView.vue
@@ -1,0 +1,342 @@
+<script setup>
+// Purchase Order form — create + edit (draft only). Supplier + project header and
+// an editable item grid (item, qty, uom, rate → amount). Honors ?mr=<id> to convert
+// an approved Material Request: project + still-to-order lines pre-fill and the PO's
+// lines are linked back to the request. Saved via save_purchase_order.
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { showToast } from "@/utils/appToast";
+import { getPurchaseOrder, getMrForPo, savePurchaseOrder } from "@/data/procurementApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { fmtINR } from "@/utils/format";
+
+const route = useRoute();
+const router = useRouter();
+
+const editingId = computed(() => route.params.id || null);
+const isEdit = computed(() => !!editingId.value);
+
+function emptyLine() {
+	return { item_code: "", description: "", qty: null, uom: "", rate: null };
+}
+function inDays(n) {
+	return new Date(Date.now() + n * 86400000).toISOString().slice(0, 10);
+}
+
+const form = ref({
+	supplier: "",
+	project: route.query.project || "",
+	schedule_date: inDays(10),
+	material_request: null,
+	lines: [emptyLine()],
+});
+const errors = ref({});
+const saving = ref(false);
+
+// Edit mode: load the draft PO.
+watch(
+	editingId,
+	async (id) => {
+		if (!id) return;
+		try {
+			const po = await getPurchaseOrder(id);
+			if (po.state !== "Draft") {
+				showToast("Only a draft order can be edited.", "error");
+				router.replace(`/procurement/purchase-orders/${id}`);
+				return;
+			}
+			form.value = {
+				supplier: po.supplier || "",
+				project: po.project || "",
+				schedule_date: po.schedule_date || inDays(10),
+				material_request: null,
+				lines: (po.items || []).map((it) => ({
+					item_code: it.item_code || "",
+					description: it.description || "",
+					qty: it.qty,
+					uom: it.uom || "",
+					rate: it.rate ?? null,
+				})),
+			};
+			if (!form.value.lines.length) form.value.lines = [emptyLine()];
+		} catch (err) {
+			showToast(err.message || "Failed to load order", "error");
+		}
+	},
+	{ immediate: true }
+);
+
+// Convert-from-MR: prefill project + lines when opened as /new?mr=<id>.
+watch(
+	() => route.query.mr,
+	async (mrId) => {
+		if (!mrId || isEdit.value) return;
+		try {
+			const pre = await getMrForPo(mrId);
+			form.value.project = pre.project || form.value.project;
+			form.value.material_request = pre.material_request;
+			if (pre.lines?.length) {
+				form.value.lines = pre.lines.map((l) => ({
+					item_code: l.item_code || "",
+					description: l.description || "",
+					qty: l.qty,
+					uom: l.uom || "",
+					rate: l.rate ?? null,
+				}));
+			}
+		} catch (err) {
+			showToast(err.message || "Failed to load material request", "error");
+		}
+	},
+	{ immediate: true }
+);
+
+const validLines = computed(() =>
+	form.value.lines.filter((l) => l.item_code && Number(l.qty) > 0)
+);
+const total = computed(() =>
+	validLines.value.reduce((a, l) => a + Number(l.qty) * (Number(l.rate) || 0), 0)
+);
+
+function addLine() {
+	form.value.lines.push(emptyLine());
+}
+function removeLine(idx) {
+	form.value.lines.splice(idx, 1);
+	if (!form.value.lines.length) addLine();
+}
+function lineAmount(l) {
+	return (Number(l.qty) || 0) * (Number(l.rate) || 0);
+}
+
+function validate() {
+	const e = {};
+	if (!form.value.supplier) e.supplier = "Pick a supplier.";
+	if (!form.value.project) e.project = "Pick a project.";
+	if (!validLines.value.length) e.lines = "Add at least one item with a quantity.";
+	errors.value = e;
+	return Object.keys(e).length === 0;
+}
+
+async function onSave() {
+	if (!validate()) return;
+	saving.value = true;
+	try {
+		const po = await savePurchaseOrder({
+			name: editingId.value || undefined,
+			supplier: form.value.supplier,
+			project: form.value.project,
+			schedule_date: form.value.schedule_date,
+			material_request: form.value.material_request || undefined,
+			items: validLines.value.map((l) => ({
+				item_code: l.item_code,
+				description: l.description,
+				qty: Number(l.qty),
+				uom: l.uom || null,
+				rate: Number(l.rate) || 0,
+			})),
+		});
+		showToast(isEdit.value ? "Order saved." : "Order created.");
+		router.push(`/procurement/purchase-orders/${po.name}`);
+	} catch (err) {
+		showToast(err.message || "Failed to save order", "error");
+	} finally {
+		saving.value = false;
+	}
+}
+function onCancel() {
+	router.back();
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Purchase Orders", to: "/procurement/purchase-orders" },
+	isEdit.value
+		? { label: editingId.value, to: `/procurement/purchase-orders/${editingId.value}` }
+		: { label: "New" },
+	...(isEdit.value ? [{ label: "Edit" }] : []),
+]);
+const pageTitle = computed(() =>
+	isEdit.value ? `Edit ${editingId.value}` : "New Purchase Order"
+);
+const saveLabel = computed(() =>
+	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Create order"
+);
+</script>
+
+<template>
+	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="saveLabel"
+					:saving="saving"
+					@save="onSave"
+					@cancel="onCancel"
+				/>
+			</template>
+
+			<div
+				v-if="form.material_request"
+				class="mb-4 px-4 py-2 bg-info-50 border border-info-200 rounded-md text-xs text-info-700"
+			>
+				Converting from Material Request
+				<span class="font-mono">{{ form.material_request }}</span> — lines pre-filled; set
+				the supplier and rates.
+			</div>
+
+			<DeskSection title="Order" :cols="3">
+				<DeskField label="Supplier" required :error="errors.supplier">
+					<DeskLinkPicker
+						v-model="form.supplier"
+						doctype="Supplier"
+						label-field="supplier_name"
+						value-field="name"
+						:search-fields="['supplier_name', 'name']"
+						placeholder="— Select supplier —"
+					/>
+				</DeskField>
+				<DeskField
+					label="Project"
+					required
+					:error="errors.project"
+					:hint="isEdit ? 'Locked while editing.' : ''"
+				>
+					<DeskLinkPicker
+						v-model="form.project"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						:search-fields="['project_name', 'name']"
+						:disabled="isEdit"
+						placeholder="— Select project —"
+					/>
+				</DeskField>
+				<DeskField label="Required by">
+					<DeskInput v-model="form.schedule_date" type="date" />
+				</DeskField>
+			</DeskSection>
+
+			<!-- Item lines -->
+			<section class="mt-6">
+				<div class="flex items-center justify-between mb-2 gap-3">
+					<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+						Items
+					</h3>
+					<button
+						type="button"
+						class="text-xs text-brand-700 hover:underline"
+						@click="addLine"
+					>
+						+ Add item
+					</button>
+				</div>
+				<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+					<table class="w-full text-xs" style="min-width: 760px">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2" style="min-width: 200px">Item</th>
+								<th class="text-left px-3 py-2">Notes</th>
+								<th class="text-right px-3 py-2 w-20">Qty</th>
+								<th class="text-left px-3 py-2 w-28">UOM</th>
+								<th class="text-right px-3 py-2 w-28">Rate</th>
+								<th class="text-right px-3 py-2 w-28">Amount</th>
+								<th class="text-center px-2 py-2 w-8"></th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(line, idx) in form.lines"
+								:key="idx"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2" style="min-width: 200px">
+									<DeskLinkPicker
+										v-model="line.item_code"
+										doctype="Item"
+										label-field="item_name"
+										value-field="name"
+										:search-fields="['item_name', 'item_code', 'name']"
+										placeholder="— Item —"
+									/>
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model="line.description"
+										class="w-full bg-transparent text-xs py-1.5 focus:outline-none"
+										placeholder="Notes…"
+									/>
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model.number="line.qty"
+										type="number"
+										min="0"
+										class="w-full bg-transparent text-xs text-right tabular-nums py-1.5 focus:outline-none"
+									/>
+								</td>
+								<td class="px-3 py-2" style="min-width: 110px">
+									<DeskLinkPicker
+										v-model="line.uom"
+										doctype="UOM"
+										label-field="name"
+										value-field="name"
+										placeholder="—"
+									/>
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model.number="line.rate"
+										type="number"
+										min="0"
+										step="0.01"
+										class="w-full bg-transparent text-xs text-right tabular-nums py-1.5 focus:outline-none"
+									/>
+								</td>
+								<td
+									class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium"
+								>
+									{{ fmtINR(lineAmount(line)) }}
+								</td>
+								<td class="px-2 py-2 text-center">
+									<button
+										type="button"
+										class="text-ink-400 hover:text-danger-600"
+										title="Remove"
+										@click="removeLine(idx)"
+									>
+										✕
+									</button>
+								</td>
+							</tr>
+						</tbody>
+						<tfoot>
+							<tr class="border-t-2 border-ink-200 bg-ink-50">
+								<td
+									colspan="5"
+									class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider"
+								>
+									Total
+								</td>
+								<td
+									class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+								>
+									{{ fmtINR(total) }}
+								</td>
+								<td></td>
+							</tr>
+						</tfoot>
+					</table>
+				</div>
+				<p v-if="errors.lines" class="text-xs text-danger-700 mt-1">{{ errors.lines }}</p>
+			</section>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/procurement/NewPurchaseReceiptView.vue
+++ b/frontend/src/views/procurement/NewPurchaseReceiptView.vue
@@ -1,0 +1,347 @@
+<script setup>
+// Purchase Receipt form — record goods received against a submitted Purchase Order.
+// Pick an open PO and its remaining-to-receive lines pre-fill (item, uom, PO rate,
+// ordered qty, received qty default = remaining). Supplier + project are derived
+// from the PO; one receiving warehouse applies to the whole receipt. Saved via
+// save_purchase_receipt (seeded from ERPNext's PO → Receipt mapper).
+import { computed, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { showToast } from "@/utils/appToast";
+import {
+	getOpenPurchaseOrders,
+	getReceiptDraft,
+	getPurchaseReceipt,
+	savePurchaseReceipt,
+} from "@/data/procurementApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskForm from "@/components/desk/DeskForm.vue";
+import DeskActionBar from "@/components/desk/DeskActionBar.vue";
+import DeskSection from "@/components/desk/DeskSection.vue";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const route = useRoute();
+const router = useRouter();
+
+const editingId = computed(() => route.params.id || null);
+const isEdit = computed(() => !!editingId.value);
+
+function today() {
+	return new Date().toISOString().slice(0, 10);
+}
+
+const openPos = ref([]);
+const selectedPo = ref(route.query.po || "");
+const receipt = ref({
+	supplier_name: "",
+	project_name: "",
+	warehouse: "",
+	posting_date: today(),
+	lines: [],
+});
+const error = ref("");
+const saving = ref(false);
+
+const poOptions = computed(() =>
+	openPos.value.map((po) => ({
+		value: po.name,
+		label: `${po.name} — ${po.supplier_name || po.supplier}`,
+		hint: [
+			po.project_name || po.project,
+			po.schedule_date ? "due " + fmtDate(po.schedule_date) : "",
+		]
+			.filter(Boolean)
+			.join(" · "),
+	}))
+);
+
+// New receipt: load open POs for the picker.
+watch(
+	isEdit,
+	async (edit) => {
+		if (edit) return;
+		try {
+			openPos.value = await getOpenPurchaseOrders();
+		} catch (err) {
+			showToast(err.message || "Failed to load purchase orders", "error");
+		}
+	},
+	{ immediate: true }
+);
+
+// New receipt: when a PO is chosen, pull the remaining-to-receive draft lines.
+watch(
+	selectedPo,
+	async (poName) => {
+		if (!poName || isEdit.value) return;
+		try {
+			const draft = await getReceiptDraft(poName);
+			receipt.value = {
+				supplier_name: draft.supplier_name || draft.supplier,
+				project_name: draft.project_name || draft.project,
+				warehouse: draft.warehouse || "",
+				posting_date: today(),
+				lines: (draft.items || []).map((it) => ({
+					item_code: it.item_code,
+					item_name: it.item_name,
+					uom: it.uom,
+					rate: it.rate,
+					ordered_qty: it.ordered_qty,
+					received_qty: it.received_qty,
+					purchase_order_item: it.purchase_order_item,
+				})),
+			};
+		} catch (err) {
+			error.value = err.message || "Can't receive against this order.";
+		}
+	},
+	{ immediate: true }
+);
+
+// Edit mode: load the existing draft receipt.
+watch(
+	editingId,
+	async (id) => {
+		if (!id) return;
+		try {
+			const pr = await getPurchaseReceipt(id);
+			if (pr.state !== "Draft") {
+				showToast("Only a draft receipt can be edited.", "error");
+				router.replace(`/procurement/receipts/${id}`);
+				return;
+			}
+			selectedPo.value = pr.purchase_order;
+			receipt.value = {
+				supplier_name: pr.supplier_name || pr.supplier,
+				project_name: pr.project_name || pr.project,
+				warehouse: pr.warehouse || "",
+				posting_date: pr.posting_date || today(),
+				lines: (pr.items || []).map((it) => ({
+					item_code: it.item_code,
+					item_name: it.item_name,
+					uom: it.uom,
+					rate: it.rate,
+					ordered_qty: it.ordered_qty,
+					received_qty: it.received_qty,
+					purchase_order_item: it.purchase_order_item,
+				})),
+			};
+		} catch (err) {
+			showToast(err.message || "Failed to load receipt", "error");
+		}
+	},
+	{ immediate: true }
+);
+
+const receivedLines = computed(() =>
+	receipt.value.lines.filter((l) => Number(l.received_qty) > 0)
+);
+const total = computed(() =>
+	receivedLines.value.reduce((a, l) => a + Number(l.received_qty) * (Number(l.rate) || 0), 0)
+);
+const canSave = computed(
+	() => !!selectedPo.value && !!receipt.value.warehouse && receivedLines.value.length > 0
+);
+
+async function onSave() {
+	error.value = "";
+	if (!selectedPo.value) {
+		error.value = "Pick a purchase order.";
+		return;
+	}
+	if (!receipt.value.warehouse) {
+		error.value = "Pick a receiving warehouse.";
+		return;
+	}
+	if (!receivedLines.value.length) {
+		error.value = "Enter at least one received quantity.";
+		return;
+	}
+	saving.value = true;
+	try {
+		const pr = await savePurchaseReceipt({
+			name: editingId.value || undefined,
+			purchase_order: selectedPo.value,
+			posting_date: receipt.value.posting_date,
+			warehouse: receipt.value.warehouse,
+			items: receivedLines.value.map((l) => ({
+				item_code: l.item_code,
+				received_qty: Number(l.received_qty),
+				purchase_order_item: l.purchase_order_item,
+			})),
+		});
+		showToast(isEdit.value ? "Receipt saved." : "Receipt recorded.");
+		router.push(`/procurement/receipts/${pr.name}`);
+	} catch (err) {
+		error.value = err.message || "Failed to save receipt";
+	} finally {
+		saving.value = false;
+	}
+}
+function onCancel() {
+	router.back();
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Purchase Receipts", to: "/procurement/receipts" },
+	isEdit.value
+		? { label: editingId.value, to: `/procurement/receipts/${editingId.value}` }
+		: { label: "New" },
+	...(isEdit.value ? [{ label: "Edit" }] : []),
+]);
+const pageTitle = computed(() =>
+	isEdit.value ? `Edit ${editingId.value}` : "New Purchase Receipt"
+);
+const saveLabel = computed(() =>
+	saving.value ? "Saving…" : isEdit.value ? "Save changes" : "Confirm receipt"
+);
+</script>
+
+<template>
+	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
+		<DeskForm>
+			<template #action-bar>
+				<DeskActionBar
+					:save-label="saveLabel"
+					:saving="saving"
+					:can-save="canSave"
+					@save="onSave"
+					@cancel="onCancel"
+				/>
+			</template>
+
+			<div
+				v-if="error"
+				class="mb-4 bg-danger-50 border border-danger-200 rounded-lg px-4 py-2.5 text-xs text-danger-700"
+			>
+				{{ error }}
+			</div>
+
+			<DeskSection title="Receipt" :cols="3">
+				<DeskField label="Purchase order" required>
+					<DeskSearchableSelect
+						v-if="!isEdit"
+						v-model="selectedPo"
+						:options="poOptions"
+						placeholder="— Select open PO —"
+						search-placeholder="Search PO, supplier…"
+					/>
+					<div v-else class="text-sm text-ink-900 pt-1.5 font-mono">
+						{{ selectedPo }}
+					</div>
+				</DeskField>
+				<DeskField
+					label="Receiving warehouse"
+					required
+					hint="Where the goods land on site."
+				>
+					<DeskLinkPicker
+						v-model="receipt.warehouse"
+						doctype="Warehouse"
+						label-field="warehouse_name"
+						value-field="name"
+						:filters="[['is_group', '=', 0]]"
+						placeholder="— Select warehouse —"
+					/>
+				</DeskField>
+				<DeskField label="Received on">
+					<DeskInput v-model="receipt.posting_date" type="date" />
+				</DeskField>
+				<DeskField
+					v-if="receipt.supplier_name"
+					label="Supplier"
+					hint="From the purchase order."
+				>
+					<div class="text-sm text-ink-900 pt-1.5">{{ receipt.supplier_name }}</div>
+				</DeskField>
+				<DeskField
+					v-if="receipt.project_name"
+					label="Project"
+					hint="From the purchase order."
+				>
+					<div class="text-sm text-ink-900 pt-1.5">{{ receipt.project_name }}</div>
+				</DeskField>
+			</DeskSection>
+
+			<!-- Received lines -->
+			<section v-if="receipt.lines.length" class="mt-6">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700 mb-2">
+					Items received
+				</h3>
+				<div class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+					<table class="w-full text-xs" style="min-width: 680px">
+						<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+							<tr>
+								<th class="text-left px-3 py-2">Item</th>
+								<th class="text-left px-3 py-2">UOM</th>
+								<th class="text-right px-3 py-2">Ordered</th>
+								<th class="text-right px-3 py-2">PO rate</th>
+								<th class="text-right px-3 py-2 w-28">Received now</th>
+								<th class="text-right px-3 py-2">Amount</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(l, idx) in receipt.lines"
+								:key="idx"
+								class="border-t border-ink-100"
+							>
+								<td class="px-3 py-2 text-ink-900">
+									{{ l.item_name || l.item_code }}
+								</td>
+								<td class="px-3 py-2 text-ink-500">{{ l.uom || "—" }}</td>
+								<td class="px-3 py-2 text-right tabular-nums text-ink-500">
+									{{ l.ordered_qty }}
+								</td>
+								<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+									{{ fmtINR(l.rate) }}
+								</td>
+								<td class="px-3 py-2">
+									<input
+										v-model.number="l.received_qty"
+										type="number"
+										min="0"
+										:max="l.ordered_qty"
+										class="w-full bg-transparent text-xs text-right tabular-nums py-1.5 focus:outline-none border border-ink-200 rounded px-1.5"
+									/>
+								</td>
+								<td
+									class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium"
+								>
+									{{
+										fmtINR(
+											(Number(l.received_qty) || 0) * (Number(l.rate) || 0)
+										)
+									}}
+								</td>
+							</tr>
+						</tbody>
+						<tfoot>
+							<tr class="border-t-2 border-ink-200 bg-ink-50">
+								<td
+									colspan="5"
+									class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider"
+								>
+									Total received
+								</td>
+								<td
+									class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+								>
+									{{ fmtINR(total) }}
+								</td>
+							</tr>
+						</tfoot>
+					</table>
+				</div>
+			</section>
+			<div v-else-if="selectedPo" class="mt-6 text-xs text-ink-400 italic">
+				Nothing left to receive on this order.
+			</div>
+		</DeskForm>
+	</DeskPage>
+</template>

--- a/frontend/src/views/procurement/PurchaseOrderDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseOrderDetailView.vue
@@ -15,7 +15,7 @@ import {
 } from "@/data/procurementApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
-import StatusBadge from "@/components/StatusBadge.vue";
+import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
@@ -130,9 +130,9 @@ const breadcrumbs = computed(() => [
 		:title="po.name"
 		:subtitle="`${po.supplier_name || po.supplier} · ${po.project_name || po.project}`"
 		:breadcrumbs="breadcrumbs"
-		:status="po.state"
 	>
 		<template #actions>
+			<ProcurementStatusPill :status="po.status" class="self-center mr-1" />
 			<button
 				v-if="isDraft"
 				type="button"

--- a/frontend/src/views/procurement/PurchaseOrderDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseOrderDetailView.vue
@@ -1,0 +1,322 @@
+<script setup>
+// Purchase Order detail — summary strip, read-only item lines (ordered vs received),
+// and the native submittable lifecycle: Draft → Edit / Submit / Delete; Submitted →
+// Create Receipt / Cancel; Cancelled → Amend / Delete.
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import {
+	getPurchaseOrder,
+	submitPurchaseOrder,
+	cancelPurchaseOrder,
+	amendPurchaseOrder,
+	deletePurchaseOrder,
+} from "@/data/procurementApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const props = defineProps({ id: String });
+const router = useRouter();
+const confirmDialog = useConfirm();
+
+const po = ref(null);
+const loading = ref(true);
+const busy = ref(false);
+
+async function load() {
+	loading.value = true;
+	try {
+		po.value = await getPurchaseOrder(props.id);
+	} catch (err) {
+		showToast(err.message || "Failed to load order", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
+
+const isDraft = computed(() => po.value?.state === "Draft");
+const isSubmitted = computed(() => po.value?.state === "Submitted");
+const isCancelled = computed(() => po.value?.state === "Cancelled");
+const canReceive = computed(() => isSubmitted.value && (po.value?.per_received || 0) < 100);
+
+function onEdit() {
+	router.push(`/procurement/purchase-orders/${po.value.name}/edit`);
+}
+function onCreateReceipt() {
+	router.push(`/procurement/receipts/new?po=${po.value.name}`);
+}
+
+async function onSubmit() {
+	const ok = await confirmDialog({
+		title: `Submit ${po.value.name}?`,
+		message: `Submit this order to ${po.value.supplier_name || po.value.supplier} (${fmtINR(
+			po.value.grand_total
+		)})? It posts the order and locks the lines; a submitted order is amended, not edited.`,
+		confirmLabel: "Submit",
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		po.value = await submitPurchaseOrder(po.value.name);
+		showToast("Order submitted.");
+	} catch (err) {
+		showToast(err.message || "Submit failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onCancel() {
+	const ok = await confirmDialog({
+		title: `Cancel ${po.value.name}?`,
+		message: "This cancels the order. It's blocked if receipts or bills exist against it.",
+		confirmLabel: "Cancel order",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		po.value = await cancelPurchaseOrder(po.value.name);
+		showToast("Order cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onAmend() {
+	busy.value = true;
+	try {
+		const res = await amendPurchaseOrder(po.value.name);
+		showToast("Amended — a fresh draft was created.");
+		router.push(`/procurement/purchase-orders/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Amend failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onDelete() {
+	const ok = await confirmDialog({
+		title: `Delete ${po.value.name}?`,
+		message: "This order and its items will be removed permanently.",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await deletePurchaseOrder(po.value.name);
+		router.push("/procurement/purchase-orders");
+	} catch (err) {
+		showToast(err.message || "Failed to delete order", "error");
+	}
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Purchase Orders", to: "/procurement/purchase-orders" },
+	{ label: po.value?.name || props.id },
+]);
+</script>
+
+<template>
+	<DeskPage
+		v-if="po"
+		:title="po.name"
+		:subtitle="`${po.supplier_name || po.supplier} · ${po.project_name || po.project}`"
+		:breadcrumbs="breadcrumbs"
+		:status="po.state"
+	>
+		<template #actions>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="onEdit"
+			>
+				Edit
+			</button>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onSubmit"
+			>
+				Submit
+			</button>
+			<button
+				v-if="canReceive"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				title="Record a goods receipt against this order"
+				@click="onCreateReceipt"
+			>
+				+ Create Receipt
+			</button>
+			<button
+				v-if="isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onCancel"
+			>
+				Cancel
+			</button>
+			<button
+				v-if="isCancelled"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				title="Create a fresh editable draft copy (the original stays cancelled)"
+				@click="onAmend"
+			>
+				Amend
+			</button>
+			<button
+				v-if="!isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+				style="border-radius: 6px"
+				@click="onDelete"
+			>
+				Delete
+			</button>
+		</template>
+
+		<div
+			v-if="isDraft"
+			class="mb-4 px-4 py-2.5 bg-ink-50 border border-ink-200 rounded-md text-xs text-ink-600"
+		>
+			Draft — not sent to the supplier yet. Submit it to post the order.
+		</div>
+
+		<!-- Summary strip -->
+		<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Supplier</div>
+				<div class="text-sm text-ink-900 mt-0.5 truncate">
+					{{ po.supplier_name || po.supplier }}
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Project</div>
+				<DeskLink :to="`/projects/${po.project}`" class="text-sm">{{
+					po.project_name || po.project
+				}}</DeskLink>
+				<div class="text-[10px] text-ink-500">
+					{{
+						po.schedule_date
+							? "Required by " + fmtDate(po.schedule_date)
+							: fmtDate(po.transaction_date)
+					}}
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Value</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ fmtINR(po.grand_total) }}
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Received</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ Math.round(po.per_received || 0) }}%
+				</div>
+				<div class="text-[10px] text-ink-500">
+					Billed {{ Math.round(po.per_billed || 0) }}%
+				</div>
+			</div>
+		</div>
+
+		<!-- Item lines -->
+		<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<div class="bg-ink-50 px-4 py-2 border-b border-ink-200">
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Items</h3>
+			</div>
+			<table class="w-full text-xs" style="min-width: 700px">
+				<thead class="bg-white text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr>
+						<th class="text-left px-3 py-2">Item</th>
+						<th class="text-right px-3 py-2">Qty</th>
+						<th class="text-left px-3 py-2">UOM</th>
+						<th class="text-right px-3 py-2">Rate</th>
+						<th class="text-right px-3 py-2">Amount</th>
+						<th class="text-right px-3 py-2">Received</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="(it, i) in po.items"
+						:key="i"
+						class="border-t border-ink-100 align-top"
+					>
+						<td class="px-3 py-2">
+							<span class="text-ink-900">{{ it.item_name || it.item_code }}</span>
+							<span
+								v-if="it.item_name && it.item_code !== it.item_name"
+								class="text-[10px] font-mono text-ink-400 ml-1.5"
+								>{{ it.item_code }}</span
+							>
+							<span
+								v-if="it.description"
+								class="block text-[11px] text-ink-500 mt-0.5"
+								>{{ it.description }}</span
+							>
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ it.qty }}
+						</td>
+						<td class="px-3 py-2 text-ink-500">{{ it.uom || "—" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ fmtINR(it.rate) }}
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+							{{ fmtINR(it.amount) }}
+						</td>
+						<td
+							class="px-3 py-2 text-right tabular-nums font-medium"
+							:class="
+								(it.received_qty || 0) >= (it.qty || 0)
+									? 'text-success-700'
+									: 'text-ink-700'
+							"
+						>
+							{{ it.received_qty || 0 }} / {{ it.qty }}
+						</td>
+					</tr>
+				</tbody>
+				<tfoot>
+					<tr class="border-t-2 border-ink-200 bg-ink-50">
+						<td
+							colspan="4"
+							class="px-3 py-2 text-right text-xs font-semibold text-ink-700 uppercase tracking-wider"
+						>
+							Total
+						</td>
+						<td
+							class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+						>
+							{{ fmtINR(po.grand_total) }}
+						</td>
+						<td></td>
+					</tr>
+				</tfoot>
+			</table>
+		</section>
+	</DeskPage>
+
+	<div v-else class="px-3 py-2 text-sm text-ink-500">
+		{{ loading ? "Loading order…" : "Purchase order not found." }}
+	</div>
+</template>

--- a/frontend/src/views/procurement/PurchaseOrdersListView.vue
+++ b/frontend/src/views/procurement/PurchaseOrdersListView.vue
@@ -1,0 +1,164 @@
+<script setup>
+// Purchase Orders — ERPNext Purchase Order master, in-app list via DocTypeListView
+// (pagination / sort / search for free). Columns show readable names (supplier_name,
+// project → project_name) rather than record ids. Row click / New open the Desk form.
+import { computed, ref } from "vue";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
+import { useProjectNames } from "@/composables/useProjectNames";
+import { useActiveCompany } from "@/composables/useActiveCompany";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const { projectName } = useProjectNames();
+const activeCompany = useActiveCompany();
+const baseFilters = computed(() =>
+	activeCompany.value ? [["company", "=", activeCompany.value]] : []
+);
+
+const FIELDS = [
+	"name",
+	"supplier_name",
+	"project",
+	"transaction_date",
+	"schedule_date",
+	"grand_total",
+	"per_received",
+	"status",
+];
+const columns = [
+	{ key: "name", label: "PO" },
+	{ key: "supplier_name", label: "Supplier" },
+	{ key: "project", label: "Project" },
+	{ key: "transaction_date", label: "Ordered" },
+	{ key: "schedule_date", label: "Required by" },
+	{ key: "grand_total", label: "Value", align: "right" },
+	{ key: "per_received", label: "Received", align: "right" },
+	{ key: "status", label: "Status" },
+];
+
+const statusFilter = ref("");
+const projectFilter = ref("");
+const fromDate = ref("");
+const toDate = ref("");
+const filterValues = computed(() => ({
+	status: statusFilter.value,
+	project: projectFilter.value,
+	fromDate: fromDate.value,
+	toDate: toDate.value,
+}));
+const filterFieldMap = {
+	status: "status",
+	project: "project",
+	fromDate: { field: "transaction_date", op: ">=" },
+	toDate: { field: "transaction_date", op: "<=" },
+};
+
+function openDesk(row) {
+	window.open(`/app/purchase-order/${encodeURIComponent(row.name)}`, "_blank", "noopener");
+}
+function openNew() {
+	window.open("/app/purchase-order/new", "_blank", "noopener");
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Purchase Orders" },
+];
+</script>
+
+<template>
+	<DeskPage title="Purchase Orders" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button type="button" class="desk-save-btn !text-xs" @click="openNew">+ New PO</button>
+		</template>
+
+		<DocTypeListView
+			v-if="activeCompany"
+			doctype="Purchase Order"
+			:field-order="FIELDS"
+			:columns="columns"
+			:search-fields="['name', 'supplier_name']"
+			:base-filters="baseFilters"
+			:filter-values="filterValues"
+			:filter-field-map="filterFieldMap"
+			cache-key="buildsuite-purchase-orders"
+			row-key="name"
+			initial-order-by="transaction_date desc"
+			search-placeholder="Search PO, supplier…"
+			empty-message="No purchase orders yet."
+			@row-click="openDesk"
+		>
+			<template #filter-chips>
+				<DeskSelect v-model="statusFilter" class="!w-44">
+					<option value="">Status: Any</option>
+					<option>Draft</option>
+					<option>To Receive and Bill</option>
+					<option>To Bill</option>
+					<option>To Receive</option>
+					<option>Completed</option>
+					<option>On Hold</option>
+					<option>Closed</option>
+					<option>Cancelled</option>
+				</DeskSelect>
+				<div class="w-48">
+					<DeskLinkPicker
+						v-model="projectFilter"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						placeholder="All projects"
+					/>
+				</div>
+				<input
+					v-model="fromDate"
+					type="date"
+					title="From (order date)"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+				<input
+					v-model="toDate"
+					type="date"
+					title="To (order date)"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+			</template>
+
+			<template #cell-name="{ row }">
+				<span class="font-mono text-[11px] text-ink-600">{{ row.name }}</span>
+			</template>
+			<template #cell-supplier_name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.supplier_name || "—" }}</span>
+			</template>
+			<template #cell-project="{ row }">
+				<span class="text-ink-700">{{ projectName(row.project) || "—" }}</span>
+			</template>
+			<template #cell-transaction_date="{ row }">
+				<span class="text-ink-500 whitespace-nowrap">{{
+					fmtDate(row.transaction_date)
+				}}</span>
+			</template>
+			<template #cell-schedule_date="{ row }">
+				<span class="text-ink-500 whitespace-nowrap">{{
+					row.schedule_date ? fmtDate(row.schedule_date) : "—"
+				}}</span>
+			</template>
+			<template #cell-grand_total="{ row }">
+				<span class="tabular-nums text-ink-900 font-medium">{{
+					fmtINR(row.grand_total)
+				}}</span>
+			</template>
+			<template #cell-per_received="{ row }">
+				<span class="tabular-nums text-ink-700"
+					>{{ Math.round(row.per_received || 0) }}%</span
+				>
+			</template>
+			<template #cell-status="{ row }">
+				<StatusBadge :status="row.status" size="xs" />
+			</template>
+		</DocTypeListView>
+	</DeskPage>
+</template>

--- a/frontend/src/views/procurement/PurchaseOrdersListView.vue
+++ b/frontend/src/views/procurement/PurchaseOrdersListView.vue
@@ -3,6 +3,7 @@
 // (pagination / sort / search for free). Columns show readable names (supplier_name,
 // project → project_name) rather than record ids. Row click / New open the Desk form.
 import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
@@ -12,6 +13,7 @@ import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
+const router = useRouter();
 const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
@@ -56,11 +58,11 @@ const filterFieldMap = {
 	toDate: { field: "transaction_date", op: "<=" },
 };
 
-function openDesk(row) {
-	window.open(`/app/purchase-order/${encodeURIComponent(row.name)}`, "_blank", "noopener");
+function openDetail(row) {
+	router.push(`/procurement/purchase-orders/${row.name}`);
 }
 function openNew() {
-	window.open("/app/purchase-order/new", "_blank", "noopener");
+	router.push("/procurement/purchase-orders/new");
 }
 
 const breadcrumbs = [
@@ -90,7 +92,7 @@ const breadcrumbs = [
 			initial-order-by="transaction_date desc"
 			search-placeholder="Search PO, supplier…"
 			empty-message="No purchase orders yet."
-			@row-click="openDesk"
+			@row-click="openDetail"
 		>
 			<template #filter-chips>
 				<DeskSelect v-model="statusFilter" class="!w-44">

--- a/frontend/src/views/procurement/PurchaseOrdersListView.vue
+++ b/frontend/src/views/procurement/PurchaseOrdersListView.vue
@@ -1,17 +1,18 @@
 <script setup>
 // Purchase Orders — ERPNext Purchase Order master, in-app list via DocTypeListView
 // (pagination / sort / search for free). Columns show readable names (supplier_name,
-// project → project_name) rather than record ids. Row click / New open the Desk form.
+// project → project_name) not ids, the prototype's status pills + received bar; row
+// click / New open the in-app detail + form.
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
-import StatusBadge from "@/components/StatusBadge.vue";
+import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
-import { fmtDate, fmtINR } from "@/utils/format";
+import { fmtDate, fmtCompactINR } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
@@ -149,17 +150,26 @@ const breadcrumbs = [
 				}}</span>
 			</template>
 			<template #cell-grand_total="{ row }">
-				<span class="tabular-nums text-ink-900 font-medium">{{
-					fmtINR(row.grand_total)
-				}}</span>
+				<span class="tabular-nums text-ink-700">{{ fmtCompactINR(row.grand_total) }}</span>
 			</template>
 			<template #cell-per_received="{ row }">
-				<span class="tabular-nums text-ink-700"
-					>{{ Math.round(row.per_received || 0) }}%</span
-				>
+				<span class="flex items-center gap-1.5 justify-end">
+					<span class="w-14 h-1.5 rounded-full bg-ink-100 overflow-hidden">
+						<span
+							class="block h-full rounded-full"
+							:class="
+								(row.per_received || 0) >= 100 ? 'bg-success-500' : 'bg-info-500'
+							"
+							:style="{ width: Math.min(100, row.per_received || 0) + '%' }"
+						></span>
+					</span>
+					<span class="text-[11px] tabular-nums text-ink-500"
+						>{{ Math.round(row.per_received || 0) }}%</span
+					>
+				</span>
 			</template>
 			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" size="xs" />
+				<ProcurementStatusPill :status="row.status" />
 			</template>
 		</DocTypeListView>
 	</DeskPage>

--- a/frontend/src/views/procurement/PurchaseReceiptDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptDetailView.vue
@@ -15,6 +15,7 @@ import {
 } from "@/data/procurementApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
@@ -128,9 +129,9 @@ const breadcrumbs = computed(() => [
 		:title="pr.name"
 		:subtitle="`${pr.supplier_name || pr.supplier} · ${pr.project_name || pr.project}`"
 		:breadcrumbs="breadcrumbs"
-		:status="pr.state"
 	>
 		<template #actions>
+			<ProcurementStatusPill :status="pr.status" class="self-center mr-1" />
 			<button
 				v-if="isDraft"
 				type="button"

--- a/frontend/src/views/procurement/PurchaseReceiptDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptDetailView.vue
@@ -1,0 +1,268 @@
+<script setup>
+// Purchase Receipt detail — summary strip, read-only received lines, and the native
+// submittable lifecycle: Draft → Edit / Submit / Delete; Submitted → Cancel;
+// Cancelled → Amend / Delete. Submitting posts stock; cancelling reverses it.
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { useConfirm } from "@/composables/useConfirm";
+import { showToast } from "@/utils/appToast";
+import {
+	getPurchaseReceipt,
+	submitPurchaseReceipt,
+	cancelPurchaseReceipt,
+	amendPurchaseReceipt,
+	deletePurchaseReceipt,
+} from "@/data/procurementApi";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const props = defineProps({ id: String });
+const router = useRouter();
+const confirmDialog = useConfirm();
+
+const pr = ref(null);
+const loading = ref(true);
+const busy = ref(false);
+
+async function load() {
+	loading.value = true;
+	try {
+		pr.value = await getPurchaseReceipt(props.id);
+	} catch (err) {
+		showToast(err.message || "Failed to load receipt", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
+
+const isDraft = computed(() => pr.value?.state === "Draft");
+const isSubmitted = computed(() => pr.value?.state === "Submitted");
+const isCancelled = computed(() => pr.value?.state === "Cancelled");
+const total = computed(() =>
+	(pr.value?.items || []).reduce((a, it) => a + (it.received_qty || 0) * (it.rate || 0), 0)
+);
+
+function onEdit() {
+	router.push(`/procurement/receipts/${pr.value.name}/edit`);
+}
+
+async function onSubmit() {
+	const ok = await confirmDialog({
+		title: `Submit ${pr.value.name}?`,
+		message:
+			"Submitting posts the goods into stock and updates the purchase order's received quantity.",
+		confirmLabel: "Submit",
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		pr.value = await submitPurchaseReceipt(pr.value.name);
+		showToast("Receipt submitted.");
+	} catch (err) {
+		showToast(err.message || "Submit failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onCancel() {
+	const ok = await confirmDialog({
+		title: `Cancel ${pr.value.name}?`,
+		message:
+			"Cancelling reverses the receipt — the material leaves stock and the order's received quantity drops back.",
+		confirmLabel: "Cancel receipt",
+		cancelLabel: "Keep",
+		destructive: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		pr.value = await cancelPurchaseReceipt(pr.value.name);
+		showToast("Receipt cancelled.");
+	} catch (err) {
+		showToast(err.message || "Cancel failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onAmend() {
+	busy.value = true;
+	try {
+		const res = await amendPurchaseReceipt(pr.value.name);
+		showToast("Amended — a fresh draft was created.");
+		router.push(`/procurement/receipts/${res.name}`);
+	} catch (err) {
+		showToast(err.message || "Amend failed", "error");
+	} finally {
+		busy.value = false;
+	}
+}
+async function onDelete() {
+	const ok = await confirmDialog({
+		title: `Delete ${pr.value.name}?`,
+		message: "This receipt will be removed permanently.",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	try {
+		await deletePurchaseReceipt(pr.value.name);
+		router.push("/procurement/receipts");
+	} catch (err) {
+		showToast(err.message || "Failed to delete receipt", "error");
+	}
+}
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Purchase Receipts", to: "/procurement/receipts" },
+	{ label: pr.value?.name || props.id },
+]);
+</script>
+
+<template>
+	<DeskPage
+		v-if="pr"
+		:title="pr.name"
+		:subtitle="`${pr.supplier_name || pr.supplier} · ${pr.project_name || pr.project}`"
+		:breadcrumbs="breadcrumbs"
+		:status="pr.state"
+	>
+		<template #actions>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="onEdit"
+			>
+				Edit
+			</button>
+			<button
+				v-if="isDraft"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onSubmit"
+			>
+				Submit
+			</button>
+			<button
+				v-if="isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				@click="onCancel"
+			>
+				Cancel
+			</button>
+			<button
+				v-if="isCancelled"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				:disabled="busy"
+				title="Create a fresh editable draft copy (the original stays cancelled)"
+				@click="onAmend"
+			>
+				Amend
+			</button>
+			<button
+				v-if="!isSubmitted"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
+				style="border-radius: 6px"
+				@click="onDelete"
+			>
+				Delete
+			</button>
+		</template>
+
+		<div
+			v-if="isDraft"
+			class="mb-4 px-4 py-2.5 bg-ink-50 border border-ink-200 rounded-md text-xs text-ink-600"
+		>
+			Draft — not posted to stock yet. Submit it to record the goods into the warehouse.
+		</div>
+
+		<!-- Summary strip -->
+		<div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Supplier</div>
+				<div class="text-sm text-ink-900 mt-0.5 truncate">
+					{{ pr.supplier_name || pr.supplier }}
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Project</div>
+				<DeskLink :to="`/projects/${pr.project}`" class="text-sm">{{
+					pr.project_name || pr.project
+				}}</DeskLink>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Received on</div>
+				<div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(pr.posting_date) }}</div>
+				<div v-if="pr.purchase_order" class="text-[10px] text-ink-500">
+					against
+					<DeskLink
+						:to="`/procurement/purchase-orders/${pr.purchase_order}`"
+						class="font-mono"
+						>{{ pr.purchase_order }}</DeskLink
+					>
+				</div>
+			</div>
+			<div class="bg-white border border-ink-200 rounded-lg p-3">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500">Value received</div>
+				<div class="text-base font-semibold text-ink-900 tabular-nums mt-0.5">
+					{{ fmtINR(total) }}
+				</div>
+			</div>
+		</div>
+
+		<!-- Received lines -->
+		<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
+			<div
+				class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between"
+			>
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+					Items received
+				</h3>
+				<span class="text-[10px] text-ink-500">Into {{ pr.warehouse || "—" }}</span>
+			</div>
+			<table class="w-full text-xs" style="min-width: 620px">
+				<thead class="bg-white text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr>
+						<th class="text-left px-3 py-2">Item</th>
+						<th class="text-left px-3 py-2">UOM</th>
+						<th class="text-right px-3 py-2">Rate</th>
+						<th class="text-right px-3 py-2">Received</th>
+						<th class="text-right px-3 py-2">Amount</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="(it, i) in pr.items" :key="i" class="border-t border-ink-100">
+						<td class="px-3 py-2 text-ink-900">{{ it.item_name || it.item_code }}</td>
+						<td class="px-3 py-2 text-ink-500">{{ it.uom || "—" }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+							{{ fmtINR(it.rate) }}
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-success-700 font-medium">
+							{{ it.received_qty }}
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium">
+							{{ fmtINR((it.received_qty || 0) * (it.rate || 0)) }}
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</section>
+	</DeskPage>
+
+	<div v-else class="px-3 py-2 text-sm text-ink-500">
+		{{ loading ? "Loading receipt…" : "Purchase receipt not found." }}
+	</div>
+</template>

--- a/frontend/src/views/procurement/PurchaseReceiptsListView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptsListView.vue
@@ -1,0 +1,155 @@
+<script setup>
+// Purchase Receipts (goods received) — ERPNext Purchase Receipt master, in-app list via
+// DocTypeListView. Readable names (supplier_name, project → project_name); row / New open
+// the Desk form.
+import { computed, ref } from "vue";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
+import { useProjectNames } from "@/composables/useProjectNames";
+import { useActiveCompany } from "@/composables/useActiveCompany";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const { projectName } = useProjectNames();
+const activeCompany = useActiveCompany();
+const baseFilters = computed(() =>
+	activeCompany.value ? [["company", "=", activeCompany.value]] : []
+);
+
+const FIELDS = [
+	"name",
+	"supplier_name",
+	"project",
+	"posting_date",
+	"grand_total",
+	"per_billed",
+	"status",
+];
+const columns = [
+	{ key: "name", label: "Receipt" },
+	{ key: "supplier_name", label: "Supplier" },
+	{ key: "project", label: "Project" },
+	{ key: "posting_date", label: "Received" },
+	{ key: "grand_total", label: "Value", align: "right" },
+	{ key: "per_billed", label: "Billed", align: "right" },
+	{ key: "status", label: "Status" },
+];
+
+const statusFilter = ref("");
+const projectFilter = ref("");
+const fromDate = ref("");
+const toDate = ref("");
+const filterValues = computed(() => ({
+	status: statusFilter.value,
+	project: projectFilter.value,
+	fromDate: fromDate.value,
+	toDate: toDate.value,
+}));
+const filterFieldMap = {
+	status: "status",
+	project: "project",
+	fromDate: { field: "posting_date", op: ">=" },
+	toDate: { field: "posting_date", op: "<=" },
+};
+
+function openDesk(row) {
+	window.open(`/app/purchase-receipt/${encodeURIComponent(row.name)}`, "_blank", "noopener");
+}
+function openNew() {
+	window.open("/app/purchase-receipt/new", "_blank", "noopener");
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: "Purchase Receipts" },
+];
+</script>
+
+<template>
+	<DeskPage title="Purchase Receipts" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button type="button" class="desk-save-btn !text-xs" @click="openNew">
+				+ New Receipt
+			</button>
+		</template>
+
+		<DocTypeListView
+			v-if="activeCompany"
+			doctype="Purchase Receipt"
+			:field-order="FIELDS"
+			:columns="columns"
+			:search-fields="['name', 'supplier_name']"
+			:base-filters="baseFilters"
+			:filter-values="filterValues"
+			:filter-field-map="filterFieldMap"
+			cache-key="buildsuite-purchase-receipts"
+			row-key="name"
+			initial-order-by="posting_date desc"
+			search-placeholder="Search receipt, supplier…"
+			empty-message="No purchase receipts yet."
+			@row-click="openDesk"
+		>
+			<template #filter-chips>
+				<DeskSelect v-model="statusFilter" class="!w-44">
+					<option value="">Status: Any</option>
+					<option>Draft</option>
+					<option>To Bill</option>
+					<option>Completed</option>
+					<option>Return Issued</option>
+					<option>Closed</option>
+					<option>Cancelled</option>
+				</DeskSelect>
+				<div class="w-48">
+					<DeskLinkPicker
+						v-model="projectFilter"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						placeholder="All projects"
+					/>
+				</div>
+				<input
+					v-model="fromDate"
+					type="date"
+					title="From (receipt date)"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+				<input
+					v-model="toDate"
+					type="date"
+					title="To (receipt date)"
+					class="text-xs px-2 py-1.5 border border-ink-200 rounded-md bg-white text-ink-700 focus:outline-none focus:ring-2 focus:ring-brand-200"
+				/>
+			</template>
+
+			<template #cell-name="{ row }">
+				<span class="font-mono text-[11px] text-ink-600">{{ row.name }}</span>
+			</template>
+			<template #cell-supplier_name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.supplier_name || "—" }}</span>
+			</template>
+			<template #cell-project="{ row }">
+				<span class="text-ink-700">{{ projectName(row.project) || "—" }}</span>
+			</template>
+			<template #cell-posting_date="{ row }">
+				<span class="text-ink-500 whitespace-nowrap">{{ fmtDate(row.posting_date) }}</span>
+			</template>
+			<template #cell-grand_total="{ row }">
+				<span class="tabular-nums text-ink-900 font-medium">{{
+					fmtINR(row.grand_total)
+				}}</span>
+			</template>
+			<template #cell-per_billed="{ row }">
+				<span class="tabular-nums text-ink-700"
+					>{{ Math.round(row.per_billed || 0) }}%</span
+				>
+			</template>
+			<template #cell-status="{ row }">
+				<StatusBadge :status="row.status" size="xs" />
+			</template>
+		</DocTypeListView>
+	</DeskPage>
+</template>

--- a/frontend/src/views/procurement/PurchaseReceiptsListView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptsListView.vue
@@ -1,17 +1,17 @@
 <script setup>
 // Purchase Receipts (goods received) — ERPNext Purchase Receipt master, in-app list via
-// DocTypeListView. Readable names (supplier_name, project → project_name); row / New open
-// the Desk form.
+// DocTypeListView. Readable names (supplier_name, project → project_name), the prototype's
+// status pills + billed bar; row / New open the in-app detail + form.
 import { computed, ref } from "vue";
 import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
-import StatusBadge from "@/components/StatusBadge.vue";
+import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
-import { fmtDate, fmtINR } from "@/utils/format";
+import { fmtDate, fmtCompactINR } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
@@ -140,17 +140,26 @@ const breadcrumbs = [
 				<span class="text-ink-500 whitespace-nowrap">{{ fmtDate(row.posting_date) }}</span>
 			</template>
 			<template #cell-grand_total="{ row }">
-				<span class="tabular-nums text-ink-900 font-medium">{{
-					fmtINR(row.grand_total)
-				}}</span>
+				<span class="tabular-nums text-ink-700">{{ fmtCompactINR(row.grand_total) }}</span>
 			</template>
 			<template #cell-per_billed="{ row }">
-				<span class="tabular-nums text-ink-700"
-					>{{ Math.round(row.per_billed || 0) }}%</span
-				>
+				<span class="flex items-center gap-1.5 justify-end">
+					<span class="w-14 h-1.5 rounded-full bg-ink-100 overflow-hidden">
+						<span
+							class="block h-full rounded-full"
+							:class="
+								(row.per_billed || 0) >= 100 ? 'bg-success-500' : 'bg-info-500'
+							"
+							:style="{ width: Math.min(100, row.per_billed || 0) + '%' }"
+						></span>
+					</span>
+					<span class="text-[11px] tabular-nums text-ink-500"
+						>{{ Math.round(row.per_billed || 0) }}%</span
+					>
+				</span>
 			</template>
 			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" size="xs" />
+				<ProcurementStatusPill :status="row.status" />
 			</template>
 		</DocTypeListView>
 	</DeskPage>

--- a/frontend/src/views/procurement/PurchaseReceiptsListView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptsListView.vue
@@ -3,6 +3,7 @@
 // DocTypeListView. Readable names (supplier_name, project → project_name); row / New open
 // the Desk form.
 import { computed, ref } from "vue";
+import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
@@ -12,6 +13,7 @@ import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate, fmtINR } from "@/utils/format";
 
+const router = useRouter();
 const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
@@ -54,11 +56,11 @@ const filterFieldMap = {
 	toDate: { field: "posting_date", op: "<=" },
 };
 
-function openDesk(row) {
-	window.open(`/app/purchase-receipt/${encodeURIComponent(row.name)}`, "_blank", "noopener");
+function openDetail(row) {
+	router.push(`/procurement/receipts/${row.name}`);
 }
 function openNew() {
-	window.open("/app/purchase-receipt/new", "_blank", "noopener");
+	router.push("/procurement/receipts/new");
 }
 
 const breadcrumbs = [
@@ -90,7 +92,7 @@ const breadcrumbs = [
 			initial-order-by="posting_date desc"
 			search-placeholder="Search receipt, supplier…"
 			empty-message="No purchase receipts yet."
-			@row-click="openDesk"
+			@row-click="openDetail"
 		>
 			<template #filter-chips>
 				<DeskSelect v-model="statusFilter" class="!w-44">

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -11,9 +11,9 @@ const today = computed(() => {
 });
 
 const shortcuts = [
-	{ label: "Material Requests", icon: "clipboard-list", href: "/app/material-request" },
-	{ label: "Purchase Orders", icon: "file-text", href: "/app/purchase-order" },
-	{ label: "Purchase Receipts", icon: "check-circle", href: "/app/purchase-receipt" },
+	{ label: "Material Requests", icon: "clipboard-list", to: "/procurement/material-requests" },
+	{ label: "Purchase Orders", icon: "file-text", to: "/procurement/purchase-orders" },
+	{ label: "Purchase Receipts", icon: "check-circle", to: "/procurement/receipts" },
 	// Supplier bills (money out) — opens the Bills register, where direct supplier bills
 	// are listed and a new one can be raised. Matches the prototype's "Supplier Bills" tile.
 	{ label: "Supplier Bills", icon: "wallet", to: "/project-finance/bills" },


### PR DESCRIPTION
Makes the three procurement documents **fully in-app** in the Vue surface — list, create/edit form, and detail — so they can be raised, edited, submitted, cancelled and amended without ever dropping to the Desk. Replaces the earlier version where the lists just opened the Desk form.

## What's new
Each of **Material Request**, **Purchase Order** and **Purchase Receipt** now has:
- an in-app **list** (pagination / sort / search / filters via `DocTypeListView`, readable names not ids),
- a **create + edit form** (child `items` table editor), and
- a **detail** view with the native submittable lifecycle: **Draft → Submit → Cancel → Amend** (state *is* the docstatus, like ERPNext).

Cross-document flow mirrors the prototype: raise a **PO from an approved Material Request** (`?mr=`, lines linked back), and **record a Receipt against a submitted PO** (remaining qty / rate / warehouse pre-filled).

## Backend — `api/procurement_docs.py`
Whitelisted read/save + lifecycle for all three (their child `items` tables can't go through the generic adapter). Notes:
- **Company anchored to the project** (never the user default).
- Material Request uses this app's **mandatory parent `project`** custom field (stamped on each line + used to resolve company); the MR list gains a **project column + filter**.
- ERPNext requires a **warehouse** on stock lines and there's no warehouse UI in the prototype, so MR/PO stock lines auto-default the company warehouse; the Receipt form exposes a single **receiving warehouse**.
- Receipts derive from the PO via ERPNext's **`make_purchase_receipt` mapper** (import guarded for the older deployed ERPNext).
- Verified end-to-end in bench: MR → submit → PO (prefilled from MR) → submit → Receipt → submit; PO `per_received` updates to 60%.

## Report filter fix (also in this branch)
The report filter bar's **Link** controls showed the record id (a Project filter showed `PROJ-1645`); they now show the doctype's **title field** — Project → `project_name`, plus Customer/Supplier/Item/Employee/Cost Center/Warehouse/Task — falling back to `name`.

## Verified
`npx vite build` clean (all six new views compile); backend chain verified in bench; pre-commit clean.