### PR TITLE
feat: BOQ cost-code actuals log + drill-down (R1/R2) + R9 approval guard

### DIFF
--- a/buildsuite_core/api/boq.py
+++ b/buildsuite_core/api/boq.py
@@ -39,6 +39,52 @@ def submit_boq(boq):
 	return doc.status
 
 
+def _boq_codes(boq):
+	"""(group_codes, item_codes) present in a BOQ revision — the join keys."""
+	groups = [c for c in frappe.get_all("BOQ Group", filters={"boq": boq}, pluck="code") if c]
+	items = [c for c in frappe.get_all("BOQ Item", filters={"boq": boq}, pluck="code") if c]
+	return groups, items
+
+
+def _validate_codes_for_approval(doc):
+	"""R9 — the requirement that makes the rest true. Cost code is the only join key, so every
+	other rule assumes codes are stable. Block approval if two lines share a code, or if a code
+	that carries actuals in the current Approved revision is absent from this one (quietly
+	renumbered/dropped rather than retired with its code kept)."""
+	groups, items = _boq_codes(doc.name)
+	dupes = sorted({c for c in groups if groups.count(c) > 1} | {c for c in items if items.count(c) > 1})
+	if dupes:
+		frappe.throw(
+			_("Duplicate cost codes in this BOQ: {0}. Every line needs a unique code.").format(
+				", ".join(dupes)
+			)
+		)
+
+	prior = frappe.db.get_value(
+		"BOQ", {"project": doc.project, "status": "Approved", "name": ("!=", doc.name)}, "name"
+	)
+	if not prior:
+		return
+	from buildsuite_core.api.boq_actuals import _actual_entries
+
+	prior_codes = set().union(*[set(x) for x in _boq_codes(prior)])
+	with_actuals = {
+		c
+		for e in _actual_entries(doc.project)
+		for c in (e["group_code"], e["item_code"])
+		if c and c in prior_codes
+	}
+	missing = sorted(with_actuals - (set(groups) | set(items)))
+	if missing:
+		frappe.throw(
+			_(
+				"These cost codes carry actuals in the current Approved revision but are absent "
+				"from this one: {0}. Keep the code (retire the line) or restore it — codes are "
+				"immutable once approved."
+			).format(", ".join(missing))
+		)
+
+
 @frappe.whitelist()
 def approve_boq(boq):
 	"""Approve a Submitted BOQ; supersede any other Approved revision of the same
@@ -48,6 +94,7 @@ def approve_boq(boq):
 	doc = frappe.get_doc("BOQ", boq)
 	if doc.status not in ("Submitted", "Draft"):
 		frappe.throw(_("Only a Draft or Submitted BOQ can be approved."))
+	_validate_codes_for_approval(doc)
 	for other in frappe.get_all(
 		"BOQ",
 		filters={"project": doc.project, "status": "Approved", "name": ("!=", doc.name)},

--- a/buildsuite_core/api/boq_actuals.py
+++ b/buildsuite_core/api/boq_actuals.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""BOQ actuals — the cost-code actuals log (BuildSuite Core · BOQ Actuals & Commitments).
+
+Real spend reaches the BOQ through the cost code, never through a BOQ record id. Three rails
+produce actual cost — Material Consumption (Stock Entry / Material Issue), Subcontractor Bill,
+and Expense Entry — each carrying a cost code (a group like "D" or an item like "D.02", scoped
+to the project). Which BOQ a code lands on is decided at read time by the Approved revision.
+
+This module is the "actuals log" as a DERIVED GETTER (decision D4, kept as a getter until
+volume demands a real DocType): every contribution is computed live from the submitted source
+documents, never hand-edited. Because it reads only submitted docs, cancelling a source removes
+its entries for free (R3), and actuals resolve identically in every revision (R8). The summary
+here is the single calculation path behind the BOQ Actual column (R2), and the same entries feed
+the per-code drill-down (R1).
+
+Rails (all post on Submit, reverse on Cancel):
+  Material Consumption   qty x valuation rate  (Stock Entry.total_outgoing_value)  -> "Material"
+  Subcontractor Bill     this-period amount    (Subcontractor Bill Line)           -> "Subcontract"
+  Expense Entry          expense amount        (Expense Entry Table)               -> "Overhead"
+
+Cost is recognised at consumption, not at purchase — a Purchase Receipt increases stock but
+does not touch BOQ actual. The Subcontractor Work Order (Committed) is a separate promise and
+lives in its own column (see subcontract.committed_by_cost_code), not here.
+"""
+
+import frappe
+from frappe.utils import flt
+
+
+def _material_entries(project):
+	"""Submitted Material Issues (Stock Entry) charged to a cost code. The code lives on the
+	Stock Entry header (one code per issue); the amount is the issue's outgoing value."""
+	out = []
+	rows = frappe.get_all(
+		"Stock Entry",
+		filters={
+			"project": project,
+			"docstatus": 1,
+			"purpose": "Material Issue",
+			"custom_cost_code_type": ["in", ["Group", "Item"]],
+		},
+		fields=[
+			"name",
+			"posting_date",
+			"total_outgoing_value",
+			"custom_cost_code_type",
+			"custom_cost_code_group",
+			"custom_cost_code_item",
+			"custom_cost_code_label",
+		],
+	)
+	for r in rows:
+		if not (r.custom_cost_code_group or r.custom_cost_code_item):
+			continue
+		out.append(
+			{
+				"cost_code_type": r.custom_cost_code_type,
+				"group_code": r.custom_cost_code_group or "",
+				"item_code": r.custom_cost_code_item or "",
+				"cost_type": "Material",
+				"amount": flt(r.total_outgoing_value),
+				"source_doctype": "Stock Entry",
+				"source_name": r.name,
+				"source_line": None,
+				"party": None,
+				"date": str(r.posting_date) if r.posting_date else None,
+				"label": r.custom_cost_code_label or "",
+			}
+		)
+	return out
+
+
+def _subcontract_entries(project):
+	"""Submitted Subcontractor Bill lines — this-period certified amount, by cost code."""
+	bills = {
+		b.name: b
+		for b in frappe.get_all(
+			"Subcontractor Bill",
+			filters={"project": project, "docstatus": 1},
+			fields=["name", "date", "subcontractor_name", "ra_no"],
+		)
+	}
+	if not bills:
+		return []
+	out = []
+	for l in frappe.get_all(
+		"Subcontractor Bill Line",
+		filters={"parent": ["in", list(bills)]},
+		fields=[
+			"name",
+			"parent",
+			"cost_code_type",
+			"cost_code_group",
+			"cost_code_item",
+			"cost_code_label",
+			"this_period_amount",
+		],
+	):
+		if not (l.cost_code_group or l.cost_code_item) or flt(l.this_period_amount) == 0:
+			continue
+		b = bills[l.parent]
+		out.append(
+			{
+				"cost_code_type": l.cost_code_type,
+				"group_code": l.cost_code_group or "",
+				"item_code": l.cost_code_item or "",
+				"cost_type": "Subcontract",
+				"amount": flt(l.this_period_amount),
+				"source_doctype": "Subcontractor Bill",
+				"source_name": l.parent,
+				"source_line": l.name,
+				"party": b.subcontractor_name,
+				"date": str(b.date) if b.date else None,
+				"label": l.cost_code_label or (f"Bill {b.ra_no}" if b.ra_no else ""),
+			}
+		)
+	return out
+
+
+def _expense_entries(project):
+	"""Submitted Expense Entry lines charged to a cost code — informal direct cost."""
+	heads = {
+		e.name: e
+		for e in frappe.get_all(
+			"Expense Entry",
+			filters={"project": project, "docstatus": 1},
+			fields=["name", "date"],
+		)
+	}
+	if not heads:
+		return []
+	out = []
+	for r in frappe.get_all(
+		"Expense Entry Table",
+		filters={"parent": ["in", list(heads)]},
+		fields=[
+			"name",
+			"parent",
+			"cost_code_type",
+			"cost_code_group",
+			"cost_code_item",
+			"cost_code_label",
+			"amount",
+			"expense_account_name",
+			"description",
+		],
+	):
+		if not (r.cost_code_group or r.cost_code_item) or flt(r.amount) == 0:
+			continue
+		e = heads[r.parent]
+		out.append(
+			{
+				"cost_code_type": r.cost_code_type,
+				"group_code": r.cost_code_group or "",
+				"item_code": r.cost_code_item or "",
+				"cost_type": "Overhead",
+				"amount": flt(r.amount),
+				"source_doctype": "Expense Entry",
+				"source_name": r.parent,
+				"source_line": r.name,
+				"party": r.expense_account_name or None,
+				"date": str(e.date) if e.date else None,
+				"label": r.cost_code_label or r.description or "",
+			}
+		)
+	return out
+
+
+def _actual_entries(project):
+	"""The full actuals log for a project — one line per contributing source line, across all
+	three rails. Derived live from submitted documents (never stored). This is the single source
+	the summary and the drill-down both read, so they can never disagree (R2)."""
+	if not project:
+		return []
+	return _material_entries(project) + _subcontract_entries(project) + _expense_entries(project)
+
+
+# The cost types a group row reports, in display order. A type with no source shows "— pending",
+# never 0 — a zero claims there was nothing; an em-dash is the truth about our data.
+COST_TYPES = ("Material", "Labour", "Plant", "Subcontract", "Overhead")
+
+
+@frappe.whitelist()
+def get_actuals_log(project, cost_type=None, from_date=None, to_date=None, source_doctype=None):
+	"""The actuals log, optionally filtered by cost type / date range / source doctype (R4).
+	Also the data source for cost-vs-budget."""
+	entries = _actual_entries(project)
+	if cost_type:
+		entries = [e for e in entries if e["cost_type"] == cost_type]
+	if source_doctype:
+		entries = [e for e in entries if e["source_doctype"] == source_doctype]
+	if from_date:
+		entries = [e for e in entries if (e["date"] or "") >= from_date]
+	if to_date:
+		entries = [e for e in entries if (e["date"] or "") <= to_date]
+	entries.sort(key=lambda e: (e["group_code"], e["item_code"], e["date"] or ""))
+	return entries
+
+
+@frappe.whitelist()
+def get_actuals_summary(project):
+	"""Per-code actual for the BOQ, plus the coverage split. An item-coded line credits its item
+	AND its parent group (roll up, never down); group totals reconcile identically whether the
+	lines beneath were coded fine or coarse. Returns:
+
+	  by_group[code] = {actual, by_cost_type{}, item_coded, group_coded, items[]}
+	  by_item[code]  = {actual, by_cost_type{}}
+
+	`item_coded` vs `group_coded` drives the reader's coverage line ("₹X of ₹Y tracked at item
+	level"). The frontend reads Actual from here — one calculation path, not two (R2)."""
+	entries = _actual_entries(project)
+	by_group = {}
+	by_item = {}
+	for e in entries:
+		amt = flt(e["amount"])
+		is_item = e["cost_code_type"] == "Item" and e["item_code"]
+		if e["group_code"]:
+			g = by_group.setdefault(
+				e["group_code"],
+				{"actual": 0, "by_cost_type": {}, "item_coded": 0, "group_coded": 0, "items": set()},
+			)
+			g["actual"] += amt
+			g["by_cost_type"][e["cost_type"]] = g["by_cost_type"].get(e["cost_type"], 0) + amt
+			if is_item:
+				g["item_coded"] += amt
+				g["items"].add(e["item_code"])
+			else:
+				g["group_coded"] += amt
+		if is_item:
+			it = by_item.setdefault(e["item_code"], {"actual": 0, "by_cost_type": {}})
+			it["actual"] += amt
+			it["by_cost_type"][e["cost_type"]] = it["by_cost_type"].get(e["cost_type"], 0) + amt
+	for g in by_group.values():
+		g["items"] = sorted(g["items"])
+	return {
+		"by_group": by_group,
+		"by_item": by_item,
+		"total": sum(flt(e["amount"]) for e in entries),
+	}
+
+
+@frappe.whitelist()
+def get_actuals_for_code(project, group_code=None, item_code=None):
+	"""The contributing entries behind one code, for the drill-down (R1). An item code returns
+	only its own lines; a group code rolls up every line carrying that group (both group-coded
+	and item-coded), never splitting a group-coded total down to items by guesswork."""
+	entries = _actual_entries(project)
+	if item_code:
+		sel = [e for e in entries if e["item_code"] == item_code]
+	elif group_code:
+		sel = [e for e in entries if e["group_code"] == group_code]
+	else:
+		sel = []
+	sel.sort(key=lambda e: (e["cost_type"], e["date"] or "", e["source_name"]))
+	return {"entries": sel, "total": sum(flt(e["amount"]) for e in sel)}

