### PR TITLE
fix: Cypress follow-ups — read-mirror perms, workflow + seeding spec updates

### DIFF
--- a/buildsuite_core/install.py
+++ b/buildsuite_core/install.py
@@ -5,7 +5,7 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 
 from buildsuite_core.custom_property_list.custom_field import CUSTOM_FIELD
 from buildsuite_core.custom_property_list.property_field import get_property_setters
-from buildsuite_core.permissions.setup import setup_record_permissions
+from buildsuite_core.permissions.setup import setup_child_table_read_access, setup_record_permissions
 from buildsuite_core.utils.project import backfill_project_status
 from buildsuite_core.utils.task import backfill_native_task_type, backfill_task_status
 
@@ -34,6 +34,12 @@ def after_migrate():
 	backfill_work_order_company()
 	backfill_bill_company()
 	seed_master_data()
+	# Self-heal the reference read-mirror on EVERY migrate. It's purely additive + idempotent
+	# (grants only the missing reads, never revokes), so running it LAST — after all patches and
+	# fixture syncs this migrate — guarantees the child-table / link-target reads survive any
+	# authoritative perm re-apply (e.g. a subcontract patch resetting Supplier's role list) that
+	# ran earlier. This removes the "must remember to run the mirror last by hand" footgun.
+	setup_child_table_read_access()
 
 
 def _backfill_project_company(doctype, extra_where=""):

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -32,3 +32,4 @@ buildsuite_core.patches.reseed_project_finance_bespoke # 2026-08-20
 buildsuite_core.patches.reseed_project_finance_bespoke_views # 2026-08-20
 buildsuite_core.patches.fix_stage_planning_workflow_roles # 2026-08-20
 buildsuite_core.patches.reseed_procurement_bespoke_reports # 2026-08-20
+buildsuite_core.patches.grant_child_table_read_access # 2026-08-21

--- a/buildsuite_core/patches/grant_child_table_read_access.py
+++ b/buildsuite_core/patches/grant_child_table_read_access.py
@@ -10,9 +10,16 @@ on install; this applies the same grant to already-migrated sites."""
 
 import frappe
 
-from buildsuite_core.permissions.setup import setup_child_table_read_access
+from buildsuite_core.permissions.setup import (
+	setup_child_table_read_access,
+	setup_subcontract_permissions,
+)
 
 
 def execute():
+	# Re-apply subcontract perms first (adds Estimator read on Subcontractor Bill — the WO list
+	# shows a "% billed" column, so a WO reader without Bill read 403s the whole list), then the
+	# reference read-mirror on top.
+	setup_subcontract_permissions()
 	setup_child_table_read_access()
 	frappe.clear_cache()

--- a/buildsuite_core/patches/grant_child_table_read_access.py
+++ b/buildsuite_core/patches/grant_child_table_read_access.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Mirror read to child tables on existing sites.
+
+Custom DocPerms override standard perms, so a BuildSuite role granted read on a parent doctype
+gets nothing on that parent's child (Table) doctypes — a list/detail view that fetches child
+rows directly then 403s (e.g. HR Manager on Crew Member). setup_child_table_read_access() runs
+on install; this applies the same grant to already-migrated sites."""
+
+import frappe
+
+from buildsuite_core.permissions.setup import setup_child_table_read_access
+
+
+def execute():
+	setup_child_table_read_access()
+	frappe.clear_cache()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -564,12 +564,15 @@ MEASUREMENT_BOOK_ROLE_PERMS = {
 	"BuildSuite Accountant": _READ,
 }
 # Subcontractor Bill (RA Bill) — submittable. The QS + subcontract full roles raise and
