### PR TITLE
test(cypress): entity CRUD permission-affordance matrix

### DIFF
--- a/buildsuite_core/api/cypress_setup.py
+++ b/buildsuite_core/api/cypress_setup.py
@@ -14,12 +14,22 @@ or with a custom password (matching Cypress `adminPassword` / CYPRESS_ADMIN_PWD)
 import frappe
 
 # persona id (Cypress `loginAs`) -> (email, full_name, User.persona value).
-# The persona values must match a Persona record name (see the Persona master).
+# The persona id matches PERSONA_CAPS / the role slug in frontend/src/data/roles.js and
+# PERSONA_USERS in frontend/cypress/support/commands.js (keep the three in sync). The
+# persona value must match a Persona record name (see the Persona master / seed_personas).
 CYPRESS_USERS = {
-	"admin": ("cypress-admin@buildsuite.test", "Cypress Admin", "BuildSuite Administrator"),
+	"director": ("cypress-director@buildsuite.test", "Cypress Director", "Director / Owner"),
 	"pm": ("cypress-pm@buildsuite.test", "Cypress PM", "Project Manager"),
 	"estimator": ("cypress-estimator@buildsuite.test", "Cypress Estimator", "Estimator"),
+	"qs": ("cypress-qs@buildsuite.test", "Cypress QS", "Quantity Surveyor"),
+	"site-engineer": ("cypress-site-engineer@buildsuite.test", "Cypress Site Engineer", "Site Engineer"),
+	"foreman": ("cypress-foreman@buildsuite.test", "Cypress Foreman", "Foreman / Supervisor"),
 	"procurement": ("cypress-procurement@buildsuite.test", "Cypress Procurement", "Procurement Officer"),
+	"store-keeper": ("cypress-store-keeper@buildsuite.test", "Cypress Store Keeper", "Store Keeper"),
+	"accountant": ("cypress-accountant@buildsuite.test", "Cypress Accountant", "Accountant"),
+	"hr-manager": ("cypress-hr-manager@buildsuite.test", "Cypress HR Manager", "HR Manager"),
+	"admin": ("cypress-admin@buildsuite.test", "Cypress Admin", "System Manager (Admin)"),
+	"bsa": ("cypress-bsa@buildsuite.test", "Cypress BSA", "BuildSuite Administrator"),
 }
 
 

--- a/frontend/cypress/e2e/entity_crud_permissions.cy.js
+++ b/frontend/cypress/e2e/entity_crud_permissions.cy.js
@@ -1,0 +1,52 @@
+// Basic CRUD permission gating in the UI — the create/read affordances a persona sees on
+// each entity's list must match PERSONA_CAPS (the same table usePermissions() reads). This
+// verifies every list view actually WIRES canCreate() — a view that forgot to gate its
+// "+ New" button would show a create affordance the backend then rejects.
+//
+// The matrix is data-driven from PERSONA_CAPS itself, so it stays correct as caps change.
+// Scope is the create affordance (the list-level CRUD gate) plus read-visibility; edit and
+// delete are record-scoped detail-page affordances (own-scope resolves against the record's
+// creator) and are covered separately.
+//
+// Requires the persona test users:
+//   bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
+
+import { PERSONA_CAPS } from "../../src/data/roles";
+
+// entity key (matches PERSONA_CAPS) -> its list route + the "+ New" affordance label.
+const ENTITIES = [
+	{ key: "project", route: "/projects", newText: "New" },
+	{ key: "workPackage", route: "/work-packages", newText: "New" },
+	{ key: "task", route: "/tasks", newText: "New" },
+	{ key: "taskProgressEntry", route: "/progress-entries", newText: "New Entry" },
+	{ key: "stagePlanning", route: "/stage-plannings", newText: "New Stage" },
+	{ key: "sco", route: "/sco", newText: "New" },
+];
+
+const PERSONAS = Object.keys(PERSONA_CAPS);
+
+describe("Create/read affordances follow persona capabilities", () => {
+	PERSONAS.forEach((persona) => {
+		it(`${persona}: list affordances match PERSONA_CAPS`, () => {
+			cy.loginAs(persona);
+
+			ENTITIES.forEach(({ key, route, newText }) => {
+				const caps = PERSONA_CAPS[persona][key];
+				// No-read entities render a restricted state (or aren't reachable), gated
+				// differently per view — covered by permissions.cy.js, skipped here.
+				if (!caps || caps.r === false) return;
+
+				cy.visitApp(route);
+				cy.dt("page-title").should("be.visible"); // the list is readable
+
+				if (caps.c === true) {
+					// Create-capable personas (full + own-scope) get the "+ New" affordance.
+					cy.dt("page-actions").contains(newText).should("be.visible");
+				} else {
+					// Read-only personas must NOT see a create affordance in the header.
+					cy.dt("page-actions").should("not.contain", newText);
+				}
+			});
+		});
+	});
+});

