### PR TITLE
feat: Equipment reports match the prototype (utilisation + register)

### DIFF
--- a/buildsuite_core/api/equipment.py
+++ b/buildsuite_core/api/equipment.py
@@ -18,10 +18,21 @@ def get_dashboard() -> dict:
 def _equipment_cost() -> float:
 	mu = frappe.qb.DocType("Machinery Usage")
 	# qty * rate + fuel, summed across all usage rows
-	row = (
-		frappe.qb.from_(mu).select(Sum(mu.quantity * mu.rate), Sum(mu.fuel_cost))
-	).run()[0]
+	row = (frappe.qb.from_(mu).select(Sum(mu.quantity * mu.rate), Sum(mu.fuel_cost))).run()[0]
 	return flt(row[0]) + flt(row[1])
+
+
+def _name_map(doctype, value_field, ids):
+	"""{docname: value_field} for the given ids, in one query. Resolved server-side so a caller
+	that can read Machinery Usage but not Machinery / Task still gets readable labels (the
+	client used to run a second list query that came back empty under such perms — ISS-142)."""
+	ids = [i for i in set(ids) if i]
+	if not ids:
+		return {}
+	return {
+		r.name: r.get(value_field)
+		for r in frappe.get_all(doctype, filters={"name": ["in", ids]}, fields=["name", value_field])
+	}
 
 
 def _recent_usage() -> list[dict]:
@@ -31,9 +42,53 @@ def _recent_usage() -> list[dict]:
 		order_by="date desc",
 		limit=6,
 	)
+	machine_names = _name_map("Machinery", "machinery_name", [r.machine for r in rows])
 	for r in rows:
+		r["machine_name"] = machine_names.get(r.machine) or r.machine
 		r["total"] = flt(r.quantity) * flt(r.rate) + flt(r.fuel_cost)
 	return rows
+
+
+@frappe.whitelist()
+def machinery_usage_report() -> list[dict]:
+	"""Machinery Utilisation report — every usage entry with its machine, project and task
+	resolved to readable names and the total cost (qty * rate + fuel) computed server-side, so
+	the report renders without any second lookup. Newest first."""
+	rows = frappe.get_list(
+		"Machinery Usage",
+		fields=["name", "machine", "project", "task", "date", "quantity", "unit", "rate", "fuel_cost"],
+		order_by="date desc",
+		limit_page_length=0,
+	)
+	machine_names = _name_map("Machinery", "machinery_name", [r.machine for r in rows])
+	project_names = _name_map("Project", "project_name", [r.project for r in rows])
+	task_subjects = _name_map("Task", "subject", [r.task for r in rows])
+	for r in rows:
+		r["machine_name"] = machine_names.get(r.machine) or r.machine
+		r["project_name"] = project_names.get(r.project) or r.project
+		r["task_subject"] = task_subjects.get(r.task) or r.task
+		r["total"] = flt(r.quantity) * flt(r.rate) + flt(r.fuel_cost)
+	return rows
+
+
+@frappe.whitelist()
+def machinery_register() -> list[dict]:
+	"""Equipment Register report — owned + hired plant with their rates. Ordered by name."""
+	return frappe.get_list(
+		"Machinery",
+		fields=[
+			"name",
+			"machinery_name",
+			"machinery_type",
+			"ownership",
+			"rate",
+			"rate_unit",
+			"owner_vendor",
+			"status",
+		],
+		order_by="machinery_name asc",
+		limit_page_length=0,
+	)
 
 
 def _register() -> list[dict]:

--- a/frontend/src/data/equipmentApi.js
+++ b/frontend/src/data/equipmentApi.js
@@ -12,3 +12,5 @@ async function call(method) {
 }
 
 export const getEquipmentDashboard = () => call("get_dashboard");
+export const getMachineryUsageReport = () => call("machinery_usage_report");
+export const getMachineryRegister = () => call("machinery_register");

--- a/frontend/src/views/MachineryListView.vue
+++ b/frontend/src/views/MachineryListView.vue
@@ -1,45 +1,63 @@
 <script setup>
-// Machinery register — Desk-styled list (Equipment workspace), mirrors the demo.
+// Machinery Register — the Equipment Register report (Equipment workspace). Owned + hired
+// plant with their rates, with the prototype's filter strip (type, ownership, status).
 
