### PR TITLE
fix: advances misclassified as receipts/payments when fully consumed

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -129,10 +129,17 @@ def _linked_advances(doc):
 		is_advance = pe_name in table_pes
 		if not is_advance:
 			pe = frappe.db.get_value(
-				PE, pe_name, ["payment_type", "paid_amount", "unallocated_amount"], as_dict=True
+				PE,
+				pe_name,
+				["payment_type", "paid_amount", "unallocated_amount", "custom_is_bs_advance"],
+				as_dict=True,
 			)
-			is_advance = bool(pe) and _ref_is_advance(
-				pe.payment_type, pe.paid_amount, pe.unallocated_amount, total
+			# The durable flag (set when the advance was recorded / linked) is authoritative;
+			# fall back to the unallocated-leftover heuristic for legacy entries without it —
+			# without the flag a fully-consumed advance is indistinguishable from a receipt.
+			is_advance = bool(pe) and (
+				pe.custom_is_bs_advance
+				or _ref_is_advance(pe.payment_type, pe.paid_amount, pe.unallocated_amount, total)
 			)
 		if is_advance:
 			out.append({"payment_entry": pe_name, "allocated": total})
@@ -516,6 +523,7 @@ def record_advance(customer, amount, date=None, deposit_to=None, mode_of_payment
 	if reference_no:
 		pe.reference_no = reference_no
 		pe.reference_date = date or nowdate()
+	pe.custom_is_bs_advance = 1  # durable marker — a fully-consumed advance must never read as a receipt
 	pe.flags.ignore_permissions = True
 	pe.set_missing_values()
 	pe.insert()
@@ -632,6 +640,10 @@ def link_advance(name, payment_entry, amount):
 	pe = frappe.get_doc(PE, payment_entry)
 	if pe.docstatus != 1 or pe.payment_type != "Receive" or pe.party != si.customer:
 		frappe.throw(_("{0} is not an advance from this customer.").format(payment_entry))
+	# On-account advance being adjusted — flag it durably so it always reads as an advance
+	# (not a receipt), even once fully consumed, and to backfill entries made before this flag.
+	if not pe.get("custom_is_bs_advance"):
+		frappe.db.set_value(PE, payment_entry, "custom_is_bs_advance", 1, update_modified=False)
 	available = flt(pe.unallocated_amount)
 	if amount > available + 0.01:
 		frappe.throw(_("Only {0} is unadjusted on {1}.").format(available, payment_entry))

--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -129,10 +129,17 @@ def _linked_advances(doc):
 		is_advance = pe_name in table_pes
 		if not is_advance:
 			pe = frappe.db.get_value(
-				PE, pe_name, ["payment_type", "paid_amount", "unallocated_amount"], as_dict=True
+				PE,
+				pe_name,
+				["payment_type", "paid_amount", "unallocated_amount", "custom_is_bs_advance"],
+				as_dict=True,
 			)
-			is_advance = bool(pe) and _ref_is_advance(
-				pe.payment_type, pe.paid_amount, pe.unallocated_amount, total
+			# The durable flag (set when the advance was recorded / linked) is authoritative;
+			# fall back to the unallocated-leftover heuristic for legacy entries without it —
+			# without the flag a fully-consumed advance is indistinguishable from a receipt.
+			is_advance = bool(pe) and (
+				pe.custom_is_bs_advance
+				or _ref_is_advance(pe.payment_type, pe.paid_amount, pe.unallocated_amount, total)
 			)
 		if is_advance:
 			out.append({"payment_entry": pe_name, "allocated": total})
@@ -671,6 +678,7 @@ def record_advance(supplier, amount, date=None, pay_from=None, mode_of_payment=N
 	if reference_no:
 		pe.reference_no = reference_no
 		pe.reference_date = date or nowdate()
+	pe.custom_is_bs_advance = 1  # durable marker — a fully-consumed advance must never read as a payment
 	pe.flags.ignore_permissions = True
 	pe.set_missing_values()
 	pe.insert()
@@ -785,6 +793,10 @@ def link_advance(name, payment_entry, amount):
 	pe = frappe.get_doc(PE, payment_entry)
 	if pe.docstatus != 1 or pe.payment_type != "Pay" or pe.party != pi.supplier:
 		frappe.throw(_("{0} is not an advance to this supplier.").format(payment_entry))
+	# On-account advance being adjusted — flag it durably so it always reads as an advance
+	# (not a payment), even once fully consumed, and to backfill entries made before this flag.
+	if not pe.get("custom_is_bs_advance"):
+		frappe.db.set_value(PE, payment_entry, "custom_is_bs_advance", 1, update_modified=False)
 	available = flt(pe.unallocated_amount)
 	if amount > available + 0.01:
 		frappe.throw(_("Only {0} is unadjusted on {1}.").format(available, payment_entry))

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -1,4 +1,21 @@
 CUSTOM_FIELD = {
+	# Marks a Payment Entry as a BuildSuite on-account ADVANCE (from record_advance / linked
+	# via the bill's Advance Payments). A fully-consumed advance is otherwise indistinguishable
+	# from a plain receipt, so the classification (api.invoice / api.supplier_bill _linked_advances)
+	# reads this flag to keep advances out of the Payments/Receipts list.
+	"Payment Entry": [
+		{
+			"fieldname": "custom_is_bs_advance",
+			"fieldtype": "Check",
+			"label": "BuildSuite Advance",
+			"insert_after": "unallocated_amount",
+			"read_only": 1,
+			"hidden": 1,
+			"print_hide": 1,
+			"no_copy": 1,
+			"module": "BuildSuite Core",
+		},
+	],
 	"Project": [
 		{
 			"fieldname": "custom_project_id",


### PR DESCRIPTION
## The bug
A customer or supplier **advance fully applied** to an invoice/bill showed up under **Receipts / Payments** instead of **Advance Payments** (your screenshots: the advance appearing as a payment after the title).

The classifier (`_linked_advances` in both `api/invoice.py` and `api/supplier_bill.py`) distinguished an advance from a plain receipt **only by leftover unallocated money**. So a fully-consumed advance (unallocated = 0, paid == allocated) is byte-for-byte indistinguishable from a receipt → it leaked into the Payments/Receipts list. (Confirmed on bs.local: fully-consumed advance PEs classify as receipts.)

## The fix — everywhere it occurs
A durable **`custom_is_bs_advance`** flag on Payment Entry:
- **Set at creation** — both `record_advance` (customer in `invoice.py`, supplier/subcontractor in `supplier_bill.py`).
- **Set at link** — both `link_advance`, so on-account PEs made outside `record_advance` are covered, and pre-flag entries get **backfilled on re-link**.
- **Classification** now treats the flag as authoritative; the old unallocated heuristic stays only as a fallback for legacy entries.

This fixes both surfaces from one place: the **Sales Invoice** (customer) receipts vs advances, and the **Subcontractor / Supplier Bill** (supplier) payments vs advances.

## Verified
- Flagging a fully-consumed PE moves it **out of receipts and into Advance Payments** (direct check on real data).
- `test_invoice` **33/33 green**.
- `test_supplier_bill` / `test_subcontractor_bill` failures on this bench are **pre-existing / environmental** — india_compliance's HSN-code validation on Item creation (from installing the app) + the `make_payment_entry` reconciliation tests — confirmed by stashing this change.

## Notes
- The custom field is created on `after_migrate`, so existing sites pick it up on migrate. Legacy advances already **fully consumed** before this flag can't be auto-identified — **re-linking** them (or any new advance) sets the flag.
- Independent of the bill-detail PR (#191) which handles the Advance Payments section **position** (below totals, before attachments). Both touch `supplier_bill.py`, so whichever merges second needs a trivial merge.
