### PR TITLE
fix: persona-granted System Manager stripped on switch + report-access matrix

### DIFF
--- a/buildsuite_core/buildsuite_core/report/billing_and_collection/billing_and_collection.json
+++ b/buildsuite_core/buildsuite_core/report/billing_and_collection/billing_and_collection.json
@@ -32,7 +32,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2026-08-18 00:00:00.000000",
+ "modified": "2026-08-20 00:00:00.000000",
  "module": "BuildSuite Core",
  "name": "Billing and Collection",
  "owner": "Administrator",
@@ -41,11 +41,20 @@
  "report_name": "Billing and Collection",
  "report_type": "Script Report",
  "roles": [
-  {"role": "System Manager"},
-  {"role": "BuildSuite Administrator"},
-  {"role": "BuildSuite Director"},
-  {"role": "BuildSuite PM"},
-  {"role": "BuildSuite QS"},
-  {"role": "BuildSuite Accountant"}
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "BuildSuite Administrator"
+  },
+  {
+   "role": "BuildSuite Director"
+  },
+  {
+   "role": "BuildSuite PM"
+  },
+  {
+   "role": "BuildSuite Accountant"
+  }
  ]
 }

--- a/buildsuite_core/buildsuite_core/report/material_status/material_status.json
+++ b/buildsuite_core/buildsuite_core/report/material_status/material_status.json
@@ -27,7 +27,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2026-08-18 00:00:00.000000",
+ "modified": "2026-08-20 00:00:00.000000",
  "module": "BuildSuite Core",
  "name": "Material Status",
  "owner": "Administrator",
@@ -36,12 +36,32 @@
  "report_name": "Material Status",
  "report_type": "Script Report",
  "roles": [
-  {"role": "System Manager"},
-  {"role": "BuildSuite Administrator"},
-  {"role": "BuildSuite Director"},
-  {"role": "BuildSuite PM"},
-  {"role": "BuildSuite QS"},
-  {"role": "BuildSuite Site Engineer"},
-  {"role": "BuildSuite Foreman"}
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "BuildSuite Administrator"
+  },
+  {
+   "role": "BuildSuite Director"
+  },
+  {
+   "role": "BuildSuite PM"
+  },
+  {
+   "role": "BuildSuite QS"
+  },
+  {
+   "role": "BuildSuite Site Engineer"
+  },
+  {
+   "role": "BuildSuite Foreman"
+  },
+  {
+   "role": "BuildSuite Procurement Officer"
+  },
+  {
+   "role": "BuildSuite Store Keeper"
+  }
  ]
 }

--- a/buildsuite_core/buildsuite_core/report/measurement_book_register/measurement_book_register.json
+++ b/buildsuite_core/buildsuite_core/report/measurement_book_register/measurement_book_register.json
@@ -38,7 +38,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2026-08-18 00:00:00.000000",
+ "modified": "2026-08-20 00:00:00.000000",
  "module": "BuildSuite Core",
  "name": "Measurement Book Register",
  "owner": "Administrator",
@@ -47,11 +47,26 @@
  "report_name": "Measurement Book Register",
  "report_type": "Script Report",
  "roles": [
-  {"role": "System Manager"},
-  {"role": "BuildSuite Administrator"},
-  {"role": "BuildSuite Director"},
-  {"role": "BuildSuite PM"},
-  {"role": "BuildSuite QS"},
-  {"role": "BuildSuite Accountant"}
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "BuildSuite Administrator"
+  },
+  {
+   "role": "BuildSuite Director"
+  },
+  {
+   "role": "BuildSuite PM"
+  },
+  {
+   "role": "BuildSuite QS"
+  },
+  {
+   "role": "BuildSuite Site Engineer"
+  },
+  {
+   "role": "BuildSuite Accountant"
+  }
  ]
 }

--- a/buildsuite_core/buildsuite_core/report/subcontractor_position/subcontractor_position.json
+++ b/buildsuite_core/buildsuite_core/report/subcontractor_position/subcontractor_position.json
@@ -23,7 +23,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2026-08-18 00:00:00.000000",
+ "modified": "2026-08-20 00:00:00.000000",
  "module": "BuildSuite Core",
  "name": "Subcontractor Position",
  "owner": "Administrator",