-import { computed, ref } from "vue";
+import { computed, onMounted, reactive, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
-import { useDocTypeList } from "@/composables/useDocTypeList";
-import { fmtINR } from "@/utils/format";
-import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
+
 import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import ReportFilters from "@/components/reports/ReportFilters.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { getMachineryRegister } from "@/data/equipmentApi";
+import { fmtINR } from "@/utils/format";
 
 const router = useRouter();
 
-const machRes = useDocTypeList("Machinery", {
-	fields: [
-		"name",
-		"machinery_name",
-		"machinery_type",
-		"ownership",
-		"rate",
-		"rate_unit",
-		"owner_vendor",
-		"status",
-	],
-	orderBy: "machinery_name asc",
-	pageLength: 0,
-	cache: "buildsuite-machinery-list",
-	transform: (data) => data.map((m) => ({ id: m.name, ...m })),
+const all = ref([]);
+const loading = ref(true);
+const error = ref("");
+
+onMounted(async () => {
+	try {
+		all.value = (await getMachineryRegister()) || [];
+	} catch (e) {
+		error.value = e.message || "Failed to load machinery.";
+	} finally {
+		loading.value = false;
+	}
 });
 
 const search = ref("");
+const BLANK = { type: "", ownership: "", status: "" };
+const f = reactive({ ...BLANK });
+const anyFilter = computed(
+	() => Object.keys(BLANK).some((k) => f[k] !== BLANK[k]) || !!search.value
+);
+function clearFilters() {
+	Object.assign(f, BLANK);
+	search.value = "";
+}
+const typeOptions = computed(() =>
+	[...new Set(all.value.map((m) => m.machinery_type).filter(Boolean))]
+		.map((v) => ({ value: v, label: v }))
+		.sort((a, b) => a.label.localeCompare(b.label))
+);
+
 const rows = computed(() => {
-	let data = machRes.data || [];
-	const q = search.value.trim().toLowerCase();
-	if (q)
-		data = data.filter(
-			(m) =>
-				(m.machinery_name || "").toLowerCase().includes(q) ||
-				(m.machinery_type || "").toLowerCase().includes(q),
-		);
-	return data;
+	const t = search.value.trim().toLowerCase();
+	return all.value.filter(
+		(m) =>
+			(!f.type || m.machinery_type === f.type) &&
+			(!f.ownership || m.ownership === f.ownership) &&
+			(!f.status || m.status === f.status) &&
+			(!t ||
+				(m.machinery_name || "").toLowerCase().includes(t) ||
+				(m.machinery_type || "").toLowerCase().includes(t))
+	);
 });
 
 const columns = [
@@ -58,7 +76,7 @@ const breadcrumbs = [
 ];
 
 function onRowClick(row) {
-	router.push(`/machinery/${row.id}`);
+	router.push(`/machinery/${row.name}`);
 }
 </script>
 
@@ -68,47 +86,93 @@ function onRowClick(row) {
 			<RouterLink to="/machinery/new" class="desk-save-btn">+ New</RouterLink>
 		</template>
 
-		<DeskList
-			v-model="search"
-			:rows="rows"
-			:columns="columns"
-			row-key="id"
-			search-placeholder="Search name, type…"
-			@row-click="onRowClick"
-		>
-			<template #cell-machinery_name="{ row }">
-				<DeskLink :to="`/machinery/${row.id}`" class="font-medium" @click.stop
-					>{{ row.machinery_name }}</DeskLink
-				>
-			</template>
-			<template #cell-machinery_type="{ row }">
-				<span
-					v-if="row.machinery_type"
-					class="text-[11px] px-1.5 py-0.5 bg-ink-100 text-ink-700 rounded"
-					>{{ row.machinery_type }}</span
-				>
-				<span v-else class="text-ink-300">—</span>
-			</template>
-			<template #cell-rate="{ row }">
-				<span class="tabular-nums text-ink-700"
-					>{{ row.rate ? fmtINR(row.rate) + "/" + (row.rate_unit || "—") : "—" }}</span
-				>
-			</template>
-			<template #cell-owner_vendor="{ row }">
-				<span class="text-ink-500">{{ row.owner_vendor || "—" }}</span>
-			</template>
-			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" />
-			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{ machRes.loading ? "Loading machinery…" : "No machinery yet." }}
-					<RouterLink v-if="!machRes.loading" to="/machinery/new" class="desk-link"
-						>Add one →</RouterLink
+		<div v-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
+		<template v-else>
+			<ReportFilters
+				:active="anyFilter"
+				:shown="rows.length"
+				:total="all.length"
+				noun="machines"
+				@clear="clearFilters"
+			>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Type</span
 					>
-				</div>
-			</template>
-		</DeskList>
+					<span class="w-44 inline-block">
+						<DeskSearchableSelect
+							v-model="f.type"
+							:options="typeOptions"
+							allow-clear
+							placeholder="All types"
+							search-placeholder="Search…"
+						/>
+					</span>
+				</label>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Ownership</span
+					>
+					<DeskSelect v-model="f.ownership" class="!w-36">
+						<option value="">Any</option>
+						<option value="Owned">Owned</option>
+						<option value="Hired">Hired</option>
+					</DeskSelect>
+				</label>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Status</span
+					>
+					<DeskSelect v-model="f.status" class="!w-36">
+						<option value="">Any</option>
+						<option value="Active">Active</option>
+						<option value="Inactive">Inactive</option>
+					</DeskSelect>
+				</label>
+			</ReportFilters>
+
+			<DeskList
+				v-model="search"
+				:rows="rows"
+				:columns="columns"
+				row-key="name"
+				search-placeholder="Search machinery…"
+				@row-click="onRowClick"
+			>
+				<template #cell-machinery_name="{ row }">
+					<DeskLink :to="`/machinery/${row.name}`" class="font-medium" @click.stop>{{
+						row.machinery_name
+					}}</DeskLink>
+				</template>
+				<template #cell-machinery_type="{ row }">
+					<span
+						v-if="row.machinery_type"
+						class="text-[11px] px-1.5 py-0.5 bg-ink-100 text-ink-700 rounded"
+						>{{ row.machinery_type }}</span
+					>
+					<span v-else class="text-ink-300">—</span>
+				</template>
+				<template #cell-rate="{ row }">
+					<span class="tabular-nums text-ink-700">{{
+						row.rate ? fmtINR(row.rate) + "/" + (row.rate_unit || "—") : "—"
+					}}</span>
+				</template>
+				<template #cell-owner_vendor="{ row }">
+					<span class="text-ink-500">{{ row.owner_vendor || "—" }}</span>
+				</template>
+				<template #cell-status="{ row }">
+					<StatusBadge :status="row.status" />
+				</template>
+
+				<template #empty>
+					<div class="text-sm text-ink-500">
+						{{ loading ? "Loading machinery…" : "No machinery yet." }}
+						<RouterLink v-if="!loading" to="/machinery/new" class="desk-link"
+							>Add one →</RouterLink
+						>
+					</div>
+				</template>
+			</DeskList>
+		</template>
 	</DeskPage>
 </template>

--- a/frontend/src/views/MachineryUsageListView.vue
+++ b/frontend/src/views/MachineryUsageListView.vue
@@ -1,78 +1,78 @@
 <script setup>
-// Machinery Usage log — Desk-styled list (Equipment workspace), mirrors the demo.
+// Machinery Usage Log — the Machinery Utilisation report (Equipment workspace). Plant usage +
+// cost by machine / project / task, with the prototype's filter strip (machine, project,
+// period). Rows come resolved from the server (machine / project / task names + total cost) so
+// nothing is looked up a second time on the client — see ISS-142.
 
-import { computed, ref } from "vue";
+import { computed, onMounted, reactive, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
-import { useDocTypeList } from "@/composables/useDocTypeList";
-import { useProjectNames } from "@/composables/useProjectNames";
-import { fmtINR, fmtDate } from "@/utils/format";
-import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
+
+import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskList from "@/components/desk/DeskList.vue";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import ReportFilters from "@/components/reports/ReportFilters.vue";
+import { getMachineryUsageReport } from "@/data/equipmentApi";
+import { fmtDate, fmtINR } from "@/utils/format";
 
 const router = useRouter();
-const { projectName } = useProjectNames();
 
-const usageRes = useDocTypeList("Machinery Usage", {
-	fields: [
-		"name",
-		"machine",
-		"project",
-		"task",
-		"date",
-		"quantity",
-		"unit",
-		"rate",
-		"fuel_cost",
-	],
-	orderBy: "date desc",
-	pageLength: 0,
-	cache: "buildsuite-machinery-usage-list",
-	transform: (data) => data.map((u) => ({ id: u.name, ...u })),
-});
+const all = ref([]);
+const loading = ref(true);
+const error = ref("");
 
-// The usage log stores machine + task ids; resolve them to readable names for display.
-const machineryRes = useDocTypeList("Machinery", {
-	fields: ["name", "machinery_name"],
-	pageLength: 0,
-	cache: "buildsuite-machinery-names",
+onMounted(async () => {
+	try {
+		all.value = (await getMachineryUsageReport()) || [];
+	} catch (e) {
+		error.value = e.message || "Failed to load the usage log.";
+	} finally {
+		loading.value = false;
+	}
 });
-const machineNameById = computed(() => {
-	const map = {};
-	for (const m of machineryRes.data || []) map[m.name] = m.machinery_name;
-	return map;
-});
-const machineName = (id) => machineNameById.value[id] || id;
-
-const taskRes = useDocTypeList("Task", {
-	fields: ["name", "subject"],
-	pageLength: 0,
-	cache: "buildsuite-task-subjects",
-});
-const taskSubjectById = computed(() => {
-	const map = {};
-	for (const t of taskRes.data || []) map[t.name] = t.subject;
-	return map;
-});
-const taskSubject = (id) => taskSubjectById.value[id] || id;
-
-function totalFor(row) {
-	return (Number(row.quantity) || 0) * (Number(row.rate) || 0) + (Number(row.fuel_cost) || 0);
-}
 
 const search = ref("");
+const BLANK = { machine: "", project: "", from: "", to: "" };
+const f = reactive({ ...BLANK });
+const anyFilter = computed(
+	() => Object.keys(BLANK).some((k) => f[k] !== BLANK[k]) || !!search.value
+);
+function clearFilters() {
+	Object.assign(f, BLANK);
+	search.value = "";
+}
+
+// Machine + project pickers are built from the entries themselves, so no option offers a value
+// with nothing behind it.
+const machineOptions = computed(() => {
+	const m = new Map();
+	for (const u of all.value) if (u.machine) m.set(u.machine, u.machine_name || u.machine);
+	return [...m.entries()]
+		.map(([value, label]) => ({ value, label }))
+		.sort((a, b) => a.label.localeCompare(b.label));
+});
+const projectOptions = computed(() => {
+	const m = new Map();
+	for (const u of all.value) if (u.project) m.set(u.project, u.project_name || u.project);
+	return [...m.entries()]
+		.map(([value, label]) => ({ value, label }))
+		.sort((a, b) => a.label.localeCompare(b.label));
+});
+
 const rows = computed(() => {
-	let data = usageRes.data || [];
-	const q = search.value.trim().toLowerCase();
-	if (q)
-		data = data.filter(
-			(u) =>
-				machineName(u.machine).toLowerCase().includes(q) ||
-				taskSubject(u.task).toLowerCase().includes(q) ||
-				(u.project || "").toLowerCase().includes(q) ||
-				projectName(u.project).toLowerCase().includes(q)
-		);
-	return data;
+	const t = search.value.trim().toLowerCase();
+	return all.value.filter(
+		(u) =>
+			(!f.machine || u.machine === f.machine) &&
+			(!f.project || u.project === f.project) &&
+			(!f.from || (u.date || "") >= f.from) &&
+			(!f.to || (u.date || "") <= f.to) &&
+			(!t ||
+				(u.machine_name || "").toLowerCase().includes(t) ||
+				(u.project_name || "").toLowerCase().includes(t) ||
+				(u.task_subject || "").toLowerCase().includes(t))
+	);
 });
 
 const columns = [
@@ -81,7 +81,7 @@ const columns = [
 	{ key: "project", label: "Project" },
 	{ key: "task", label: "Task" },
 	{ key: "quantity", label: "Qty", align: "right" },
-	{ key: "total", label: "Total", align: "right" },
+	{ key: "total", label: "Total cost", align: "right" },
 ];
 
 const breadcrumbs = [
@@ -91,7 +91,7 @@ const breadcrumbs = [
 ];
 
 function onRowClick(row) {
-	router.push(`/machinery-usage/${row.id}`);
+	router.push(`/machinery-usage/${row.name}`);
 }
 </script>
 
@@ -101,48 +101,93 @@ function onRowClick(row) {
 			<RouterLink to="/machinery-usage/new" class="desk-save-btn">+ Log usage</RouterLink>
 		</template>
 
-		<DeskList
-			v-model="search"
-			:rows="rows"
-			:columns="columns"
-			row-key="id"
-			search-placeholder="Search machine, project…"
-			@row-click="onRowClick"
-		>
-			<template #cell-machine="{ row }">
-				<DeskLink :to="`/machinery/${row.machine}`" @click.stop>{{
-					machineName(row.machine)
-				}}</DeskLink>
-			</template>
-			<template #cell-project="{ row }">
-				<span class="text-ink-700">{{ projectName(row.project) || "—" }}</span>
-			</template>
-			<template #cell-task="{ row }">
-				<span class="text-ink-500">{{ row.task ? taskSubject(row.task) : "—" }}</span>
-			</template>
-			<template #cell-date="{ row }">
-				<span class="text-ink-500">{{ fmtDate(row.date) }}</span>
-			</template>
-			<template #cell-quantity="{ row }">
-				<span class="tabular-nums">{{ row.quantity }} {{ row.unit }}</span>
-			</template>
-			<template #cell-total="{ row }">
-				<span class="tabular-nums text-ink-900 font-medium">{{
-					fmtINR(totalFor(row))
-				}}</span>
-			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{ usageRes.loading ? "Loading usage log…" : "No usage logged yet." }}
-					<RouterLink
-						v-if="!usageRes.loading"
-						to="/machinery-usage/new"
-						class="desk-link"
-						>Log usage →</RouterLink
+		<div v-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
+		<template v-else>
+			<ReportFilters
+				:active="anyFilter"
+				:shown="rows.length"
+				:total="all.length"
+				noun="entries"
+				@clear="clearFilters"
+			>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Machine</span
 					>
-				</div>
-			</template>
-		</DeskList>
+					<span class="w-48 inline-block">
+						<DeskSearchableSelect
+							v-model="f.machine"
+							:options="machineOptions"
+							allow-clear
+							placeholder="All machines"
+							search-placeholder="Search…"
+						/>
+					</span>
+				</label>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Project</span
+					>
+					<span class="w-52 inline-block">
+						<DeskSearchableSelect
+							v-model="f.project"
+							:options="projectOptions"
+							allow-clear
+							placeholder="All projects"
+							search-placeholder="Search…"
+						/>
+					</span>
+				</label>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Used</span
+					>
+					<DeskInput v-model="f.from" type="date" class="!w-36" />
+					<span class="text-[11px] text-ink-400">to</span>
+					<DeskInput v-model="f.to" type="date" class="!w-36" />
+				</label>
+			</ReportFilters>
+
+			<DeskList
+				v-model="search"
+				:rows="rows"
+				:columns="columns"
+				row-key="name"
+				search-placeholder="Search usage…"
+				@row-click="onRowClick"
+			>
+				<template #cell-date="{ row }">
+					<span class="text-ink-500">{{ fmtDate(row.date) }}</span>
+				</template>
+				<template #cell-machine="{ row }">
+					<DeskLink :to="`/machinery/${row.machine}`" @click.stop>{{
+						row.machine_name
+					}}</DeskLink>
+				</template>
+				<template #cell-project="{ row }">
+					<span class="text-ink-700">{{ row.project_name || "—" }}</span>
+				</template>
+				<template #cell-task="{ row }">
+					<span class="text-ink-500">{{ row.task ? row.task_subject : "—" }}</span>
+				</template>
+				<template #cell-quantity="{ row }">
+					<span class="tabular-nums">{{ row.quantity }} {{ row.unit }}</span>
+				</template>
+				<template #cell-total="{ row }">
+					<span class="tabular-nums text-ink-900 font-medium">{{
+						fmtINR(row.total)
+					}}</span>
+				</template>
+
+				<template #empty>
+					<div class="text-sm text-ink-500">
+						{{ loading ? "Loading usage log…" : "No usage logged yet." }}
+						<RouterLink v-if="!loading" to="/machinery-usage/new" class="desk-link"
+							>Log usage →</RouterLink
+						>
+					</div>
+				</template>
+			</DeskList>
+		</template>
 	</DeskPage>
 </template>

--- a/frontend/src/views/workspaces/EquipmentDashboardView.vue
+++ b/frontend/src/views/workspaces/EquipmentDashboardView.vue
@@ -138,7 +138,7 @@ const register = computed(() => kpis.value?.register || []);
 							>
 								<div class="flex items-center justify-between">
 									<span class="text-sm text-ink-900 font-medium">{{
-										u.machine
+										u.machine_name || u.machine
 									}}</span>
 									<span class="text-sm text-ink-900 tabular-nums">{{
 										fmtCompactINR(u.total)

--- a/frontend/src/views/workspaces/EquipmentWorkspace.vue
+++ b/frontend/src/views/workspaces/EquipmentWorkspace.vue
@@ -1,7 +1,7 @@
 <script setup>
-// Equipment (plant & machinery) workspace landing — mirrors the demo. The
-// Machinery / Machinery Usage shortcuts and the Equipment Dashboard tile navigate;
-// the report tiles are static stubs (not wired in the Frappe app yet).
+// Equipment (plant & machinery) workspace landing — mirrors the demo. The Machinery /
+// Machinery Usage shortcuts and the Equipment Dashboard tile navigate; the two report tiles
+// open the Machinery Utilisation (usage log) and Equipment Register (machinery) reports.
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
@@ -17,6 +17,8 @@ const shortcuts = [
 	{ label: "Machinery Usage", icon: "clipboard-list", to: "/machinery-usage" },
 ];
 
+// Fuel & running cost was dropped (prototype S314): fuel is captured per usage entry and
+// already carried in the utilisation total, so a separate report would only re-slice one column.
 const reports = [
 	{
 		label: "Machinery utilisation",
@@ -29,12 +31,6 @@ const reports = [
 		icon: "wrench",
 		description: "Owned + hired plant with rates.",
 		to: "/machinery",
-	},
-	{
-		label: "Fuel & running cost",
-		icon: "chart-line",
-		description: "Fuel logged against usage entries.",
-		prevent: true,
 	},
 ];
 </script>
@@ -70,7 +66,9 @@ const reports = [
 					</div>
 					<div class="flex-1 min-w-0">
 						<div class="flex items-center gap-2">
-							<div class="text-base font-semibold text-ink-900 group-hover:text-brand-700 transition-colors">
+							<div
+								class="text-base font-semibold text-ink-900 group-hover:text-brand-700 transition-colors"
+							>
 								Equipment Dashboard
 							</div>
 							<span
@@ -83,7 +81,11 @@ const reports = [
 							Plant register, utilisation and equipment cost at a glance.
 						</div>
 					</div>
-					<div class="text-brand-400 group-hover:text-brand-600 transition-colors text-xl">→</div>
+					<div
+						class="text-brand-400 group-hover:text-brand-600 transition-colors text-xl"
+					>
+						→
+					</div>
 				</div>
 			</RouterLink>
 


### PR DESCRIPTION
Brings the two Equipment workspace reports in line with the prototype and fixes ISS-142 (machine name not displaying) at its source. Split out of PR #194 (which merged the finance reports).

## What changed
- **Machinery Utilisation** (usage log): adds the prototype's filter strip — Machine, Project and a Used from/to period.
- **Equipment Register** (machinery): adds the prototype's Type / Ownership / Status filters.
- Both reports read fully-resolved rows from new server endpoints `api.equipment.machinery_usage_report` / `machinery_register` — machine, project and task names + total cost resolved server-side in one query.
- **ISS-142 fix**: the usage list used to run a second client query for machine names that came back empty for a persona without Machinery read access, leaving the raw docname on screen. The same `_name_map` fix also corrects recent-usage on the Equipment Dashboard.
- Drops the dead "Fuel & running cost" tile (prototype S314) — fuel is captured per usage entry and already carried in the utilisation total.

## Verification
- Backend on bs.local: machine/project/task names + totals resolve correctly.
- `yarn build` and `pre-commit` pass.