### PR TITLE
fix: Stage Planning workflow uses BuildSuite roles (persona users can act)

### DIFF
--- a/buildsuite_core/fixtures/workflow.json
+++ b/buildsuite_core/fixtures/workflow.json
@@ -1,102 +1,222 @@
 [
-    {
-        "doctype": "Workflow",
-        "name": "Stage Planning Approval",
-        "workflow_name": "Stage Planning Approval",
-        "document_type": "Stage Planning",
-        "is_active": 1,
-        "override_status": 0,
-        "send_email_alert": 0,
-        "workflow_state_field": "workflow_state",
-        "states": [
-            {
-                "state": "Draft",
-                "doc_status": "0",
-                "allow_edit": "Projects User",
-                "is_optional_state": 0
-            },
-            {
-                "state": "Pending Approval",
-                "doc_status": "0",
-                "allow_edit": "Projects Manager",
-                "is_optional_state": 0
-            },
-            {
-                "state": "Approved",
-                "doc_status": "0",
-                "allow_edit": "System Manager",
-                "is_optional_state": 0
-            },
-            {
-                "state": "Rejected",
-                "doc_status": "0",
-                "allow_edit": "Projects User",
-                "is_optional_state": 0
-            },
-            {
-                "state": "Cancelled",
-                "doc_status": "0",
-                "allow_edit": "System Manager",
-                "is_optional_state": 1
-            }
-        ],
-        "transitions": [
-            {
-                "state": "Draft",
-                "action": "Submit for Approval",
-                "next_state": "Pending Approval",
-                "allowed": "Projects User",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Draft",
-                "action": "Submit for Approval",
-                "next_state": "Pending Approval",
-                "allowed": "Projects Manager",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Pending Approval",
-                "action": "Approve",
-                "next_state": "Approved",
-                "allowed": "Projects Manager",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Pending Approval",
-                "action": "Reject",
-                "next_state": "Rejected",
-                "allowed": "Projects Manager",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Approved",
-                "action": "Revise",
-                "next_state": "Draft",
-                "allowed": "Projects Manager",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Approved",
-                "action": "Revise",
-                "next_state": "Draft",
-                "allowed": "System Manager",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Approved",
-                "action": "Cancel",
-                "next_state": "Cancelled",
-                "allowed": "Projects Manager",
-                "allow_self_approval": 1
-            },
-            {
-                "state": "Approved",
-                "action": "Cancel",
-                "next_state": "Cancelled",
-                "allowed": "System Manager",
-                "allow_self_approval": 1
-            }
-        ]
-    }
+ {
+  "doctype": "Workflow",
+  "name": "Stage Planning Approval",
+  "workflow_name": "Stage Planning Approval",
+  "document_type": "Stage Planning",
+  "is_active": 1,
+  "override_status": 0,
+  "send_email_alert": 0,
+  "workflow_state_field": "workflow_state",
+  "states": [
+   {
+    "state": "Draft",
+    "doc_status": "0",
+    "allow_edit": "BuildSuite Project User",
+    "is_optional_state": 0
+   },
+   {
+    "state": "Pending Approval",
+    "doc_status": "0",
+    "allow_edit": "BuildSuite Project User",
+    "is_optional_state": 0
+   },
+   {
+    "state": "Approved",
+    "doc_status": "0",
+    "allow_edit": "BuildSuite Project User",
+    "is_optional_state": 0
+   },
+   {
+    "state": "Rejected",
+    "doc_status": "0",
+    "allow_edit": "BuildSuite Project User",
+    "is_optional_state": 0
+   },
+   {
+    "state": "Cancelled",
+    "doc_status": "0",
+    "allow_edit": "BuildSuite Project User",
+    "is_optional_state": 1
+   }
+  ],
+  "transitions": [
+   {
+    "state": "Draft",
+    "action": "Submit for Approval",
+    "next_state": "Pending Approval",
+    "allowed": "BuildSuite Director",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Draft",
+    "action": "Submit for Approval",
+    "next_state": "Pending Approval",
+    "allowed": "BuildSuite PM",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Draft",
+    "action": "Submit for Approval",
+    "next_state": "Pending Approval",
+    "allowed": "BuildSuite Administrator",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Draft",
+    "action": "Submit for Approval",
+    "next_state": "Pending Approval",
+    "allowed": "System Manager",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Draft",
+    "action": "Submit for Approval",
+    "next_state": "Pending Approval",
+    "allowed": "BuildSuite Site Engineer",
+    "allow_self_approval": 1,
+    "condition": "doc.owner == frappe.session.user"
+   },
+   {
+    "state": "Draft",
+    "action": "Submit for Approval",
+    "next_state": "Pending Approval",
+    "allowed": "BuildSuite Foreman",
+    "allow_self_approval": 1,
+    "condition": "doc.owner == frappe.session.user"
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Approve",
+    "next_state": "Approved",
+    "allowed": "BuildSuite Director",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Approve",
+    "next_state": "Approved",
+    "allowed": "BuildSuite PM",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Approve",
+    "next_state": "Approved",
+    "allowed": "BuildSuite Administrator",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Approve",
+    "next_state": "Approved",
+    "allowed": "System Manager",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Reject",
+    "next_state": "Rejected",
+    "allowed": "BuildSuite Director",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Reject",
+    "next_state": "Rejected",
+    "allowed": "BuildSuite PM",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Reject",
+    "next_state": "Rejected",
+    "allowed": "BuildSuite Administrator",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Pending Approval",
+    "action": "Reject",
+    "next_state": "Rejected",
+    "allowed": "System Manager",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Revise",
+    "next_state": "Draft",
+    "allowed": "BuildSuite Director",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Revise",
+    "next_state": "Draft",
+    "allowed": "BuildSuite PM",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Revise",
+    "next_state": "Draft",
+    "allowed": "BuildSuite Administrator",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Revise",
+    "next_state": "Draft",
+    "allowed": "System Manager",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Cancel",
+    "next_state": "Cancelled",
+    "allowed": "BuildSuite Director",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Cancel",
+    "next_state": "Cancelled",
+    "allowed": "BuildSuite PM",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Cancel",
+    "next_state": "Cancelled",
+    "allowed": "BuildSuite Administrator",
+    "allow_self_approval": 1,
+    "condition": ""
+   },
+   {
+    "state": "Approved",
+    "action": "Cancel",
+    "next_state": "Cancelled",
+    "allowed": "System Manager",
+    "allow_self_approval": 1,
+    "condition": ""
+   }
+  ]
+ }
 ]

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -30,3 +30,4 @@ buildsuite_core.patches.reseed_subcontract_reports # 2026-08-18
 buildsuite_core.patches.reseed_project_finance_reports # 2026-08-18
 buildsuite_core.patches.reseed_project_finance_bespoke # 2026-08-20
 buildsuite_core.patches.reseed_project_finance_bespoke_views # 2026-08-20
