### PR TITLE
fix: M3 admin permissions — WO submit + Crew/Employee/Machinery Type/Customer

### DIFF
--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -371,6 +371,22 @@ def _apply_role_perms(doctype, role_perms, ptypes=_PTYPES):
 			)
 
 
+def _upgrade_role_perms(doctype, role_perms, ptypes=_PTYPES):
+	"""Raise perms for specific roles WITHOUT revoking anyone else — layer write/delete on top
+	of a read mirror. Customer and Employee are readable by many roles (link pickers), but only
+	some may write/delete them; _apply_role_perms would revoke every unlisted role's read, so
+	use this to upgrade the writers while the mirror keeps the readers."""
+	if not frappe.db.exists("DocType", doctype):
+		return
+	from frappe.permissions import add_permission, update_permission_property
+
+	for role, perms in role_perms.items():
+		_ensure_role(role)
+		add_permission(doctype, role, 0)
+		for ptype in ptypes:
+			update_permission_property(doctype, role, 0, ptype, perms.get(ptype, 0), validate=False)
+
+
 def setup_project_permissions():
 	_apply_role_perms("Project", PROJECT_ROLE_PERMS)
 
@@ -536,6 +552,16 @@ SUBCONTRACT_BILL_ROLE_PERMS = {
 	"BuildSuite Accountant": _READ,
 	"BuildSuite Site Engineer": _READ,
 }
+# Subcontractor Work Order — the commitment document is natively submittable (Draft →
+# Submitted → Cancelled + Amend), so the full roles get CRWDSX, not just CRWD. QS prepares
+# and submits alongside PM / Procurement / Director; Estimator / Site Engineer / Accountant
+# read. (Matches the M3 matrix; the old grant gave CRWD only, so no one could submit/cancel.)
+SUBCONTRACT_WO_ROLE_PERMS = {
+	**{role: _FULL_SUB for role in _BILL_FULL_ROLES},
+	"BuildSuite Estimator": _READ,
+	"BuildSuite Site Engineer": _READ,
+	"BuildSuite Accountant": _READ,
+}
 
 # Scope Change Order — role matrix (SCO is header-only + status-based, not submittable,
 # so Submit/Cancel don't apply; "full" = CRWD). PM/QS prepare + quantify, Director
@@ -609,7 +635,7 @@ def setup_subcontract_permissions():
 	# Subcontractors are native Suppliers (supplier_type="Subcontractor") — grant the
 	# BuildSuite roles CRUD on Supplier so the Vue "Subcontractor" screens work.
 	_apply_role_perms("Supplier", SUBCONTRACT_ROLE_PERMS)
-	_apply_role_perms("Subcontractor Work Order", SUBCONTRACT_ROLE_PERMS)
+	_apply_role_perms("Subcontractor Work Order", SUBCONTRACT_WO_ROLE_PERMS, _SUBMIT_PTYPES)
 	_apply_role_perms("Measurement Book", MEASUREMENT_BOOK_ROLE_PERMS)
 	_apply_role_perms("Subcontractor Bill", SUBCONTRACT_BILL_ROLE_PERMS, _SUBMIT_PTYPES)
 	_apply_role_perms("Construction Trade", SUBCONTRACT_MASTER_ROLE_PERMS)
@@ -653,8 +679,36 @@ DERIVED_ATTENDANCE_ROLE_PERMS = {
 }
 
 
+# Worker master — the standard Employee doctype (BuildSuite has no separate Field Employee
+# doctype). HR owns it; PM + admin tier full; Site Engineer edits (no delete); Director +
+# Accountant + Foreman read. Employee is a linked-master read mirror already (every Project
+# role reads it for owner/assignee pickers), so this only UPGRADES the writers — it must not
+# revoke the pickers' read, hence _upgrade_role_perms.
+EMPLOYEE_WRITE_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite PM": _FULL,
+	"BuildSuite HR Manager": _FULL,
+	"BuildSuite Site Engineer": _CRW,
+}
+# Crew — standalone labour-grouping master (not tied to a project). Foreman maintains
+# membership day to day (edit, no delete); Site Engineer + PM + HR + admin tier full;
+# Director reads. Crew Member is a child table and inherits Crew's perms.
+CREW_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Director": _READ,
+	"BuildSuite PM": _FULL,
+	"BuildSuite Site Engineer": _FULL,
+	"BuildSuite Foreman": _CRW,
+	"BuildSuite HR Manager": _FULL,
+}
+
+
 def setup_workforce_permissions():
 	_apply_role_perms("Field Attendance", FIELD_ATTENDANCE_ROLE_PERMS, _SUBMIT_PTYPES)
