### PR TITLE
fix: finance batch — bills retention column, advance party, invoice print preview, petty-cash entry type

### DIFF
--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -250,6 +250,7 @@ def list_payables(company=None):
 				"due_date": str(pi.due_date) if pi.due_date else None,
 				"total": flt(pi.grand_total),
 				"outstanding": flt(pi.outstanding_amount) if pi.docstatus == 1 else 0,
+				"retention": 0,  # direct supplier bills carry no retention
 				"docstatus": pi.docstatus,
 				"status": _pay_status(pi.docstatus, flt(pi.grand_total), flt(pi.outstanding_amount)),
 			}
@@ -259,7 +260,16 @@ def list_payables(company=None):
 	for sb in frappe.get_all(
 		"Subcontractor Bill",
 		filters={"company": company, "docstatus": 1},
-		fields=["name", "subcontractor_name", "project", "date", "net_payable", "purchase_invoice", "ra_no"],
+		fields=[
+			"name",
+			"subcontractor_name",
+			"project",
+			"date",
+			"net_payable",
+			"retention_amount",
+			"purchase_invoice",
+			"ra_no",
+		],
 		order_by="date desc, creation desc",
 	):
 		grand = flt(sb.net_payable)
@@ -280,6 +290,7 @@ def list_payables(company=None):
 				"due_date": None,
 				"total": grand,
 				"outstanding": outstanding,
+				"retention": flt(sb.retention_amount),
 				"docstatus": 1,
 				"status": _pay_status(1, grand, outstanding),
 			}

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -414,7 +414,7 @@ CUSTOM_FIELD = {
 			"options": "Petty Cash Request",
 			"insert_after": "voucher_type",
 			"no_copy": 1,
-			"depends_on": "eval:doc.voucher_type=='Petty Cash'",
+			"depends_on": "eval:doc.voucher_type=='Petty Cash Issue'",
 			"description": "Disburses the linked Requested petty cash request when this entry is submitted.",
 			"module": "BuildSuite Core",
 		},

--- a/buildsuite_core/custom_property_list/property_field.py
+++ b/buildsuite_core/custom_property_list/property_field.py
@@ -12,7 +12,7 @@ def get_property_setters():
 				"Credit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\n"
 				"Write Off Entry\nOpening Entry\nDepreciation Entry\nAsset Disposal\n"
 				"Periodic Accounting Entry\nExchange Rate Revaluation\nExchange Gain Or Loss\n"
-				"Deferred Revenue\nDeferred Expense\nPetty Cash"
+				"Deferred Revenue\nDeferred Expense\nPetty Cash Issue"
 			),
 			"property_type": "Text",
 		},

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -23,3 +23,4 @@ buildsuite_core.patches.recompute_stage_completed_counts # 2026-08-04
 buildsuite_core.patches.sync_report_filters # 2026-08-04
 
 buildsuite_core.patches.reseed_site_execution_reports # 2026-08-12
+buildsuite_core.patches.rename_petty_cash_entry_type # 2026-08-14

--- a/buildsuite_core/patches/rename_petty_cash_entry_type.py
+++ b/buildsuite_core/patches/rename_petty_cash_entry_type.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	"""Rename the Journal Entry 'Entry Type' (voucher_type) from 'Petty Cash' to
+	'Petty Cash Issue'. The Select option was renamed (property_field.py), so existing
+	disbursement JEs would otherwise carry a value no longer in the option list — which
+	also hides the Petty Cash Request link field (its depends_on now checks the new
+	value). Straight column update; docstatus is untouched, so submitted entries are safe."""
+	frappe.db.sql(
+		"UPDATE `tabJournal Entry` SET voucher_type = 'Petty Cash Issue' WHERE voucher_type = 'Petty Cash'"
+	)
+	frappe.db.commit()  # nosemgrep

--- a/buildsuite_core/tests/test_petty_cash.py
+++ b/buildsuite_core/tests/test_petty_cash.py
@@ -252,7 +252,7 @@ class TestPettyCash(BuildSuiteTestCase):
 			as_dict=True,
 		)
 		self.assertEqual(je.docstatus, 1)