@@ -32,11 +32,26 @@
  "report_name": "Subcontractor Position",
  "report_type": "Script Report",
  "roles": [
-  {"role": "System Manager"},
-  {"role": "BuildSuite Administrator"},
-  {"role": "BuildSuite Director"},
-  {"role": "BuildSuite PM"},
-  {"role": "BuildSuite QS"},
-  {"role": "BuildSuite Accountant"}
+  {
+   "role": "System Manager"
+  },
+  {
+   "role": "BuildSuite Administrator"
+  },
+  {
+   "role": "BuildSuite Director"
+  },
+  {
+   "role": "BuildSuite PM"
+  },
+  {
+   "role": "BuildSuite QS"
+  },
+  {
+   "role": "BuildSuite Procurement Officer"
+  },
+  {
+   "role": "BuildSuite Accountant"
+  }
  ]
 }

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -1,0 +1,251 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+"""Permission-matrix tests — persona role sync (what happens when a user's persona
+changes) and per-persona report access, encoded from the Dashboard/Report access
+sheets.
+
+Two dimensions are covered here:
+
+* **Persona role sync** (``TestPersonaRoleSync``) — creating a user with a persona,
+  and *switching* a user's persona, must leave exactly the right BuildSuite roles.
+  This is where the reported "System Manager carried over after switching persona"
+  bug lives.
+
+* **Report access** (``TestReportAccessMatrix``) — the six role-gated Script Reports
+  must be runnable by exactly the personas the access sheet says, and no others.
+
+Dashboard / workspace visibility is intentionally NOT tested here: it is enforced
+entirely client-side (``frontend/src/data/roles.js`` ``WORKSPACE_VISIBILITY``), so
+there is nothing on the Python backend to assert. See the module docstring note.
+"""
+
+import frappe
+
+from buildsuite_core.permissions.setup import WORKFLOW_EDITOR_ROLE
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+# persona record name -> the single BuildSuite/native role it manages.
+PERSONA_ROLE = {
+	"Director / Owner": "BuildSuite Director",
+	"Project Manager": "BuildSuite PM",
+	"Estimator": "BuildSuite Estimator",
+	"Quantity Surveyor": "BuildSuite QS",
+	"Site Engineer": "BuildSuite Site Engineer",
+	"Foreman / Supervisor": "BuildSuite Foreman",
+	"Procurement Officer": "BuildSuite Procurement Officer",
+	"Store Keeper": "BuildSuite Store Keeper",
+	"Accountant": "BuildSuite Accountant",
+	"HR Manager": "BuildSuite HR Manager",
+	"System Manager (Admin)": "System Manager",
+	"BuildSuite Administrator": "BuildSuite Administrator",
+}
+ADMIN_PERSONAS = ("System Manager (Admin)", "BuildSuite Administrator")
+FIELD_PERSONAS = [p for p in PERSONA_ROLE if p not in ADMIN_PERSONAS]
+MANAGED_ROLES = set(PERSONA_ROLE.values())
+
+
+class _PersonaBase(BuildSuiteTestCase):
+	def _make_user(self, persona):
+		email = f"pm-{persona[:4].strip().lower().replace(' ', '')}-{self._n}-{frappe.generate_hash(length=4)}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "Matrix",
+				"user_type": "System User",
+				"send_welcome_email": 0,
+				"persona": persona,
+			}
+		).insert(ignore_permissions=True)
+		return email
+
+	def _switch(self, email, persona):
+		u = frappe.get_doc("User", email)
+		u.persona = persona
+		u.save(ignore_permissions=True)
+
+	def _roles(self, email):
+		return {r.role for r in frappe.get_doc("User", email).roles}
+
+
+class TestPersonaRoleSync(_PersonaBase):
+	# --- granting -------------------------------------------------------------
+	def test_each_persona_grants_only_its_managed_role(self):
+		"""Setting a persona grants that persona's role + the workflow-editor marker,
+		and none of the OTHER personas' managed roles."""
+		for persona, role in PERSONA_ROLE.items():
+			with self.subTest(persona=persona):
+				email = self._make_user(persona)
+				roles = self._roles(email)
+				self.assertIn(role, roles, f"{persona} should grant {role}")
+				self.assertIn(WORKFLOW_EDITOR_ROLE, roles, f"{persona} should grant the workflow-editor role")
+				stray = (MANAGED_ROLES - {role}) & roles
+				self.assertFalse(stray, f"{persona} leaked other personas' roles: {stray}")
+
+	# --- switching between field personas ------------------------------------
+	def test_switch_chain_keeps_only_current_field_persona_role(self):
+		"""Switch one user through every ordinary persona in turn. At each step it must
+		hold the new persona's role and NONE of the personas seen earlier — the running
+		'changes of persona' the report sheet cares about. (One user, to stay under the
+		User-creation throttle.)"""
+		chain = FIELD_PERSONAS
+		email = self._make_user(chain[0])
+		seen = {chain[0]}
+		for nxt in chain[1:]:
+			self._switch(email, nxt)
+			seen.add(nxt)
+			roles = self._roles(email)
+			with self.subTest(step=nxt):
+				self.assertIn(PERSONA_ROLE[nxt], roles, f"{nxt} role not granted after switch")
+				stale = {PERSONA_ROLE[p] for p in seen if p != nxt} & roles
+				self.assertFalse(stale, f"stale role(s) survived after switching to {nxt}: {stale}")
+
+	# --- switching AWAY FROM an admin persona (the reported bug) --------------
+	def test_switch_away_from_admin_persona_strips_admin_role(self):
+		"""THE REPORTED BUG. A user on an admin persona, moved to an ordinary persona,
+		must lose the admin role that only the admin persona granted."""
+		for admin in ADMIN_PERSONAS:
+			with self.subTest(frm=admin):
+				email = self._make_user(admin)
+				self.assertIn(PERSONA_ROLE[admin], self._roles(email))
+				self._switch(email, "Site Engineer")
+				roles = self._roles(email)
+				self.assertNotIn(
+					PERSONA_ROLE[admin],
+					roles,
+					f"{PERSONA_ROLE[admin]} (granted only by the {admin} persona) survived the switch to Site Engineer",
+				)
+				self.assertIn("BuildSuite Site Engineer", roles)
+
+	# --- switching INTO an admin persona -------------------------------------
+	def test_switch_into_admin_persona_grants_admin_role(self):
+		for admin in ADMIN_PERSONAS:
+			with self.subTest(to=admin):
+				email = self._make_user("Site Engineer")
+				self._switch(email, admin)
+				roles = self._roles(email)
+				self.assertIn(PERSONA_ROLE[admin], roles)
+				self.assertNotIn("BuildSuite Site Engineer", roles, "stale Site Engineer role survived")
+
+	# --- round trip through the admin persona --------------------------------
+	def test_round_trip_through_admin_persona(self):
+		"""Admin -> field -> admin: the admin role is gone in the middle and back at
+		the end (no stale accumulation, correct re-grant)."""
+		email = self._make_user("System Manager (Admin)")
+		self._switch(email, "Site Engineer")
+		self.assertNotIn("System Manager", self._roles(email), "System Manager not dropped mid round-trip")
+		self._switch(email, "System Manager (Admin)")
+		self.assertIn("System Manager", self._roles(email), "System Manager not re-granted on return")
+
+	# --- manual (non-persona) roles are preserved ----------------------------
+	def test_manual_role_survives_persona_switch(self):
+		"""A role added on top of a persona (not granted by it) must never be stripped
+		by a later persona switch — combined-responsibility users are legitimate."""
+		email = self._make_user("Project Manager")
+		u = frappe.get_doc("User", email)
+		u.append("roles", {"role": "BuildSuite QS"})  # manual add, not from the PM persona
+		u.save(ignore_permissions=True)
+		self._switch(email, "Estimator")
+		roles = self._roles(email)
+		self.assertIn("BuildSuite QS", roles, "manually-added role was wrongly stripped on switch")
+		self.assertIn("BuildSuite Estimator", roles)
+		self.assertNotIn("BuildSuite PM", roles, "stale PM role survived")
+
+	# --- no accumulation across repeated switches ----------------------------
+	def test_repeated_switches_do_not_accumulate_roles(self):
+		email = self._make_user("Project Manager")
+		self._switch(email, "Estimator")
+		self._switch(email, "Quantity Surveyor")
+		managed = self._roles(email) & MANAGED_ROLES
+		self.assertEqual(
+			managed,
+			{"BuildSuite QS"},
+			f"only the final persona's role should remain, found {managed}",
+		)
+
+
+# The six role-gated Script Reports, transcribed from the "Report access by persona"
+# sheet: the personas each report should be runnable by. "O" (by-decision) cells are
+# treated as expected-access. The other matrix rows are ungated route tiles / bespoke
+# Vue views (no Report to gate) and can't be asserted here.
+REPORT_MATRIX = {
+	"Billing and Collection": {
+		"Director / Owner",
+		"Project Manager",
+		"Accountant",
+		"System Manager (Admin)",
+		"BuildSuite Administrator",
+	},
+	"Subcontractor Position": {
+		"Director / Owner",
+		"Project Manager",
+		"Quantity Surveyor",
+		"Procurement Officer",  # "O" — by decision (T3 exception)
+		"Accountant",
+		"System Manager (Admin)",
+		"BuildSuite Administrator",
+	},
+	"Material Status": {
+		"Director / Owner",
+		"Project Manager",
+		"Quantity Surveyor",
+		"Site Engineer",
+		"Foreman / Supervisor",
+		"Procurement Officer",
+		"Store Keeper",
+		"System Manager (Admin)",
+		"BuildSuite Administrator",
+	},
+	"Subcontractor Work Order Register": {
+		"Director / Owner",
+		"Project Manager",
+		"Quantity Surveyor",
+		"Accountant",
+		"System Manager (Admin)",
+		"BuildSuite Administrator",
+	},
+	"Measurement Book Register": {
+		"Director / Owner",
+		"Project Manager",
+		"Quantity Surveyor",
+		"Site Engineer",
+		"Accountant",
+		"System Manager (Admin)",
+		"BuildSuite Administrator",
+	},
+	"Subcontractor Bill Register": {
+		"Director / Owner",
+		"Project Manager",
+		"Quantity Surveyor",
+		"Accountant",
+		"System Manager (Admin)",
+		"BuildSuite Administrator",
+	},
+}
+
+
+class TestReportAccessMatrix(_PersonaBase):
+	def _can_run(self, email, report):
+		"""True if the given user is allowed to run the report (its is_permitted gate)."""
+		frappe.set_user(email)
+		try:
+			return bool(frappe.get_cached_doc("Report", report).is_permitted())
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_report_access_matches_the_matrix(self):
+		"""Each of the six role-gated reports must be runnable by exactly the personas
+		the access sheet lists — a persona outside the row must be denied."""
+		# One user per persona, reused across reports.
+		users = {p: self._make_user(p) for p in PERSONA_ROLE}
+		for report, allowed_personas in REPORT_MATRIX.items():
+			if not frappe.db.exists("Report", report):
+				self.skipTest(f"Report {report!r} not installed on this site")
+			for persona, email in users.items():
+				expected = persona in allowed_personas
+				with self.subTest(report=report, persona=persona):
+					self.assertEqual(
+						self._can_run(email, report),
+						expected,
+						f"{persona} {'should' if expected else 'should NOT'} be able to run {report!r}",
+					)