+	# Worker master + Crew (the M3 matrix missed both — Crew had no BuildSuite grant at all,
+	# and Employee was read-only via the picker mirror, so HR/PM/admin couldn't maintain it).
+	_upgrade_role_perms("Employee", EMPLOYEE_WRITE_ROLE_PERMS)
+	_apply_role_perms("Crew", CREW_ROLE_PERMS)
 	for dt in ("Labour Attendance Register", "Overtime Attendance Register"):
 		# These registers historically shipped an over-broad `All` grant (write for every
 		# user). The derived rule is "no role edits directly", so drop any `All` custom
@@ -692,9 +746,21 @@ MACHINERY_USAGE_ROLE_PERMS = {
 }
 
 
+# Machinery Type — the master the Machinery register's `machinery_type` picker resolves.
+# Everyone who can see a machine reads its type; Procurement / Store Keeper / admin maintain
+# the list. Without this the type dropdown is empty for every role (it had no grant at all).
+MACHINERY_TYPE_ROLE_PERMS = {
+	**{role: _READ for role in MACHINERY_ROLE_PERMS},
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Procurement Officer": _FULL,
+	"BuildSuite Store Keeper": _FULL,
+}
+
+
 def setup_equipment_permissions():
 	_apply_role_perms("Machinery", MACHINERY_ROLE_PERMS)
 	_apply_role_perms("Machinery Usage", MACHINERY_USAGE_ROLE_PERMS)
+	_apply_role_perms("Machinery Type", MACHINERY_TYPE_ROLE_PERMS)
 
 
 # --- M3 — Project Finance (customer-side money) -------------------------------
@@ -720,9 +786,23 @@ PAYMENT_ENTRY_ROLE_PERMS = {
 }
 
 
+# Customer — the commercial master. Director + Accountant + admin tier maintain it fully
+# (incl. delete); PM edits (no delete). It's a linked-master read mirror (every Project role
+# reads it for the client picker), so upgrade only the writers without revoking pickers' read.
+CUSTOMER_WRITE_ROLE_PERMS = {
+	"BuildSuite Administrator": _FULL,
+	"BuildSuite Director": _FULL,
+	"BuildSuite Accountant": _FULL,
+	"BuildSuite PM": _CRW,
+}
+
+
 def setup_project_finance_permissions():
 	_apply_role_perms("Sales Invoice", SALES_INVOICE_ROLE_PERMS, _SUBMIT_PTYPES)
 	_apply_role_perms("Payment Entry", PAYMENT_ENTRY_ROLE_PERMS, _SUBMIT_PTYPES)
+	# Customer was read-only for everyone via the picker mirror, so even admins couldn't
+	# delete it. Upgrade the commercial writers on top of that mirror.
+	_upgrade_role_perms("Customer", CUSTOMER_WRITE_ROLE_PERMS)
 
 
 def _ensure_workflow_state(name):

--- a/buildsuite_core/tests/test_permissions.py
+++ b/buildsuite_core/tests/test_permissions.py
@@ -269,6 +269,40 @@ class TestPermissions(BuildSuiteTestCase):
 		finally:
 			frappe.set_user("Administrator")
 