-# submit progress bills; the Accountant + Site Engineer read them.
+# submit progress bills; the Accountant + Site Engineer + Estimator read them. Every role that
+# can read a Work Order reads Bills too — the WO list shows a "% billed" column sourced from
+# them, so a WO reader without Bill read would 403 the whole list.
 _BILL_FULL_ROLES = _SUBCONTRACT_FULL_ROLES + ("BuildSuite QS",)
 SUBCONTRACT_BILL_ROLE_PERMS = {
 	**{role: _FULL_SUB for role in _BILL_FULL_ROLES},
 	"BuildSuite Accountant": _READ,
 	"BuildSuite Site Engineer": _READ,
+	"BuildSuite Estimator": _READ,
 }
 # Subcontractor Work Order — the commitment document is natively submittable (Draft →
 # Submitted → Cancelled + Amend), so the full roles get CRWDSX, not just CRWD. QS prepares

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -889,6 +889,66 @@ def setup_subcontractor_wo_workflow():
 		)
 
 
+# Core/system doctypes never auto-granted by the read mirror, even if a BuildSuite doctype
+# links to them — read here would be an over-grant, not a display convenience.
+_READ_MIRROR_DENYLIST = {
+	"User",
+	"Role",
+	"DocType",
+	"DocField",
+	"DocPerm",
+	"Custom DocPerm",
+	"Custom Field",
+	"Property Setter",
+	"Workflow",
+	"Print Format",
+	"Report",
+	"Page",
+	"File",
+	"Server Script",
+	"Client Script",
+	"Webhook",
+	"Email Account",
+}
+
+
+def setup_child_table_read_access():
+	"""Grant each BuildSuite role read on the doctypes REFERENCED by every parent it can read —
+	the parent's child (Table) doctypes AND its Link-field targets.
+
+	Custom DocPerms completely override standard perms, so a role granted read on a parent has
+	NO grant on the child tables or linked masters that parent's list/detail views render (line
+	items, a `trade` → Labour Trade column, a filter dropdown, …) — and the fetch then 403s
+	(e.g. HR Manager reads Crew but not its `trade` → Labour Trade). Mirroring read to those
+	referenced doctypes closes that class of gap. Read only (never write/delete), layered on top
+	of existing perms, system doctypes excluded — idempotent."""
+	grants = frappe.get_all(
+		"Custom DocPerm",
+		filters={"read": 1, "permlevel": 0, "role": ["in", list(BUILDSUITE_ROLES)]},
+		fields=["parent as doctype", "role"],
+	)
+	roles_by_parent = {}
+	for g in grants:
+		roles_by_parent.setdefault(g.doctype, set()).add(g.role)
+
+	for parent, roles in roles_by_parent.items():
+		if not frappe.db.exists("DocType", parent):
+			continue
+		meta = frappe.get_meta(parent)
+		referenced = {df.options for df in meta.get_table_fields() if df.options}
+		referenced |= {
+			df.options
+			for df in meta.get_link_fields()
+			if df.options and df.options not in _READ_MIRROR_DENYLIST
+		}
+		read_only = {role: {"read": 1} for role in roles}
+		for ref in referenced:
+			if not frappe.db.exists("DocType", ref) or frappe.get_meta(ref).issingle:
+				continue
+			# ptypes=("read",) — grant read without disturbing any other permission on the target.
+			_upgrade_role_perms(ref, read_only, ptypes=("read",))
+
+
 def setup_record_permissions():
 	"""Seed roles + DocPerms for every BuildSuite-scoped doctype."""
 	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import seed_personas
@@ -915,6 +975,9 @@ def setup_record_permissions():
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()
 	setup_subcontractor_wo_workflow()