--- a/buildsuite_core/tests/test_user.py
+++ b/buildsuite_core/tests/test_user.py
@@ -62,8 +62,11 @@ class TestUserPersona(BuildSuiteTestCase):
 		self.assertIn("BuildSuite Estimator", roles)
 		self.assertNotIn("BuildSuite PM", roles)  # stale managed role dropped
 
-	def test_system_manager_is_never_revoked_by_persona(self):
-		# A persona may grant System Manager, but switching persona must not strip it.
+	def test_manually_added_system_manager_survives_persona_switch(self):
+		# System Manager added MANUALLY (not granted by the persona) must survive a
+		# persona switch — only the previous persona's own grants are ever stripped.
+		# (A persona that GRANTS System Manager — the admin persona — is the opposite
+		# case, covered in test_permission_matrix: leaving it DOES strip the role.)
 		u = self._make_user("Project Manager")
 		u.append("roles", {"role": "System Manager"})
 		u.persona = "Estimator"
@@ -85,9 +88,7 @@ class TestUserPersona(BuildSuiteTestCase):
 		# link picker queries — they can only be assigned from the Frappe desk.
 		for name in ("System Manager (Admin)", "BuildSuite Administrator"):
 			self.assertEqual(frappe.db.get_value("Persona", name, "backend_only"), 1)