+	def test_admin_can_submit_subcontractor_work_order(self):
+		# M3 — the Work Order is submittable; the admin tier (and the subcontract full
+		# roles) must have submit/cancel/amend, not just CRWD.
+		self._as("BuildSuite Administrator", "basub")
+		try:
+			for ptype in ("create", "write", "delete", "submit", "cancel", "amend"):
+				self.assertTrue(frappe.has_permission("Subcontractor Work Order", ptype), ptype)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_admin_full_on_m3_masters(self):
+		# M3 — the admin tier gets full CRWD on the worker/crew/equipment/commercial
+		# masters that the matrix had left read-only (Employee, Customer) or ungranted
+		# (Crew, Machinery Type).
+		self._as("BuildSuite Administrator", "bamaster")
+		try:
+			for dt in ("Employee", "Crew", "Machinery Type", "Customer"):
+				self.assertTrue(frappe.has_permission(dt, "create"), dt)
+				self.assertTrue(frappe.has_permission(dt, "write"), dt)
+				self.assertTrue(frappe.has_permission(dt, "delete"), dt)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_master_upgrade_preserves_picker_read(self):
+		# The Employee/Customer write upgrade must not revoke the link-picker read that
+		# other roles rely on — QS still reads both even though it cannot write them.
+		self._as("Quantity Surveyor", "qspick")
+		try:
+			for dt in ("Employee", "Customer"):
+				self.assertTrue(frappe.has_permission(dt, "read"), dt)
+				self.assertFalse(frappe.has_permission(dt, "delete"), dt)
+		finally:
+			frappe.set_user("Administrator")
+
 	def test_rate_update_guard_rejects_non_governance(self):
 		# PERM-013 — the PO-submit rate-update endpoint rejects a non-governance role
 		# and accepts the empowered Procurement Officer.


### PR DESCRIPTION
## Summary
PR #142 seeded the M3 permission matrices but left gaps that blocked the **BuildSuite Administrator** (and other full roles) on several M3 DocTypes — the "does not have doctype access via role permission for document Subcontractor Work Order" error, plus can't-edit / can't-delete / empty-dropdown on the masters. Fixes all of those in `permissions/setup.py` (re-applied on `after_migrate`).

| DocType | Was | Now | Fixes |
|---|---|---|---|
| **Subcontractor Work Order** | CRWD (no submit) | **CRWDSX** for BA/PM/Dir/Proc/QS | Submit / Cancel / Amend (the screenshot error) |
| **Employee** (worker master) | read-only (picker mirror) | **CRWD** for BA/PM/HR, CRW for SE | Create / edit / save |
| **Crew** (+ Crew Member child) | *no grant at all* | **CRWD** for BA/PM/SE/HR, CRW Foreman | Create / edit / save |
| **Machinery Type** | *no grant* | read all machinery roles, **write** Proc/Store/BA | Empty type dropdown |
| **Customer** | read-only (picker mirror) | **CRWD** for BA/Dir/Acct, CRW PM | Delete from Desk |

Adds a non-revoking `_upgrade_role_perms` helper so layering write/delete on the two **link-picker masters** (Employee, Customer) doesn't strip the read that other roles need for their pickers — verified QS still reads both.

## Verification
- Applied on `bs.local`; BA now `RWCDSCA` on Subcontractor Work Order and `RWCD` on Employee / Crew / Machinery Type / Customer; QS still reads Employee + Customer.
- Tests: **+3** (admin submits WO; admin full on the four masters; upgrade preserves QS picker read) — all green. The 2 unrelated Stage Planning workflow test errors are **pre-existing on develop** (confirmed by stashing this change).

## NOT in this PR (they aren't permission bugs)
The remaining items you listed are a different class and need a separate look:
- **"Required field missing" on submitting Subcontractor Bill / Supplier Bill (Purchase Invoice) / Sales Invoice** — those DocTypes already have full perms for BA (verified `RWCDSCA`), so this is a **validation / mandatory-field** issue, likely when driving the raw Desk form instead of the Vue flow that auto-fills those fields. Needs the exact field + repro steps to fix correctly.
- **UI: remove the dead Purchase Invoice link, add the Subcontract Invoice Reference table + reposition the Advance Payments table** — frontend prototype-matching work, separate from permissions.
