### PR TITLE
feat: six bespoke Procurement reports (replace borrowed ERPNext report links)

### DIFF
--- a/buildsuite_core/api/procurement_report.py
+++ b/buildsuite_core/api/procurement_report.py
@@ -1,0 +1,344 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Real-data backends for the six bespoke Procurement report views. These answer the
+procurement questions a construction contractor actually asks — what site has requested that
+is not yet ordered, which deliveries are late, what is on the ground, whether purchase prices
+track the QS estimate, the full purchase register, and where material was issued — computed
+from the live records (Material Request / Purchase Order / Purchase Receipt / Material Issue /
+Construction Rate Master), so every figure comes from a document.
+
+One whitelisted endpoint per report. Each takes an optional `project` that narrows the report
+to that project and its direct sub-projects; without it the report runs portfolio-wide. The
+Vue view applies the lighter, in-reading filters (search, supplier, status, dates, the
+one-click narrowings) over the rows returned here."""
+
+import frappe
+from frappe.utils import flt
+
+from buildsuite_core.api.material_consumption import get_warehouse_from_project
+
+
+def _scoped_projects(project):
+	"""The project plus its direct sub-projects, or None for portfolio-wide — the same rollup
+	rule the rest of the app follows for a parent project."""
+	if not project or not isinstance(project, str):
+		return None
+	ids = {project}
+	for child in frappe.get_all("Project", filters={"parent_project": project}, pluck="name"):
+		ids.add(child)
+	return ids
+
+
+def _project_names(ids):
+	"""{project: project_name} for the given ids, in one query."""
+	ids = [i for i in set(ids) if i]
+	if not ids:
+		return {}
+	return {
+		p.name: p.project_name
+		for p in frappe.get_all("Project", filters={"name": ["in", ids]}, fields=["name", "project_name"])
+	}
+
+
+def _item_meta(item_codes):
+	"""{item_code: {item_name, uom, standard_rate}} for the given items, in one query."""
+	item_codes = [i for i in set(item_codes) if i]
+	if not item_codes:
+		return {}
+	return {
+		it.name: {"item_name": it.item_name, "uom": it.stock_uom, "standard_rate": flt(it.standard_rate)}
+		for it in frappe.get_all(
+			"Item",
+			filters={"name": ["in", item_codes]},
+			fields=["name", "item_name", "stock_uom", "standard_rate"],
+		)
+	}
+
+
+@frappe.whitelist()
+def requests_to_order(project=None):
+	"""Requests waiting to be ordered — submitted Purchase Material Requests not fully ordered
+	(the gap between the request book and the order book). Value is the still-to-order portion,
+	item count and dates let the view flag age and lateness."""
+	scope = _scoped_projects(project)
+	filters = {"docstatus": 1, "material_request_type": "Purchase", "per_ordered": ["<", 100]}
+	if scope is not None:
+		filters["project"] = ["in", list(scope)]
+	mrs = frappe.get_all(
+		"Material Request",
+		filters=filters,
+		fields=["name", "project", "transaction_date", "schedule_date", "status", "per_ordered"],
+		order_by="schedule_date asc",
+	)
+	rollup = _item_rollup("Material Request Item", [m.name for m in mrs])
+	names = _project_names([m.project for m in mrs])
+	rows = []
+	for m in mrs:
+		agg = rollup.get(m.name, {"count": 0, "value": 0.0})
+		rows.append(
+			{
+				"name": m.name,
+				"project": m.project,
+				"project_name": names.get(m.project) or m.project,
+				"request_date": str(m.transaction_date) if m.transaction_date else None,
+				"required_by": str(m.schedule_date) if m.schedule_date else None,
+				"item_count": agg["count"],
+				"value": agg["value"],
+				"status": m.status,
+			}
+		)
+	return rows
+
+
+def _item_rollup(child_doctype, parents):
+	"""{parent: {count, value}} — line count and still-to-order value (qty - ordered_qty) * rate
+	across each request's items."""
+	if not parents:
+		return {}
+	rows = frappe.db.sql(
+		f"""SELECT parent, COUNT(*) AS cnt, IFNULL(SUM((qty - IFNULL(ordered_qty, 0)) * rate), 0) AS val
+		FROM `tab{child_doctype}` WHERE parent IN %s GROUP BY parent""",
+		(tuple(parents),),
+		as_dict=True,
+	)
+	return {r.parent: {"count": r.cnt, "value": flt(r.val)} for r in rows}
+
+
+@frappe.whitelist()
+def delivery_followup(project=None):
+	"""Delivery follow-up — submitted Purchase Orders not fully received, with how much has
+	landed (per_received) and the value still due. The view sorts the chase list and flags the
+	overdue ones off `required_by`."""
+	scope = _scoped_projects(project)
+	filters = {"docstatus": 1, "per_received": ["<", 100]}
+	if scope is not None:
+		filters["project"] = ["in", list(scope)]
+	pos = frappe.get_all(
+		"Purchase Order",
+		filters=filters,
+		fields=[
+			"name",
+			"supplier",
+			"supplier_name",
+			"project",
+			"schedule_date",
+			"per_received",
+			"grand_total",
+		],
+		order_by="schedule_date asc",
+	)
+	names = _project_names([p.project for p in pos])
+	rows = []
+	for p in pos:
+		pct = flt(p.per_received)
+		rows.append(
+			{
+				"name": p.name,
+				"supplier": p.supplier_name or p.supplier,
+				"project": p.project,
+				"project_name": names.get(p.project) or p.project,
+				"required_by": str(p.schedule_date) if p.schedule_date else None,
+				"pct": round(pct),
+				"pending_value": round(flt(p.grand_total) * (100 - pct) / 100),
+			}
+		)
+	return rows
+
+
+@frappe.whitelist()
+def site_stock(project=None):
+	"""Material at site — received minus consumed, per item, at each project store. Received
+	counts posted Purchase Receipts; consumed counts posted Material Issues. A cancelled
+	receipt never entered stock."""
+	scope = _scoped_projects(project)
+
+	def _scoped(sql, alias):
+		if scope is None:
+			return sql, ()
+		return sql + f" AND {alias}.project IN %s", (tuple(scope),)
+
+	recv_sql, recv_params = _scoped(
+		"""SELECT pr.project AS project, pri.item_code AS item_code, IFNULL(SUM(pri.received_qty), 0) AS qty
+		FROM `tabPurchase Receipt Item` pri JOIN `tabPurchase Receipt` pr ON pr.name = pri.parent
+		WHERE pr.docstatus = 1""",
+		"pr",
+	)
+	received = frappe.db.sql(recv_sql + " GROUP BY pr.project, pri.item_code", recv_params, as_dict=True)
+
+	cons_sql, cons_params = _scoped(
+		"""SELECT se.project AS project, sed.item_code AS item_code, IFNULL(SUM(sed.qty), 0) AS qty
+		FROM `tabStock Entry Detail` sed JOIN `tabStock Entry` se ON se.name = sed.parent
+		WHERE se.docstatus = 1 AND se.stock_entry_type = 'Material Issue'""",
+		"se",
+	)
+	consumed = frappe.db.sql(cons_sql + " GROUP BY se.project, sed.item_code", cons_params, as_dict=True)
+
+	merged = {}
+	for r in received:
+		merged.setdefault((r.project, r.item_code), {"received": 0.0, "consumed": 0.0})["received"] += flt(
+			r.qty
+		)
+	for r in consumed:
+		merged.setdefault((r.project, r.item_code), {"received": 0.0, "consumed": 0.0})["consumed"] += flt(
+			r.qty
+		)
+
+	names = _project_names([k[0] for k in merged])
+	meta = _item_meta([k[1] for k in merged])
+	rows = []
+	for (proj, item_code), v in merged.items():
+		info = meta.get(item_code, {})
+		rows.append(
+			{
+				"project": proj,
+				"project_name": names.get(proj) or proj or "No project store",
+				"item": info.get("item_name") or item_code,
+				"received": flt(v["received"]),
+				"consumed": flt(v["consumed"]),
+				"available": flt(v["received"] - v["consumed"]),
+				"uom": info.get("uom") or "",
+			}
+		)
+	return rows
+
+
+@frappe.whitelist()
+def rate_check(project=None):
+	"""Purchase rate vs estimate — the latest order line per item that carries a Rate Master
+	code, against the Rate Master's current QS rate. Lines without a code are counted as
+	`unlinked` rather than silently dropped."""
+	scope = _scoped_projects(project)
+	where = "po.docstatus = 1"
+	params = []
+	if scope is not None:
+		where += " AND po.project IN %s"
+		params.append(tuple(scope))
+	lines = frappe.db.sql(
+		f"""SELECT poi.item_code, poi.item_name, poi.uom, poi.rate, poi.custom_rate_master AS code,
+			po.supplier_name AS supplier, po.supplier AS supplier_id, po.name AS po, po.transaction_date AS order_date
+		FROM `tabPurchase Order Item` poi JOIN `tabPurchase Order` po ON po.name = poi.parent
+		WHERE {where}""",
+		tuple(params),
+		as_dict=True,
+	)
+	latest = {}
+	unlinked = 0
+	for ln in lines:
+		if not ln.code:
+			unlinked += 1
+			continue
+		prev = latest.get(ln.item_code)
+		if not prev or (str(ln.order_date) or "") > (str(prev["order_date"]) or ""):
+			latest[ln.item_code] = ln
+
+	# Current QS rate + unit from the Rate Master, resolved once for the codes in play.
+	codes = list({ln.code for ln in latest.values()})
+	rm = {}
+	if codes:
+		rm = {
+			r.name: r
+			for r in frappe.get_all(
+				"Construction Rate Master",
+				filters={"name": ["in", codes]},
+				fields=["name", "rate_code", "current_rate", "uom"],
+			)
+		}
+	rows = []
+	for ln in latest.values():
+		master = rm.get(ln.code)
+		est = flt(master.current_rate) if master else 0.0
+		rows.append(
+			{
+				"item": ln.item_name or ln.item_code,
+				"code": master.rate_code if master else ln.code,
+				"rate": flt(ln.rate),
+				"estimate": est,
+				"unit": (master.uom if master else None) or ln.uom,
+				"supplier": ln.supplier or ln.supplier_id,
+				"po": ln.po,
+				"order_date": str(ln.order_date) if ln.order_date else None,
+				"variance": ((flt(ln.rate) - est) / est * 100) if est else None,
+			}
+		)
+	rows.sort(key=lambda r: (r["variance"] if r["variance"] is not None else -999), reverse=True)
+	return {"rows": rows, "unlinked": unlinked}
+
+
+@frappe.whitelist()
+def purchase_register(project=None):
+	"""Purchase register — every purchase order line (order not cancelled): date, order,
+	supplier, item, quantity, rate and amount, so last-paid is one search away."""
+	scope = _scoped_projects(project)
+	where = "po.docstatus < 2"
+	params = []
+	if scope is not None:
+		where += " AND po.project IN %s"
+		params.append(tuple(scope))
+	lines = frappe.db.sql(
+		f"""SELECT po.name AS po, po.transaction_date AS date, po.supplier_name AS supplier,
+			po.supplier AS supplier_id, po.project AS project, poi.item_code, poi.item_name,
+			poi.qty, poi.uom, poi.rate, poi.amount
+		FROM `tabPurchase Order Item` poi JOIN `tabPurchase Order` po ON po.name = poi.parent
+		WHERE {where}
+		ORDER BY po.transaction_date DESC, po.name DESC""",
+		tuple(params),
+		as_dict=True,
+	)
+	names = _project_names([ln.project for ln in lines])
+	return [
+		{
+			"po": ln.po,
+			"date": str(ln.date) if ln.date else None,
+			"supplier": ln.supplier or ln.supplier_id,
+			"project": ln.project,
+			"project_name": names.get(ln.project) or ln.project,
+			"item": ln.item_name or ln.item_code,
+			"qty": flt(ln.qty),
+			"uom": ln.uom,
+			"rate": flt(ln.rate),
+			"amount": flt(ln.amount) or flt(ln.qty) * flt(ln.rate),
+		}
+		for ln in lines
+	]
+
+
+@frappe.whitelist()
+def consumption_by_cost_code(project=None):
+	"""Consumption by cost code — material issued to site (posted Material Issues), one row per
+	issue line with the cost code it was booked against, its date, and a value at the item
+	master's standard rate (a list price, not the actual issue cost — issue valuation needs
+	stock rates, which aren't modelled). The view date-filters then groups by cost code + item."""
+	scope = _scoped_projects(project)
+	where = "se.docstatus = 1 AND se.stock_entry_type = 'Material Issue'"
+	params = []
+	if scope is not None:
+		where += " AND se.project IN %s"
+		params.append(tuple(scope))
+	lines = frappe.db.sql(
+		f"""SELECT se.project AS project, se.posting_date AS date, se.custom_cost_code_label AS code,
+			sed.item_code, sed.item_name, sed.qty, sed.uom
+		FROM `tabStock Entry Detail` sed JOIN `tabStock Entry` se ON se.name = sed.parent
+		WHERE {where}""",
+		tuple(params),
+		as_dict=True,
+	)
+	meta = _item_meta([ln.item_code for ln in lines])
+	names = _project_names([ln.project for ln in lines])
+	rows = []
+	for ln in lines:
+		info = meta.get(ln.item_code, {})
+		qty = flt(ln.qty)
+		rows.append(
+			{
+				"project": ln.project,
+				"project_name": names.get(ln.project) or ln.project,
+				"date": str(ln.date) if ln.date else None,
+				"code": ln.code or "Not coded",
+				"item": ln.item_name or info.get("item_name") or ln.item_code,
+				"uom": ln.uom or info.get("uom") or "",
+				"qty": qty,
+				"value": qty * info.get("standard_rate", 0.0),
+			}
+		)
+	return rows