-		assignable = frappe.get_all(
-			"Persona", filters={"enabled": 1, "backend_only": 0}, pluck="name"
-		)
+		assignable = frappe.get_all("Persona", filters={"enabled": 1, "backend_only": 0}, pluck="name")
 		self.assertNotIn("BuildSuite Administrator", assignable)
 		self.assertNotIn("System Manager (Admin)", assignable)
 		self.assertIn("Project Manager", assignable)
@@ -101,9 +102,7 @@ class TestUserPersona(BuildSuiteTestCase):
 		)
 
 		frappe.db.set_value("Persona", "BuildSuite Administrator", "enabled", 0)
-		self.assertNotIn(
-			"BuildSuite Administrator", [p["name"] for p in list_personas()]
-		)
+		self.assertNotIn("BuildSuite Administrator", [p["name"] for p in list_personas()])
 		repair_default_personas()
 		self.assertEqual(frappe.db.get_value("Persona", "BuildSuite Administrator", "enabled"), 1)
 		self.assertIn("BuildSuite Administrator", [p["name"] for p in list_personas()])

--- a/buildsuite_core/utils/user.py
+++ b/buildsuite_core/utils/user.py
@@ -14,8 +14,13 @@ legitimate flow, so manual additions must never be silently reverted.
 The only roles ever removed are the ones the *previous* persona granted that the
 new persona no longer grants, and only when the persona actually CHANGES — so
 switching persona doesn't leave the old persona's roles piled on, while a plain
