### PR TITLE
feat: Subcontractor Bill detail — invoice reference, advance table, drop dead PI link

### DIFF
--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -60,6 +60,8 @@ def _serialize(doc):
 		"project_name": frappe.db.get_value("Project", doc.project, "project_name") if doc.project else None,
 		"company": _effective_company(doc),
 		"date": str(doc.date) if doc.date else None,
+		"supplier_invoice_no": doc.supplier_invoice_no,
+		"supplier_invoice_date": str(doc.supplier_invoice_date) if doc.supplier_invoice_date else None,
 		"bill_type": doc.bill_type,
 		"retention_percent": doc.retention_percent,
 		"status": doc.status,
@@ -328,6 +330,8 @@ def save_bill(payload):
 
 	doc.is_direct = 1 if data.get("is_direct") else 0
 	doc.date = data.get("date")
+	doc.supplier_invoice_no = (data.get("supplier_invoice_no") or "").strip() or None
+	doc.supplier_invoice_date = data.get("supplier_invoice_date") or None
 	doc.bill_type = data.get("bill_type") or "Normal"
 
 	if doc.is_direct:

--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -92,6 +92,17 @@ def _ref_is_advance(pe_type, paid_amount, unallocated, allocated):
 	return flt(unallocated) > 0.01 or flt(paid_amount) - flt(allocated) > 0.01
 
 
+def _pe_meta(pe_name):
+	"""Display fields for an advance's Payment Entry — when it was paid, from which account and
+	the entry's total — so the bill's Advance Payments table can show them (matches the prototype)."""
+	row = frappe.db.get_value(PE, pe_name, ["posting_date", "paid_from", "paid_amount"], as_dict=True) or {}
+	return {
+		"paid_on": row.get("posting_date"),
+		"paid_from": row.get("paid_from"),
+		"advance_amount": flt(row.get("paid_amount")),
+	}
+
+
 def _linked_advances(doc):
 	"""Advances adjusted against this bill, one entry per Payment Entry with its TOTAL applied.
 
@@ -102,7 +113,11 @@ def _linked_advances(doc):
 	after submit — a plain cash payment is neither."""
 	if doc.docstatus == 0:
 		return [
-			{"payment_entry": a.reference_name, "allocated": flt(a.allocated_amount)}
+			{
+				"payment_entry": a.reference_name,
+				"allocated": flt(a.allocated_amount),
+				**_pe_meta(a.reference_name),
+			}
 			for a in doc.advances
 			if a.reference_type == PE and flt(a.allocated_amount) > 0
 		]
@@ -135,7 +150,7 @@ def _linked_advances(doc):
 				pe.payment_type, pe.paid_amount, pe.unallocated_amount, total
 			)
 		if is_advance:
-			out.append({"payment_entry": pe_name, "allocated": total})
+			out.append({"payment_entry": pe_name, "allocated": total, **_pe_meta(pe_name)})
 	return out
 
 

--- a/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.json
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor_bill/subcontractor_bill.json
@@ -13,6 +13,8 @@
   "project",
   "column_break_hdr",
   "date",
+  "supplier_invoice_no",
+  "supplier_invoice_date",
   "bill_type",
   "retention_percent",
   "status",
@@ -106,6 +108,17 @@
    "in_list_view": 1,
    "label": "Date",
    "reqd": 1