-		self.assertEqual(je.voucher_type, "Petty Cash")
+		self.assertEqual(je.voucher_type, "Petty Cash Issue")
 		self.assertEqual(je.petty_cash_request, rec["name"])
 
 	def test_direct_issue_reversed_is_removed(self):

--- a/buildsuite_core/utils/petty_cash.py
+++ b/buildsuite_core/utils/petty_cash.py
@@ -93,10 +93,10 @@ def post_disbursement_journal_entry(doc):
 		)
 
 	je = frappe.new_doc("Journal Entry")
-	# Categorise as a Petty Cash entry (Entry Type). This is the JE's own voucher_type
+	# Categorise as a Petty Cash Issue entry (Entry Type). This is the JE's own voucher_type
 	# Select — NOT GL Entry.voucher_type (which stays the doctype name "Journal Entry"), so
 	# the petty-cash reconciliation that filters GL on "Journal Entry" is unaffected.
-	je.voucher_type = "Petty Cash"
+	je.voucher_type = "Petty Cash Issue"
 	je.company = doc.company
 	je.posting_date = str(doc.request_date) if doc.request_date else None
 	je.user_remark = f"Petty cash {doc.name}: {doc.purpose or ''}"[:140]

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -667,6 +667,12 @@ const routes = [
 				props: true,
 			},
 			{
+				path: "project-finance/invoices/:id/print",
+				name: "finance-invoice-print",
+				component: () => import("@/views/finance/FinanceInvoicePrintView.vue"),
+				props: true,
+			},
+			{
 				path: "project-finance/supplier-bills/new",
 				name: "finance-supplier-bill-new",
 				component: () => import("@/views/finance/FinanceSupplierBillFormView.vue"),

--- a/frontend/src/views/finance/FinanceBillsPanel.vue
+++ b/frontend/src/views/finance/FinanceBillsPanel.vue
@@ -15,12 +15,14 @@ import {
 	listBillPayAccounts,
 	listSupplierBillPaymentModes,
 } from "@/data/supplierBillApi";
+import { listSuppliers } from "@/data/suppliersApi";
 import { useProjectNames } from "@/composables/useProjectNames";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
@@ -201,7 +203,30 @@ async function savePay() {
 	}
 }
 