--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
@@ -58,22 +58,40 @@ _SEED = {
 	),
 	"procurement": (
 		{
-			"label": "Stock Balance",
-			"icon": "chart-bar",
-			"route": "/app/query-report/Stock Balance",
-			"description": "Item-wise on-hand quantity across warehouses.",
-		},
-		{
-			"label": "Stock Ledger",
-			"icon": "file-text",
-			"route": "/app/query-report/Stock Ledger",
-			"description": "Every stock movement — receipts, issues, transfers.",
-		},
-		{
-			"label": "Item-wise Purchase Register",
+			"label": "Requests waiting to be ordered",
 			"icon": "clipboard-list",
-			"route": "/app/query-report/Item-wise Purchase Register",
-			"description": "POs and GRNs grouped by item, with value rollups.",
+			"route": "/procurement/report/requests-to-order",
+			"description": "Asked for by site, not yet on an order.",
+		},
+		{
+			"label": "Delivery follow-up",
+			"icon": "chart-line",
+			"route": "/procurement/report/delivery-followup",
+			"description": "Open orders by the date they were needed, and what is late.",
+		},
+		{
+			"label": "Material at site",
+			"icon": "package",
+			"route": "/procurement/report/site-stock",
+			"description": "Received minus consumed, per item, at each project store.",
+		},
+		{
+			"label": "Purchase rate vs estimate",
+			"icon": "chart-bar",
+			"route": "/procurement/report/rate-check",
+			"description": "What you are paying against the QS rate in the Rate Master.",
+		},
+		{
+			"label": "Purchase register",
+			"icon": "file-text",
+			"route": "/procurement/report/purchase-register",
+			"description": "Every order line — supplier, item, quantity, rate.",
+		},
+		{
+			"label": "Consumption by cost code",
+			"icon": "hard-hat",
+			"route": "/procurement/report/consumption-by-cost-code",
+			"description": "Material issued to site, against the cost code it was booked to.",
 		},
 	),
 }

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -30,3 +30,4 @@ buildsuite_core.patches.reseed_subcontract_reports # 2026-08-18
 buildsuite_core.patches.reseed_project_finance_reports # 2026-08-18
 buildsuite_core.patches.reseed_project_finance_bespoke # 2026-08-20
 buildsuite_core.patches.reseed_project_finance_bespoke_views # 2026-08-20