+	# Mirror read to child tables of everything the BuildSuite roles can read (must run AFTER
+	# all the parent grants above are in place).
+	setup_child_table_read_access()
 	# Personas map to the roles ensured above — seed them once the roles exist.
 	seed_personas()
 	# Per-workspace report tiles (Query Reports + the Workspace Setting table).

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -925,15 +925,21 @@ def setup_child_table_read_access():
 	(e.g. HR Manager reads Crew but not its `trade` → Labour Trade). Mirroring read to those
 	referenced doctypes closes that class of gap. Read only (never write/delete), layered on top
 	of existing perms, system doctypes excluded — idempotent."""
+	# Parents = doctypes with a REAL perm-map grant, identified by print=1 (every perm shorthand
+	# — _READ/_FULL/_RAISE/… — carries it). This deliberately excludes the mirror's OWN grants
+	# (which set only read=1), so a re-run doesn't treat mirror-granted masters as parents and
+	# fan out second-order — that's what keeps after_migrate fast.
 	grants = frappe.get_all(
 		"Custom DocPerm",
-		filters={"read": 1, "permlevel": 0, "role": ["in", list(BUILDSUITE_ROLES)]},
+		filters={"read": 1, "print": 1, "permlevel": 0, "role": ["in", list(BUILDSUITE_ROLES)]},
 		fields=["parent as doctype", "role"],
 	)
 	roles_by_parent = {}
 	for g in grants:
 		roles_by_parent.setdefault(g.doctype, set()).add(g.role)
 
+	# desired[ref] = the roles that should be able to read `ref` (a child table or link target).
+	desired = {}
 	for parent, roles in roles_by_parent.items():
 		if not frappe.db.exists("DocType", parent):
 			continue
@@ -944,12 +950,29 @@ def setup_child_table_read_access():
 			for df in meta.get_link_fields()
 			if df.options and df.options not in _READ_MIRROR_DENYLIST
 		}
-		read_only = {role: {"read": 1} for role in roles}
 		for ref in referenced:
-			if not frappe.db.exists("DocType", ref) or frappe.get_meta(ref).issingle:
-				continue
-			# ptypes=("read",) — grant read without disturbing any other permission on the target.
-			_upgrade_role_perms(ref, read_only, ptypes=("read",))
+			desired.setdefault(ref, set()).update(roles)
+	if not desired:
+		return
+
+	# Everything already read-granted on those refs, in ONE query — so a steady-state re-run
+	# (after_migrate) does zero writes and stays fast enough to run on every migrate.
+	have = {}
+	for row in frappe.get_all(
+		"Custom DocPerm",
+		filters={"parent": ["in", list(desired)], "permlevel": 0, "read": 1},
+		fields=["parent as doctype", "role"],
+	):
+		have.setdefault(row.doctype, set()).add(row.role)
+
+	for ref, roles in desired.items():
+		missing = roles - have.get(ref, set())
+		if not missing:
+			continue
+		if not frappe.db.exists("DocType", ref) or frappe.get_meta(ref).issingle:
+			continue
+		# ptypes=("read",) — grant read without disturbing any other permission on the target.
+		_upgrade_role_perms(ref, {role: {"read": 1} for role in missing}, ptypes=("read",))
 
 
 def setup_record_permissions():

--- a/frontend/cypress/e2e/entity_crud_permissions.cy.js
+++ b/frontend/cypress/e2e/entity_crud_permissions.cy.js
@@ -20,7 +20,7 @@ const ENTITIES = [
 	{ key: "task", route: "/tasks", newText: "New" },
 	{ key: "taskProgressEntry", route: "/progress-entries", newText: "New Entry" },
 	{ key: "stagePlanning", route: "/stage-plannings", newText: "New Stage" },
-	{ key: "sco", route: "/sco", newText: "New" },
+	{ key: "sco", route: "/sco", newText: "Raise SCO" },
 ];
 
 const PERSONAS = Object.keys(PERSONA_CAPS);

--- a/frontend/cypress/e2e/project_create.cy.js
+++ b/frontend/cypress/e2e/project_create.cy.js
@@ -16,10 +16,16 @@ describe("Create project from template", () => {
 
 		cy.dt("field-name").type(`Cypress Project ${stamp}`);
 		cy.dt("field-code").type(`CYP-${stamp}`);
-		cy.fillLink("pick-project-type", "Commercial");
+		// Template seeding is keyed by the Project CATEGORY (pick-project-category), not the
+		// native ERPNext Project Type. The Commercial category has a template.
+		cy.fillLink("pick-project-category", "Commercial");
 		// Company is required on Project (§14) and the field renders on this
 		// multi-company site — pick any valid Company.
 		cy.fillLink("pick-company");
+
+		// Wait for the template preview to confirm the category registered — its
+		// "Seed default stages" toggle is on by default, so stages seed on insert.
+		cy.contains("Seed default stages").should("be.visible");
 
 		cy.dt("save-btn").click();
 

--- a/frontend/cypress/e2e/stage_workflow.cy.js
+++ b/frontend/cypress/e2e/stage_workflow.cy.js
@@ -29,12 +29,14 @@ describe("Stage Planning approval workflow", () => {
 		cy.loginAs("pm"); // PM can submit + approve (self-approval allowed)
 		createDraftStage(Date.now());
 
-		// Submit + Approve apply the workflow directly on click (no confirm dialog) —
+		// Submit + Approve each open a ConfirmDialog (confirmAccept) before applying —
 		// the new state badge is the gate.
 		cy.dt("page-actions").contains("Submit for Approval").click();
+		cy.confirmAccept(); // Submit now asks for confirmation (ConfirmDialog)
 		cy.contains("Pending Approval").should("be.visible");
 
 		cy.dt("page-actions").contains("Approve").click();
+		cy.confirmAccept(); // Approve now asks for confirmation (ConfirmDialog)
 		cy.contains("Approved").should("be.visible");
 	});
 
@@ -43,6 +45,7 @@ describe("Stage Planning approval workflow", () => {
 		createDraftStage(Date.now() + 1);
 
 		cy.dt("page-actions").contains("Submit for Approval").click();
+		cy.confirmAccept(); // Submit now asks for confirmation (ConfirmDialog)
 		cy.contains("Pending Approval").should("be.visible");
 
 		// Reject opens a reason modal (not a confirm dialog).
@@ -59,8 +62,10 @@ describe("Stage Planning approval workflow", () => {
 		createDraftStage(Date.now() + 2);
 
 		cy.dt("page-actions").contains("Submit for Approval").click();
+		cy.confirmAccept(); // Submit now asks for confirmation (ConfirmDialog)
 		cy.contains("Pending Approval").should("be.visible");
 		cy.dt("page-actions").contains("Approve").click();
+		cy.confirmAccept(); // Approve now asks for confirmation (ConfirmDialog)
 		cy.contains("Approved").should("be.visible");
 
 		cy.dt("page-actions").should("not.contain", "Edit");
@@ -75,8 +80,10 @@ describe("Stage Planning approval workflow", () => {
 		createDraftStage(Date.now() + 3);
 
 		cy.dt("page-actions").contains("Submit for Approval").click();
+		cy.confirmAccept(); // Submit now asks for confirmation (ConfirmDialog)
 		cy.contains("Pending Approval").should("be.visible");
 		cy.dt("page-actions").contains("Approve").click();
+		cy.confirmAccept(); // Approve now asks for confirmation (ConfirmDialog)
 		cy.contains("Approved").should("be.visible");
 
 		cy.dt("stage-activity").within(() => {
@@ -92,6 +99,7 @@ describe("Stage Planning approval workflow", () => {
 		createDraftStage(Date.now() + 4);
 
 		cy.dt("page-actions").contains("Submit for Approval").click();
+		cy.confirmAccept(); // Submit now asks for confirmation (ConfirmDialog)
 		cy.contains("Pending Approval").should("be.visible");
 		cy.dt("page-actions").contains("Reject").click();
 		cy.dt("reject-reason-input").type("Cypress: revise flow");
@@ -102,6 +110,7 @@ describe("Stage Planning approval workflow", () => {
 		// different stage that is back in Draft.
 		cy.location("pathname").then((rejectedPath) => {
 			cy.dt("page-actions").contains("Revise").click();
+			cy.confirmAccept(); // Revise (clone) now asks for confirmation (ConfirmDialog)
 			cy.location("pathname", { timeout: 30000 })
 				.should("match", /\/stage-plannings\/.+/)
 				.and("not.eq", rejectedPath);

--- a/frontend/cypress/e2e/task_progress.cy.js
+++ b/frontend/cypress/e2e/task_progress.cy.js
@@ -1,15 +1,32 @@
-// File a Task Progress Entry from the task detail page and confirm the parent
-// Task updates via the real server hook. Opens an existing seeded task (read from
-// the list) so we don't depend on the create form here.
+// File a Task Progress Entry from the task detail page and confirm the parent Task updates
+// via the real server hook.
 //
-// Uses 100% because progress is cumulative + monotonic — 100 is always >= the
-// task's current progress, so the entry is valid regardless of which task is
-// first in the list, and it drives the task to Completed (a clear success signal).
+// The global Tasks list is scoped to the active company, which may hold no tasks, so this
+// self-seeds: it creates a Commercial-category project (its template imports tasks under the
+// project's company), then opens one of those tasks from the project's Tasks tab.
+//
+// Uses 100% because progress is cumulative + monotonic — 100 is always >= a seeded task's
+// current progress, so the entry is valid and drives the task to Completed (a clear signal).
 
 describe("Task progress entry updates the task", () => {
 	it("filing 100% completes the task", () => {
+		const stamp = Date.now();
 		cy.login();
-		cy.visitApp("/tasks");
+
+		// --- seed tasks via a Commercial project (template imports tasks by default) ---
+		cy.visitApp("/projects");
+		cy.dt("page-actions").contains("New").click();
+		cy.location("pathname").should("include", "/projects/new");
+		cy.dt("field-name").type(`Cypress TaskProj ${stamp}`);
+		cy.dt("field-code").type(`CYTP-${stamp}`);
+		cy.fillLink("pick-project-category", "Commercial"); // category drives the template
+		cy.fillLink("pick-company");
+		cy.contains("Import default tasks").should("be.visible"); // template loaded → tasks will import
+		cy.dt("save-btn").click();
+		cy.location("pathname", { timeout: 30000 }).should("match", /\/projects\/.+/);
+
+		// --- open a seeded task from the project's Tasks tab ---
+		cy.contains("button", "Tasks").click();
 		cy.dt("desk-list").find("[data-test-row]").first().click();
 		cy.location("pathname").should("match", /\/tasks\/.+/);
 

--- a/frontend/cypress/e2e/template_seed.cy.js
+++ b/frontend/cypress/e2e/template_seed.cy.js
@@ -20,7 +20,8 @@ describe("Re-seed Stage Planning from template", () => {
 
 		cy.dt("field-name").type(`Cypress Reseed ${stamp}`);
 		cy.dt("field-code").type(`CYR-${stamp}`);
-		cy.fillLink("pick-project-type", "Commercial");
+		// Template seeding is keyed by the Project CATEGORY, not the native Project Type.
+		cy.fillLink("pick-project-category", "Commercial");
 		cy.fillLink("pick-company");
 
 		// Opt OUT of create-time seeding so the project lands with zero stages.
@@ -54,7 +55,8 @@ describe("Project Type seed modes", () => {
 
 		cy.dt("field-name").type(`Cypress TasksOnly ${stamp}`);
 		cy.dt("field-code").type(`CYT-${stamp}`);
-		cy.fillLink("pick-project-type", "Commercial");
+		// Template seeding is keyed by the Project CATEGORY, not the native Project Type.
+		cy.fillLink("pick-project-category", "Commercial");
 		cy.fillLink("pick-company");
 
 		// tasks-only mode: stages OFF, tasks ON. (The "Import default tasks" toggle
@@ -69,8 +71,7 @@ describe("Project Type seed modes", () => {
 		cy.contains("button", "Stage Planning").click();
 		cy.contains("No stages planned yet.").should("be.visible");
 
-		// ...but tasks were imported (the tab header shows a non-zero count).
-		cy.contains("button", "Tasks").click();
-		cy.contains(/[1-9]\d* tasks/).should("be.visible");
+		// ...but tasks were imported (the Tasks tab shows a non-zero count).
+		cy.contains(/Tasks \([1-9]\d*\)/, { timeout: 30000 }).should("be.visible");
 	});
 });

--- a/frontend/cypress/e2e/template_seed.cy.js
+++ b/frontend/cypress/e2e/template_seed.cy.js
@@ -71,7 +71,8 @@ describe("Project Type seed modes", () => {
 		cy.contains("button", "Stage Planning").click();
 		cy.contains("No stages planned yet.").should("be.visible");
 
-		// ...but tasks were imported (the Tasks tab shows a non-zero count).
-		cy.contains(/Tasks \([1-9]\d*\)/, { timeout: 30000 }).should("be.visible");
+		// ...but tasks were imported — the Tasks tab opens onto a non-empty list.
+		cy.contains("button", "Tasks").click();
+		cy.dt("desk-list").find("[data-test-row]").should("have.length.at.least", 1);
 	});
 });

--- a/frontend/src/views/TaskProgressEntriesView.vue
+++ b/frontend/src/views/TaskProgressEntriesView.vue
@@ -66,6 +66,9 @@ const entriesResource = adapter.list("Task Progress Entry", {
 			creation: row?.creation || null,
 		}));
 	},
+	// Don't fetch (and 403) when the persona has no Task Progress Entry read — the
+	// template shows the restricted notice instead. Mirrors the StagePlanningsView gate.
+	auto: canRead("taskProgressEntry"),
 });
 function toArray(data) {
 	if (Array.isArray(data)) return data;


### PR DESCRIPTION
Follow-ups to the Cypress suite after the stage-planning / task-progress / project-seeding UI changes. Diagnosed from the failure screenshots (Cypress can't run in the dev sandbox — SIGILL — so fixes are evidence-based; please re-run to confirm).

## Backend
- **Read-mirror (`b6958ad`)** — the `module_entity_crud` 403s were **not** stale perms (those existed) but **never-granted linked masters**: list views render link columns (e.g. Crew's `trade` → **Labour Trade**) that some personas couldn't read. `setup_child_table_read_access()` now grants each BuildSuite role read on the **child tables AND Link-field targets** of every doctype it can read (read-only, system doctypes denylisted, singles skipped), wired into `setup_record_permissions`. Patch `grant_child_table_read_access` applies it to existing sites. Verified on bs.local: HR → Labour Trade now reads.

## Spec fixes
- **entity_crud_permissions** — SCO create button is "+ Raise SCO", not "+ New".
- **stage_workflow** — Submit / Approve / Revise now open a `ConfirmDialog`; added `cy.confirmAccept()` (Reject keeps its reason modal).
- **project_create / template_seed** — seeding is keyed by the Project **CATEGORY** (`pick-project-category`), not the native Type; the specs targeted the wrong field with a non-existent "Commercial" type. Now select the Commercial category (its template seeds "Foundation"), wait for the async seed preview, and confirm the seed dialog.
- **task_progress** — the global Tasks list is company-scoped and the active company had no tasks; the spec now self-seeds via a Commercial project and opens a task from its Tasks tab (progress-entry selectors were unchanged).

## Note
`setup_record_permissions` is `after_install`-only, so permission changes reach existing sites via patches (this PR's `grant_child_table_read_access`) — running `bench migrate` applies it. The read-mirror is deliberately broad (all readable doctypes' link targets, minus a system denylist); tighten the denylist if a narrower scope is preferred.