### PR TITLE
feat: bespoke Delay Analysis report view (stages / silent tasks / weekly trend)

### DIFF
--- a/buildsuite_core/api/delay_analysis.py
+++ b/buildsuite_core/api/delay_analysis.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Delay Analysis report — the bespoke Site Execution report the flat Query Report can't
+express. Three views over a project (and its sub-projects), each computed live:
+
+  • Stages       — every Stage Planning: completion, slip (days past planned end while
+                   incomplete) and what waits on it downstream (stages that depend on it).
+  • Silent tasks — active tasks with no progress entry in the last 3 days (or ever).
+  • Weekly trend — progress entries filed / completions per week over the last 6 weeks.
+
+Stage completion reuses the Stage Planning controller's own mean_progress + task counts,
+so this report and the Stage Planning screens never disagree.
+"""
+
+import frappe
+from frappe.utils import add_days, flt, getdate, nowdate
+
+SILENT_DAYS = 3
+TREND_WEEKS = 6
+
+
+def _scope(project):
+	"""A project plus its immediate sub-projects — tasks and progress hang off the children."""
+	children = frappe.get_all("Project", filters={"parent_project": project}, pluck="name")
+	return [project, *children]
+
+
+def _stages(project, as_of):
+	stages = frappe.get_all(
+		"Stage Planning",
+		filters={"project": project},
+		fields=[
+			"name",
+			"stage_name",
+			"planned_start",
+			"planned_end",
+			"mean_progress",
+			"task_count",
+			"completed_task_count",
+		],
+		order_by="planned_start asc",
+	)
+	if not stages:
+		return []
+
+	label_by_name = {s.name: s.stage_name for s in stages}
+	# A dependency row lives on the stage that HAS the dependency and points (`stage`) at the
+	# stage it waits on. So for each dependency, the pointed-at stage's downstream gains the
+	# owning (parent) stage.
+	downstream = {}
+	for d in frappe.get_all(
+		"Stage Planning Dependency",
+		filters={"parent": ["in", list(label_by_name)]},
+		fields=["parent", "stage"],
+	):
+		if d.stage:
+			downstream.setdefault(d.stage, []).append(label_by_name.get(d.parent, d.parent))
+
+	out = []
+	for s in stages:
+		pct = round(flt(s.mean_progress)) if s.task_count else None
+		end = getdate(s.planned_end) if s.planned_end else None
+		overdue = (as_of - end).days if (end and end < as_of and (pct is None or pct < 100)) else 0
+		out.append(
+			{
+				"name": s.name,
+				"stage_name": s.stage_name,
+				"planned_start": str(s.planned_start) if s.planned_start else None,
+				"planned_end": str(s.planned_end) if s.planned_end else None,
+				"pct": pct,
+				"task_count": s.task_count or 0,
+				"done_count": s.completed_task_count or 0,
+				"overdue": overdue,
+				"downstream": downstream.get(s.name, []),
+			}
+		)
+	out.sort(key=lambda r: (-r["overdue"], r["planned_start"] or ""))
+	return out
+
+
+def _silent_tasks(project, as_of):
+	tasks = frappe.get_all(
+		"Task",
+		filters={
+			"project": ["in", _scope(project)],
+			"is_group": 0,
+			"task_status": ["not in", ["Completed", "Yet To Start"]],
+		},
+		fields=["name", "subject", "task_status"],
+	)
+	if not tasks:
+		return []
+
+	last_by_task = {
+		r.task: r.last
+		for r in frappe.db.sql(
+			"""SELECT task, MAX(entry_date) AS last FROM `tabTask Progress Entry`
+			WHERE task IN %(tasks)s GROUP BY task""",
+			{"tasks": [t.name for t in tasks]},
+			as_dict=True,
+		)
+	}
+	out = []
+	for t in tasks:
+		last = last_by_task.get(t.name)
+		days = (as_of - getdate(last)).days if last else None
+		if days is None or days >= SILENT_DAYS:
+			out.append(
+				{
+					"task": t.name,
+					"subject": t.subject,
+					"status": t.task_status,
+					"last": str(last) if last else None,
+					"days": days,
+				}
+			)
+	out.sort(key=lambda r: r["days"] if r["days"] is not None else 9999, reverse=True)
+	return out
+
+
+def _weekly_trend(project, as_of):
+	tasks = frappe.get_all("Task", filters={"project": ["in", _scope(project)]}, pluck="name")
+	weeks = []
+	for i in range(TREND_WEEKS - 1, -1, -1):
+		end = add_days(as_of, -i * 7)
+		start = add_days(end, -6)
+		entries = (
+			frappe.get_all(
+				"Task Progress Entry",
+				filters={"task": ["in", tasks], "entry_date": ["between", [start, end]]},
+				fields=["cumulative_progress"],
+			)
+			if tasks
+			else []
+		)
+		completed = sum(1 for e in entries if flt(e.cumulative_progress) >= 100)
+		weeks.append({"label": str(start), "entries": len(entries), "completed": completed})
+	mx = max([1, *[w["entries"] for w in weeks]])
+	for w in weeks:
+		w["pct"] = (w["entries"] / mx) * 100
+	return weeks
+
+
+@frappe.whitelist()
+def delay_analysis(project=None):
+	"""The three Delay Analysis views for a project. Empty payload when no project is given."""
+	if not project:
+		return {"stages": [], "silent_tasks": [], "weekly_trend": []}
+	as_of = getdate(nowdate())
+	return {
+		"stages": _stages(project, as_of),
+		"silent_tasks": _silent_tasks(project, as_of),
+		"weekly_trend": _weekly_trend(project, as_of),
+	}

--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
@@ -11,6 +11,10 @@ tiles. Idempotent per workspace — a workspace that already has rows is left un
 
 import frappe
 
+# Delay Analysis is served by a bespoke in-app view (not the flat Query Report renderer), so
+# its workspace tile points at this route rather than referencing the Report.
+DELAY_ANALYSIS_ROUTE = "/reports/delay-analysis"
+
 # Reusable Report Filter rows (Frappe's server-side filter defs the in-app FrappeReport
 # renderer reads). A Query Report's SQL uses them via %(fieldname)s; the "empty ⇒ all"
 # guard (%(x)s = '' OR …) keeps every filter optional.
@@ -263,8 +267,12 @@ def seed_workspace_reports():
 	# Site Execution — prefer migrated admin config, else the default report set.
 	if "site-execution" not in existing:
 		legacy = _legacy_site_execution_rows()
+		# Delay Analysis is a bespoke in-app view, not a flat Query Report — tile it as a plain
+		# route so the Workspace Setting reads clearly (a URL, not a report reference).
 		rows = legacy or [
-			{"report": name, "icon": icon, "description": desc}
+			{"label": name, "route": DELAY_ANALYSIS_ROUTE, "icon": icon, "description": desc}
+			if name == "Delay Analysis"
+			else {"report": name, "icon": icon, "description": desc}
 			for name, _ref, icon, desc, _q, _f, _r in REPORTS
 		]
 		for r in rows:

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -24,3 +24,4 @@ buildsuite_core.patches.sync_report_filters # 2026-08-04
 
 buildsuite_core.patches.reseed_site_execution_reports # 2026-08-12
 buildsuite_core.patches.rename_petty_cash_entry_type # 2026-08-14
+buildsuite_core.patches.point_delay_analysis_tile_to_route # 2026-08-17

--- a/buildsuite_core/patches/point_delay_analysis_tile_to_route.py
+++ b/buildsuite_core/patches/point_delay_analysis_tile_to_route.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	"""Point the Site Execution 'Delay Analysis' workspace tile at the bespoke in-app view's
+	route (/reports/delay-analysis) instead of referencing the flat Query Report. The report is
+	now rendered by a dedicated view, so the Workspace Setting should read as a plain URL — which
+	is also how new sites are seeded (seed_workspace_reports)."""
+	if not frappe.db.has_column("Workspace Report", "route"):
+		return
+	settings = frappe.get_single("Workspace Setting")
+	changed = False
+	for r in settings.reports:
+		if r.workspace == "site-execution" and (r.report or "") == "Delay Analysis":
+			r.report = None
+			r.route = "/reports/delay-analysis"
+			r.label = r.label or "Delay Analysis"
+			changed = True
+	if changed:
+		settings.flags.ignore_permissions = True
+		settings.save()
+		frappe.db.commit()  # nosemgrep

--- a/frontend/src/components/reports/ReportFilters.vue
+++ b/frontend/src/components/reports/ReportFilters.vue
@@ -1,0 +1,41 @@
+<script setup>
+// The filter strip every report sits under — one component so reports don't each invent
+// their own bar: same chrome, same Clear affordance, plus the two things a filtered report
+// must have — a live "N of M" count (so a narrowed report is never mistaken for the whole
+// set) and a Clear that appears only when something is actually filtering. Reports pass
+// their own controls through the default slot. print:hidden — a filter row is a control,
+// not part of the printed document.
+defineProps({
+	active: { type: Boolean, default: false }, // true when ≥1 filter is set → Clear appears
+	shown: { type: Number, default: null }, // rows currently shown
+	total: { type: Number, default: null }, // rows before filtering
+	noun: { type: String, default: "rows" },
+});
+defineEmits(["clear"]);
+</script>
+
+<template>
+	<div
+		class="bg-ink-50 border border-ink-200 px-3 py-2 mb-3 flex items-center gap-x-4 gap-y-2 flex-wrap print:hidden"
+		style="border-radius: 6px"
+	>
+		<slot />
+
+		<div class="ml-auto flex items-center gap-3">
+			<span v-if="shown !== null" class="text-[11px] text-ink-500 tabular-nums">
+				<template v-if="total !== null && shown !== total"
+					>{{ shown }} of {{ total }} {{ noun }}</template
+				>
+				<template v-else>{{ shown }} {{ noun }}</template>
+			</span>
+			<button
+				v-if="active"
+				type="button"
+				class="text-[11px] text-brand-700 hover:underline"
+				@click="$emit('clear')"
+			>
+				Clear filters
+			</button>
+		</div>
+	</div>
+</template>

--- a/frontend/src/data/delayAnalysisApi.js
+++ b/frontend/src/data/delayAnalysisApi.js
@@ -1,0 +1,15 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Delay Analysis report data — stages (slip + downstream), silent tasks and the weekly
+// completion trend for a project. Backed by buildsuite_core.api.delay_analysis.
+export async function getDelayAnalysis(project) {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.delay_analysis.delay_analysis",
+			params: { project: project || "" },
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to load Delay Analysis.");
+	}
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -39,6 +39,7 @@ const PAGE_TITLES = {
 	"site-execution": "Site Execution",
 	"project-dashboard": "Project Dashboard",
 	"report-stub": "Report",
+	"report-delay-analysis": "Delay Analysis",
 	estimation: "Estimation",
 	procurement: "Procurement",
 	"procurement-dashboard": "Procurement Dashboard",
@@ -299,6 +300,13 @@ const routes = [
 				name: "report-view",
 				component: () => import("@/views/ReportView.vue"),
 				props: true,
+			},
+			{
+				// Bespoke Site Execution report — its own route so the Workspace Setting tile
+				// points at a plain URL rather than a Query Report the flat renderer can't express.
+				path: "reports/delay-analysis",
+				name: "report-delay-analysis",
+				component: () => import("@/views/DelayAnalysisReportView.vue"),
 			},
 			{
 				path: "reports/:slug",

--- a/frontend/src/views/DelayAnalysisReportView.vue
+++ b/frontend/src/views/DelayAnalysisReportView.vue
@@ -1,0 +1,241 @@
+<script setup>
+// Delay Analysis — bespoke Site Execution report (the flat Query Report can't express it).
+// Scope from ?project=; three views over the project + its sub-projects:
+//   • Stages       — completion, slip (days past planned end while incomplete), downstream.
+//   • Silent tasks — active tasks with no progress entry in the last 3 days (or ever).
+//   • Weekly trend — progress entries filed / completions per week over 6 weeks.
+// Data is computed live server-side (buildsuite_core.api.delay_analysis); this view only renders.
+import { ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { getDelayAnalysis } from "@/data/delayAnalysisApi";
+import { showToast } from "@/utils/appToast";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { fmtDate } from "@/utils/format";
+
+const route = useRoute();
+const router = useRouter();
+
+const projectId = ref(route.query.project || "");
+const delayView = ref("stages");
+const loading = ref(false);
+const data = ref({ stages: [], silent_tasks: [], weekly_trend: [] });
+
+async function load(pid) {
+	if (!pid) {
+		data.value = { stages: [], silent_tasks: [], weekly_trend: [] };
+		return;
+	}
+	loading.value = true;
+	try {
+		data.value = (await getDelayAnalysis(pid)) || {
+			stages: [],
+			silent_tasks: [],
+			weekly_trend: [],
+		};
+	} catch (err) {
+		showToast(err.message || "Failed to load Delay Analysis", "error");
+		data.value = { stages: [], silent_tasks: [], weekly_trend: [] };
+	} finally {
+		loading.value = false;
+	}
+}
+watch(projectId, (id) => {
+	// Keep the project deep-linkable so the report can be shared / reloaded.
+	router.replace({ path: route.path, query: { ...route.query, project: id || undefined } });
+	load(id);
+});
+load(projectId.value);
+
+const TABS = [
+	["stages", "Stages"],
+	["silent", "Silent tasks"],
+	["trend", "Weekly trend"],
+];
+
+function printReport() {
+	window.print();
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Site Execution", to: "/site-execution" },
+	{ label: "Delay Analysis" },
+];
+</script>
+
+<template>
+	<DeskPage title="Delay Analysis" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="printReport"
+			>
+				Print
+			</button>
+		</template>
+
+		<p class="text-xs text-ink-500 mb-3">
+			Stages slipping, what sits downstream, silent tasks and the weekly completion trend.
+		</p>
+
+		<!-- Scope + view switch -->
+		<div class="flex flex-wrap items-center gap-3 mb-4">
+			<div class="w-72">
+				<DeskLinkPicker
+					v-model="projectId"
+					doctype="Project"
+					label-field="project_name"
+					value-field="name"
+					:search-fields="['project_name', 'name']"
+					placeholder="Pick a project…"
+				/>
+			</div>
+			<div v-if="projectId" class="flex border border-ink-200 rounded-md overflow-hidden">
+				<button
+					v-for="v in TABS"
+					:key="v[0]"
+					type="button"
+					class="px-3 py-1 text-xs border-l border-ink-200 first:border-l-0"
+					:class="
+						delayView === v[0]
+							? 'bg-brand-50 text-brand-700 font-medium'
+							: 'bg-white text-ink-600 hover:bg-ink-50'
+					"
+					@click="delayView = v[0]"
+				>
+					{{ v[1] }}
+				</button>
+			</div>
+			<span v-if="loading" class="text-[11px] text-ink-400">Loading…</span>
+		</div>
+
+		<div v-if="!projectId" class="text-sm text-ink-500 italic py-10 text-center">
+			Pick a project to run this report.
+		</div>
+
+		<template v-else>
+			<!-- Stages -->
+			<div
+				v-if="delayView === 'stages'"
+				class="bg-white border border-ink-200 rounded-lg overflow-x-auto"
+			>
+				<table class="w-full text-xs" style="min-width: 720px">
+					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="text-left px-3 py-2">Stage</th>
+							<th class="text-left px-3 py-2">Planned</th>
+							<th class="text-right px-3 py-2">Complete</th>
+							<th class="text-right px-3 py-2">Slip</th>
+							<th class="text-left px-3 py-2">Downstream</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr v-for="r in data.stages" :key="r.name" class="border-t border-ink-100">
+							<td class="px-3 py-2 text-ink-900">{{ r.stage_name }}</td>
+							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
+								{{ fmtDate(r.planned_start) }} → {{ fmtDate(r.planned_end) }}
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+								<template v-if="r.pct !== null">{{ r.pct }}%</template>
+								<span v-else class="text-ink-400">—</span>
+								<span class="text-[10px] text-ink-400 ml-1"
+									>({{ r.done_count }}/{{ r.task_count }})</span
+								>
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums">
+								<span v-if="r.overdue" class="text-danger-700 font-medium"
+									>{{ r.overdue }}d</span
+								>
+								<span v-else class="text-success-700">—</span>
+							</td>
+							<td class="px-3 py-2 text-ink-600">
+								{{ r.downstream.length ? r.downstream.join(", ") : "—" }}
+							</td>
+						</tr>
+						<tr v-if="!data.stages.length">
+							<td colspan="5" class="px-3 py-8 text-center text-ink-400 italic">
+								No stages planned on this project.
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Silent tasks -->
+			<div
+				v-else-if="delayView === 'silent'"
+				class="bg-white border border-ink-200 rounded-lg overflow-x-auto"
+			>
+				<table class="w-full text-xs" style="min-width: 560px">
+					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="text-left px-3 py-2">Task</th>
+							<th class="text-left px-3 py-2">Status</th>
+							<th class="text-left px-3 py-2">Last entry</th>
+							<th class="text-right px-3 py-2">Days silent</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="r in data.silent_tasks"
+							:key="r.task"
+							class="border-t border-ink-100"
+						>
+							<td class="px-3 py-2 text-ink-900">{{ r.subject }}</td>
+							<td class="px-3 py-2"><StatusBadge :status="r.status" size="xs" /></td>
+							<td class="px-3 py-2 text-ink-500">
+								{{ r.last ? fmtDate(r.last) : "Never" }}
+							</td>
+							<td
+								class="px-3 py-2 text-right tabular-nums"
+								:class="
+									(r.days ?? 99) >= 7
+										? 'text-danger-700 font-medium'
+										: 'text-warning-700'
+								"
+							>
+								{{ r.days ?? "—" }}
+							</td>
+						</tr>
+						<tr v-if="!data.silent_tasks.length">
+							<td colspan="4" class="px-3 py-8 text-center text-ink-400 italic">
+								Every active task has reported in the last 3 days.
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Weekly trend -->
+			<div v-else class="bg-white border border-ink-200 rounded-lg p-4">
+				<div class="space-y-2.5">
+					<div
+						v-for="w in data.weekly_trend"
+						:key="w.label"
+						class="flex items-center gap-3"
+					>
+						<span class="text-[11px] text-ink-500 w-24 flex-shrink-0">{{
+							fmtDate(w.label)
+						}}</span>
+						<div class="flex-1 h-3 bg-ink-100 rounded-full overflow-hidden">
+							<div
+								class="h-full bg-brand-500 rounded-full"
+								:style="`width:${w.pct}%`"
+							></div>
+						</div>
+						<span class="text-[11px] tabular-nums text-ink-700 w-32 text-right"
+							>{{ w.entries }} entries · {{ w.completed }} completed</span
+						>
+					</div>
+				</div>
+				<p class="text-[11px] text-ink-400 mt-3">
+					Progress entries filed per week, most recent last.
+				</p>
+			</div>
+		</template>
+	</DeskPage>
+</template>

--- a/frontend/src/views/DelayAnalysisReportView.vue
+++ b/frontend/src/views/DelayAnalysisReportView.vue
@@ -4,13 +4,17 @@
 //   • Stages       — completion, slip (days past planned end while incomplete), downstream.
 //   • Silent tasks — active tasks with no progress entry in the last 3 days (or ever).
 //   • Weekly trend — progress entries filed / completions per week over 6 weeks.
-// Data is computed live server-side (buildsuite_core.api.delay_analysis); this view only renders.
-import { ref, watch } from "vue";
+// The server computes the full sets (buildsuite_core.api.delay_analysis); the per-view
+// filters here narrow them client-side, with a live "N of M" count so a narrowed view is
+// never mistaken for the whole set.
+import { computed, reactive, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { getDelayAnalysis } from "@/data/delayAnalysisApi";
 import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import ReportFilters from "@/components/reports/ReportFilters.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate } from "@/utils/format";
 
@@ -21,6 +25,49 @@ const projectId = ref(route.query.project || "");
 const delayView = ref("stages");
 const loading = ref(false);
 const data = ref({ stages: [], silent_tasks: [], weekly_trend: [] });
+
+// --- filters (client-side, over the loaded sets) ---
+const BLANK = { q: "", from: "", to: "", lateOnly: false };
+const f = reactive({ ...BLANK });
+function clearFilters() {
+	Object.assign(f, BLANK);
+}
+const anyFilter = computed(() => Object.keys(BLANK).some((k) => f[k] !== BLANK[k]));
+const hit = (hay, needle) =>
+	!needle ||
+	String(hay || "")
+		.toLowerCase()
+		.includes(needle.trim().toLowerCase());
+const inDates = (d) => (!f.from || (d || "") >= f.from) && (!f.to || (d || "") <= f.to);
+
+const stagesShown = computed(() =>
+	data.value.stages
+		.filter((r) => hit(r.stage_name, f.q))
+		.filter((r) => inDates(r.planned_end))
+		.filter((r) => !f.lateOnly || r.overdue > 0)
+);
+const silentShown = computed(() => data.value.silent_tasks.filter((r) => hit(r.subject, f.q)));
+
+// Per-view filter-bar config: which count to show, and the search placeholder.
+const viewMeta = computed(() => {
+	if (delayView.value === "silent") {
+		return {
+			shown: silentShown.value.length,
+			total: data.value.silent_tasks.length,
+			noun: "tasks",
+			find: "Task…",
+		};
+	}
+	if (delayView.value === "stages") {
+		return {
+			shown: stagesShown.value.length,
+			total: data.value.stages.length,
+			noun: "stages",
+			find: "Stage…",
+		};
+	}
+	return { shown: null, total: null, noun: "", find: "" }; // trend — a chart of everything
+});
 
 async function load(pid) {
 	if (!pid) {
@@ -42,7 +89,7 @@ async function load(pid) {
 	}
 }
 watch(projectId, (id) => {
-	// Keep the project deep-linkable so the report can be shared / reloaded.
+	clearFilters(); // a filter from the previous project shouldn't leak onto the next
 	router.replace({ path: route.path, query: { ...route.query, project: id || undefined } });
 	load(id);
 });
@@ -82,18 +129,32 @@ const breadcrumbs = [
 			Stages slipping, what sits downstream, silent tasks and the weekly completion trend.
 		</p>
 
-		<!-- Scope + view switch -->
-		<div class="flex flex-wrap items-center gap-3 mb-4">
-			<div class="w-72">
-				<DeskLinkPicker
-					v-model="projectId"
-					doctype="Project"
-					label-field="project_name"
-					value-field="name"
-					:search-fields="['project_name', 'name']"
-					placeholder="Pick a project…"
-				/>
-			</div>
+		<!-- Scope + filters -->
+		<ReportFilters
+			:active="anyFilter"
+			:shown="viewMeta.shown"
+			:total="viewMeta.total"
+			:noun="viewMeta.noun"
+			@clear="clearFilters"
+		>
+			<label class="flex items-center gap-1.5">
+				<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+					>Project</span
+				>
+				<span class="w-56 inline-block">
+					<DeskLinkPicker
+						v-model="projectId"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						:search-fields="['project_name', 'name']"
+						placeholder="Pick a project…"
+					/>
+				</span>
+			</label>
+
+			<!-- The three delay views — a view switch rather than a filter, but it belongs
+				 with the other controls. -->
 			<div v-if="projectId" class="flex border border-ink-200 rounded-md overflow-hidden">
 				<button
 					v-for="v in TABS"
@@ -110,8 +171,34 @@ const breadcrumbs = [
 					{{ v[1] }}
 				</button>
 			</div>
-			<span v-if="loading" class="text-[11px] text-ink-400">Loading…</span>
-		</div>
+
+			<template v-if="projectId">
+				<!-- Weekly trend is a chart of everything — nothing to narrow. -->
+				<label v-if="delayView !== 'trend'" class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Find</span
+					>
+					<DeskInput v-model="f.q" :placeholder="viewMeta.find" class="!w-52" />
+				</label>
+
+				<label v-if="delayView === 'stages'" class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Planned end</span
+					>
+					<DeskInput v-model="f.from" type="date" class="!w-36" />
+					<span class="text-[11px] text-ink-400">to</span>
+					<DeskInput v-model="f.to" type="date" class="!w-36" />
+				</label>
+
+				<label
+					v-if="delayView === 'stages'"
+					class="flex items-center gap-1.5 cursor-pointer"
+				>
+					<input v-model="f.lateOnly" type="checkbox" class="accent-brand-600" />
+					<span class="text-[11px] text-ink-600">Slipping only</span>
+				</label>
+			</template>
+		</ReportFilters>
 
 		<div v-if="!projectId" class="text-sm text-ink-500 italic py-10 text-center">
 			Pick a project to run this report.
@@ -134,7 +221,7 @@ const breadcrumbs = [
 						</tr>
 					</thead>
 					<tbody>
-						<tr v-for="r in data.stages" :key="r.name" class="border-t border-ink-100">
+						<tr v-for="r in stagesShown" :key="r.name" class="border-t border-ink-100">
 							<td class="px-3 py-2 text-ink-900">{{ r.stage_name }}</td>
 							<td class="px-3 py-2 text-ink-500 whitespace-nowrap">
 								{{ fmtDate(r.planned_start) }} → {{ fmtDate(r.planned_end) }}
@@ -156,9 +243,13 @@ const breadcrumbs = [
 								{{ r.downstream.length ? r.downstream.join(", ") : "—" }}
 							</td>
 						</tr>
-						<tr v-if="!data.stages.length">
+						<tr v-if="!stagesShown.length">
 							<td colspan="5" class="px-3 py-8 text-center text-ink-400 italic">
-								No stages planned on this project.
+								{{
+									data.stages.length
+										? "No stages match the filters."
+										: "No stages planned on this project."
+								}}
 							</td>
 						</tr>
 					</tbody>
@@ -180,11 +271,7 @@ const breadcrumbs = [
 						</tr>
 					</thead>
 					<tbody>
-						<tr
-							v-for="r in data.silent_tasks"
-							:key="r.task"
-							class="border-t border-ink-100"
-						>
+						<tr v-for="r in silentShown" :key="r.task" class="border-t border-ink-100">
 							<td class="px-3 py-2 text-ink-900">{{ r.subject }}</td>
 							<td class="px-3 py-2"><StatusBadge :status="r.status" size="xs" /></td>
 							<td class="px-3 py-2 text-ink-500">
@@ -201,9 +288,13 @@ const breadcrumbs = [
 								{{ r.days ?? "—" }}
 							</td>
 						</tr>
-						<tr v-if="!data.silent_tasks.length">
+						<tr v-if="!silentShown.length">
 							<td colspan="4" class="px-3 py-8 text-center text-ink-400 italic">
-								Every active task has reported in the last 3 days.
+								{{
+									data.silent_tasks.length
+										? "No tasks match the filters."
+										: "Every active task has reported in the last 3 days."
+								}}
 							</td>
 						</tr>
 					</tbody>

--- a/frontend/src/views/ReportView.vue
+++ b/frontend/src/views/ReportView.vue
@@ -6,14 +6,9 @@ import { computed } from "vue";
 import { useRoute } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import FrappeReport from "@/components/FrappeReport.vue";
-import DelayAnalysisReportView from "@/views/DelayAnalysisReportView.vue";
 
 const route = useRoute();
 const report = computed(() => route.params.report || "");
-// Reports with a bespoke view (richer than a flat Query Report table) render their own
-// component; everything else falls through to the generic FrappeReport renderer.
-const CUSTOM_VIEWS = { "Delay Analysis": DelayAnalysisReportView };
-const customView = computed(() => CUSTOM_VIEWS[report.value] || null);
 // Where this report belongs, so the breadcrumb points back (defaults to Reports).
 const backTo = computed(() => route.query.from || "");
 const backLabel = computed(() => route.query.fromLabel || "Reports");
@@ -27,9 +22,7 @@ const breadcrumbs = computed(() => {
 </script>
 
 <template>
-	<!-- Bespoke report views render their own page chrome. -->
-	<component :is="customView" v-if="customView" />
-	<DeskPage v-else :title="report" subtitle="Report" :breadcrumbs="breadcrumbs">
+	<DeskPage :title="report" subtitle="Report" :breadcrumbs="breadcrumbs">
 		<FrappeReport :report="report" />
 	</DeskPage>
 </template>

--- a/frontend/src/views/ReportView.vue
+++ b/frontend/src/views/ReportView.vue
@@ -6,9 +6,14 @@ import { computed } from "vue";
 import { useRoute } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import FrappeReport from "@/components/FrappeReport.vue";
+import DelayAnalysisReportView from "@/views/DelayAnalysisReportView.vue";
 
 const route = useRoute();
 const report = computed(() => route.params.report || "");
+// Reports with a bespoke view (richer than a flat Query Report table) render their own
+// component; everything else falls through to the generic FrappeReport renderer.
+const CUSTOM_VIEWS = { "Delay Analysis": DelayAnalysisReportView };
+const customView = computed(() => CUSTOM_VIEWS[report.value] || null);
 // Where this report belongs, so the breadcrumb points back (defaults to Reports).
 const backTo = computed(() => route.query.from || "");
 const backLabel = computed(() => route.query.fromLabel || "Reports");
@@ -22,7 +27,9 @@ const breadcrumbs = computed(() => {
 </script>
 
 <template>
-	<DeskPage :title="report" subtitle="Report" :breadcrumbs="breadcrumbs">
+	<!-- Bespoke report views render their own page chrome. -->
+	<component :is="customView" v-if="customView" />
+	<DeskPage v-else :title="report" subtitle="Report" :breadcrumbs="breadcrumbs">
 		<FrappeReport :report="report" />
 	</DeskPage>
 </template>


### PR DESCRIPTION
The flat Query Report can't express Delay Analysis (it has three distinct views), so this gives it a **bespoke in-app view** matching the prototype — while every other report keeps the generic renderer.

## Backend — `api/delay_analysis.py`
`delay_analysis(project)` computes three views live over the project **and its sub-projects**:
- **Stages** — each Stage Planning's completion (reusing the controller's own `mean_progress` + task counts, so it never disagrees with the Stage screens), **slip** (days past planned end while incomplete) and **downstream** (stages that depend on it).
- **Silent tasks** — active tasks (`task_status` not Completed/Yet-To-Start) with **no progress entry in the last 3 days** (or ever).
- **Weekly trend** — progress entries filed / completions **per week over the last 6 weeks**.

## Frontend
- `DelayAnalysisReportView.vue` — project picker + a **Stages / Silent tasks / Weekly trend** segmented switch, `?project=` deep-linkable, Print. Layout matches the prototype's delay-analysis section.
- `ReportView` renders this component when the report name is **"Delay Analysis"**, so the existing **Site Execution report tile picks it up with no seed/data change**; all other report tiles still use the generic `FrappeReport` table.

## Verified
On bs.local (PROJ-0260): stages populate with real % (50% 1/2, 100% 2/2, 67% 2/3…), one silent task surfaces (never reported), and the weekly trend shows entries/completions per week. `npx vite build` clean; pre-commit clean.

Frontend + backend, no migrate. Pull the branch, `bench build`, and open the Delay Analysis tile from the Site Execution workspace (then pick a project).