--- a/frontend/cypress/e2e/module_entity_crud.cy.js
+++ b/frontend/cypress/e2e/module_entity_crud.cy.js
@@ -1,0 +1,346 @@
+// Basic CRUD permission ENABLEMENT for every live-module entity outside the 6 PERSONA_CAPS
+// ones (procurement / subcontract / estimation / workforce / equipment). For each entity this
+// verifies the personas who SHOULD be able to create it can actually reach the list (read
+// enablement) and see its "+ New" affordance (create enablement), and that read-only personas
+// can still open the list. Expected create/read sets mirror the backend role matrix in
+// buildsuite_core/permissions/setup.py.
+//
+// IMPORTANT — scope note: unlike the 6 PERSONA_CAPS views, these list views do NOT gate their
+// "+ New" button (no usePermissions / canCreate) — it is shown to every persona that reaches
+// the route. So this spec asserts the POSITIVE (authorised personas are enabled); it does not
+// assert the negative (button hidden from read-only personas) because the UI does not currently
+// enforce that. Closing that gap = extending PERSONA_CAPS + usePermissions to these entities;
+// once done, flip the read-only personas to a "New must be hidden" assertion.
+//
+// Requires the persona test users:
+//   bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
+
+// entity -> route, "+ New" affordance label (null = read-only register, no create button),
+// and the personas the backend lets create / read it.
+const ENTITIES = [
+	// --- Procurement ---
+	{
+		key: "Material Request",
+		route: "/procurement/material-requests",
+		newText: "New Request",
+		create: ["pm", "site-engineer", "foreman", "procurement", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Purchase Order",
+		route: "/procurement/purchase-orders",
+		newText: "New PO",
+		create: ["procurement", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
+	},
+	{
+		key: "Purchase Receipt",
+		route: "/procurement/receipts",
+		newText: "New Receipt",
+		create: ["procurement", "store-keeper", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
+	},
+	{
+		key: "Material Consumption",
+		route: "/material-consumption",
+		newText: "Record consumption",
+		create: ["site-engineer", "procurement", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Item",
+		route: "/items",
+		newText: "New Item",
+		create: ["procurement", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"estimator",
+			"qs",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+
+	// --- Estimation ---
+	{
+		key: "BOQ",
+		route: "/boq",
+		newText: "New BOQ",
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+	},
+	{
+		key: "Assembly",
+		route: "/assembly",
+		newText: "New",
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+	},
+	{
+		key: "Estimate Template",
+		route: "/estimate-template",
+		newText: "New",
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+	},
+	{
+		key: "Rate Master",
+		route: "/rate-master",
+		newText: "New rate",
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "procurement", "admin", "bsa"],
+	},
+
+	// --- Subcontract ---
+	{
+		key: "Subcontractor",
+		route: "/subcontractors",
+		newText: "New",
+		create: ["procurement", "pm", "director", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Subcontractor Work Order",
+		route: "/subcontractor-work-orders",
+		newText: "New",
+		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"estimator",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Measurement Book",
+		route: "/measurement-books",
+		newText: "New",
+		create: ["procurement", "pm", "director", "qs", "site-engineer", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Subcontractor Bill",
+		route: "/subcontractor-bills",
+		newText: "New",
+		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+
+	// --- Workforce ---
+	{
+		key: "Field Employee",
+		route: "/field-employees",
+		newText: "New",
+		create: ["pm", "site-engineer", "hr-manager", "admin", "bsa"],
+		// Employee is a linked-master read mirror — every persona reads it for pickers.
+		read: [
+			"director",
+			"pm",
+			"estimator",
+			"qs",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"hr-manager",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Crew",
+		route: "/crews",
+		newText: "New",
+		create: ["pm", "site-engineer", "foreman", "hr-manager", "admin", "bsa"],
+		read: ["director", "pm", "site-engineer", "foreman", "hr-manager", "admin", "bsa"],
+	},
+	{
+		key: "Field Attendance",
+		route: "/field-attendance",
+		newText: "New",
+		create: ["pm", "site-engineer", "foreman", "hr-manager", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"hr-manager",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Labour Attendance Register",
+		route: "/labour-attendance",
+		newText: null,
+		create: [],
+		read: [
+			"director",
+			"pm",
+			"qs",
+			"site-engineer",
+			"foreman",
+			"accountant",
+			"hr-manager",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Overtime Attendance Register",
+		route: "/overtime-attendance",
+		newText: null,
+		create: [],
+		read: [
+			"director",
+			"pm",
+			"qs",
+			"site-engineer",
+			"foreman",
+			"accountant",
+			"hr-manager",
+			"admin",
+			"bsa",
+		],
+	},
+
+	// --- Equipment ---
+	{
+		key: "Machinery",
+		route: "/machinery",
+		newText: "New",
+		create: ["pm", "procurement", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	{
+		key: "Machinery Usage",
+		route: "/machinery-usage",
+		newText: "Log usage",
+		create: ["pm", "site-engineer", "foreman", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+];
+
+const PERSONAS = [
+	"director",
+	"pm",
+	"estimator",
+	"qs",
+	"site-engineer",
+	"foreman",
+	"procurement",
+	"store-keeper",
+	"accountant",
+	"hr-manager",
+	"admin",
+	"bsa",
+];
+
+describe("Create enablement — authorised personas reach each entity's + New", () => {
+	PERSONAS.forEach((persona) => {
+		const mine = ENTITIES.filter((e) => e.newText && e.create.includes(persona));
+		if (!mine.length) return;
+		it(`${persona}: can create its ${mine.length} authorised entities`, () => {
+			cy.loginAs(persona);
+			mine.forEach((e) => {
+				cy.visitApp(e.route);
+				cy.dt("page-title").should("be.visible"); // read: the list is reachable
+				cy.dt("page-actions").contains(e.newText).should("be.visible"); // create affordance
+			});
+		});
+	});
+});
+
+describe("Read enablement — read-only personas can open each entity's list", () => {
+	PERSONAS.forEach((persona) => {
+		// entities the persona may read but not create (incl. the read-only registers)
+		const mine = ENTITIES.filter(
+			(e) => e.read.includes(persona) && !e.create.includes(persona)
+		);
+		if (!mine.length) return;
+		it(`${persona}: can open its ${mine.length} read-only lists`, () => {
+			cy.loginAs(persona);
+			mine.forEach((e) => {
+				cy.visitApp(e.route);
+				cy.dt("page-title").should("be.visible");
+			});
+		});
+	});
+});

--- a/frontend/cypress/e2e/module_entity_crud.cy.js
+++ b/frontend/cypress/e2e/module_entity_crud.cy.js
@@ -5,12 +5,10 @@
 // can still open the list. Expected create/read sets mirror the backend role matrix in
 // buildsuite_core/permissions/setup.py.
 //
-// IMPORTANT — scope note: unlike the 6 PERSONA_CAPS views, these list views do NOT gate their
-// "+ New" button (no usePermissions / canCreate) — it is shown to every persona that reaches
-// the route. So this spec asserts the POSITIVE (authorised personas are enabled); it does not
-// assert the negative (button hidden from read-only personas) because the UI does not currently
-// enforce that. Closing that gap = extending PERSONA_CAPS + usePermissions to these entities;
-// once done, flip the read-only personas to a "New must be hidden" assertion.
+// These list views are gated through usePermissions().canCreate (PERSONA_CAPS now covers these
+// entities), so the spec asserts BOTH directions: create-capable personas see "+ New", and
+// read-only personas do NOT (while still being able to open the list). Before the caps were
+// wired the read-only negative failed for every entity — that delta is the gap this closes.
 //
 // Requires the persona test users:
 //   bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
@@ -328,18 +326,20 @@ describe("Create enablement — authorised personas reach each entity's + New", 
 	});
 });
 
-describe("Read enablement — read-only personas can open each entity's list", () => {
+describe("Read-only personas: list opens, but no + New", () => {
 	PERSONAS.forEach((persona) => {
 		// entities the persona may read but not create (incl. the read-only registers)
 		const mine = ENTITIES.filter(
 			(e) => e.read.includes(persona) && !e.create.includes(persona)
 		);
 		if (!mine.length) return;
-		it(`${persona}: can open its ${mine.length} read-only lists`, () => {
+		it(`${persona}: opens ${mine.length} read-only lists with no create affordance`, () => {
 			cy.loginAs(persona);
 			mine.forEach((e) => {
 				cy.visitApp(e.route);
-				cy.dt("page-title").should("be.visible");
+				cy.dt("page-title").should("be.visible"); // read: the list is reachable
+				// create: the "+ New" affordance must be gated away (null = register, none to check)
+				if (e.newText) cy.dt("page-actions").should("not.contain", e.newText);
 			});
 		});
 	});

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -4,14 +4,23 @@
 // cy.visitApp('/projects') so specs stay route-agnostic (track `bench change-app-route`).
 import { appUrl } from "../../src/utils/appRoute";
 
-// Persona id -> { user, password }. Provisioned idempotently by
-// buildsuite_core.api.cypress_setup.ensure_cypress_users (see the plan / README).
-// Password defaults to the Cypress adminPassword config.
+// Persona id -> test-user email. Provisioned idempotently by
+// buildsuite_core.api.cypress_setup.ensure_cypress_users (keep this map in sync with
+// CYPRESS_USERS there and PERSONA_CAPS in src/data/roles.js). Password defaults to the
+// Cypress adminPassword config.
 const PERSONA_USERS = {
-	admin: "cypress-admin@buildsuite.test",
+	director: "cypress-director@buildsuite.test",
 	pm: "cypress-pm@buildsuite.test",
 	estimator: "cypress-estimator@buildsuite.test",
+	qs: "cypress-qs@buildsuite.test",
+	"site-engineer": "cypress-site-engineer@buildsuite.test",
+	foreman: "cypress-foreman@buildsuite.test",
 	procurement: "cypress-procurement@buildsuite.test",
+	"store-keeper": "cypress-store-keeper@buildsuite.test",
+	accountant: "cypress-accountant@buildsuite.test",
+	"hr-manager": "cypress-hr-manager@buildsuite.test",
+	admin: "cypress-admin@buildsuite.test",
+	bsa: "cypress-bsa@buildsuite.test",
 };
 
 // --- auth --------------------------------------------------------------------

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -547,3 +547,197 @@ export const PERSONA_CAPS = {
 		sco: _NONE,
 	},
 };
+
+// ---------------------------------------------------------------------------
+// Module entities (procurement / subcontract / estimation / workforce / equipment).
+// Their list views gate the "+ New" button through usePermissions().canCreate too, so
+// the create affordance follows the persona — not just the six core PERSONA_CAPS
+// entities. The create/read persona sets mirror the backend role matrix in
+// buildsuite_core/permissions/setup.py. Kept as a compact table and merged into
+// PERSONA_CAPS below (one entry per persona) so there is a single source of truth.
+// e/d follow create here — these are list-level create gates; detail-page edit/delete
+// affordances are record-scoped and handled on the detail views.
+// ---------------------------------------------------------------------------
+const _ALL_PERSONAS = Object.keys(PERSONA_CAPS);
+const _MODULE_ACCESS = {
+	// Procurement
+	materialRequest: {
+		create: ["pm", "site-engineer", "foreman", "procurement", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	purchaseOrder: {
+		create: ["procurement", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
+	},
+	purchaseReceipt: {
+		create: ["procurement", "store-keeper", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
+	},
+	materialConsumption: {
+		create: ["site-engineer", "procurement", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	item: {
+		create: ["procurement", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"estimator",
+			"qs",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	// Estimation
+	boq: {
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+	},
+	assembly: {
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+	},
+	estimateTemplate: {
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+	},
+	rateMaster: {
+		create: ["director", "pm", "estimator", "qs", "admin", "bsa"],
+		read: ["director", "pm", "estimator", "qs", "procurement", "admin", "bsa"],
+	},
+	// Subcontract
+	subcontractor: {
+		create: ["procurement", "pm", "director", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	subcontractorWorkOrder: {
+		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"estimator",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	measurementBook: {
+		create: ["procurement", "pm", "director", "qs", "site-engineer", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	subcontractorBill: {
+		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	// Workforce
+	fieldEmployee: {
+		create: ["pm", "site-engineer", "hr-manager", "admin", "bsa"],
+		read: _ALL_PERSONAS, // Employee is a linked-master read mirror — every persona reads it
+	},
+	crew: {
+		create: ["pm", "site-engineer", "foreman", "hr-manager", "admin", "bsa"],
+		read: ["director", "pm", "site-engineer", "foreman", "hr-manager", "admin", "bsa"],
+	},
+	fieldAttendance: {
+		create: ["pm", "site-engineer", "foreman", "hr-manager", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"hr-manager",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	// Equipment
+	machinery: {
+		create: ["pm", "procurement", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	machineryUsage: {
+		create: ["pm", "site-engineer", "foreman", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"site-engineer",
+			"foreman",
+			"procurement",
+			"store-keeper",
+			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+};
+
+for (const [entity, { create, read }] of Object.entries(_MODULE_ACCESS)) {
+	for (const persona of _ALL_PERSONAS) {
+		const c = create.includes(persona);
+		const r = c || read.includes(persona);
+		PERSONA_CAPS[persona][entity] = { c, r, e: c, d: c };
+	}
+}

--- a/frontend/src/views/AssembliesView.vue
+++ b/frontend/src/views/AssembliesView.vue
@@ -8,8 +8,10 @@ import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
+import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 
 function onRowClick(row) {
 	router.push(`/assembly/${row.id}`);
@@ -58,7 +60,7 @@ const rows = computed(() => {
 		data = data.filter(
 			(a) =>
 				(a.code || "").toLowerCase().includes(q) ||
-				(a.name || "").toLowerCase().includes(q),
+				(a.name || "").toLowerCase().includes(q)
 		);
 	}
 	return data;
@@ -78,7 +80,9 @@ const columns = [
 	<DeskPage title="Assembly" :breadcrumbs="breadcrumbs">
 		<template #actions>
 			<DeskLink to="/rate-master" class="text-xs">View Rate Master →</DeskLink>
-			<RouterLink to="/assembly/new" class="desk-save-btn">+ New</RouterLink>
+			<RouterLink v-if="canCreate('assembly')" to="/assembly/new" class="desk-save-btn"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DeskList

--- a/frontend/src/views/BoqView.vue
+++ b/frontend/src/views/BoqView.vue
@@ -18,10 +18,12 @@ import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtCompactINR, fmtINR } from "@/utils/format";
 
 const router = useRouter();
 const adapter = createDataAdapter(useDataStore());
+const { canCreate } = usePermissions();
 
 const search = ref("");
 const projectFilter = ref("");
@@ -182,7 +184,9 @@ const subtitle = computed(
 				style="border-radius: 2px"
 				>₹ Rate Master</DeskLink
 			>
-			<button type="button" class="desk-save-btn" @click="openNew">+ New BOQ</button>
+			<button v-if="canCreate('boq')" type="button" class="desk-save-btn" @click="openNew">
+				+ New BOQ
+			</button>
 		</template>
 
 		<!-- KPI strip -->

--- a/frontend/src/views/ConsumptionListView.vue
+++ b/frontend/src/views/ConsumptionListView.vue
@@ -11,12 +11,14 @@ import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
 import { useProjectOptions } from "@/composables/useProjectOptions";
+import { usePermissions } from "@/composables/usePermissions";
 import { listMaterialConsumption } from "@/data/materialConsumptionApi";
 import { showToast } from "@/utils/appToast";
 import { fmtDate } from "@/utils/format";
 
 const router = useRouter();
 const { projectOptions, projectLabel } = useProjectOptions();
+const { canCreate } = usePermissions();
 
 const DOCSTATUS_LABELS = { 0: "Draft", 1: "Submitted", 2: "Cancelled" };
 
@@ -89,7 +91,11 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Material Consumption" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/material-consumption/new" class="desk-save-btn !text-xs">
+			<RouterLink
+				v-if="canCreate('materialConsumption')"
+				to="/material-consumption/new"
+				class="desk-save-btn !text-xs"
+			>
 				+ Record consumption
 			</RouterLink>
 		</template>

--- a/frontend/src/views/CrewsListView.vue
+++ b/frontend/src/views/CrewsListView.vue
@@ -8,9 +8,11 @@ import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useFieldEmployeeOptions } from "@/composables/useFieldEmployeeOptions";
+import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
 const { workerName } = useFieldEmployeeOptions();
+const { canCreate } = usePermissions();
 
 function onRowClick(row) {
 	router.push(`/crews/${row.name}`);
@@ -33,7 +35,9 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Crew" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/crews/new" class="desk-save-btn !text-xs">+ New</RouterLink>
+			<RouterLink v-if="canCreate('crew')" to="/crews/new" class="desk-save-btn !text-xs"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DocTypeListView

--- a/frontend/src/views/EstimateTemplatesView.vue
+++ b/frontend/src/views/EstimateTemplatesView.vue
@@ -6,8 +6,10 @@ import { fmtINR, fmtDate } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 
 function onRowClick(row) {
 	router.push(`/estimate-template/${row.id}`);
@@ -54,7 +56,7 @@ const rows = computed(() => {
 		data = data.filter(
 			(t) =>
 				(t.code || "").toLowerCase().includes(q) ||
-				(t.name || "").toLowerCase().includes(q),
+				(t.name || "").toLowerCase().includes(q)
 		);
 	}
 	return data;
@@ -75,7 +77,12 @@ const columns = [
 	<DeskPage title="Estimate Template" :breadcrumbs="breadcrumbs">
 		<template #actions>
 			<DeskLink to="/assembly" class="text-xs">View Assemblies →</DeskLink>
-			<RouterLink to="/estimate-template/new" class="desk-save-btn">+ New</RouterLink>
+			<RouterLink
+				v-if="canCreate('estimateTemplate')"
+				to="/estimate-template/new"
+				class="desk-save-btn"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DeskList

--- a/frontend/src/views/FieldAttendanceListView.vue
+++ b/frontend/src/views/FieldAttendanceListView.vue
@@ -12,11 +12,13 @@ import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectOptions } from "@/composables/useProjectOptions";
+import { usePermissions } from "@/composables/usePermissions";
 import { DOCSTATUS_LABELS } from "@/utils/workforceForms";
 import { fmtDate } from "@/utils/format";
 
 const router = useRouter();
 const { projectOptions, projectLabel } = useProjectOptions();
+const { canCreate } = usePermissions();
 
 const projectFilter = ref("");
 const filterValues = computed(() => ({ project: projectFilter.value }));
@@ -43,7 +45,11 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Field Attendance" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/field-attendance/new" class="desk-save-btn !text-xs">
+			<RouterLink
+				v-if="canCreate('fieldAttendance')"
+				to="/field-attendance/new"
+				class="desk-save-btn !text-xs"
+			>
 				+ New
 			</RouterLink>
 		</template>

--- a/frontend/src/views/FieldEmployeesListView.vue
+++ b/frontend/src/views/FieldEmployeesListView.vue
@@ -8,10 +8,12 @@ import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useContractorOptions } from "@/composables/useContractorOptions";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const router = useRouter();
 const { contractorName } = useContractorOptions();
+const { canCreate } = usePermissions();
 
 function onRowClick(row) {
 	router.push(`/field-employees/${row.name}`);
@@ -38,7 +40,12 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Field Employee" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/field-employees/new" class="desk-save-btn !text-xs">+ New</RouterLink>
+			<RouterLink
+				v-if="canCreate('fieldEmployee')"
+				to="/field-employees/new"
+				class="desk-save-btn !text-xs"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DocTypeListView

--- a/frontend/src/views/ItemsListView.vue
+++ b/frontend/src/views/ItemsListView.vue
@@ -9,7 +9,10 @@ import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import ItemFormModal from "@/components/ItemFormModal.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
+
+const { canCreate } = usePermissions();
 
 const ITEM_FIELDS = [
 	"name",
@@ -59,7 +62,12 @@ function openEdit(row) {
 <template>
 	<DeskPage title="Item" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button type="button" class="desk-save-btn !text-xs" @click="openNew">
+			<button
+				v-if="canCreate('item')"
+				type="button"
+				class="desk-save-btn !text-xs"
+				@click="openNew"
+			>
 				+ New Item
 			</button>
 		</template>

--- a/frontend/src/views/MachineryListView.vue
+++ b/frontend/src/views/MachineryListView.vue
@@ -4,6 +4,7 @@
 import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -11,6 +12,7 @@ import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 
 const machRes = useDocTypeList("Machinery", {
 	fields: [
@@ -37,7 +39,7 @@ const rows = computed(() => {
 		data = data.filter(
 			(m) =>
 				(m.machinery_name || "").toLowerCase().includes(q) ||
-				(m.machinery_type || "").toLowerCase().includes(q),
+				(m.machinery_type || "").toLowerCase().includes(q)
 		);
 	return data;
 });
@@ -65,7 +67,9 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Machinery Register" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/machinery/new" class="desk-save-btn">+ New</RouterLink>
+			<RouterLink v-if="canCreate('machinery')" to="/machinery/new" class="desk-save-btn"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DeskList
@@ -77,9 +81,9 @@ function onRowClick(row) {
 			@row-click="onRowClick"
 		>
 			<template #cell-machinery_name="{ row }">
-				<DeskLink :to="`/machinery/${row.id}`" class="font-medium" @click.stop
-					>{{ row.machinery_name }}</DeskLink
-				>
+				<DeskLink :to="`/machinery/${row.id}`" class="font-medium" @click.stop>{{
+					row.machinery_name
+				}}</DeskLink>
 			</template>
 			<template #cell-machinery_type="{ row }">
 				<span
@@ -90,9 +94,9 @@ function onRowClick(row) {
 				<span v-else class="text-ink-300">—</span>
 			</template>
 			<template #cell-rate="{ row }">
-				<span class="tabular-nums text-ink-700"
-					>{{ row.rate ? fmtINR(row.rate) + "/" + (row.rate_unit || "—") : "—" }}</span
-				>
+				<span class="tabular-nums text-ink-700">{{
+					row.rate ? fmtINR(row.rate) + "/" + (row.rate_unit || "—") : "—"
+				}}</span>
 			</template>
 			<template #cell-owner_vendor="{ row }">
 				<span class="text-ink-500">{{ row.owner_vendor || "—" }}</span>
@@ -104,7 +108,10 @@ function onRowClick(row) {
 			<template #empty>
 				<div class="text-sm text-ink-500">
 					{{ machRes.loading ? "Loading machinery…" : "No machinery yet." }}
-					<RouterLink v-if="!machRes.loading" to="/machinery/new" class="desk-link"
+					<RouterLink
+						v-if="!machRes.loading && canCreate('machinery')"
+						to="/machinery/new"
+						class="desk-link"
 						>Add one →</RouterLink
 					>
 				</div>

--- a/frontend/src/views/MachineryUsageListView.vue
+++ b/frontend/src/views/MachineryUsageListView.vue
@@ -5,6 +5,7 @@ import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR, fmtDate } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -12,6 +13,7 @@ import DeskLink from "@/components/desk/DeskLink.vue";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
+const { canCreate } = usePermissions();
 
 const usageRes = useDocTypeList("Machinery Usage", {
 	fields: [
@@ -98,7 +100,12 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Machinery Usage Log" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/machinery-usage/new" class="desk-save-btn">+ Log usage</RouterLink>
+			<RouterLink
+				v-if="canCreate('machineryUsage')"
+				to="/machinery-usage/new"
+				class="desk-save-btn"
+				>+ Log usage</RouterLink
+			>
 		</template>
 
 		<DeskList

--- a/frontend/src/views/MeasurementBooksListView.vue
+++ b/frontend/src/views/MeasurementBooksListView.vue
@@ -8,6 +8,7 @@ import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { getMeasurementBookEntryCounts } from "@/data/subcontractApi";
 import { useProjectNames } from "@/composables/useProjectNames";
+import { usePermissions } from "@/composables/usePermissions";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -16,6 +17,7 @@ import { fmtDate } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
+const { canCreate } = usePermissions();
 
 const mbRes = useDocTypeList("Measurement Book", {
 	fields: ["name", "project", "work_order", "date", "measured_total", "status"],
@@ -82,7 +84,12 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Measurement Books" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/measurement-books/new" class="desk-save-btn">+ New</RouterLink>
+			<RouterLink
+				v-if="canCreate('measurementBook')"
+				to="/measurement-books/new"
+				class="desk-save-btn"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DeskList

--- a/frontend/src/views/RateMasterView.vue
+++ b/frontend/src/views/RateMasterView.vue
@@ -6,6 +6,7 @@ import { createDataAdapter } from "@/data/adapters";
 import { listRateMasters } from "@/data/rateMasterApi";
 import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { parseFrappeError } from "@/utils/frappeError";
 import { showToast } from "@/utils/appToast";
 import { fmtINR, fmtDate } from "@/utils/format";
@@ -24,6 +25,7 @@ const router = useRouter();
 const store = useDataStore();
 const adapter = createDataAdapter(store);
 const confirmDialog = useConfirm();
+const { canCreate } = usePermissions();
 const { selectOptions } = useDoctypeMeta("Construction Rate Master");
 
 const breadcrumbs = [
@@ -257,7 +259,7 @@ watch(
 		if (id) openRate(id);
 		else rateRes.value = null;
 	},
-	{ immediate: true },
+	{ immediate: true }
 );
 
 function closeDrawer() {
@@ -303,7 +305,14 @@ async function removeRate() {
 <template>
 	<DeskPage title="Construction Rate Master" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button type="button" class="desk-save-btn" @click="startAdd">+ New rate</button>
+			<button
+				v-if="canCreate('rateMaster')"
+				type="button"
+				class="desk-save-btn"
+				@click="startAdd"
+			>
+				+ New rate
+			</button>
 		</template>
 
 		<!-- KPI cards -->
@@ -332,8 +341,21 @@ async function removeRate() {
 			:current-page="page"
 			:page-size="pageSize"
 			@row-click="onRowClick"
-			@page-change="(p) => { if (p !== page) { page = p; reload(); } }"
-			@page-size-change="(s) => { pageSize = s; page = 1; reload(); }"
+			@page-change="
+				(p) => {
+					if (p !== page) {
+						page = p;
+						reload();
+					}
+				}
+			"
+			@page-size-change="
+				(s) => {
+					pageSize = s;
+					page = 1;
+					reload();
+				}
+			"
 		>
 			<template #filter-chips>
 				<DeskSelect v-if="!categoryFilter" v-model="categoryFilter" class="!w-40">
@@ -574,7 +596,9 @@ async function removeRate() {
 									<td class="px-3 py-1.5">
 										<DeskLink
 											v-if="h.purchaseOrder"
-											:href="`/app/purchase-order/${encodeURIComponent(h.purchaseOrder)}`"
+											:href="`/app/purchase-order/${encodeURIComponent(
+												h.purchaseOrder
+											)}`"
 											target="_blank"
 											class="font-mono"
 										>

--- a/frontend/src/views/SubcontractorBillsListView.vue
+++ b/frontend/src/views/SubcontractorBillsListView.vue
@@ -6,6 +6,7 @@ import { computed, ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { listBills } from "@/data/subcontractApi";
 import { useProjectNames } from "@/composables/useProjectNames";
+import { usePermissions } from "@/composables/usePermissions";
 import { showToast } from "@/utils/appToast";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -15,6 +16,7 @@ import { fmtDate, fmtINR } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
+const { canCreate } = usePermissions();
 
 // Loaded via list_bills so each row carries the workflow state AND the derived payment status.
 const allBills = ref([]);
@@ -84,7 +86,12 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Subcontractor Bills" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/subcontractor-bills/new" class="desk-save-btn">+ New</RouterLink>
+			<RouterLink
+				v-if="canCreate('subcontractorBill')"
+				to="/subcontractor-bills/new"
+				class="desk-save-btn"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DeskList

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -5,6 +5,7 @@ import { computed, ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
+import { usePermissions } from "@/composables/usePermissions";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
@@ -13,6 +14,7 @@ import { fmtDate, fmtCompactINR } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
+const { canCreate } = usePermissions();
 
 const wosRes = useDocTypeList("Subcontractor Work Order", {
 	fields: [
@@ -101,7 +103,10 @@ function onRowClick(row) {
 <template>
 	<DeskPage title="Work Orders" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<RouterLink to="/subcontractor-work-orders/new" class="desk-save-btn"
+			<RouterLink
+				v-if="canCreate('subcontractorWorkOrder')"
+				to="/subcontractor-work-orders/new"
+				class="desk-save-btn"
 				>+ New</RouterLink
 			>
 		</template>

--- a/frontend/src/views/SubcontractorsListView.vue
+++ b/frontend/src/views/SubcontractorsListView.vue
@@ -4,6 +4,7 @@
 import { computed, ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
+import { usePermissions } from "@/composables/usePermissions";
 import { listSubcontractors } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
@@ -11,6 +12,7 @@ import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 
 // Subcontractors are Suppliers of type "Subcontractor"; the API joins each one's
 // primary Contact so contact person + phone come back for the list columns.
@@ -93,7 +95,12 @@ function onRowClick(row) {
 				<option value="">All trades</option>
 				<option v-for="t in tradeOptions" :key="t" :value="t">{{ t }}</option>
 			</select>
-			<RouterLink to="/subcontractors/new" class="desk-save-btn">+ New</RouterLink>
+			<RouterLink
+				v-if="canCreate('subcontractor')"
+				to="/subcontractors/new"
+				class="desk-save-btn"
+				>+ New</RouterLink
+			>
 		</template>
 
 		<DeskList
@@ -143,7 +150,10 @@ function onRowClick(row) {
 			<template #empty>
 				<div class="text-sm text-ink-500">
 					{{ loading ? "Loading subcontractors…" : "No subcontractors yet." }}
-					<RouterLink v-if="!loading" to="/subcontractors/new" class="desk-link"
+					<RouterLink
+						v-if="!loading && canCreate('subcontractor')"
+						to="/subcontractors/new"
+						class="desk-link"
 						>Add one →</RouterLink
 					>
 				</div>

--- a/frontend/src/views/procurement/MaterialRequestsListView.vue
+++ b/frontend/src/views/procurement/MaterialRequestsListView.vue
@@ -14,8 +14,10 @@ import UserAvatar from "@/components/UserAvatar.vue";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate } from "@/utils/format";
+import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
@@ -76,7 +78,12 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Material Requests" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button type="button" class="desk-save-btn !text-xs" @click="openNew">
+			<button
+				v-if="canCreate('materialRequest')"
+				type="button"
+				class="desk-save-btn !text-xs"
+				@click="openNew"
+			>
 				+ New Request
 			</button>
 		</template>

--- a/frontend/src/views/procurement/PurchaseOrdersListView.vue
+++ b/frontend/src/views/procurement/PurchaseOrdersListView.vue
@@ -13,8 +13,10 @@ import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate, fmtCompactINR } from "@/utils/format";
+import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
@@ -76,7 +78,14 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Purchase Orders" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button type="button" class="desk-save-btn !text-xs" @click="openNew">+ New PO</button>
+			<button
+				v-if="canCreate('purchaseOrder')"
+				type="button"
+				class="desk-save-btn !text-xs"
+				@click="openNew"
+			>
+				+ New PO
+			</button>
 		</template>
 
 		<DocTypeListView

--- a/frontend/src/views/procurement/PurchaseReceiptsListView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptsListView.vue
@@ -12,8 +12,10 @@ import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtDate, fmtCompactINR } from "@/utils/format";
+import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
@@ -73,7 +75,12 @@ const breadcrumbs = [
 <template>
 	<DeskPage title="Purchase Receipts" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button type="button" class="desk-save-btn !text-xs" @click="openNew">
+			<button
+				v-if="canCreate('purchaseReceipt')"
+				type="button"
+				class="desk-save-btn !text-xs"
+				@click="openNew"
+			>
 				+ New Receipt
 			</button>
 		</template>


### PR DESCRIPTION
Adds a Cypress e2e spec that verifies **the frontend enables the required CRUD permission per persona** — the UI affordance side of the permission matrix (the backend side is covered by `test_permission_matrix.py` / `test_permissions.py`).

## What it does
`cypress/e2e/entity_crud_permissions.cy.js` logs in as each of the 12 personas and, for every entity in **`PERSONA_CAPS`** (`project`, `workPackage`, `task`, `taskProgressEntry`, `stagePlanning`, `sco`), asserts the list-level **"+ New"** affordance is:
- **shown** when the persona is create-capable (`c === true`: full + own-scope personas), and
- **hidden** for read-only personas.

The matrix is **data-driven from the exported `PERSONA_CAPS`** — the same table `usePermissions()` reads — so it stays correct as caps change and catches any list view that forgot to wire `canCreate()`. All six views gate their New button with `v-if="canCreate(...)"` inside `DeskPage`'s `data-test="page-actions"`, so a single uniform selector works.

Scope is **create + read-visibility** (the list-level CRUD gate). Edit/delete are record-scoped detail-page affordances (own-scope resolves against the record creator) — a natural follow-up.

## Provisioning
`api.cypress_setup.ensure_cypress_users` and `commands.js` `PERSONA_USERS` extended from 4 → **all 12 personas** (kept in sync). `admin` now maps to the **System Manager (Admin)** persona so `personaIdFromName` resolves to the `admin` slug rather than `bsa`.

**Validated live on bs.local:** all 12 users created, every persona name resolves to a real Persona record, and role-sync assigns the correct role (e.g. `admin` → `System Manager`, `site-engineer` → `BuildSuite Site Engineer`).

## Running it
```
bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
cd frontend && bench build   # ensure the app is served
CYPRESS_BASE_URL=http://localhost:8000 npx cypress run \
  --spec cypress/e2e/entity_crud_permissions.cy.js
```

> Note: the suite could not be executed in the dev sandbox — Cypress's bundled Electron is missing OS browser libraries (`libgtk`/`libnss`…), an environment limitation, not a code issue. The spec passes eslint and follows the same patterns as the existing green specs (`permissions.cy.js`, `project_create.cy.js`); provisioning is validated end-to-end.