### PR TITLE
fix: Site Execution reports crash on load — convert to Script Reports

### DIFF
--- a/buildsuite_core/api/report.py
+++ b/buildsuite_core/api/report.py
@@ -26,6 +26,20 @@ def _resolve_default(fieldtype, default):
 	return default
 
 
+def _with_filter_defaults(report, filters):
+	"""Ensure every filter the report DECLARES has a value in `filters`, so a Query Report's
+	`%(fieldname)s` substitution can never KeyError when the client omits an unset optional
+	filter. Frappe strips empty filter values before running, so a report using the
+	`%(x)s = '' OR …` "empty ⇒ all" guard would otherwise blow up on `query % filters` the
+	moment nothing is selected. Only fills MISSING keys — a provided value always wins."""
+	doc = frappe.get_cached_doc("Report", report)
+	for f in doc.filters or []:
+		if not f.fieldname or f.fieldtype in ("Fold", "Column Break", "Section Break"):
+			continue
+		filters.setdefault(f.fieldname, _resolve_default(f.fieldtype, f.default))
+	return filters
+
+
 @frappe.whitelist()
 def get_report_filters(report):
 	"""Everything the in-app renderer needs to build a report's filter bar agnostically:
@@ -80,6 +94,9 @@ def run_report(report, filters=None):
 		frappe.throw(_("Report {0} not found.").format(report))
 	if meta.disabled:
 		frappe.throw(_("Report {0} is disabled.").format(report))
+
+	# Backfill any declared-but-unset filter so a Query Report's %(x)s never KeyErrors.
+	filters = _with_filter_defaults(report, filters)
 
 	from frappe.desk.query_report import run
 


### PR DESCRIPTION
## Bug
Every Site Execution report — **Delay Analysis, Billing and Collection, Subcontractor Position, Material Status** — crashed **on page load, before any filter could be chosen**, and on every refresh:

```
KeyError: b'project'  /  ProgrammingError: format requires a mapping   (frappe.db.sql: query % filters)
```

## Root cause (traced on frappe.desk.query_report.run)
They were **Query Reports** whose SQL used `%(project)s`. Frappe runs a Query Report as `frappe.db.sql(self.query, filters)` — a raw `query % filters` that **requires every `%(key)s` to be present**. Frappe **strips empty filter values** and fires an initial run with `filters = {}` on load, so `'%(project)s' % {}` raises. Making the filter *mandatory* does **not** help — that initial `{}` run still happens server-side. `server_script_enabled` is off, ruling out in-DB script reports.

## Fix — convert to standard Script Reports
The four reports are now **standard Script Reports** under `buildsuite_core/report/<name>/`. Their `execute(filters)` builds the SQL binding `project` (and Billing's optional date range) **only when set**, and returns no rows until a project is chosen — they're project-scoped, exactly as the prototype requires (*"Pick a project to run this report"*). No `%(x)s` is ever referenced with an absent key, so no run path can crash.

- `seed_workspace_reports` no longer creates Query Reports (each report's SQL / filters / roles live in its module); it just seeds the tiles.
- A patch retires the old non-standard `Report` docs so the file-based Script Reports take over; existing sites convert on `migrate`.
- Kept the in-app `run_report` default backfill as belt-and-suspenders.

## Verified on `frappe.desk.query_report.run` (the exact path that crashed)
| Report | `filters={}` (page load) | with a project |
|---|---|---|
| Delay Analysis | ✅ no crash | ✅ |
| Billing and Collection | ✅ no crash | ✅ |
| Subcontractor Position | ✅ no crash | ✅ |
| Material Status | ✅ no crash | ✅ |