### PR TITLE
feat: show the role switcher only in developer mode

### DIFF
--- a/buildsuite_core/api/permission.py
+++ b/buildsuite_core/api/permission.py
@@ -36,8 +36,19 @@ def _has_app_permission(log_denial: bool = True) -> bool:
 @frappe.whitelist(methods=["GET"], allow_guest=True)  # nosemgrep
 def get_access_context():
 	user = frappe.session.user
+	# Site-level developer flag (site_config.json) — the frontend uses it to show
+	# dev-only affordances like the role switcher.
+	developer_mode = bool(frappe.conf.developer_mode)
 	if user == "Guest":
-		return frappe._dict({"allowed": False, "user": user, "roles": [], "reason": "guest"})
+		return frappe._dict(
+			{
+				"allowed": False,
+				"user": user,
+				"roles": [],
+				"reason": "guest",
+				"developer_mode": developer_mode,
+			}
+		)
 
 	roles = list(frappe.get_roles())
 	allowed = _has_app_permission(log_denial=False)
@@ -54,5 +65,6 @@ def get_access_context():
 			"roles": roles,
 			"persona": persona,
 			"reason": reason,
+			"developer_mode": developer_mode,
 		}
 	)

--- a/frontend/src/components/RoleSwitcher.vue
+++ b/frontend/src/components/RoleSwitcher.vue
@@ -1,11 +1,16 @@
 <script setup>
 import { ref, computed } from "vue";
 import { useDataStore } from "@/stores";
+import { useSessionStore } from "@/stores/session";
 import { ROLES } from "@/data/roles";
 
 const store = useDataStore();
+const session = useSessionStore();
 const open = ref(false);
 const currentRole = computed(() => store.currentRole);
+// Dev-only affordance: the role switcher impersonates personas, so it's shown only
+// when the Frappe site runs in developer mode (site_config.json developer_mode).
+const visible = computed(() => session.developerMode);
 
 function pickRole(roleId) {
 	store.setRole(roleId);
@@ -14,7 +19,7 @@ function pickRole(roleId) {
 </script>
 
 <template>
-	<div class="relative">
+	<div v-if="visible" class="relative">
 		<!-- Trigger -->
 		<button
 			@click="open = !open"

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -6,6 +6,9 @@ export const useSessionStore = defineStore("session", {
 		initialized: false,
 		user: "Guest",
 		authenticated: false,
+		// Site-level developer flag (from get_access_context → site_config.json). Gates
+		// dev-only affordances like the role switcher.
+		developerMode: false,
 		access: {
 			allowed: false,
 			roles: [],
@@ -49,6 +52,7 @@ export const useSessionStore = defineStore("session", {
 				persona: context.persona || null,
 				reason: context.reason || (context.allowed ? "ok" : "missing_role"),
 			};
+			this.developerMode = Boolean(context.developer_mode);
 			this.lastCheckedAt = Date.now();
 			return this.access;
 		},


### PR DESCRIPTION
The role switcher impersonates BuildSuite personas — a dev/testing affordance that shouldn't be visible on production sites.

## Change
- `get_access_context` now returns the site's `developer_mode` flag (`bool(frappe.conf.developer_mode)` from `site_config.json`).
- The session store carries it as `developerMode` (set from the context on `refreshAccess`).
- `RoleSwitcher.vue` gates its root on `session.developerMode` — one `v-if` in the component covers all three shells that render it (DeskShell, LandingShell, HomeView).

So the switcher shows only when the Frappe site runs in developer mode, and is hidden everywhere else (e.g. production, beta sites with `developer_mode: 0`).

## Verified
`get_access_context` returns `developer_mode` (bs.local: `0` → switcher hidden). `npx vite build` clean; pre-commit clean.

To show it on a local site: `bench --site <site> set-config developer_mode 1` (then restart), which is the standard dev toggle.