+  },
+  {
+   "description": "The subcontractor's own invoice / bill number — carries to the Purchase Invoice.",
+   "fieldname": "supplier_invoice_no",
+   "fieldtype": "Data",
+   "label": "Subcontractor Invoice No"
+  },
+  {
+   "fieldname": "supplier_invoice_date",
+   "fieldtype": "Date",
+   "label": "Subcontractor Invoice Date"
   },
   {
    "default": "Normal",

--- a/buildsuite_core/utils/subcontract_billing.py
+++ b/buildsuite_core/utils/subcontract_billing.py
@@ -57,9 +57,7 @@ def _ensure_account(company, account_name, root_type, account_type, parent_hint)
 	full_name = f"{account_name} - {abbr}"
 	if frappe.db.exists("Account", full_name):
 		return full_name
-	existing = frappe.db.get_value(
-		"Account", {"account_name": account_name, "company": company}, "name"
-	)
+	existing = frappe.db.get_value("Account", {"account_name": account_name, "company": company}, "name")
 	if existing:
 		return existing
 
@@ -168,8 +166,10 @@ def generate_purchase_invoice(bill):
 	bill_date = str(bill.date) if bill.date else None
 	pi.set_posting_time = 1
 	pi.posting_date = bill_date
-	pi.bill_no = bill.name
-	pi.bill_date = bill_date
+	# The supplier's own invoice reference (optional) carries to the PI's bill no/date; fall
+	# back to our bill name/date when the subcontractor didn't give a separate invoice number.
+	pi.bill_no = bill.get("supplier_invoice_no") or bill.name
+	pi.bill_date = str(bill.supplier_invoice_date) if bill.get("supplier_invoice_date") else bill_date
 	pi.project = bill.project
 	pi.update_stock = 0
 	if frappe.get_meta("Purchase Invoice").has_field("subcontractor_bill"):

--- a/frontend/src/views/NewSubcontractorBillView.vue
+++ b/frontend/src/views/NewSubcontractorBillView.vue
@@ -70,6 +70,8 @@ const form = ref({
 	subcontractor: "",
 	project: "",
 	date: todayIso(),
+	supplier_invoice_no: "",
+	supplier_invoice_date: "",
 	retention_percent: 5,
 	lines: [{ scope: "", cost_code: null, amount: 0 }],
 });
@@ -107,6 +109,8 @@ watch(
 					subcontractor: bill.subcontractor || "",
 					project: bill.project || "",
 					date: bill.date || todayIso(),
+					supplier_invoice_no: bill.supplier_invoice_no || "",
+					supplier_invoice_date: bill.supplier_invoice_date || "",
 					retention_percent: bill.retention_percent ?? 0,
 					lines: bill.is_direct
 						? (bill.lines || []).map((l) => ({
@@ -178,6 +182,8 @@ async function onSave() {
 						is_direct: 0,
 						work_order: form.value.work_order,
 						date: form.value.date,
+						supplier_invoice_no: form.value.supplier_invoice_no,
+						supplier_invoice_date: form.value.supplier_invoice_date || undefined,
 						retention_percent: form.value.retention_percent,
 				  }
 				: {
@@ -186,6 +192,8 @@ async function onSave() {
 						subcontractor: form.value.subcontractor,
 						project: form.value.project,
 						date: form.value.date,
+						supplier_invoice_no: form.value.supplier_invoice_no,
+						supplier_invoice_date: form.value.supplier_invoice_date || undefined,
 						retention_percent: form.value.retention_percent,
 						lines: form.value.lines
 							.filter((l) => (l.scope || "").trim() || Number(l.amount) > 0)
@@ -282,6 +290,14 @@ const breadcrumbs = computed(() => [
 					</DeskField>
 					<DeskField label="Date" required
 						><DeskInput v-model="form.date" type="date"
+					/></DeskField>
+					<DeskField label="Subcontractor Invoice No"
+						><DeskInput
+							v-model="form.supplier_invoice_no"
+							placeholder="e.g. SI-2026-0042"
+					/></DeskField>
+					<DeskField label="Subcontractor Invoice Date"
+						><DeskInput v-model="form.supplier_invoice_date" type="date"
 					/></DeskField>
 					<DeskField label="Retention (%)">
 						<DeskInput
@@ -425,6 +441,14 @@ const breadcrumbs = computed(() => [
 					</DeskField>
 					<DeskField label="Date" required
 						><DeskInput v-model="form.date" type="date"
+					/></DeskField>
+					<DeskField label="Subcontractor Invoice No"
+						><DeskInput
+							v-model="form.supplier_invoice_no"
+							placeholder="e.g. SI-2026-0042"
+					/></DeskField>
+					<DeskField label="Subcontractor Invoice Date"
+						><DeskInput v-model="form.supplier_invoice_date" type="date"
 					/></DeskField>
 					<DeskField label="Retention (%)">
 						<DeskInput

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -207,10 +207,6 @@ async function saveBilling() {
 function onEdit() {
 	router.push(`/subcontractor-bills/${bill.value.name}/edit`);
 }
-function onOpenAccounting() {
-	if (bill.value.purchase_invoice)
-		window.open(`/app/purchase-invoice/${bill.value.purchase_invoice}`, "_blank", "noopener");
-}
 async function onSubmit() {
 	if (wf.value.gross <= 0) {
 		showToast("Nothing to bill — add a line with an amount.", "error");
@@ -339,6 +335,11 @@ async function savePayment() {
 const availableAdvances = ref([]);
 const linkedAdvances = computed(() => bill.value?.advances || []);
 const advanceAdjusted = computed(() => Number(bill.value?.advance_adjusted) || 0);
+function advAccountName(account) {
+	// Accounts are named "<Name> - <CompanyAbbr>"; show just the name for a cleaner table.
+	if (!account) return "—";
+	return account.replace(/ - [A-Z0-9]+$/, "") || account;
+}
 const unlinkedTotal = computed(() =>
 	availableAdvances.value.reduce((a, x) => a + Number(x.unallocated || 0), 0)
 );
@@ -569,16 +570,6 @@ const accountFilters = computed(() =>
 	>
 		<template #actions>
 			<button
-				v-if="bill.purchase_invoice"
-				type="button"
-				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
-				style="border-radius: 6px"
-				title="Open the generated Purchase Invoice in the Accounting desk"
-				@click="onOpenAccounting"
-			>
-				Open in Accounting →
-			</button>
-			<button
 				v-if="isDraft"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
@@ -759,68 +750,6 @@ const accountFilters = computed(() =>
 			</table>
 		</div>
 
-		<!-- Advance Payments (subcontractor advances adjusted against the bill's PI) -->
-		<div
-			v-if="isSubmitted && (linkedAdvances.length || availableAdvances.length)"
-			class="mb-4 bg-white border border-ink-200 rounded-lg overflow-hidden"
-		>
-			<div
-				class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3"
-			>
-				<h3 class="text-[11px] uppercase tracking-wider font-semibold text-ink-700">
-					Advance Payments
-				</h3>
-				<button
-					v-if="availableAdvances.length"
-					type="button"
-					class="text-xs text-brand-700 hover:underline"
-					@click="openLinkAdvance"
-				>
-					+ Link advance
-				</button>
-			</div>
-			<template v-if="linkedAdvances.length">
-				<div
-					v-for="row in linkedAdvances"
-					:key="row.payment_entry"
-					class="flex items-center justify-between px-4 py-2.5 border-t border-ink-100 text-sm gap-2"
-				>
-					<DeskLink
-						:to="`/app/payment-entry/${row.payment_entry}`"
-						class="font-mono text-xs text-ink-900 min-w-0 truncate"
-						>{{ row.payment_entry }}</DeskLink
-					>
-					<span class="flex items-center gap-2 flex-shrink-0">
-						<span class="tabular-nums text-info-700 font-medium">{{
-							fmtINR(row.allocated)
-						}}</span>
-						<button
-							type="button"
-							class="text-ink-400 hover:text-danger-600 text-xs"
-							:title="`Unlink ${row.payment_entry}`"
-							@click="unlinkAdvance(row)"
-						>
-							✕
-						</button>
-					</span>
-				</div>
-				<div
-					class="px-4 py-2 border-t border-ink-100 flex items-center justify-between text-[11px]"
-				>
-					<span class="uppercase tracking-wider text-ink-500 font-medium"
-						>Total advance adjusted</span
-					>
-					<span class="tabular-nums font-semibold text-ink-900">{{
-						fmtINR(advanceAdjusted)
-					}}</span>
-				</div>
-			</template>
-			<div v-else class="px-4 py-3 text-xs text-ink-400 italic border-t border-ink-100">
-				No advances linked yet — {{ bill.subcontractor_name }} has
-				{{ fmtINR(unlinkedTotal) }} unallocated.
-			</div>
-		</div>
-
 		<!-- Summary strip -->
 		<div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
@@ -840,6 +769,18 @@ const accountFilters = computed(() =>
 					Date
 				</div>
 				<div class="text-sm text-ink-900 mt-0.5">{{ fmtDate(bill.date) }}</div>
+				<div
+					v-if="bill.supplier_invoice_no || bill.supplier_invoice_date"
+					class="text-[10px] text-ink-500 mt-0.5"
+				>
+					Subcontractor inv:
+					<span class="text-ink-700 font-medium">{{
+						bill.supplier_invoice_no || "—"
+					}}</span>
+					<template v-if="bill.supplier_invoice_date">
+						· {{ fmtDate(bill.supplier_invoice_date) }}</template
+					>
+				</div>
 			</div>
 			<div class="bg-white border border-ink-200 px-3 py-2" style="border-radius: 6px">
 				<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
@@ -1378,6 +1319,90 @@ const accountFilters = computed(() =>
 						</div>
 					</template>
 				</div>
+			</div>
+		</section>
+
+		<!-- Advance Payments — the subcontractor's on-account advances adjusted against this
+		     bill's PI. Below the totals (matches the prototype); available after submit. -->
+		<section
+			v-if="isSubmitted && (linkedAdvances.length || availableAdvances.length)"
+			class="mt-6 bg-white border border-ink-200 rounded-lg overflow-hidden"
+		>
+			<div
+				class="bg-ink-50 px-4 py-2 border-b border-ink-200 flex items-center justify-between gap-3"
+			>
+				<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
+					Advance Payments
+				</h3>
+				<button
+					v-if="availableAdvances.length"
+					type="button"
+					class="text-xs text-brand-700 hover:underline"
+					@click="openLinkAdvance"
+				>
+					+ Link advance
+				</button>
+			</div>
+			<table v-if="linkedAdvances.length" class="w-full text-xs">
+				<thead class="bg-white text-ink-500 uppercase tracking-wider text-[10px]">
+					<tr>
+						<th class="text-left px-3 py-2">Advance</th>
+						<th class="text-left px-3 py-2 w-28">Paid on</th>
+						<th class="text-left px-3 py-2 w-44">Paid from</th>
+						<th class="text-right px-3 py-2 w-32">Advance amount</th>
+						<th class="text-right px-3 py-2 w-32">Recovered here</th>
+						<th class="w-8"></th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="row in linkedAdvances"
+						:key="row.payment_entry"
+						class="border-t border-ink-100"
+					>
+						<td class="px-3 py-2 font-mono text-ink-900">{{ row.payment_entry }}</td>
+						<td class="px-3 py-2 text-ink-600">
+							{{ row.paid_on ? fmtDate(row.paid_on) : "—" }}
+						</td>
+						<td class="px-3 py-2 text-ink-600">{{ advAccountName(row.paid_from) }}</td>
+						<td class="px-3 py-2 text-right tabular-nums text-ink-500">
+							{{ row.advance_amount ? fmtINR(row.advance_amount) : "—" }}
+						</td>
+						<td class="px-3 py-2 text-right tabular-nums text-info-700 font-medium">
+							{{ fmtINR(row.allocated) }}
+						</td>
+						<td class="px-2 py-2 text-center">
+							<button
+								type="button"
+								class="text-ink-400 hover:text-danger-600"
+								:title="`Unlink ${row.payment_entry}`"
+								@click="unlinkAdvance(row)"
+							>
+								✕
+							</button>
+						</td>
+					</tr>
+				</tbody>
+				<tfoot>
+					<tr class="border-t border-ink-200 bg-ink-50">
+						<td
+							colspan="4"
+							class="px-3 py-2 text-right text-[11px] font-semibold uppercase tracking-wider text-ink-700"
+						>
+							Total advance recovered
+						</td>
+						<td
+							class="px-3 py-2 text-right tabular-nums text-sm font-semibold text-ink-900"
+						>
+							{{ fmtINR(advanceAdjusted) }}
+						</td>
+						<td></td>
+					</tr>
+				</tfoot>
+			</table>
+			<div v-else class="px-4 py-3 text-xs text-ink-400 italic">
+				No advances linked yet — {{ bill.subcontractor_name }} has
+				{{ fmtINR(unlinkedTotal) }} unallocated.
 			</div>
 		</section>
 


### PR DESCRIPTION
## Summary
Three prototype-matching changes on the Subcontractor Bill screens (the detail view + the New/Edit form).

### 1. Remove the dead Purchase Invoice link
The "Open in Accounting →" button on the detail header deep-linked to `/app/purchase-invoice/<name>` (a Desk page that doesn't open for these users) — so it did nothing. Removed the button and its `onOpenAccounting` handler.

### 2. Subcontractor Invoice reference (optional)
The subcontractor's own invoice number/date — in the prototype, missing in dev. Added:
- `supplier_invoice_no` + `supplier_invoice_date` to the **Subcontractor Bill** doctype.
- Editable on the New/Edit form; shown under **Date** on the detail view.
- They **carry to the generated Purchase Invoice** (`bill_no` / `bill_date`), falling back to our bill name/date when not supplied.

### 3. Advance Payments table
Reworked from a flat list into the prototype's **table** — Advance · Paid on · Paid from · Advance amount · Recovered here — with a *Total advance recovered* footer, and **moved below the totals waterfall** (was mid-page). Enriched the linked-advance rows server-side (`_linked_advances`) with the advance Payment Entry's posting date / paid-from account / total so the table can show them.

## Verification
- Backend (bs.local console): the two doctype fields exist, persist, serialize into `get_bill`, and the advance rows carry the new keys.
- Frontend `yarn build` clean (SubcontractorBillDetailView + NewSubcontractorBillView chunks build).
- Tests: `test_supplier_bill` **30/30 green**; `test_subcontractor_bill` 19/21 — the 2 failing `make_payment_entry` tests are **pre-existing on develop** (confirmed by stashing this change; they fail in ERPNext's Payment Entry `validate_transaction_reference`, untouched here).

## Not included (next PR)
The **GST "Missing Required Field: Select Billing Address"** error on submit (india_compliance) — the generated PI needs a company billing address to fetch the Company GSTIN. Deferred while india_compliance is being set up on dev to reproduce/verify; will also improve the submit toast to surface the real server message instead of a generic one.