+buildsuite_core.patches.fix_stage_planning_workflow_roles # 2026-08-20

--- a/buildsuite_core/patches/fix_stage_planning_workflow_roles.py
+++ b/buildsuite_core/patches/fix_stage_planning_workflow_roles.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Rewire the Stage Planning Approval workflow to BuildSuite roles on existing sites.
+
+The workflow fixture historically carried ERPNext's native `Projects User` / `Projects
+Manager` roles, which no BuildSuite persona holds — so persona users could not submit,
+approve, reject, revise or cancel a stage ("Not a valid Workflow Action"). The rewire
+(setup_stage_planning_workflow) only ran on after_install, never on migrate, so already-
+migrated sites were left on the stale roles. This heals them once; the fixture now ships
+the correct roles for fresh installs and re-imports."""
+
+import frappe
+
+from buildsuite_core.permissions.setup import setup_stage_planning_workflow
+
+
+def execute():
+	if not frappe.db.exists("Workflow", "Stage Planning Approval"):
+		return
+	setup_stage_planning_workflow()


### PR DESCRIPTION
## The bug
The **Stage Planning Approval** workflow was gated on ERPNext's native `Projects User` / `Projects Manager` roles — which **no BuildSuite persona holds**. So a persona user (PM, Site Engineer, Director…) hit `WorkflowTransitionError: Not a valid Workflow Action` on every transition (Submit / Approve / Reject / Revise / Cancel); a stage could only move past Draft as `Administrator`. This is the "general problem lately" surfaced by the 2 erroring tests in `test_permissions.py`.

## Root cause
`setup_stage_planning_workflow()` (in `permissions/setup.py`) already rewires the workflow to BuildSuite roles — but it is only called from `setup_record_permissions()`, which runs on **`after_install` only, never `after_migrate`**. Meanwhile the workflow **fixture** (`fixtures/workflow.json`) still shipped the stale native roles, so every `bench migrate` re-imported the broken workflow and nothing re-applied the rewire.

## Fix
- **`fixtures/workflow.json`** regenerated with BuildSuite roles so fresh installs and fixture re-imports are correct:
  - `allow_edit` = `BuildSuite Project User` (the marker every persona carries; DocPerm + `has_stage_planning_permission` is the real gate).
  - **Submit for Approval** open to all editors; Site Engineer / Foreman restricted to their **own** draft via a `doc.owner == frappe.session.user` condition.
  - **Approve / Reject / Revise / Cancel** = the full-write roles: `BuildSuite Director`, `BuildSuite PM`, `BuildSuite Administrator`, `System Manager`.
- **Patch `fix_stage_planning_workflow_roles`** runs `setup_stage_planning_workflow()` once to heal already-migrated sites deterministically (the fixture re-import alone may not replace child transition rows).

## Verification
- `test_permissions` → **22/22** (was `FAILED (errors=2)`).
- Ran a full `bench migrate` (fixture re-import **+** patch) and confirmed the workflow keeps the BuildSuite roles with **no stale `Projects User` / `Projects Manager`** left — so it won't silently re-break on the next migrate.

## Note
This also means `setup_record_permissions` as a whole is install-only; other permission changes rely on explicit patches (the app's established pattern). This PR only addresses the Stage Planning workflow — no change to that broader convention.