-save (persona unchanged) strips nothing. Protected native roles (System Manager,
-Administrator) are never stripped.
+save (persona unchanged) strips nothing. A role a persona GRANTS is stripped when
+you leave that persona even if it is System Manager (the "System Manager (Admin)"
+persona grants it) — otherwise switching an admin down to a field persona would
+silently leave platform-admin rights behind. Only two things are always kept: the
+Frappe-internal roles (Administrator, All, Guest), and any role added MANUALLY on
+top of a persona (a manual add is never in the previous persona's grant set, so it
+is never eligible for stripping).
 
 Delete needs no handler: Frappe cascades the Has Role child rows when the User is
 deleted.
@@ -25,8 +30,12 @@ import frappe
 
 from buildsuite_core.permissions.setup import WORKFLOW_EDITOR_ROLE
 
-# Native roles this hook must never revoke, even on a persona switch.
-PROTECTED_ROLES = {"System Manager", "Administrator", "All", "Guest"}
+# Frappe-internal roles this hook must never revoke on a persona switch. System Manager is
+# deliberately NOT here: the "System Manager (Admin)" persona grants it, so leaving that persona
+# must be able to strip it — like any other persona-granted role. A System Manager role added
+# MANUALLY on top of a field persona still survives (only the previous persona's own grants are
+# ever eligible for stripping), so this set only needs Frappe's own housekeeping roles.
+PROTECTED_ROLES = {"Administrator", "All", "Guest"}
 
 
 def _persona_roles(persona):


### PR DESCRIPTION
Adds a backend permission-matrix test suite and fixes the two bug groups it surfaced.

## The reported bug — System Manager carried over on persona switch
Switching a user *away* from the **System Manager (Admin)** persona left the `System Manager` role behind, because `System Manager` was in `PROTECTED_ROLES` in [utils/user.py](buildsuite_core/utils/user.py) and so was never stripped.

**Fix:** `System Manager` is removed from `PROTECTED_ROLES`. A role a persona *grants* is now stripped when you leave that persona (System Manager included), while a `System Manager` role added **manually** on top of a field persona still survives — only the *previous persona's own grants* are ever eligible for stripping. Frappe-internal roles (`Administrator`, `All`, `Guest`) stay protected; the Administrator user is skipped entirely. Switches between ordinary personas were already correct.

## Report-access matrix — 5 cells reconciled with the sheet
The six role-gated Script Reports' `roles` didn't match the Report-access sheet:
| Report | Change |
|---|---|
| Billing and Collection | remove **QS** |
| Material Status | add **Procurement Officer**, **Store Keeper** |
| Subcontractor Position | add **Procurement Officer** (by-decision T3 exception) |
| Measurement Book Register | add **Site Engineer** |

`modified` bumped on each JSON so `bench migrate` re-syncs the roles on deploy (standard reports skip re-import when the timestamp is unchanged).

## Tests
New `buildsuite_core/tests/test_permission_matrix.py` — `TestPersonaRoleSync` (persona grant, switch chains, switch away from / into admin personas, round-trip, manual-role preservation, no accumulation) and `TestReportAccessMatrix` (each gated report runnable by exactly the sheet's personas). Both classes now pass (8 tests); existing `test_user` (9) still passes.

Dashboard/workspace visibility is enforced only client-side (`frontend/src/data/roles.js`), so it isn't covered here — nothing to assert on the backend.

## Out of scope
`test_permissions.py` has 2 pre-existing errors (`test_pm_can_approve_stage`, `test_approved_stage_delete_is_approver_only`: `WorkflowTransitionError` in the Stage Planning workflow) — a separate subsystem, unaffected by this change.