### PR TITLE
fix: System Manager keeps full access on BuildSuite-permissioned doctypes

### DIFF
--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -346,6 +346,22 @@ def _ensure_role(role_name):
 		).insert(ignore_permissions=True)
 
 
+def _grant_system_manager(doctype):
+	"""Re-grant System Manager full access on `doctype`.
+
+	System Manager is Frappe's native super-admin, but a doctype's *Custom* DocPerms COMPLETELY
+	override its standard perms — so the moment we add any BuildSuite Custom DocPerm, SM loses
+	its native grant unless we re-add it here. Give SM the full set (CRWD, plus submit/cancel/
+	amend on submittable doctypes), matching the M-series matrices where SM is full everywhere.
+	Idempotent — safe to call from every _apply/_upgrade pass over the same doctype."""
+	from frappe.permissions import add_permission, update_permission_property
+
+	ptypes = _SUBMIT_PTYPES if frappe.db.get_value("DocType", doctype, "is_submittable") else _PTYPES
+	add_permission(doctype, "System Manager", 0)
+	for ptype in ptypes:
+		update_permission_property(doctype, "System Manager", 0, ptype, 1, validate=False)
+
+
 def _apply_role_perms(doctype, role_perms, ptypes=_PTYPES):
 	if not frappe.db.exists("DocType", doctype):
 		return
@@ -356,6 +372,8 @@ def _apply_role_perms(doctype, role_perms, ptypes=_PTYPES):
 	# mirror), so removing a role from a matrix actually revokes its access.
 	for role in set(BUILDSUITE_ROLES) - set(role_perms):
 		frappe.db.delete("Custom DocPerm", {"parent": doctype, "role": role})
+
+	_grant_system_manager(doctype)
 
 	for role, perms in role_perms.items():
 		_ensure_role(role)
@@ -380,6 +398,7 @@ def _upgrade_role_perms(doctype, role_perms, ptypes=_PTYPES):
 		return
 	from frappe.permissions import add_permission, update_permission_property
 
+	_grant_system_manager(doctype)
 	for role, perms in role_perms.items():
 		_ensure_role(role)
 		add_permission(doctype, role, 0)

--- a/buildsuite_core/tests/test_permissions.py
+++ b/buildsuite_core/tests/test_permissions.py
@@ -303,6 +303,42 @@ class TestPermissions(BuildSuiteTestCase):
 		finally:
 			frappe.set_user("Administrator")
 
+	def test_system_manager_retains_full_access(self):
+		# A doctype's Custom DocPerms COMPLETELY override its standard perms, so adding any
+		# BuildSuite grant would strip System Manager (the native super-admin) unless it is
+		# re-granted. It must stay full — create + delete (+ submit on submittable doctypes) —
+		# on every doctype the matrices touch.
+		email = f"smtest-{self._n}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "SM",
+				"send_welcome_email": 0,
+				"user_type": "System User",
+				"roles": [{"role": "System Manager"}],
+			}
+		).insert(ignore_permissions=True)
+		frappe.set_user(email)
+		try:
+			for dt in (
+				"Customer",
+				"Supplier",
+				"Sales Invoice",
+				"Payment Entry",
+				"Subcontractor Work Order",
+				"Subcontractor Bill",
+				"Expense Entry",
+				"Employee",
+				"Crew",
+			):
+				self.assertTrue(frappe.has_permission(dt, "create"), dt)
+				self.assertTrue(frappe.has_permission(dt, "delete"), dt)
+			for dt in ("Sales Invoice", "Subcontractor Work Order", "Subcontractor Bill"):
+				self.assertTrue(frappe.has_permission(dt, "submit"), dt)
+		finally:
+			frappe.set_user("Administrator")
+
 	def test_rate_update_guard_rejects_non_governance(self):
 		# PERM-013 — the PO-submit rate-update endpoint rejects a non-governance role
 		# and accepts the empowered Procurement Officer.


### PR DESCRIPTION
## Context
The System Manager fix was authored on top of #190 but pushed **after** #190 had already merged, so its commit never made it into develop — this re-PRs it cleanly off develop.

## The fix
A doctype's Custom DocPerms **completely override** its standard perms, so once BuildSuite adds any grant, **System Manager (the native super-admin) loses access** unless re-granted — it had **no row** on Customer / Supplier / Sales Invoice / Payment Entry / Purchase Invoice / Employee, and an incomplete one on Subcontractor Work Order (no submit) and Expense Entry (no cancel/amend).

Adds `_grant_system_manager(doctype)` — called from both `_apply_role_perms` and `_upgrade_role_perms` — re-granting SM the full set (CRWD, plus submit/cancel/amend on submittable doctypes) on every doctype the matrices touch. Runs on `after_migrate`, so it's idempotent and self-healing. Clears **ISS-143 → ISS-153**.

## Verified
After re-running setup: System Manager is `RWCD` on the masters (Customer/Supplier/Employee/Crew/Machinery) and `RWCDSCA` on the submittables (Sales Invoice/Payment Entry/Expense Entry/Purchase Invoice/Subcontractor WO/Subcontractor Bill). +1 regression test (`test_system_manager_retains_full_access`); all permission tests green.