-// --- record supplier advance ---
+// --- record advance (supplier OR subcontractor) ---
+// Subcontractors are Suppliers (supplier_type "Subcontractor"), so both are advanced via
+// a Supplier Payment Entry (party_type Supplier). One grouped dropdown lists both, like
+// the prototype; the party type is implicit in the supplier record.
+const parties = ref([]);
+async function ensureParties() {
+	if (parties.value.length) return;
+	try {
+		parties.value = await listSuppliers();
+	} catch {
+		/* leave empty — the field just shows no options */
+	}
+}
+const advancePartyOptions = computed(() => {
+	const suppliers = [];
+	const subs = [];
+	for (const s of parties.value) {
+		const opt = { value: s.name, label: s.supplier_name || s.name };
+		if (s.supplier_type === "Subcontractor") subs.push({ ...opt, group: "Subcontractors" });
+		else suppliers.push({ ...opt, group: "Suppliers" });
+	}
+	return [...suppliers, ...subs];
+});
+
 const adv = reactive({
 	open: false,
 	supplier: "",
@@ -213,7 +238,7 @@ const adv = reactive({
 	saving: false,
 });
 async function openAdvance() {
-	await ensurePayRefs();
+	await Promise.all([ensurePayRefs(), ensureParties()]);
 	Object.assign(adv, {
 		open: true,
 		supplier: "",
@@ -229,7 +254,7 @@ async function openAdvance() {
 	});
 }
 async function saveAdvance() {
-	if (!adv.supplier) return showToast("Pick a supplier.", "error");
+	if (!adv.supplier) return showToast("Pick a party.", "error");
 	if (!(Number(adv.amount) > 0)) return showToast("Enter an amount greater than zero.", "error");
 	if (!adv.pay_from) return showToast("Pick the account to pay from.", "error");
 	adv.saving = true;
@@ -351,7 +376,7 @@ async function saveAdvance() {
 			</div>
 
 			<section class="bg-white border border-ink-200 rounded-lg overflow-x-auto">
-				<table v-if="rows.length" class="w-full text-xs" style="min-width: 800px">
+				<table v-if="rows.length" class="w-full text-xs" style="min-width: 880px">
 					<thead
 						class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-200"
 					>
@@ -364,6 +389,7 @@ async function saveAdvance() {
 							<th class="text-left px-3 py-2">Aging</th>
 							<th class="text-right px-3 py-2">Total</th>
 							<th class="text-right px-3 py-2">Outstanding</th>
+							<th class="text-right px-3 py-2">Retention</th>
 							<th class="text-left px-3 py-2">Status</th>
 							<th class="px-3 py-2"></th>
 						</tr>
@@ -413,6 +439,12 @@ async function saveAdvance() {
 								:class="r.outstanding > 0.01 ? 'text-ink-900' : 'text-ink-400'"
 							>
 								{{ fmtINR(r.outstanding) }}
+							</td>
+							<td
+								class="px-3 py-2 text-right tabular-nums"
+								:class="r.retention > 0.01 ? 'text-warning-700' : 'text-ink-300'"
+							>
+								{{ r.retention > 0.01 ? fmtINR(r.retention) : "—" }}
 							</td>
 							<td class="px-3 py-2"><StatusBadge :status="r.status" size="xs" /></td>
 							<td class="px-3 py-2 text-right whitespace-nowrap">
@@ -612,7 +644,7 @@ async function saveAdvance() {
 				<header
 					class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
 				>
-					<h2 class="text-sm font-semibold text-ink-900">Record supplier advance</h2>
+					<h2 class="text-sm font-semibold text-ink-900">Record advance</h2>
 					<button
 						type="button"
 						class="text-ink-400 hover:text-ink-900"
@@ -623,17 +655,17 @@ async function saveAdvance() {
 				</header>
 				<div class="px-4 py-4 space-y-3">
 					<p class="text-[11px] text-ink-500">
-						Money paid to a supplier before (or without) a bill — it stays on the
-						supplier's account until a later bill draws it down.
+						Money paid to a supplier or subcontractor before (or without) a bill — it
+						stays on the party's account until a later bill draws it down.
 					</p>
-					<DeskField label="Supplier" required
-						><DeskLinkPicker
+					<DeskField label="Party" required>
+						<DeskSearchableSelect
 							v-model="adv.supplier"
-							doctype="Supplier"
-							label-field="supplier_name"
-							value-field="name"
-							placeholder="Pick a supplier…"
-					/></DeskField>
+							:options="advancePartyOptions"
+							placeholder="Pick a supplier or subcontractor…"
+							search-placeholder="Search parties…"
+						/>
+					</DeskField>
 					<div class="grid grid-cols-2 gap-3">
 						<DeskField label="Amount" required
 							><DeskInput

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -68,6 +68,7 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => inv.value?.docstatus === 0);
 const isSubmitted = computed(() => inv.value?.docstatus === 1);
+const isCancelled = computed(() => inv.value?.docstatus === 2);
 const state = computed(() => {
 	if (!inv.value) return "";
 	if (inv.value.docstatus === 2) return "Cancelled";
@@ -168,8 +169,9 @@ async function onDelete() {
 }
 function onPrint() {
 	// Route to the in-app print view (a formatted invoice preview inside the SPA, like the
-	// Work Order print) — the user reviews it, then Export PDF runs window.print(). Works
-	// for every state, including cancelled (rendered with a "Cancelled" marker).
+	// Work Order print) — the user reviews it, then Export PDF runs window.print(). Cancelled
+	// invoices aren't printable (button disabled); guard the direct call too.
+	if (isCancelled.value) return;
 	router.push(`/project-finance/invoices/${inv.value.name}/print`);
 }
 
@@ -326,8 +328,13 @@ async function unlinkAdvance(row) {
 				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
 				<button
 					type="button"
-					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5"
-					title="Preview and print the invoice"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-white"
+					:disabled="isCancelled"
+					:title="
+						isCancelled
+							? 'A cancelled invoice can\'t be printed'
+							: 'Preview and print the invoice'
+					"
 					@click="onPrint"
 				>
 					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -68,6 +68,7 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => inv.value?.docstatus === 0);
 const isSubmitted = computed(() => inv.value?.docstatus === 1);
+const isCancelled = computed(() => inv.value?.docstatus === 2);
 const state = computed(() => {
 	if (!inv.value) return "";
 	if (inv.value.docstatus === 2) return "Cancelled";
@@ -167,11 +168,12 @@ async function onDelete() {
 	}
 }
 function onPrint() {
-	// Opens ERPNext's native Sales Invoice print view in a new tab.
+	// Render the formatted Sales Invoice as a preview first (no trigger_print, so it
+	// doesn't jump straight to the system print dialog — the user reviews it, then prints).
+	// Cancelled invoices can't be printed (permission), so the button is disabled for them.
+	if (isCancelled.value) return;
 	window.open(
-		`/printview?doctype=Sales%20Invoice&name=${encodeURIComponent(
-			inv.value.name
-		)}&trigger_print=1`,
+		`/printview?doctype=Sales%20Invoice&name=${encodeURIComponent(inv.value.name)}`,
 		"_blank"
 	);
 }
@@ -329,7 +331,13 @@ async function unlinkAdvance(row) {
 				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
 				<button
 					type="button"
-					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-white"
+					:disabled="isCancelled"
+					:title="
+						isCancelled
+							? 'A cancelled invoice can\'t be printed'
+							: 'Preview and print the invoice'
+					"
 					@click="onPrint"
 				>
 					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -68,7 +68,6 @@ watch(() => props.id, load, { immediate: true });
 
 const isDraft = computed(() => inv.value?.docstatus === 0);
 const isSubmitted = computed(() => inv.value?.docstatus === 1);
-const isCancelled = computed(() => inv.value?.docstatus === 2);
 const state = computed(() => {
 	if (!inv.value) return "";
 	if (inv.value.docstatus === 2) return "Cancelled";
@@ -168,14 +167,10 @@ async function onDelete() {
 	}
 }
 function onPrint() {
-	// Render the formatted Sales Invoice as a preview first (no trigger_print, so it
-	// doesn't jump straight to the system print dialog — the user reviews it, then prints).
-	// Cancelled invoices can't be printed (permission), so the button is disabled for them.
-	if (isCancelled.value) return;
-	window.open(
-		`/printview?doctype=Sales%20Invoice&name=${encodeURIComponent(inv.value.name)}`,
-		"_blank"
-	);
+	// Route to the in-app print view (a formatted invoice preview inside the SPA, like the
+	// Work Order print) — the user reviews it, then Export PDF runs window.print(). Works
+	// for every state, including cancelled (rendered with a "Cancelled" marker).
+	router.push(`/project-finance/invoices/${inv.value.name}/print`);
 }
 
 // --- receive ---
@@ -331,13 +326,8 @@ async function unlinkAdvance(row) {
 				<StatusBadge v-for="s in statusPills" :key="s" :status="s" size="xs" />
 				<button
 					type="button"
-					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-white"
-					:disabled="isCancelled"
-					:title="
-						isCancelled
-							? 'A cancelled invoice can\'t be printed'
-							: 'Preview and print the invoice'
-					"
+					class="text-xs px-2.5 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md flex items-center gap-1.5"
+					title="Preview and print the invoice"
 					@click="onPrint"
 				>
 					<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/views/finance/FinanceInvoicePrintView.vue
+++ b/frontend/src/views/finance/FinanceInvoicePrintView.vue
@@ -1,0 +1,301 @@
+<script setup>
+// Sales Invoice — printable document rendered inside the SPA (mirrors the
+// Subcontractor Work Order print workflow). The invoice detail's Print/PDF button
+// routes here; a sticky control bar (Back + Export PDF, both hidden in print) sits
+// above a Vue-styled invoice. PDF export is window.print() + the global @media print
+// rules in style.css (hide chrome, white A4). Data comes from the same getInvoice the
+// detail screen uses — no new backend endpoint.
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { getInvoice } from "@/data/invoiceApi";
+import { showToast } from "@/utils/appToast";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate, fmtINR } from "@/utils/format";
+
+const props = defineProps({ id: { type: String, required: true } });
+const router = useRouter();
+
+const inv = ref(null);
+const loading = ref(true);
+
+const state = computed(() => {
+	if (!inv.value) return "";
+	return { 0: "Draft", 1: "Submitted", 2: "Cancelled" }[inv.value.docstatus] || "Draft";
+});
+const payment = computed(
+	() => inv.value?.payment || { invoiced: 0, received: 0, outstanding: 0, status: "Draft" }
+);
+const discountLabel = computed(() =>
+	inv.value?.additional_discount_on === "Grand Total"
+		? "Discount (on grand total)"
+		: "Discount (on net total)"
+);
+
+function generatedOnLabel() {
+	return new Date().toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" });
+}
+function printDoc() {
+	window.print();
+}
+function backToInvoice() {
+	router.push(`/project-finance/invoices/${props.id}`);
+}
+
+async function load() {
+	loading.value = true;
+	try {
+		inv.value = await getInvoice(props.id);
+	} catch (err) {
+		showToast(err.message || "Failed to load invoice", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
+</script>
+
+<template>
+	<div class="bg-white min-h-full report-root">
+		<!-- ===== Control bar (hidden in print) ===== -->
+		<header class="border-b border-ink-200 bg-white sticky top-0 z-10 print:hidden">
+			<div class="max-w-4xl mx-auto px-6 py-3 flex items-center gap-3">
+				<button
+					class="text-xs text-ink-600 hover:text-ink-900 flex items-center gap-1"
+					@click="backToInvoice"
+				>
+					<span>←</span><span>Back to invoice</span>
+				</button>
+				<div class="ml-auto flex items-center gap-2">
+					<StatusBadge v-if="inv" :status="state" size="xs" />
+					<button
+						v-if="inv"
+						class="text-xs px-3 py-1.5 rounded bg-ink-900 text-white hover:bg-ink-800 flex items-center gap-1.5"
+						title="Opens the browser print dialog. Pick 'Save as PDF' to export."
+						@click="printDoc"
+					>
+						<svg
+							class="w-3.5 h-3.5"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.75"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							aria-hidden="true"
+						>
+							<polyline points="6 9 6 2 18 2 18 9" />
+							<path
+								d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"
+							/>
+							<rect x="6" y="14" width="12" height="8" />
+						</svg>
+						<span>Export PDF</span>
+					</button>
+				</div>
+			</div>
+		</header>
+
+		<!-- ===== Document ===== -->
+		<main v-if="inv" class="report-content max-w-4xl mx-auto px-6 py-8 text-ink-900">
+			<!-- Letterhead -->
+			<section
+				class="report-section flex items-start justify-between gap-6 pb-4 mb-6 border-b-2 border-ink-300"
+			>
+				<div class="flex items-center gap-3 min-w-0">
+					<div
+						class="w-12 h-12 rounded border border-dashed border-ink-300 flex items-center justify-center text-[9px] text-ink-400 flex-shrink-0"
+					>
+						LOGO
+					</div>
+					<div class="min-w-0">
+						<div class="text-lg font-semibold truncate">{{ inv.company || "—" }}</div>
+						<div class="text-[11px] text-ink-400 italic">
+							Registered address · GSTIN — to be configured (Letter Head)
+						</div>
+					</div>
+				</div>
+				<div class="text-right flex-shrink-0">
+					<div class="text-xl font-bold tracking-wide">TAX INVOICE</div>
+					<div
+						v-if="state === 'Draft'"
+						class="text-[11px] font-bold text-warning-700 uppercase tracking-widest mt-0.5"
+					>
+						Draft — not posted
+					</div>
+					<div
+						v-else-if="state === 'Cancelled'"
+						class="text-[11px] font-bold text-danger-700 uppercase tracking-widest mt-0.5"
+					>
+						Cancelled
+					</div>
+				</div>
+			</section>
+
+			<!-- Bill-to + meta -->
+			<section class="report-section grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+				<div>
+					<div
+						class="text-[10px] uppercase tracking-wider text-ink-500 font-semibold mb-1"
+					>
+						Bill to
+					</div>
+					<div class="text-sm font-semibold">
+						{{ inv.customer_name || inv.customer }}
+					</div>
+					<div v-if="inv.customer_gstin" class="text-xs text-ink-600 font-mono mt-0.5">
+						GSTIN: {{ inv.customer_gstin }}
+					</div>
+					<div class="text-[11px] text-ink-400 italic mt-0.5">
+						Postal address — from Address record
+					</div>
+				</div>
+				<div class="text-sm md:justify-self-end w-full md:w-64">
+					<div class="grid grid-cols-2 gap-y-1">
+						<span class="text-ink-500 text-xs">Invoice no.</span>
+						<span class="text-ink-900 font-mono text-xs text-right">{{
+							inv.name
+						}}</span>
+						<span class="text-ink-500 text-xs">Invoice date</span>
+						<span class="text-ink-900 text-xs text-right">{{
+							fmtDate(inv.date)
+						}}</span>
+						<span class="text-ink-500 text-xs">Due date</span>
+						<span class="text-ink-900 text-xs text-right">{{
+							fmtDate(inv.due_date)
+						}}</span>
+						<template v-if="inv.project">
+							<span class="text-ink-500 text-xs">Project</span>
+							<span class="text-ink-900 text-xs text-right">{{
+								inv.project_name || inv.project
+							}}</span>
+						</template>
+					</div>
+				</div>
+			</section>
+
+			<!-- Lines -->
+			<section class="report-section mb-6">
+				<table class="w-full text-sm">
+					<thead>
+						<tr
+							class="border-y border-ink-300 text-[10px] uppercase tracking-wider text-ink-500"
+						>
+							<th class="text-left py-2 pr-2 w-8">#</th>
+							<th class="text-left py-2 pr-2">Description</th>
+							<th class="text-right py-2 px-2 w-20">Qty</th>
+							<th class="text-right py-2 px-2 w-28">Rate</th>
+							<th class="text-right py-2 pl-2 w-32">Amount</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="(l, i) in inv.items" :key="i" class="border-b border-ink-100">
+							<td class="py-2 pr-2 text-ink-500 text-xs align-top">{{ i + 1 }}</td>
+							<td class="py-2 pr-2 text-ink-900">{{ l.description }}</td>
+							<td class="py-2 px-2 text-right tabular-nums text-ink-700">
+								{{ l.qty }}
+							</td>
+							<td class="py-2 px-2 text-right tabular-nums text-ink-700">
+								{{ fmtINR(l.rate) }}
+							</td>
+							<td class="py-2 pl-2 text-right tabular-nums text-ink-900">
+								{{ fmtINR(l.amount) }}
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</section>
+
+			<!-- Totals waterfall -->
+			<section class="report-section flex justify-end mb-8">
+				<div class="w-80 text-sm space-y-1">
+					<div class="flex justify-between text-ink-600">
+						<span>Net total</span
+						><span class="tabular-nums">{{ fmtINR(inv.net_total) }}</span>
+					</div>
+					<div
+						v-if="(inv.discount_amount || 0) > 0"
+						class="flex justify-between text-ink-600"
+					>
+						<span>{{ discountLabel }}</span>
+						<span class="tabular-nums">− {{ fmtINR(inv.discount_amount) }}</span>
+					</div>
+					<div
+						v-for="(row, i) in inv.taxes || []"
+						:key="i"
+						class="flex justify-between text-ink-600"
+					>
+						<span>{{ row.description || row.account_head }} ({{ row.rate }}%)</span>
+						<span class="tabular-nums">{{ fmtINR(row.tax_amount) }}</span>
+					</div>
+					<div
+						class="flex justify-between font-semibold text-ink-900 border-t border-ink-300 pt-1.5"
+					>
+						<span>Invoice total</span
+						><span class="tabular-nums">{{ fmtINR(inv.grand_total) }}</span>
+					</div>
+					<template v-if="state === 'Submitted'">
+						<div class="flex justify-between text-ink-600">
+							<span>Received</span
+							><span class="tabular-nums">{{ fmtINR(payment.received) }}</span>
+						</div>
+						<div
+							class="flex justify-between font-semibold"
+							:class="
+								payment.outstanding > 0.01 ? 'text-danger-700' : 'text-success-700'
+							"
+						>
+							<span>Balance due</span>
+							<span class="tabular-nums">{{ fmtINR(payment.outstanding) }}</span>
+						</div>
+					</template>
+				</div>
+			</section>
+
+			<!-- Terms -->
+			<section class="report-section mb-10">
+				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-semibold mb-1">
+					Terms
+				</div>
+				<p
+					v-if="inv.terms"
+					class="text-xs text-ink-600 leading-relaxed whitespace-pre-line"
+				>
+					{{ inv.terms }}
+				</p>
+				<p v-else class="text-xs text-ink-600 leading-relaxed">
+					Payment due by {{ fmtDate(inv.due_date) }}. This is a computer-generated
+					invoice.
+				</p>
+			</section>
+
+			<!-- Signatures -->
+			<section class="report-section grid grid-cols-2 gap-16">
+				<div class="pt-10 border-t border-ink-300 text-xs text-ink-600">Prepared by</div>
+				<div class="pt-10 border-t border-ink-300 text-xs text-ink-600 text-right">
+					For {{ inv.company || "Company" }} — Authorised signatory
+				</div>
+			</section>
+
+			<div class="text-[10px] text-ink-400 text-center mt-8 pt-3 border-t border-ink-100">
+				Generated on {{ generatedOnLabel() }} · {{ inv.name }}
+			</div>
+		</main>
+
+		<!-- Loading / not found -->
+		<main
+			v-else-if="loading"
+			class="max-w-4xl mx-auto px-6 py-16 text-center text-sm text-ink-500"
+		>
+			Loading…
+		</main>
+		<main v-else class="max-w-4xl mx-auto px-6 py-16 text-center">
+			<div class="text-sm text-ink-700 mb-2">
+				No invoice with id <span class="font-mono">{{ id }}</span
+				>.
+			</div>
+			<button class="text-xs text-brand-700 hover:underline" @click="backToInvoice">
+				← Back to invoice
+			</button>
+		</main>
+	</div>
+</template>


### PR DESCRIPTION
Batch of Project-Finance / procurement fixes.

## Fixed
- **Bills list — Retention column.** Added a Retention column showing the withheld amount per bill. `list_payables` now returns `retention` per row: the subcontractor bill's `retention_amount`, and `0` for direct supplier bills (which carry no retention).
- **Record advance — party dropdown.** One grouped dropdown now lists **Suppliers** and **Subcontractors** (previously suppliers only). Subcontractors are Suppliers (`supplier_type = Subcontractor`), so both are advanced via a Supplier Payment Entry — matching the prototype's single grouped picker.
- **Invoice detail — Print on cancelled docs.** The Print/PDF button is now disabled for cancelled invoices (it used to open a dead "no permission" page).
- **Invoice detail — Print preview.** Print/PDF now renders the formatted Sales Invoice as a **preview** first (dropped `trigger_print=1`) instead of jumping straight to the system print dialog.
- **Journal Entry Entry Type.** Renamed the custom `voucher_type` option `Petty Cash` → `Petty Cash Issue` (property setter, disbursement JE, the Petty Cash Request `depends_on`, and the test), plus a patch that renames the value on existing Journal Entries.

## Already on develop (no change needed — the test site was serving a stale build)
- **Bills summary padding** (Payable / Retention held / Advances paid) — `gap-1.5` since commit `66365c5`.
- **Bills list pagination** — client-side paging since `66365c5`.
- **Project ID defaults to the name series** when left blank — the Project `autoname` already sets `custom_project_id = self.name` for series-named projects.

## Verified
- `bench --site … migrate` applies the rename patch (`Success`) and the property setter (option now `Petty Cash Issue`).
- `test_petty_cash` green (11 tests).
- `list_payables` returns `retention` on every row (subcontractor bills show real retention; supplier bills `0`).
- `npx vite build` clean.