+buildsuite_core.patches.reseed_procurement_bespoke_reports # 2026-08-20

--- a/buildsuite_core/patches/reseed_procurement_bespoke_reports.py
+++ b/buildsuite_core/patches/reseed_procurement_bespoke_reports.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Procurement reports, take two. The three borrowed ERPNext report links (Stock Balance /
+Stock Ledger / Item-wise Purchase Register) are replaced by six bespoke in-app Vue reports
+computed from live records (api.procurement_report): requests-to-order, delivery-followup,
+site-stock, rate-check, purchase-register, consumption-by-cost-code. This repoints the
+Procurement workspace tiles on sites seeded before the change."""
+
+import frappe
+
+from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import _SEED
+
+
+def execute():
+	# Repoint only the procurement tiles; leave the other workspaces' rows untouched.
+	settings = frappe.get_single("Workspace Setting")
+	kept = [
+		{
+			"workspace": r.workspace,
+			"label": r.label,
+			"report": r.report,
+			"route": r.route,
+			"icon": r.icon,
+			"description": r.description,
+		}
+		for r in settings.reports
+		if r.workspace != "procurement"
+	]
+	settings.set("reports", [])
+	for row in kept:
+		settings.append("reports", row)
+	for row in _SEED["procurement"]:
+		settings.append("reports", {"workspace": "procurement", **row})
+	settings.flags.ignore_permissions = True
+	settings.save()

--- a/frontend/src/data/procurementReportApi.js
+++ b/frontend/src/data/procurementReportApi.js
@@ -1,0 +1,34 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Real-data backends for the six bespoke Procurement report views
+// (buildsuite_core.api.procurement_report.*). Each takes an optional `project` that narrows the
+// report to that project and its direct sub-projects; without it the report runs portfolio-wide.
+async function call(method, project) {
+	try {
+		return await frappeRequest({
+			url: `buildsuite_core.api.procurement_report.${method}`,
+			params: project ? { project } : {},
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+export const getRequestsToOrder = (project) => call("requests_to_order", project);
+export const getDeliveryFollowup = (project) => call("delivery_followup", project);
+export const getSiteStock = (project) => call("site_stock", project);
+export const getRateCheck = (project) => call("rate_check", project);
+export const getPurchaseRegister = (project) => call("purchase_register", project);
+export const getConsumptionByCostCode = (project) => call("consumption_by_cost_code", project);
+
+// slug → fetcher, so the dispatcher view can load whichever report the route asks for.
+export const PROCUREMENT_REPORTS = {
+	"requests-to-order": getRequestsToOrder,
+	"delivery-followup": getDeliveryFollowup,
+	"site-stock": getSiteStock,
+	"rate-check": getRateCheck,
+	"purchase-register": getPurchaseRegister,
+	"consumption-by-cost-code": getConsumptionByCostCode,
+};

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -698,6 +698,12 @@ const routes = [
 				props: true,
 			},
 			{
+				path: "procurement/report/:slug",
+				name: "procurement-report",
+				component: () => import("@/views/procurement/reports/ProcurementReportView.vue"),
+				props: true,
+			},
+			{
 				path: "project-finance/report/:slug",
 				name: "finance-report",
 				component: () => import("@/views/finance/FinanceReportPageView.vue"),

--- a/frontend/src/views/procurement/reports/ProcurementReportView.vue
+++ b/frontend/src/views/procurement/reports/ProcurementReportView.vue
@@ -1,0 +1,920 @@
+<script setup>
+// The six Procurement reports, computed from live records via
+// buildsuite_core.api.procurement_report. One view, one section per :slug on
+// /procurement/report/:slug — matching the finance report pattern. An optional ?project=
+// narrows every report to that project and its sub-projects (resolved server-side); the rest
+// of the filters — search, supplier, status, dates, the one-click narrowings — are applied
+// here over the rows the backend returns.
+
+import { computed, onMounted, reactive, ref, watch } from "vue";
+import { useRoute, useRouter, RouterLink } from "vue-router";
+
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import ReportFilters from "@/components/reports/ReportFilters.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { useProjectOptions } from "@/composables/useProjectOptions";
+import { PROCUREMENT_REPORTS } from "@/data/procurementReportApi";
+import { fmtCompactINR, fmtDate, fmtINR } from "@/utils/format";
+
+const route = useRoute();
+const router = useRouter();
+const { projectOptions } = useProjectOptions();
+
+const DAY = 86400000;
+const todayISO = new Date().toISOString().slice(0, 10);
+const daysSince = (iso) =>
+	!iso ? null : Math.floor((new Date(todayISO) - new Date(iso + "T00:00:00")) / DAY);
+
+const META = {
+	"requests-to-order": {
+		title: "Requests waiting to be ordered",
+		desc: "What site has asked for that is not yet on a purchase order — the gap between the request book and the order book.",
+	},
+	"delivery-followup": {
+		title: "Delivery follow-up",
+		desc: "Open orders by the date they were needed, how much has landed, and what is still outstanding.",
+	},
+	"site-stock": {
+		title: "Material at site",
+		desc: "Received minus consumed, per item, at each project store.",
+	},
+	"rate-check": {
+		title: "Purchase rate vs estimate",
+		desc: "What you are paying against the QS rate in the Rate Master. Only lines carrying a rate code can be compared.",
+	},
+	"purchase-register": {
+		title: "Purchase register",
+		desc: "Every purchase order line — supplier, item, quantity and rate — so last paid is one search away.",
+	},
+	"consumption-by-cost-code": {
+		title: "Consumption by cost code",
+		desc: "Material issued to site, grouped by the cost code it was booked against.",
+	},
+};
+
+const slug = computed(() => route.params.slug);
+const meta = computed(() => META[slug.value] || null);
+const projectId = computed(() => route.query.project || "");
+function setProject(id) {
+	router.replace({
+		query: id ? { ...route.query, project: id } : { ...route.query, project: undefined },
+	});
+}
+
+// -------------------------------------------------------------- data load ---
+const raw = ref(null); // an array, or { rows, unlinked } for rate-check
+const loading = ref(true);
+const error = ref("");
+
+async function load() {
+	if (!meta.value) {
+		raw.value = null;
+		loading.value = false;
+		return;
+	}
+	loading.value = true;
+	error.value = "";
+	try {
+		raw.value = await PROCUREMENT_REPORTS[slug.value](projectId.value || undefined);
+	} catch (e) {
+		error.value = e.message || "Failed to load the report.";
+		raw.value = null;
+	} finally {
+		loading.value = false;
+	}
+}
+onMounted(load);
+watch(slug, () => Object.assign(f, BLANK)); // a new report starts unfiltered
+watch([slug, projectId], load); // re-scope from the server when the report or project changes
+
+const rowsArr = computed(() => (Array.isArray(raw.value) ? raw.value : raw.value?.rows || []));
+
+// ---------------------------------------------------------------- filters ---
+const BLANK = {
+	q: "",
+	supplier: "",
+	status: "",
+	from: "",
+	to: "",
+	lateOnly: false,
+	overOnly: false,
+	inStockOnly: false,
+	code: "",
+};
+const f = reactive({ ...BLANK });
+function clearFilters() {
+	Object.assign(f, BLANK);
+	if (projectId.value) setProject("");
+}
+const anyFilter = computed(
+	() => !!projectId.value || Object.keys(BLANK).some((k) => f[k] !== BLANK[k])
+);
+
+const hit = (hay, needle) =>
+	!needle ||
+	String(hay || "")
+		.toLowerCase()
+		.includes(needle.trim().toLowerCase());
+const inDates = (d) => (!f.from || (d || "") >= f.from) && (!f.to || (d || "") <= f.to);
+
+// Distinct pickers, built from the rows themselves so nothing offers a value with no rows.
+const distinct = (pick) =>
+	[...new Set(rowsArr.value.map(pick).filter(Boolean))]
+		.sort()
+		.map((v) => ({ value: v, label: v }));
+const supplierOptions = computed(() => distinct((r) => r.supplier));
+const statusOptions = computed(() => distinct((r) => r.status));
+const costCodeOptions = computed(() => distinct((r) => r.code));
+
+// ------------------------------------------------- 1. requests to order ---
+const requestsToOrder = computed(() =>
+	rowsArr.value
+		.filter((m) => !f.status || m.status === f.status)
+		.filter((m) => inDates(m.required_by))
+		.filter((m) => hit(m.name, f.q) || hit(m.project_name, f.q))
+		.map((m) => ({
+			...m,
+			age: daysSince(m.request_date),
+			lateBy: m.required_by && m.required_by < todayISO ? daysSince(m.required_by) : 0,
+		}))
+		.filter((m) => !f.lateOnly || m.lateBy > 0)
+		.sort((a, b) => (a.required_by || "~").localeCompare(b.required_by || "~"))
+);
+const requestsValue = computed(() =>
+	requestsToOrder.value.reduce((a, m) => a + (Number(m.value) || 0), 0)
+);
+
+// ---------------------------------------------------- 2. delivery chase ---
+const deliveryFollowup = computed(() =>
+	rowsArr.value
+		.filter((p) => !f.supplier || p.supplier === f.supplier)
+		.filter((p) => inDates(p.required_by))
+		.filter((p) => hit(p.name, f.q) || hit(p.supplier, f.q) || hit(p.project_name, f.q))
+		.map((p) => ({
+			...p,
+			lateBy: p.required_by && p.required_by < todayISO ? daysSince(p.required_by) : 0,
+		}))
+		.filter((p) => !f.lateOnly || p.lateBy > 0)
+		.sort(
+			(a, b) =>
+				b.lateBy - a.lateBy || (a.required_by || "~").localeCompare(b.required_by || "~")
+		)
+);
+const pendingValue = computed(() =>
+	deliveryFollowup.value.reduce((a, p) => a + (Number(p.pending_value) || 0), 0)
+);
+const overdueCount = computed(() => deliveryFollowup.value.filter((p) => p.lateBy > 0).length);
+
+// -------------------------------------------------------- 3. site stock ---
+const siteStock = computed(() =>
+	rowsArr.value
+		.filter((r) => hit(r.item, f.q) || hit(r.project_name, f.q))
+		.filter((r) => !f.inStockOnly || r.available > 0)
+		.sort(
+			(a, b) =>
+				(a.project_name || "").localeCompare(b.project_name || "") ||
+				a.item.localeCompare(b.item)
+		)
+);
+
+// -------------------------------------------------------- 4. rate check ---
+const rateCheckRows = computed(() =>
+	(raw.value?.rows || [])
+		.filter((r) => hit(r.item, f.q) || hit(r.code, f.q) || hit(r.supplier, f.q))
+		.filter((r) => !f.overOnly || (r.variance ?? 0) > 0)
+);
+const rateUnlinked = computed(() => raw.value?.unlinked || 0);
+
+// -------------------------------------------------- 5. purchase register ---
+const purchaseRegister = computed(() =>
+	rowsArr.value
+		.filter((r) => !f.supplier || r.supplier === f.supplier)
+		.filter((r) => inDates(r.date))
+		.filter((r) => hit(r.item, f.q) || hit(r.po, f.q) || hit(r.supplier, f.q))
+);
+const registerTotal = computed(() =>
+	purchaseRegister.value.reduce((a, r) => a + (Number(r.amount) || 0), 0)
+);
+
+// ------------------------------------------- 6. consumption by cost code ---
+const consumptionByCostCode = computed(() => {
+	const map = new Map();
+	for (const c of rowsArr.value) {
+		if (f.code && c.code !== f.code) continue;
+		if (!inDates(c.date)) continue;
+		if (!(hit(c.item, f.q) || hit(c.code, f.q))) continue;
+		const key = `${c.project}|${c.code}|${c.item}`;
+		if (!map.has(key))
+			map.set(key, {
+				project: c.project,
+				project_name: c.project_name,
+				code: c.code,
+				item: c.item,
+				uom: c.uom,
+				qty: 0,
+				value: 0,
+			});
+		const g = map.get(key);
+		g.qty += Number(c.qty) || 0;
+		g.value += Number(c.value) || 0;
+	}
+	return [...map.values()].sort(
+		(a, b) => a.code.localeCompare(b.code) || a.item.localeCompare(b.item)
+	);
+});
+const consumptionValue = computed(() =>
+	consumptionByCostCode.value.reduce((a, r) => a + r.value, 0)
+);
+
+// The filter-bar count + labels, per report — each with its own word for a row.
+const COUNTS = {
+	"requests-to-order": () => ({
+		shown: requestsToOrder.value.length,
+		total: rowsArr.value.length,
+		noun: "requests",
+		date: "Needed by",
+		find: "Request, project…",
+	}),
+	"delivery-followup": () => ({
+		shown: deliveryFollowup.value.length,
+		total: rowsArr.value.length,
+		noun: "orders",
+		date: "Needed by",
+		find: "Order, supplier, project…",
+	}),
+	"site-stock": () => ({
+		shown: siteStock.value.length,
+		total: rowsArr.value.length,
+		noun: "items",
+		date: "",
+		find: "Item or store…",
+	}),
+	"rate-check": () => ({
+		shown: rateCheckRows.value.length,
+		total: (raw.value?.rows || []).length,
+		noun: "items",
+		date: "",
+		find: "Item, code, supplier…",
+	}),
+	"purchase-register": () => ({
+		shown: purchaseRegister.value.length,
+		total: rowsArr.value.length,
+		noun: "lines",
+		date: "Ordered",
+		find: "Item, order, supplier…",
+	}),
+	"consumption-by-cost-code": () => ({
+		shown: consumptionByCostCode.value.length,
+		total: null,
+		noun: "lines",
+		date: "Issued",
+		find: "Item or cost code…",
+	}),
+};
+const counts = computed(() =>
+	COUNTS[slug.value]
+		? COUNTS[slug.value]()
+		: { shown: null, total: null, noun: "rows", date: "", find: "Search…" }
+);
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Procurement", to: "/procurement" },
+	{ label: meta.value?.title || "Reports" },
+]);
+
+const tone = (v) => (v > 0.5 ? "text-danger-700" : v < -0.5 ? "text-success-700" : "text-ink-700");
+const inr = (n) => (n || n === 0 ? Number(n).toLocaleString("en-IN") : n);
+</script>
+
+<template>
+	<DeskPage
+		:title="meta ? meta.title : 'Report not found'"
+		:subtitle="meta ? meta.desc : `No report registered for '${slug}'`"
+		:breadcrumbs="breadcrumbs"
+	>
+		<div
+			v-if="!meta"
+			class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-500 rounded-lg"
+		>
+			No report is registered under that name.
+			<RouterLink to="/procurement" class="text-brand-700 hover:underline ml-1"
+				>Back to Procurement →</RouterLink
+			>
+		</div>
+
+		<template v-else>
+			<ReportFilters
+				:active="anyFilter"
+				:shown="counts.shown"
+				:total="counts.total"
+				:noun="counts.noun"
+				@clear="clearFilters"
+			>
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Project</span
+					>
+					<span class="w-56 inline-block">
+						<DeskSearchableSelect
+							:model-value="projectId"
+							:options="projectOptions"
+							allow-clear
+							placeholder="All projects"
+							search-placeholder="Search projects…"
+							@update:model-value="setProject"
+						/>
+					</span>
+				</label>
+
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Find</span
+					>
+					<DeskInput v-model="f.q" :placeholder="counts.find" class="!w-52" />
+				</label>
+
+				<label v-if="slug === 'requests-to-order'" class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Status</span
+					>
+					<DeskSelect v-model="f.status" class="!w-44">
+						<option value="">Any</option>
+						<option v-for="o in statusOptions" :key="o.value" :value="o.value">
+							{{ o.label }}
+						</option>
+					</DeskSelect>
+				</label>
+
+				<label
+					v-if="slug === 'delivery-followup' || slug === 'purchase-register'"
+					class="flex items-center gap-1.5"
+				>
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Supplier</span
+					>
+					<span class="w-52 inline-block">
+						<DeskSearchableSelect
+							v-model="f.supplier"
+							:options="supplierOptions"
+							allow-clear
+							placeholder="All suppliers"
+							search-placeholder="Search suppliers…"
+						/>
+					</span>
+				</label>
+
+				<label
+					v-if="slug === 'consumption-by-cost-code'"
+					class="flex items-center gap-1.5"
+				>
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Cost code</span
+					>
+					<span class="w-56 inline-block">
+						<DeskSearchableSelect
+							v-model="f.code"
+							:options="costCodeOptions"
+							allow-clear
+							placeholder="All cost codes"
+							search-placeholder="Search cost codes…"
+						/>
+					</span>
+				</label>
+
+				<label v-if="counts.date" class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium">{{
+						counts.date
+					}}</span>
+					<DeskInput v-model="f.from" type="date" class="!w-36" />
+					<span class="text-[11px] text-ink-400">to</span>
+					<DeskInput v-model="f.to" type="date" class="!w-36" />
+				</label>
+
+				<label
+					v-if="slug === 'requests-to-order' || slug === 'delivery-followup'"
+					class="flex items-center gap-1.5 cursor-pointer"
+				>
+					<input v-model="f.lateOnly" type="checkbox" class="accent-brand-600" />
+					<span class="text-[11px] text-ink-600">Overdue only</span>
+				</label>
+				<label
+					v-if="slug === 'rate-check'"
+					class="flex items-center gap-1.5 cursor-pointer"
+				>
+					<input v-model="f.overOnly" type="checkbox" class="accent-brand-600" />
+					<span class="text-[11px] text-ink-600">Over estimate only</span>
+				</label>
+				<label
+					v-if="slug === 'site-stock'"
+					class="flex items-center gap-1.5 cursor-pointer"
+				>
+					<input v-model="f.inStockOnly" type="checkbox" class="accent-brand-600" />
+					<span class="text-[11px] text-ink-600">Hide emptied items</span>
+				</label>
+			</ReportFilters>
+
+			<p v-if="projectId" class="text-[11px] text-ink-500 -mt-1 mb-3">
+				Includes sub-projects.
+			</p>
+
+			<div v-if="loading" class="text-sm text-ink-500 italic py-10 text-center">
+				Loading…
+			</div>
+			<div v-else-if="error" class="text-sm text-danger-600 py-10 text-center">
+				{{ error }}
+			</div>
+
+			<template v-else>
+				<!-- 1. Requests waiting to be ordered -->
+				<div v-if="slug === 'requests-to-order'">
+					<div
+						v-if="requestsToOrder.length"
+						class="border border-ink-200 overflow-x-auto rounded-lg"
+					>
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="bg-ink-50 border-b border-ink-200 text-[11px] uppercase tracking-wider text-ink-500"
+								>
+									<th class="text-left font-medium px-3 py-2">Request</th>
+									<th class="text-left font-medium px-3 py-2">Project</th>
+									<th class="text-left font-medium px-3 py-2">Raised</th>
+									<th class="text-left font-medium px-3 py-2">Needed by</th>
+									<th class="text-right font-medium px-3 py-2">Items</th>
+									<th class="text-right font-medium px-3 py-2">Value</th>
+									<th class="text-left font-medium px-3 py-2">Status</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="m in requestsToOrder"
+									:key="m.name"
+									class="border-b border-ink-100 last:border-b-0 hover:bg-brand-50/40"
+								>
+									<td class="px-3 py-2">
+										<RouterLink
+											:to="`/procurement/material-requests/${m.name}`"
+											class="text-ink-900 font-medium hover:underline"
+											>{{ m.name }}</RouterLink
+										>
+										<div class="text-[10px] text-ink-500">
+											{{ m.age }}d old
+										</div>
+									</td>
+									<td class="px-3 py-2 text-ink-700">{{ m.project_name }}</td>
+									<td class="px-3 py-2 text-ink-700">
+										{{ fmtDate(m.request_date) }}
+									</td>
+									<td
+										class="px-3 py-2 tabular-nums"
+										:class="
+											m.lateBy > 0
+												? 'text-danger-700 font-medium'
+												: 'text-ink-700'
+										"
+									>
+										{{ fmtDate(m.required_by) }}
+										<span v-if="m.lateBy > 0" class="text-[10px]">
+											· {{ m.lateBy }}d late</span
+										>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ m.item_count }}
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+										{{ fmtINR(m.value) }}
+									</td>
+									<td class="px-3 py-2">
+										<StatusBadge :status="m.status" size="xs" />
+									</td>
+								</tr>
+							</tbody>
+							<tfoot>
+								<tr
+									class="bg-ink-50 border-t border-ink-200 font-semibold text-ink-900"
+								>
+									<td class="px-3 py-2" colspan="5">
+										{{ requestsToOrder.length }} request{{
+											requestsToOrder.length === 1 ? "" : "s"
+										}}
+										waiting
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums">
+										{{ fmtINR(requestsValue) }}
+									</td>
+									<td></td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+					<div
+						v-else
+						class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-400 italic rounded-lg"
+					>
+						<template v-if="anyFilter">No requests match these filters.</template>
+						<template v-else
+							>Nothing waiting — every request in scope has been ordered.</template
+						>
+					</div>
+				</div>
+
+				<!-- 2. Delivery follow-up -->
+				<div v-else-if="slug === 'delivery-followup'">
+					<div
+						v-if="deliveryFollowup.length"
+						class="border border-ink-200 overflow-x-auto rounded-lg"
+					>
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="bg-ink-50 border-b border-ink-200 text-[11px] uppercase tracking-wider text-ink-500"
+								>
+									<th class="text-left font-medium px-3 py-2">Order</th>
+									<th class="text-left font-medium px-3 py-2">Supplier</th>
+									<th class="text-left font-medium px-3 py-2">Project</th>
+									<th class="text-left font-medium px-3 py-2">Needed by</th>
+									<th class="text-right font-medium px-3 py-2">Received</th>
+									<th class="text-right font-medium px-3 py-2">Still due</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="p in deliveryFollowup"
+									:key="p.name"
+									class="border-b border-ink-100 last:border-b-0 hover:bg-brand-50/40"
+								>
+									<td class="px-3 py-2">
+										<RouterLink
+											:to="`/procurement/purchase-orders/${p.name}`"
+											class="text-ink-900 font-medium hover:underline"
+											>{{ p.name }}</RouterLink
+										>
+									</td>
+									<td class="px-3 py-2 text-ink-700">{{ p.supplier }}</td>
+									<td class="px-3 py-2 text-ink-700">
+										{{ p.project_name || "—" }}
+									</td>
+									<td
+										class="px-3 py-2 tabular-nums"
+										:class="
+											p.lateBy > 0
+												? 'text-danger-700 font-medium'
+												: 'text-ink-700'
+										"
+									>
+										{{ fmtDate(p.required_by) }}
+										<span v-if="p.lateBy > 0" class="text-[10px]">
+											· {{ p.lateBy }}d late</span
+										>
+									</td>
+									<td class="px-3 py-2 text-right">
+										<div class="flex items-center justify-end gap-2">
+											<div
+												class="w-16 h-1.5 bg-ink-100 overflow-hidden rounded-full"
+											>
+												<div
+													class="h-full"
+													:class="
+														p.pct >= 100
+															? 'bg-success-500'
+															: p.pct > 0
+															? 'bg-info-500'
+															: 'bg-ink-300'
+													"
+													:style="{ width: p.pct + '%' }"
+												></div>
+											</div>
+											<span class="tabular-nums text-ink-700 w-9 text-right"
+												>{{ p.pct }}%</span
+											>
+										</div>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+										{{ fmtINR(p.pending_value) }}
+									</td>
+								</tr>
+							</tbody>
+							<tfoot>
+								<tr
+									class="bg-ink-50 border-t border-ink-200 font-semibold text-ink-900"
+								>
+									<td class="px-3 py-2" colspan="5">
+										{{ deliveryFollowup.length }} open order{{
+											deliveryFollowup.length === 1 ? "" : "s"
+										}}
+										<span v-if="overdueCount" class="text-danger-700">
+											· {{ overdueCount }} overdue</span
+										>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums">
+										{{ fmtINR(pendingValue) }}
+									</td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+					<div
+						v-else
+						class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-400 italic rounded-lg"
+					>
+						<template v-if="anyFilter">No orders match these filters.</template>
+						<template v-else>No open orders in scope.</template>
+					</div>
+				</div>
+
+				<!-- 3. Material at site -->
+				<div v-else-if="slug === 'site-stock'">
+					<div
+						v-if="siteStock.length"
+						class="border border-ink-200 overflow-x-auto rounded-lg"
+					>
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="bg-ink-50 border-b border-ink-200 text-[11px] uppercase tracking-wider text-ink-500"
+								>
+									<th class="text-left font-medium px-3 py-2">Project store</th>
+									<th class="text-left font-medium px-3 py-2">Item</th>
+									<th class="text-right font-medium px-3 py-2">Received</th>
+									<th class="text-right font-medium px-3 py-2">Consumed</th>
+									<th class="text-right font-medium px-3 py-2">At site</th>
+									<th class="text-left font-medium px-3 py-2">Unit</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="(r, i) in siteStock"
+									:key="i"
+									class="border-b border-ink-100 last:border-b-0 hover:bg-brand-50/40"
+								>
+									<td class="px-3 py-2 text-ink-700">{{ r.project_name }}</td>
+									<td class="px-3 py-2 text-ink-900">{{ r.item }}</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ inr(r.received) }}
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ inr(r.consumed) }}
+									</td>
+									<td
+										class="px-3 py-2 text-right tabular-nums font-medium"
+										:class="
+											r.available === 0 ? 'text-warning-700' : 'text-ink-900'
+										"
+									>
+										{{ inr(r.available) }}
+									</td>
+									<td class="px-3 py-2 text-ink-500">{{ r.uom }}</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<div
+						v-else
+						class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-400 italic rounded-lg"
+					>
+						<template v-if="anyFilter">No items match these filters.</template>
+						<template v-else>Nothing received at site yet in scope.</template>
+					</div>
+					<p class="text-[11px] text-ink-500 mt-2">
+						Received counts posted purchase receipts; consumed counts posted
+						consumption. A cancelled receipt never entered stock.
+					</p>
+				</div>
+
+				<!-- 4. Purchase rate vs estimate -->
+				<div v-else-if="slug === 'rate-check'">
+					<div
+						v-if="rateCheckRows.length"
+						class="border border-ink-200 overflow-x-auto rounded-lg"
+					>
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="bg-ink-50 border-b border-ink-200 text-[11px] uppercase tracking-wider text-ink-500"
+								>
+									<th class="text-left font-medium px-3 py-2">Item</th>
+									<th class="text-left font-medium px-3 py-2">
+										Last bought from
+									</th>
+									<th class="text-right font-medium px-3 py-2">Paid</th>
+									<th class="text-right font-medium px-3 py-2">Rate Master</th>
+									<th class="text-right font-medium px-3 py-2">Variance</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="r in rateCheckRows"
+									:key="r.item"
+									class="border-b border-ink-100 last:border-b-0 hover:bg-brand-50/40"
+								>
+									<td class="px-3 py-2">
+										<div class="text-ink-900">{{ r.item }}</div>
+										<div class="text-[10px] text-ink-500 font-mono">
+											{{ r.code }}
+										</div>
+									</td>
+									<td class="px-3 py-2 text-ink-700">
+										{{ r.supplier }}
+										<div class="text-[10px] text-ink-500">
+											{{ r.po }} · {{ fmtDate(r.order_date) }}
+										</div>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+										{{ fmtINR(r.rate)
+										}}<span class="text-[10px] text-ink-500">
+											/ {{ r.unit }}</span
+										>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ r.estimate ? fmtINR(r.estimate) : "—" }}
+									</td>
+									<td
+										class="px-3 py-2 text-right tabular-nums font-medium"
+										:class="
+											r.variance === null ? 'text-ink-400' : tone(r.variance)
+										"
+									>
+										<template v-if="r.variance === null">—</template>
+										<template v-else
+											>{{ r.variance > 0 ? "+" : ""
+											}}{{ r.variance.toFixed(1) }}%</template
+										>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<div
+						v-else
+						class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-400 italic rounded-lg"
+					>
+						<template v-if="anyFilter">No items match these filters.</template>
+						<template v-else
+							>No order line in scope carries a rate code, so there is nothing to
+							compare.</template
+						>
+					</div>
+					<p v-if="rateUnlinked" class="text-[11px] text-ink-500 mt-2">
+						{{ rateUnlinked }} order line{{ rateUnlinked === 1 ? "" : "s" }} could not
+						be checked — no rate code on the line. Linking the item to a Rate Master
+						entry under
+						<RouterLink to="/items" class="text-brand-700 hover:underline"
+							>Items</RouterLink
+						>
+						brings it into this report.
+					</p>
+				</div>
+
+				<!-- 5. Purchase register -->
+				<div v-else-if="slug === 'purchase-register'">
+					<div
+						v-if="purchaseRegister.length"
+						class="border border-ink-200 overflow-x-auto rounded-lg"
+					>
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="bg-ink-50 border-b border-ink-200 text-[11px] uppercase tracking-wider text-ink-500"
+								>
+									<th class="text-left font-medium px-3 py-2">Date</th>
+									<th class="text-left font-medium px-3 py-2">Order</th>
+									<th class="text-left font-medium px-3 py-2">Supplier</th>
+									<th class="text-left font-medium px-3 py-2">Item</th>
+									<th class="text-right font-medium px-3 py-2">Qty</th>
+									<th class="text-right font-medium px-3 py-2">Rate</th>
+									<th class="text-right font-medium px-3 py-2">Amount</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="(r, i) in purchaseRegister"
+									:key="i"
+									class="border-b border-ink-100 last:border-b-0 hover:bg-brand-50/40"
+								>
+									<td class="px-3 py-2 text-ink-700 whitespace-nowrap">
+										{{ fmtDate(r.date) }}
+									</td>
+									<td class="px-3 py-2">
+										<RouterLink
+											:to="`/procurement/purchase-orders/${r.po}`"
+											class="text-ink-900 hover:underline"
+											>{{ r.po }}</RouterLink
+										>
+										<div class="text-[10px] text-ink-500">
+											{{ r.project_name || "—" }}
+										</div>
+									</td>
+									<td class="px-3 py-2 text-ink-700">{{ r.supplier }}</td>
+									<td class="px-3 py-2 text-ink-900">{{ r.item }}</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ inr(r.qty) }}
+										<span class="text-[10px] text-ink-500">{{ r.uom }}</span>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ fmtINR(r.rate) }}
+									</td>
+									<td
+										class="px-3 py-2 text-right tabular-nums text-ink-900 font-medium"
+									>
+										{{ fmtINR(r.amount) }}
+									</td>
+								</tr>
+							</tbody>
+							<tfoot>
+								<tr
+									class="bg-ink-50 border-t border-ink-200 font-semibold text-ink-900"
+								>
+									<td class="px-3 py-2" colspan="6">
+										{{ purchaseRegister.length }} lines
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums">
+										{{ fmtCompactINR(registerTotal) }}
+									</td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+					<div
+						v-else
+						class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-400 italic rounded-lg"
+					>
+						<template v-if="anyFilter">No lines match these filters.</template>
+						<template v-else>No purchase orders in scope.</template>
+					</div>
+				</div>
+
+				<!-- 6. Consumption by cost code -->
+				<div v-else-if="slug === 'consumption-by-cost-code'">
+					<div
+						v-if="consumptionByCostCode.length"
+						class="border border-ink-200 overflow-x-auto rounded-lg"
+					>
+						<table class="w-full text-sm">
+							<thead>
+								<tr
+									class="bg-ink-50 border-b border-ink-200 text-[11px] uppercase tracking-wider text-ink-500"
+								>
+									<th class="text-left font-medium px-3 py-2">Cost code</th>
+									<th class="text-left font-medium px-3 py-2">Project</th>
+									<th class="text-left font-medium px-3 py-2">Item</th>
+									<th class="text-right font-medium px-3 py-2">Issued</th>
+									<th class="text-right font-medium px-3 py-2">
+										At standard rate
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="(r, i) in consumptionByCostCode"
+									:key="i"
+									class="border-b border-ink-100 last:border-b-0 hover:bg-brand-50/40"
+								>
+									<td class="px-3 py-2 text-ink-900">{{ r.code }}</td>
+									<td class="px-3 py-2 text-ink-700">
+										{{ r.project_name || "—" }}
+									</td>
+									<td class="px-3 py-2 text-ink-700">{{ r.item }}</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+										{{ inr(r.qty) }}
+										<span class="text-[10px] text-ink-500">{{ r.uom }}</span>
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ r.value ? fmtINR(r.value) : "—" }}
+									</td>
+								</tr>
+							</tbody>
+							<tfoot>
+								<tr
+									class="bg-ink-50 border-t border-ink-200 font-semibold text-ink-900"
+								>
+									<td class="px-3 py-2" colspan="4">
+										{{ consumptionByCostCode.length }} lines
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums">
+										{{ fmtINR(consumptionValue) }}
+									</td>
+								</tr>
+							</tfoot>
+						</table>
+					</div>
+					<div
+						v-else
+						class="border border-ink-200 px-5 py-10 text-center text-sm text-ink-400 italic rounded-lg"
+					>
+						<template v-if="anyFilter">No lines match these filters.</template>
+						<template v-else>Nothing issued to site yet in scope.</template>
+					</div>
+					<p class="text-[11px] text-ink-500 mt-2">
+						Valued at the item master's standard rate — a list price, not what this
+						particular material cost. Issue valuation needs stock rates, which are not
+						modelled.
+					</p>
+				</div>
+			</template>
+		</template>
+	</DeskPage>
+</template>


### PR DESCRIPTION
Replaces the three borrowed ERPNext Desk report links on the Procurement workspace (Stock Balance / Stock Ledger / Item-wise Purchase Register — half of which describe things BuildSuite does not model) with the prototype's **six bespoke in-app reports**, each computed from live records so every figure comes from a document.

## The six reports
1. **Requests waiting to be ordered** — submitted Purchase Material Requests not fully ordered.
2. **Delivery follow-up** — open POs by the date they were needed, % received, value still due, overdue flagged.
3. **Material at site** — received (Purchase Receipts) minus consumed (Material Issues), per item, per project store.
4. **Purchase rate vs estimate** — latest PO line per item carrying a rate code vs the Construction Rate Master's current QS rate; unlinked lines counted, not dropped.
5. **Purchase register** — every PO line: date, order, supplier, item, qty, rate, amount.
6. **Consumption by cost code** — Material Issues grouped by cost code, valued at the item standard rate.

## Implementation
- **Backend** `api/procurement_report.py`: one whitelisted endpoint per report, each taking an optional `project` that rolls up its direct sub-projects server-side.
- **Frontend**: one dispatcher `ProcurementReportView.vue` (mirrors the finance report pattern) at a new `/procurement/report/:slug` route + `procurementReportApi.js`. Project scope is server-side (deep-linkable via `?project=`); search / supplier / status / date / one-click narrowings are applied client-side, matching the prototype.
- **Seed**: `_SEED["procurement"]` now points at the six `/procurement/report/<slug>` tiles; patch `reseed_procurement_bespoke_reports` repoints tiles on already-seeded sites.

## Verification
- All six endpoints run clean on bs.local; `delivery_followup` (4 open orders) and `purchase_register` (10 lines) return real data, the rest render empty states (sparse demo data).
- Tiles reseeded and confirmed pointing at the six routes.
- `yarn build` and `pre-commit` pass.