### PR TITLE
fix: direct subcontractor bill drops the picked cost code (only label saved)

### DIFF
--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -346,6 +346,11 @@ def save_bill(payload):
 				"lines",
 				{
 					"scope": (row.get("scope") or "").strip(),
+					# Persist the full cost code (type + group + item), not just the label —
+					# the BOQ actuals log joins on cost_code_group / cost_code_item.
+					"cost_code_type": row.get("cost_code_type") or "",
+					"cost_code_group": row.get("cost_code_group") or "",
+					"cost_code_item": row.get("cost_code_item") or "",
 					"cost_code_label": row.get("cost_code_label") or row.get("cost_code") or "",
 					"this_period_amount": amount,
 				},

--- a/frontend/src/views/NewSubcontractorBillView.vue
+++ b/frontend/src/views/NewSubcontractorBillView.vue
@@ -30,6 +30,37 @@ function todayIso() {
 	return new Date().toISOString().slice(0, 10);
 }
 
+// A direct-bill line's cost code is a CostCodePicker object {type, group_code, item_code,
+// label}. Flatten it to the four stored fields on save (the BOQ actuals log joins on
+// cost_code_group / cost_code_item, not the label), and rebuild the object on edit-load.
+function costCodeForSave(cc) {
+	if (cc && typeof cc === "object") {
+		return {
+			cost_code_type: cc.type === "item" ? "Item" : "Group",
+			cost_code_group: cc.group_code || "",
+			cost_code_item: cc.item_code || "",
+			cost_code_label: cc.label || "",
+		};
+	}
+	return {
+		cost_code_type: "",
+		cost_code_group: "",
+		cost_code_item: "",
+		cost_code_label: cc || "",
+	};
+}
+function costCodeFromLine(l) {
+	if (!l.cost_code_type && !l.cost_code_group && !l.cost_code_item) {
+		return l.cost_code_label || null; // legacy line saved with only a label
+	}
+	return {
+		type: (l.cost_code_type || "").toLowerCase(),
+		group_code: l.cost_code_group || "",
+		item_code: l.cost_code_item || null,
+		label: l.cost_code_label || "",
+	};
+}
+
 const mode = ref("wo"); // 'wo' | 'direct'
 const saving = ref(false);
 const errors = ref({});
@@ -80,7 +111,7 @@ watch(
 					lines: bill.is_direct
 						? (bill.lines || []).map((l) => ({
 								scope: l.scope || "",
-								cost_code: l.cost_code_label || null,
+								cost_code: costCodeFromLine(l),
 								amount: l.this_period_amount || 0,
 						  }))
 						: [{ scope: "", cost_code: null, amount: 0 }],
@@ -160,10 +191,7 @@ async function onSave() {
 							.filter((l) => (l.scope || "").trim() || Number(l.amount) > 0)
 							.map((l) => ({
 								scope: l.scope,
-								cost_code:
-									l.cost_code && typeof l.cost_code === "object"
-										? l.cost_code.label
-										: l.cost_code || "",
+								...costCodeForSave(l.cost_code),
 								amount: Number(l.amount) || 0,
 							})),
 				  };


### PR DESCRIPTION
On a **direct (WO-less) subcontractor bill**, picking a cost code saved only its **label** — `cost_code_type`/`group`/`item` were never persisted. Since the BOQ actuals log joins on `cost_code_group`/`cost_code_item` (not the label), the line could never reach the BOQ. This is exactly what the reported bill (`SB-2026-00008`) showed: `cost_code_label` set, but type/group/item empty.

## Root cause — dropped on both sides
- **Frontend** (`NewSubcontractorBillView`): the save mapping flattened the `CostCodePicker` object to just `cost_code: l.cost_code.label`.
- **Backend** (`save_bill`): the direct-line append persisted only `cost_code_label`.

## Fix
- Frontend flattens the picker object `{type, group_code, item_code, label}` to the four `cost_code_*` fields on save, and rebuilds it on edit-load (with a fallback for legacy label-only lines).
- Backend `save_bill` now persists `cost_code_type/group/item/label` for direct lines.

## Verified
In bench: a saved direct line now carries `cost_code_group` (was empty). It then lands on the BOQ **Actual** + drill-down — provided the bill is on the **same project** as the BOQ and its code matches an **Approved** BOQ line.

Note: the existing `SB-2026-00008` was on a project (PROJ-1644) with no Approved BOQ, so re-saving it there still wouldn't show; this fix makes correctly-scoped direct bills work going forward. WO-based bills were already fine — their codes derive from the Work Order SOV lines.