--- a/frontend/src/utils/boqApi.js
+++ b/frontend/src/utils/boqApi.js
@@ -33,6 +33,34 @@ async function request(method, body) {
 	return payload.message;
 }
 
+// --- BOQ actuals log (buildsuite_core.api.boq_actuals.*) — the cost-code actuals
+// that feed the Actual column + the per-code drill-down. Same request shape, different module.
+const ACTUALS_BASE = "/api/method/buildsuite_core.api.boq_actuals.";
+async function requestActuals(method, body) {
+	const res = await fetch(ACTUALS_BASE + method, {
+		method: "POST",
+		credentials: "include",
+		headers: {
+			Accept: "application/json",
+			"Content-Type": "application/json",
+			"X-Frappe-CSRF-Token": window.csrf_token || "",
+		},
+		body: JSON.stringify(body || {}),
+	});
+	const payload = await res.json().catch(() => ({}));
+	if (!res.ok) throw new Error(serverMessage(payload, res.status));
+	return payload.message;
+}
+export const getActualsSummary = (project) => requestActuals("get_actuals_summary", { project });
+export const getActualsForCode = (project, groupCode = null, itemCode = null) =>
+	requestActuals("get_actuals_for_code", {
+		project,
+		group_code: groupCode,
+		item_code: itemCode,
+	});
+export const getActualsLog = (project, filters = {}) =>
+	requestActuals("get_actuals_log", { project, ...filters });
+
 export const submitBoq = (boq) => request("submit_boq", { boq });
 export const approveBoq = (boq) => request("approve_boq", { boq });
 export const explodeItem = (boqItem) => request("explode_item", { boq_item: boqItem });

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -1402,24 +1402,25 @@ const breadcrumbs = computed(() => {
 							{{ fmtCompactINR(groupCommitted(g)) }}
 						</div>
 						<div class="px-3 py-2 text-right text-sm text-ink-700">
-							<button
-								v-if="groupActual(g)"
-								type="button"
-								class="tabular-nums text-ink-700 hover:text-brand-700 hover:underline decoration-dotted"
-								:title="`Actual for ${g.code} — click to see the source documents`"
-								@click.stop="openGroupActuals(g)"
-							>
-								{{ fmtCompactINR(groupActual(g)) }}
-							</button>
+							<span v-if="groupActual(g)" class="relative inline-block group/cov">
+								<button
+									type="button"
+									class="tabular-nums text-ink-700 hover:text-brand-700 hover:underline decoration-dotted"
+									:title="`Actual for ${g.code} — click to see the source documents`"
+									@click.stop="openGroupActuals(g)"
+								>
+									{{ fmtCompactINR(groupActual(g)) }}
+								</button>
+								<!-- Coverage shown on hover only, so it doesn't grow the row height. -->
+								<span
+									v-if="groupCoverage(g) && groupCoverage(g).groupCoded > 0.5"
+									class="pointer-events-none absolute right-0 bottom-full mb-1 hidden group-hover/cov:block z-30 whitespace-nowrap bg-ink-900 text-white text-[10px] px-2 py-1 rounded shadow-lg"
+								>
+									{{ fmtCompactINR(groupCoverage(g).itemCoded) }} of
+									{{ fmtCompactINR(groupCoverage(g).actual) }} at item level
+								</span>
+							</span>
 							<span v-else class="text-ink-300">—</span>
-							<div
-								v-if="groupCoverage(g) && groupCoverage(g).groupCoded > 0.5"
-								class="text-[10px] text-ink-400 leading-tight"
-								:title="'The remainder is coded to the group only, not to items.'"
-							>
-								{{ fmtCompactINR(groupCoverage(g).itemCoded) }} of
-								{{ fmtCompactINR(groupCoverage(g).actual) }} at item level
-							</div>
 						</div>
 						<div
 							class="px-3 py-2 text-right text-sm tabular-nums font-medium"

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -15,7 +15,7 @@ import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
 import { parseFrappeError } from "@/utils/frappeError";
 import * as boqApi from "@/utils/boqApi";
-import { getCommittedByCostCode, getSubcontractActualByCostCode } from "@/data/subcontractApi";
+import { getCommittedByCostCode } from "@/data/subcontractApi";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -210,10 +210,9 @@ const treeGridStyle =
 
 const totals = computed(() => {
 	const planned = allItems.value.reduce((a, i) => a + (i.plannedAmount || 0), 0);
-	// Task-progress actuals + the subcontracted spend billed (submitted bills), added not replaced.
-	const subcontractActual = Object.values(subcontractActualMap.value).reduce((a, v) => a + v, 0);
-	const actual =
-		allItems.value.reduce((a, i) => a + (i.actualAmount || 0), 0) + subcontractActual;
+	// Actual = the cost-code actuals log total (Material + Subcontract + Expense), the same
+	// figure the per-group rows and the drill-down reconcile against (R2).
+	const actual = actualsSummary.value.total || 0;
 	const variance = actual - planned;
 	return {
 		planned,
@@ -379,30 +378,104 @@ function groupCommitted(group) {
 	return committedMap.value[group.code] || 0;
 }
 
-// === Actual (subcontract) — submitted bill this-period amounts by cost-code group ===
-// Added to (never replacing) the task-progress actuals, so a group's Actual reflects both
-// site-progress spend and what has been billed by subcontractors.
-const subcontractActualMap = ref({}); // { cost_code_group: amount }
+// === Actual — the cost-code actuals log ===
+// Real spend reaches the BOQ through the cost code (Material Consumption + Subcontractor Bill +
+// Expense Entry), resolved by code against this project. The Actual column and the per-code
+// drill-down both read this one summary, so the row figure and the modal total always reconcile
+// (one calculation path — R2). Derived live from submitted docs, so a cancelled source drops
+// out for free (R3).
+const EMPTY_SUMMARY = { by_group: {}, by_item: {}, total: 0 };
+const actualsSummary = ref({ ...EMPTY_SUMMARY });
 watch(
 	() => boq.value?.projectId,
 	async (pid) => {
-		subcontractActualMap.value = {};
+		actualsSummary.value = { ...EMPTY_SUMMARY };
 		if (!pid) return;
 		try {
-			subcontractActualMap.value = (await getSubcontractActualByCostCode(pid)) || {};
+			actualsSummary.value = (await boqApi.getActualsSummary(pid)) || { ...EMPTY_SUMMARY };
 		} catch {
-			subcontractActualMap.value = {};
+			actualsSummary.value = { ...EMPTY_SUMMARY };
 		}
 	},
 	{ immediate: true }
 );
-function groupSubcontractActual(group) {
-	return subcontractActualMap.value[group.code] || 0;
-}
-// A group's Actual = task-progress actuals on its items + subcontracted spend billed to its code.
 function groupActual(group) {
-	return groupTotals(group.id).actual + groupSubcontractActual(group);
+	return actualsSummary.value.by_group[group.code]?.actual || 0;
 }
+function itemActual(item) {
+	return actualsSummary.value.by_item[item.code]?.actual || 0;
+}
+// Coverage: how much of a group's actual is tracked at item level vs coded to the group only —
+// so a partly coded group is never mistaken for a fully attributed one.
+function groupCoverage(group) {
+	const g = actualsSummary.value.by_group[group.code];
+	if (!g || !g.actual) return null;
+	return { actual: g.actual, itemCoded: g.item_coded, groupCoded: g.group_coded };
+}
+
+// ===== Actuals drill-down (R1) — click a group / item Actual to open the contributing
+// source documents. A group rolls up every line carrying its code (item-coded + group-coded);
+// an item shows only its own lines. Each entry links to the source document it was derived from.
+const actualsDrill = ref(null); // null | { title, subtitle, entries, total, loading }
+async function openActualsDrill({ groupCode = null, itemCode = null, title, subtitle }) {
+	const pid = boq.value?.projectId;
+	if (!pid || (!groupCode && !itemCode)) return;
+	actualsDrill.value = { title, subtitle, entries: [], total: 0, loading: true };
+	try {
+		const res = await boqApi.getActualsForCode(pid, groupCode, itemCode);
+		actualsDrill.value = {
+			title,
+			subtitle,
+			entries: res.entries || [],
+			total: res.total || 0,
+			loading: false,
+		};
+	} catch (err) {
+		showToast(err.message || "Failed to load actuals", "error");
+		actualsDrill.value = null;
+	}
+}
+function openGroupActuals(group) {
+	if (!groupActual(group)) return;
+	openActualsDrill({
+		groupCode: group.code,
+		title: `${group.code} · ${group.name || group.groupName || ""}`.trim(),
+		subtitle: "Group actual — contributing documents",
+	});
+}
+function openItemActuals(item) {
+	if (!itemActual(item)) return;
+	openActualsDrill({
+		itemCode: item.code,
+		title: `${item.code} · ${(item.description || "").slice(0, 60)}`,
+		subtitle: "Item actual — contributing documents",
+	});
+}
+function closeActualsDrill() {
+	actualsDrill.value = null;
+}
+// Navigate to the source document an entry was derived from. In-app where a screen exists,
+// else the Desk form in a new tab.
+function openActualSource(e) {
+	if (e.source_doctype === "Subcontractor Bill") {
+		router.push(`/subcontractor-bills/${e.source_name}`);
+	} else if (e.source_doctype === "Stock Entry") {
+		window.open(`/app/stock-entry/${encodeURIComponent(e.source_name)}`, "_blank", "noopener");
+	} else if (e.source_doctype === "Expense Entry") {
+		window.open(
+			`/app/expense-entry/${encodeURIComponent(e.source_name)}`,
+			"_blank",
+			"noopener"
+		);
+	}
+}
+const COST_TYPE_TONE = {
+	Material: "bg-info-50 text-info-700",
+	Subcontract: "bg-brand-50 text-brand-700",
+	Overhead: "bg-warning-50 text-warning-700",
+	Labour: "bg-success-50 text-success-700",
+	Plant: "bg-ink-100 text-ink-700",
+};
 
 const wpRes = useDocTypeList("Work Package", {
 	fields: ["name", "code", "work_package_name"],
@@ -1328,11 +1401,25 @@ const breadcrumbs = computed(() => {
 						>
 							{{ fmtCompactINR(groupCommitted(g)) }}
 						</div>
-						<div
-							class="px-3 py-2 text-right tabular-nums text-sm text-ink-700"
-							:title="`Task-progress actuals + subcontractor bills submitted against cost code ${g.code}`"
-						>
-							{{ fmtCompactINR(groupActual(g)) }}
+						<div class="px-3 py-2 text-right text-sm text-ink-700">
+							<button
+								v-if="groupActual(g)"
+								type="button"
+								class="tabular-nums text-ink-700 hover:text-brand-700 hover:underline decoration-dotted"
+								:title="`Actual for ${g.code} — click to see the source documents`"
+								@click.stop="openGroupActuals(g)"
+							>
+								{{ fmtCompactINR(groupActual(g)) }}
+							</button>
+							<span v-else class="text-ink-300">—</span>
+							<div
+								v-if="groupCoverage(g) && groupCoverage(g).groupCoded > 0.5"
+								class="text-[10px] text-ink-400 leading-tight"
+								:title="'The remainder is coded to the group only, not to items.'"
+							>
+								{{ fmtCompactINR(groupCoverage(g).itemCoded) }} of
+								{{ fmtCompactINR(groupCoverage(g).actual) }} at item level
+							</div>
 						</div>
 						<div
 							class="px-3 py-2 text-right text-sm tabular-nums font-medium"
@@ -1521,9 +1608,18 @@ const breadcrumbs = computed(() => {
 								<div></div>
 								<div class="px-3 py-1.5">
 									<div class="flex flex-col items-end">
-										<span class="tabular-nums text-sm text-ink-700">{{
-											fmtCompactINR(item.actualAmount)
-										}}</span>
+										<button
+											v-if="itemActual(item)"
+											type="button"
+											class="tabular-nums text-sm text-ink-700 hover:text-brand-700 hover:underline decoration-dotted"
+											:title="`Actual for ${item.code} — click to see the source documents`"
+											@click.stop="openItemActuals(item)"
+										>
+											{{ fmtCompactINR(itemActual(item)) }}
+										</button>
+										<span v-else class="tabular-nums text-sm text-ink-300"
+											>—</span
+										>
 										<div
 											class="w-full h-1 bg-ink-100 overflow-hidden mt-1"
 											style="border-radius: 2px"
@@ -1531,16 +1627,16 @@ const breadcrumbs = computed(() => {
 											<div
 												class="h-full"
 												:class="
-													item.actualAmount > item.plannedAmount
+													itemActual(item) > item.plannedAmount
 														? 'bg-danger-500'
-														: item.actualAmount >
+														: itemActual(item) >
 														  item.plannedAmount * 0.9
 														? 'bg-warning-500'
 														: 'bg-success-500'
 												"
 												:style="`width: ${Math.min(
 													100,
-													pctOf(item.actualAmount, item.plannedAmount)
+													pctOf(itemActual(item), item.plannedAmount)
 												).toFixed(1)}%`"
 											></div>
 										</div>
@@ -1550,7 +1646,7 @@ const breadcrumbs = computed(() => {
 									class="px-3 py-1.5 text-right tabular-nums text-sm"
 									:class="
 										variancePill(
-											((item.actualAmount - item.plannedAmount) /
+											((itemActual(item) - item.plannedAmount) /
 												(item.plannedAmount || 1)) *
 												100
 										)
@@ -1559,7 +1655,7 @@ const breadcrumbs = computed(() => {
 									{{
 										item.plannedAmount
 											? (
-													((item.actualAmount - item.plannedAmount) /
+													((itemActual(item) - item.plannedAmount) /
 														item.plannedAmount) *
 													100
 											  ).toFixed(1)
@@ -2381,5 +2477,116 @@ const breadcrumbs = computed(() => {
 				</div>
 			</section>
 		</DeskForm>
+
+		<!-- Actuals drill-down (R1) — the source documents behind a group / item Actual -->
+		<div
+			v-if="actualsDrill"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6 overflow-y-auto"
+			@click.self="closeActualsDrill"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-2xl shadow-xl rounded-xl"
+				@click.stop
+			>
+				<header
+					class="px-4 py-3 border-b border-ink-200 flex items-start justify-between gap-3"
+				>
+					<div class="min-w-0">
+						<h2 class="text-sm font-semibold text-ink-900 truncate">
+							{{ actualsDrill.title }}
+						</h2>
+						<p class="text-[11px] text-ink-500">{{ actualsDrill.subtitle }}</p>
+					</div>
+					<button
+						type="button"
+						class="text-ink-400 hover:text-ink-900 flex-shrink-0"
+						@click="closeActualsDrill"
+					>
+						✕
+					</button>
+				</header>
+				<div class="px-4 py-3">
+					<div v-if="actualsDrill.loading" class="py-8 text-center text-xs text-ink-400">
+						Loading…
+					</div>
+					<div
+						v-else-if="!actualsDrill.entries.length"
+						class="py-8 text-center text-xs text-ink-400"
+					>
+						No source documents yet — this actual is “— pending”.
+					</div>
+					<table v-else class="w-full text-xs">
+						<thead
+							class="text-[10px] uppercase tracking-wider text-ink-500 border-b border-ink-200"
+						>
+							<tr>
+								<th class="text-left py-2 pr-2">Type</th>
+								<th class="text-left py-2 pr-2">Source document</th>
+								<th class="text-left py-2 pr-2">Party</th>
+								<th class="text-left py-2 pr-2">Date</th>
+								<th class="text-right py-2">Amount</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(e, i) in actualsDrill.entries"
+								:key="i"
+								class="border-b border-ink-100 last:border-0"
+							>
+								<td class="py-2 pr-2">
+									<span
+										class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap"
+										:class="
+											COST_TYPE_TONE[e.cost_type] ||
+											'bg-ink-100 text-ink-700'
+										"
+										>{{ e.cost_type }}</span
+									>
+								</td>
+								<td class="py-2 pr-2">
+									<button
+										type="button"
+										class="text-brand-700 hover:underline text-left"
+										@click="openActualSource(e)"
+									>
+										{{ e.source_doctype }} ·
+										<span class="font-mono">{{ e.source_name }}</span>
+									</button>
+									<div v-if="e.label" class="text-[10px] text-ink-400 truncate">
+										{{ e.label }}
+									</div>
+								</td>
+								<td class="py-2 pr-2 text-ink-600">{{ e.party || "—" }}</td>
+								<td class="py-2 pr-2 text-ink-500 whitespace-nowrap">
+									{{ e.date ? fmtDate(e.date) : "—" }}
+								</td>
+								<td class="py-2 text-right tabular-nums text-ink-900 font-medium">
+									{{ fmtINR(e.amount) }}
+								</td>
+							</tr>
+						</tbody>
+						<tfoot>
+							<tr class="border-t-2 border-ink-200">
+								<td
+									colspan="4"
+									class="py-2 text-right text-[11px] font-semibold text-ink-700 uppercase tracking-wider"
+								>
+									Total actual
+								</td>
+								<td
+									class="py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+								>
+									{{ fmtINR(actualsDrill.total) }}
+								</td>
+							</tr>
+						</tfoot>
+					</table>
+					<p class="text-[10px] text-ink-400 mt-3">
+						Every rail resolves through the cost code. Cancelling a source removes its
+						entry — the log shows live cost only.
+					</p>
+				</div>
+			</div>
+		</div>
 	</DeskPage>
 </template>


### PR DESCRIPTION
Implements the **BOQ Actuals & Commitments** spec: real spend reaches the BOQ through the **cost code**, with a per-line **drill-down** (your primary ask) and the code-stability guard.

## Where it stood (review)
- BOQ **Actual** was task-progress earned value + Subcontractor Bills (group-level only). **Material Consumption** and **Expense Entry** were **not joined**. **No actuals log**, so **no drill-down (R1)**. That's the gap this fills.

## What's built
**Backend — `api/boq_actuals.py`** (the actuals log as a **derived getter**, decision D4). Computed live from submitted source docs across the three rails — resolved by cost code, never by BOQ record id:

| Rail | Source | Amount | cost_type |
|---|---|---|---|
| Material Consumption | Stock Entry (Material Issue) | qty x valuation (`total_outgoing_value`) | Material |
| Subcontractor Bill | Subcontractor Bill Line | this-period amount | Subcontract |
| Expense Entry | Expense Entry Table | expense amount | Overhead |

- **`get_actuals_summary`** drives the Actual column. An item-coded line credits its **item AND its parent group** (roll up, never down), with an item-coded / group-coded split for the coverage line. The row and the drill-down read this one summary → they always reconcile (**R2**, one calculation path).
- **`get_actuals_for_code`** powers the **drill-down (R1)**: click a group or item Actual → modal of the contributing source documents (type · name · party · date · amount), each **clickable to open the source doc**. A group rolls up every line carrying its code; an item shows only its own.
- **`get_actuals_log`** adds cost-type / date / source-doctype filtering (R4).
- Because it reads only **submitted** docs: cancelling a source drops its entry for free (**R3**), and actuals are identical in every revision (**R8**).

**Backend — R9 (the keystone).** `approve_boq` now blocks approval if two lines share a code, or if a code carrying actuals in the current Approved revision is absent from the new one (quietly renumbered/dropped rather than retired).

**Frontend — `BoqDetailView`.** The Actual + variance now come from the log summary (group and item), with a per-group **coverage line** ("₹X of ₹Y at item level") and **"—" never ₹0** where a code has no source yet. Clicking a group/item Actual opens the drill-down modal.

## Verified
On bs.local (subcontract actuals present): summary and drill-down **reconcile** (R2 = true), log filter works, R9 helpers run. `npx vite build` clean; pre-commit clean.

## Notes / follow-ups
- **Behaviour change:** the BOQ **Actual** is now the spend log (per the spec), replacing the old task-progress earned-value + subcontract number. The `actual_amount` field (task %) still exists but no longer feeds the Actual column; the "Recalculate actuals" button is now effectively a no-op on the display — say the word and I'll remove it.
- **Material + Expense** join automatically once consumption/expenses carry cost codes; today's seeded data is subcontract-only, so those rows show as expected.
- **cost_type** is derived coarsely (Material / Subcontract / Overhead). Finer **Plant / Labour** derivation (e.g. plant hire → Plant) is a follow-up.
- Source-doc links: Subcontractor Bill opens in-app; Stock Entry / Expense Entry open the Desk form (no in-app screens yet).
- Out of scope per the doc: material valuation method, retired-code actuals (D3/R6), forecast.