### PR TITLE
feat: server-side pagination on entity lists + default modified-desc sort

### DIFF
--- a/frontend/src/components/doctype/DocTypeListView.vue
+++ b/frontend/src/components/doctype/DocTypeListView.vue
@@ -245,9 +245,11 @@ const parsedDefaultOrder = computed(() => {
 		return { field, direction: direction.toLowerCase() === "asc" ? "asc" : "desc" };
 	}
 
-	const field = meta.value?.sort_field || "modified";
-	const direction = (meta.value?.sort_order || "desc").toLowerCase() === "asc" ? "asc" : "desc";
-	return { field, direction };
+	// Default to `modified desc` so the most recently updated record is always on top —
+	// regardless of the doctype's own meta sort_field (which can be creation, a name, etc.).
+	// Every doctype has `modified`, so this is always valid; a view wanting a different
+	// default passes `initialOrderBy` explicitly.
+	return { field: "modified", direction: "desc" };
 });
 
 watch(

--- a/frontend/src/views/AssembliesView.vue
+++ b/frontend/src/views/AssembliesView.vue
@@ -1,20 +1,19 @@
 <script setup>
 import { computed, ref } from "vue";
-import { useRouter } from "vue-router";
-import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useRouter, RouterLink } from "vue-router";
 import { fmtINR } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
 const { canCreate } = usePermissions();
 
 function onRowClick(row) {
-	router.push(`/assembly/${row.id}`);
+	router.push(`/assembly/${row.name}`);
 }
 
 const breadcrumbs = [
@@ -23,57 +22,29 @@ const breadcrumbs = [
 	{ label: "Assembly" },
 ];
 
-const assembliesRes = useDocTypeList("Assembly", {
-	fields: [
-		"name",
-		"assembly_code",
-		"assembly_name",
-		"category",
-		"uom",
-		"rate_per_unit",
-		"component_count",
-		"notes",
-	],
-	orderBy: "creation desc",
-	pageLength: 0,
-	cache: "buildsuite-assembly-list",
-	transform: (data) =>
-		data.map((a) => ({
-			id: a.name,
-			code: a.assembly_code,
-			name: a.assembly_name,
-			category: a.category,
-			unit: a.uom,
-			ratePerUnit: a.rate_per_unit,
-			componentCount: a.component_count,
-			notes: a.notes,
-		})),
-});
-
-const search = ref("");
-const categoryFilter = ref("");
-const rows = computed(() => {
-	let data = assembliesRes.data || [];
-	if (categoryFilter.value) data = data.filter((a) => a.category === categoryFilter.value);
-	const q = search.value.trim().toLowerCase();
-	if (q) {
-		data = data.filter(
-			(a) =>
-				(a.code || "").toLowerCase().includes(q) ||
-				(a.name || "").toLowerCase().includes(q)
-		);
-	}
-	return data;
-});
+const FIELDS = [
+	"name",
+	"assembly_code",
+	"assembly_name",
+	"category",
+	"uom",
+	"rate_per_unit",
+	"component_count",
+	"notes",
+];
 
 const columns = [
-	{ key: "code", label: "Code" },
-	{ key: "name", label: "Name" },
+	{ key: "assembly_code", label: "Code" },
+	{ key: "assembly_name", label: "Name" },
 	{ key: "category", label: "Category" },
-	{ key: "unit", label: "Unit" },
-	{ key: "componentCount", label: "Components", align: "right" },
-	{ key: "ratePerUnit", label: "Rate / unit", align: "right" },
+	{ key: "uom", label: "Unit" },
+	{ key: "component_count", label: "Components", align: "right" },
+	{ key: "rate_per_unit", label: "Rate / unit", align: "right" },
 ];
+
+const categoryFilter = ref("");
+const filterValues = computed(() => ({ category: categoryFilter.value }));
+const filterFieldMap = { category: "category" };
 </script>
 
 <template>
@@ -85,12 +56,17 @@ const columns = [
 			>
 		</template>
 
-		<DeskList
-			v-model="search"
-			:rows="rows"
+		<DocTypeListView
+			doctype="Assembly"
+			:field-order="FIELDS"
 			:columns="columns"
-			row-key="id"
+			:search-fields="['assembly_code', 'assembly_name']"
+			:filter-values="filterValues"
+			:filter-field-map="filterFieldMap"
+			cache-key="buildsuite-assembly-list"
+			row-key="name"
 			search-placeholder="Search by code or name…"
+			empty-message="No assemblies match your filters."
 			@row-click="onRowClick"
 		>
 			<template #filter-chips>
@@ -111,13 +87,13 @@ const columns = [
 				/>
 			</template>
 
-			<template #cell-code="{ row }">
-				<DeskLink :to="`/assembly/${row.id}`" class="font-mono text-xs" @click.stop>{{
-					row.code
+			<template #cell-assembly_code="{ row }">
+				<DeskLink :to="`/assembly/${row.name}`" class="font-mono text-xs" @click.stop>{{
+					row.assembly_code
 				}}</DeskLink>
 			</template>
-			<template #cell-name="{ row }">
-				<span class="text-ink-900 font-medium">{{ row.name }}</span>
+			<template #cell-assembly_name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.assembly_name }}</span>
 				<div v-if="row.notes" class="text-[11px] text-ink-500 truncate">
 					{{ row.notes }}
 				</div>
@@ -131,29 +107,19 @@ const columns = [
 				>
 				<span v-else class="text-ink-300">—</span>
 			</template>
-			<template #cell-unit="{ row }">
-				<span class="text-ink-600 text-xs">{{ row.unit }}</span>
+			<template #cell-uom="{ row }">
+				<span class="text-ink-600 text-xs">{{ row.uom }}</span>
 			</template>
-			<template #cell-componentCount="{ row }">
+			<template #cell-component_count="{ row }">
 				<span class="text-xs text-ink-700 tabular-nums">{{
-					row.componentCount || 0
+					row.component_count || 0
 				}}</span>
 			</template>
-			<template #cell-ratePerUnit="{ row }">
+			<template #cell-rate_per_unit="{ row }">
 				<span class="text-sm font-medium text-ink-900 tabular-nums">{{
-					fmtINR(row.ratePerUnit)
+					fmtINR(row.rate_per_unit)
 				}}</span>
 			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{
-						assembliesRes.loading
-							? "Loading assemblies…"
-							: "No assemblies match your filters."
-					}}
-				</div>
-			</template>
-		</DeskList>
+		</DocTypeListView>
 	</DeskPage>
 </template>

--- a/frontend/src/views/EstimateTemplatesView.vue
+++ b/frontend/src/views/EstimateTemplatesView.vue
@@ -1,18 +1,16 @@
 <script setup>
-import { computed, ref } from "vue";
-import { useRouter } from "vue-router";
-import { useDocTypeList } from "@/composables/useDocTypeList";
+import { useRouter, RouterLink } from "vue-router";
 import { fmtINR, fmtDate } from "@/utils/format";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { usePermissions } from "@/composables/usePermissions";
 
 const router = useRouter();
 const { canCreate } = usePermissions();
 
 function onRowClick(row) {
-	router.push(`/estimate-template/${row.id}`);
+	router.push(`/estimate-template/${row.name}`);
 }
 
 const breadcrumbs = [
@@ -21,54 +19,24 @@ const breadcrumbs = [
 	{ label: "Estimate Template" },
 ];
 
-const templatesRes = useDocTypeList("Estimate Template", {
-	fields: [
-		"name",
-		"template_code",
-		"template_name",
-		"project_category",
-		"enabled",
-		"row_count",
-		"estimated_total",
-		"modified",
-	],
-	orderBy: "creation desc",
-	pageLength: 0,
-	cache: "buildsuite-estimate-template-list",
-	transform: (data) =>
-		data.map((t) => ({
-			id: t.name,
-			code: t.template_code,
-			name: t.template_name,
-			projectType: t.project_category,
-			rows: t.row_count,
-			estimated: t.estimated_total,
-			updated: t.modified,
-			enabled: t.enabled,
-		})),
-});
-
-const search = ref("");
-const rows = computed(() => {
-	let data = templatesRes.data || [];
-	const q = search.value.trim().toLowerCase();
-	if (q) {
-		data = data.filter(
-			(t) =>
-				(t.code || "").toLowerCase().includes(q) ||
-				(t.name || "").toLowerCase().includes(q)
-		);
-	}
-	return data;
-});
+const FIELDS = [
+	"name",
+	"template_code",
+	"template_name",
+	"project_category",
+	"enabled",
+	"row_count",
+	"estimated_total",
+	"modified",
+];
 
 const columns = [
-	{ key: "code", label: "Code" },
-	{ key: "name", label: "Name" },
-	{ key: "projectType", label: "Project Category" },
-	{ key: "rows", label: "Rows", align: "right" },
-	{ key: "estimated", label: "Estimated", align: "right" },
-	{ key: "updated", label: "Updated" },
+	{ key: "template_code", label: "Code" },
+	{ key: "template_name", label: "Name" },
+	{ key: "project_category", label: "Project Category" },
+	{ key: "row_count", label: "Rows", align: "right" },
+	{ key: "estimated_total", label: "Estimated", align: "right" },
+	{ key: "modified", label: "Updated" },
 	{ key: "enabled", label: "Status" },
 ];
 </script>
@@ -85,45 +53,48 @@ const columns = [
 			>
 		</template>
 
-		<DeskList
-			v-model="search"
-			:rows="rows"
+		<DocTypeListView
+			doctype="Estimate Template"
+			:field-order="FIELDS"
 			:columns="columns"
-			row-key="id"
+			:search-fields="['template_code', 'template_name']"
+			cache-key="buildsuite-estimate-template-list"
+			row-key="name"
 			search-placeholder="Search by code or name…"
+			empty-message="No estimate templates yet."
 			@row-click="onRowClick"
 		>
-			<template #cell-code="{ row }">
+			<template #cell-template_code="{ row }">
 				<DeskLink
-					:to="`/estimate-template/${row.id}`"
+					:to="`/estimate-template/${row.name}`"
 					class="font-mono text-xs"
 					@click.stop
-					>{{ row.code }}</DeskLink
+					>{{ row.template_code }}</DeskLink
 				>
 			</template>
-			<template #cell-name="{ row }">
-				<span class="text-ink-900 font-medium">{{ row.name }}</span>
+			<template #cell-template_name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.template_name }}</span>
 			</template>
-			<template #cell-projectType="{ row }">
+			<template #cell-project_category="{ row }">
 				<span
-					v-if="row.projectType"
+					v-if="row.project_category"
 					class="text-[10px] px-1.5 py-0.5 bg-ink-100 text-ink-700 font-medium"
 					style="border-radius: 9999px"
-					>{{ row.projectType }}</span
+					>{{ row.project_category }}</span
 				>
 				<span v-else class="text-ink-300">Any</span>
 			</template>
-			<template #cell-rows="{ row }">
-				<span class="text-xs text-ink-700 tabular-nums">{{ row.rows || 0 }}</span>
+			<template #cell-row_count="{ row }">
+				<span class="text-xs text-ink-700 tabular-nums">{{ row.row_count || 0 }}</span>
 			</template>
-			<template #cell-estimated="{ row }">
+			<template #cell-estimated_total="{ row }">
 				<span class="text-sm font-medium text-ink-900 tabular-nums">{{
-					fmtINR(row.estimated)
+					fmtINR(row.estimated_total)
 				}}</span>
 			</template>
-			<template #cell-updated="{ row }">
+			<template #cell-modified="{ row }">
 				<span class="text-xs text-ink-500 whitespace-nowrap">{{
-					fmtDate(row.updated)
+					fmtDate(row.modified)
 				}}</span>
 			</template>
 			<template #cell-enabled="{ row }">
@@ -140,14 +111,6 @@ const columns = [
 					>Disabled</span
 				>
 			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{
-						templatesRes.loading ? "Loading templates…" : "No estimate templates yet."
-					}}
-				</div>
-			</template>
-		</DeskList>
+		</DocTypeListView>
 	</DeskPage>
 </template>

--- a/frontend/src/views/MeasurementBooksListView.vue
+++ b/frontend/src/views/MeasurementBooksListView.vue
@@ -3,37 +3,20 @@
 // project level; each MB carries a work_order link so you can see which
 // WO it feeds.
 
-import { computed, ref, onMounted } from "vue";
+import { ref, onMounted } from "vue";
 import { useRouter, RouterLink } from "vue-router";
-import { useDocTypeList } from "@/composables/useDocTypeList";
 import { getMeasurementBookEntryCounts } from "@/data/subcontractApi";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { usePermissions } from "@/composables/usePermissions";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { fmtDate } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
 const { canCreate } = usePermissions();
-
-const mbRes = useDocTypeList("Measurement Book", {
-	fields: ["name", "project", "work_order", "date", "measured_total", "status"],
-	orderBy: "date desc",
-	pageLength: 0,
-	cache: "buildsuite-measurement-book-list",
-	transform: (data) =>
-		data.map((m) => ({
-			id: m.name,
-			project: m.project,
-			work_order: m.work_order,
-			date: m.date,
-			measured: m.measured_total,
-			status: m.status,
-		})),
-});
 
 // Entry count per MB (child rows aren't listable client-side by non-admins).
 const entryCounts = ref({});
@@ -45,28 +28,15 @@ onMounted(async () => {
 	}
 });
 
-const search = ref("");
-const rows = computed(() => {
-	let data = mbRes.data || [];
-	const q = search.value.trim().toLowerCase();
-	if (q)
-		data = data.filter(
-			(m) =>
-				(m.id || "").toLowerCase().includes(q) ||
-				(m.work_order || "").toLowerCase().includes(q) ||
-				(m.project || "").toLowerCase().includes(q) ||
-				projectName(m.project).toLowerCase().includes(q)
-		);
-	return data;
-});
+const FIELDS = ["name", "project", "work_order", "date", "measured_total", "status"];
 
 const columns = [
-	{ key: "id", label: "MB ID" },
+	{ key: "name", label: "MB ID" },
 	{ key: "project", label: "Project" },
 	{ key: "work_order", label: "Work Order" },
 	{ key: "date", label: "Date" },
 	{ key: "entries", label: "Entries", align: "right" },
-	{ key: "measured", label: "Measured", align: "right" },
+	{ key: "measured_total", label: "Measured", align: "right" },
 	{ key: "status", label: "Status" },
 ];
 
@@ -77,7 +47,7 @@ const breadcrumbs = [
 ];
 
 function onRowClick(row) {
-	router.push(`/measurement-books/${row.id}`);
+	router.push(`/measurement-books/${row.name}`);
 }
 </script>
 
@@ -92,20 +62,23 @@ function onRowClick(row) {
 			>
 		</template>
 
-		<DeskList
-			v-model="search"
-			:rows="rows"
+		<DocTypeListView
+			doctype="Measurement Book"
+			:field-order="FIELDS"
 			:columns="columns"
-			row-key="id"
+			:search-fields="['name', 'work_order', 'project']"
+			cache-key="buildsuite-measurement-book-list"
+			row-key="name"
 			search-placeholder="Search MB, WO, project…"
+			empty-message="No measurement books recorded yet."
 			@row-click="onRowClick"
 		>
-			<template #cell-id="{ row }">
+			<template #cell-name="{ row }">
 				<DeskLink
-					:to="`/measurement-books/${row.id}`"
+					:to="`/measurement-books/${row.name}`"
 					class="font-mono text-xs"
 					@click.stop
-					>{{ row.id }}</DeskLink
+					>{{ row.name }}</DeskLink
 				>
 			</template>
 			<template #cell-project="{ row }">
@@ -124,27 +97,17 @@ function onRowClick(row) {
 			</template>
 			<template #cell-entries="{ row }">
 				<span class="text-xs tabular-nums text-ink-700">{{
-					entryCounts[row.id] || 0
+					entryCounts[row.name] || 0
 				}}</span>
 			</template>
-			<template #cell-measured="{ row }">
+			<template #cell-measured_total="{ row }">
 				<span class="text-xs tabular-nums text-info-700 font-medium">{{
-					Number(row.measured || 0).toLocaleString("en-IN")
+					Number(row.measured_total || 0).toLocaleString("en-IN")
 				}}</span>
 			</template>
 			<template #cell-status="{ row }">
 				<StatusBadge :status="row.status" />
 			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{
-						mbRes.loading
-							? "Loading measurement books…"
-							: "No measurement books recorded yet."
-					}}
-				</div>
-			</template>
-		</DeskList>
+		</DocTypeListView>
 	</DeskPage>
 </template>

--- a/frontend/src/views/ScoView.vue
+++ b/frontend/src/views/ScoView.vue
@@ -8,86 +8,64 @@ import { useDocTypeList } from "@/composables/useDocTypeList";
 import { usePermissions } from "@/composables/usePermissions";
 import StatusBadge from "@/components/StatusBadge.vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { fmtINR, fmtCompactINR, fmtDate } from "@/utils/format";
 
 const router = useRouter();
 const { canCreate } = usePermissions();
 
-const scosRes = useDocTypeList("Scope Change Order", {
-	fields: [
-		"name",
-		"project",
-		"project_name",
-		"title",
-		"type",
-		"impact",
-		"recoverable",
-		"status",
-		"raised_by",
-		"raised_date",
-	],
+// KPI strip aggregates the whole register — a lightweight full fetch kept alongside
+// the paginated list (which only holds the current page).
+const kpiRes = useDocTypeList("Scope Change Order", {
+	fields: ["name", "impact", "recoverable", "status"],
 	orderBy: "creation desc",
 	pageLength: 0,
-	cache: "buildsuite-sco-list",
-	transform: (data) =>
-		data.map((s) => ({
-			id: s.name,
-			project: s.project,
-			projectName: s.project_name,
-			title: s.title,
-			type: s.type,
-			impact: s.impact,
-			recoverable: s.recoverable,
-			status: s.status,
-			raisedBy: s.raised_by,
-			raisedDate: s.raised_date,
-		})),
+	cache: "buildsuite-sco-kpis",
 });
-
-const all = computed(() => scosRes.data || []);
-const search = ref("");
-const statusFilter = ref("");
-
-const items = computed(() => {
-	let data = all.value;
-	if (statusFilter.value) data = data.filter((s) => s.status === statusFilter.value);
-	const q = search.value.trim().toLowerCase();
-	if (q)
-		data = data.filter(
-			(s) =>
-				(s.title || "").toLowerCase().includes(q) ||
-				(s.id || "").toLowerCase().includes(q),
-		);
-	return data;
-});
-
+const all = computed(() => kpiRes.data || []);
 const pendingCount = computed(
-	() => all.value.filter((s) => s.status === "Pending Approval").length,
+	() => all.value.filter((s) => s.status === "Pending Approval").length
 );
 const totalImpact = computed(() => all.value.reduce((a, s) => a + (Number(s.impact) || 0), 0));
 const recoverableTotal = computed(() =>
-	all.value.filter((s) => s.recoverable).reduce((a, s) => a + (Number(s.impact) || 0), 0),
+	all.value.filter((s) => s.recoverable).reduce((a, s) => a + (Number(s.impact) || 0), 0)
 );
 
+const statusFilter = ref("");
+const filterValues = computed(() => ({ status: statusFilter.value }));
+const filterFieldMap = { status: "status" };
+
+const FIELDS = [
+	"name",
+	"project",
+	"project_name",
+	"title",
+	"type",
+	"impact",
+	"recoverable",
+	"status",
+	"raised_by",
+	"raised_date",
+];
+
 const columns = [
-	{ key: "id", label: "ID" },
+	{ key: "name", label: "ID" },
 	{ key: "title", label: "Title" },
 	{ key: "project", label: "Project" },
 	{ key: "type", label: "Type" },
 	{ key: "impact", label: "Impact", align: "right" },
 	{ key: "recoverable", label: "Recoverable" },
 	{ key: "status", label: "Status" },
-	{ key: "raisedDate", label: "Date" },
+	{ key: "raised_date", label: "Date" },
 ];
 
 const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Scope Change Orders" }];
 
 function onRowClick(row) {
-	router.push(`/sco/${row.id}`);
+	router.push(`/sco/${row.name}`);
 }
 </script>
 
@@ -136,12 +114,17 @@ function onRowClick(row) {
 			</div>
 		</div>
 
-		<DeskList
-			v-model="search"
-			:rows="items"
+		<DocTypeListView
+			doctype="Scope Change Order"
+			:field-order="FIELDS"
 			:columns="columns"
-			row-key="id"
+			:search-fields="['name', 'title']"
+			:filter-values="filterValues"
+			:filter-field-map="filterFieldMap"
+			cache-key="buildsuite-sco-list"
+			row-key="name"
 			search-placeholder="Search SCO id or title…"
+			empty-message="No scope change orders yet."
 			@row-click="onRowClick"
 		>
 			<template #filter-chips>
@@ -159,16 +142,16 @@ function onRowClick(row) {
 				/>
 			</template>
 
-			<template #cell-id="{ row }">
-				<DeskLink :to="`/sco/${row.id}`" class="font-mono text-xs" @click.stop>{{
-					row.id
+			<template #cell-name="{ row }">
+				<DeskLink :to="`/sco/${row.name}`" class="font-mono text-xs" @click.stop>{{
+					row.name
 				}}</DeskLink>
 			</template>
 			<template #cell-title="{ row }">
 				<span class="text-ink-900 font-medium text-sm">{{ row.title }}</span>
 			</template>
 			<template #cell-project="{ row }">
-				<span class="text-ink-700 text-xs">{{ row.projectName || row.project }}</span>
+				<span class="text-ink-700 text-xs">{{ row.project_name || row.project }}</span>
 			</template>
 			<template #cell-type="{ row }">
 				<span class="text-ink-700 text-xs">{{ row.type }}</span>
@@ -197,19 +180,9 @@ function onRowClick(row) {
 			<template #cell-status="{ row }">
 				<StatusBadge :status="row.status" />
 			</template>
-			<template #cell-raisedDate="{ row }">
-				<span class="text-xs text-ink-500">{{ fmtDate(row.raisedDate) }}</span>
+			<template #cell-raised_date="{ row }">
+				<span class="text-xs text-ink-500">{{ fmtDate(row.raised_date) }}</span>
 			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{
-						scosRes.loading
-							? "Loading scope change orders…"
-							: "No scope change orders yet."
-					}}
-				</div>
-			</template>
-		</DeskList>
+		</DocTypeListView>
 	</DeskPage>
 </template>

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -1,48 +1,23 @@
 <script setup>
 // Subcontractor Work Order list — Desk-styled, mirrors the prototype.
 
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
 import { usePermissions } from "@/composables/usePermissions";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskList from "@/components/desk/DeskList.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { fmtDate, fmtCompactINR } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
 const { canCreate } = usePermissions();
 
-const wosRes = useDocTypeList("Subcontractor Work Order", {
-	fields: [
-		"name",
-		"subcontractor_name",
-		"project",
-		"date",
-		"delivery_type",
-		"total_value",
-		"docstatus",
-	],
-	orderBy: "date desc",
-	pageLength: 0,
-	cache: "buildsuite-subcontractor-wo-list",
-	// The WO is natively submittable — state is docstatus (Draft/Submitted/Cancelled), not a field.
-	transform: (data) =>
-		data.map((w) => ({
-			id: w.name,
-			subcontractor: w.subcontractor_name,
-			project: w.project,
-			date: w.date,
-			delivery_type: w.delivery_type,
-			total_value: w.total_value,
-			status: { 0: "Draft", 1: "Submitted", 2: "Cancelled" }[w.docstatus] || "Draft",
-		})),
-});
-
 // Billed-to-date per work order (sum of non-cancelled Subcontractor Bill gross) → % billed.
+// Kept as a lightweight full fetch feeding the derived "% Billed" cell.
 const billsRes = useDocTypeList("Subcontractor Bill", {
 	fields: ["name", "work_order", "gross", "docstatus"],
 	orderBy: "modified desc",
@@ -60,27 +35,26 @@ const billedByWO = computed(() => {
 function woPercentBilled(row) {
 	const total = Number(row.total_value) || 0;
 	if (total <= 0) return 0;
-	return Math.min(100, Math.round(((billedByWO.value[row.id] || 0) / total) * 1000) / 10);
+	return Math.min(100, Math.round(((billedByWO.value[row.name] || 0) / total) * 1000) / 10);
 }
 
-const search = ref("");
-const rows = computed(() => {
-	let data = wosRes.data || [];
-	const q = search.value.trim().toLowerCase();
-	if (q)
-		data = data.filter(
-			(w) =>
-				(w.id || "").toLowerCase().includes(q) ||
-				(w.subcontractor || "").toLowerCase().includes(q) ||
-				(w.project || "").toLowerCase().includes(q) ||
-				projectName(w.project).toLowerCase().includes(q)
-		);
-	return data;
-});
+function woStatus(row) {
+	return { 0: "Draft", 1: "Submitted", 2: "Cancelled" }[row.docstatus] || "Draft";
+}
+
+const FIELDS = [
+	"name",
+	"subcontractor_name",
+	"project",
+	"date",
+	"delivery_type",
+	"total_value",
+	"docstatus",
+];
 
 const columns = [
-	{ key: "id", label: "WO ID" },
-	{ key: "subcontractor", label: "Subcontractor" },
+	{ key: "name", label: "WO ID" },
+	{ key: "subcontractor_name", label: "Subcontractor" },
 	{ key: "project", label: "Project" },
 	{ key: "date", label: "Date" },
 	{ key: "delivery_type", label: "Type" },
@@ -96,7 +70,7 @@ const breadcrumbs = [
 ];
 
 function onRowClick(row) {
-	router.push(`/subcontractor-work-orders/${row.id}`);
+	router.push(`/subcontractor-work-orders/${row.name}`);
 }
 </script>
 
@@ -111,24 +85,27 @@ function onRowClick(row) {
 			>
 		</template>
 
-		<DeskList
-			v-model="search"
-			:rows="rows"
+		<DocTypeListView
+			doctype="Subcontractor Work Order"
+			:field-order="FIELDS"
 			:columns="columns"
-			row-key="id"
+			:search-fields="['name', 'subcontractor_name', 'project']"
+			cache-key="buildsuite-subcontractor-wo-list"
+			row-key="name"
 			search-placeholder="Search WO, subcontractor, project…"
+			empty-message="No work orders raised yet."
 			@row-click="onRowClick"
 		>
-			<template #cell-id="{ row }">
+			<template #cell-name="{ row }">
 				<DeskLink
-					:to="`/subcontractor-work-orders/${row.id}`"
+					:to="`/subcontractor-work-orders/${row.name}`"
 					class="font-mono text-xs"
 					@click.stop
-					>{{ row.id }}</DeskLink
+					>{{ row.name }}</DeskLink
 				>
 			</template>
-			<template #cell-subcontractor="{ row }">
-				<span class="text-ink-900 font-medium">{{ row.subcontractor }}</span>
+			<template #cell-subcontractor_name="{ row }">
+				<span class="text-ink-900 font-medium">{{ row.subcontractor_name }}</span>
 			</template>
 			<template #cell-project="{ row }">
 				<span class="text-xs text-ink-700">{{ projectName(row.project) }}</span>
@@ -153,14 +130,8 @@ function onRowClick(row) {
 				<span class="text-xs tabular-nums text-ink-700">{{ woPercentBilled(row) }}%</span>
 			</template>
 			<template #cell-status="{ row }">
-				<StatusBadge :status="row.status" />
+				<StatusBadge :status="woStatus(row)" />
 			</template>
-
-			<template #empty>
-				<div class="text-sm text-ink-500">
-					{{ wosRes.loading ? "Loading work orders…" : "No work orders raised yet." }}
-				</div>
-			</template>
-		</DeskList>
+		</DocTypeListView>
 	</DeskPage>
 </template>


### PR DESCRIPTION
Makes every entity list paginate, upgrades the clean ones to true server-side pagination, and defaults the list renderer to newest-updated-first.

## Default sort → `modified desc`
`DocTypeListView` now defaults its sort to **`modified desc`** (latest updated on top) regardless of the doctype's own `sort_field` — every doctype has `modified`, so it's always valid. A view can still override with `initial-order-by`. Applies to every server-paginated list at once.

## 5 lists converted DeskList → DocTypeListView (server pagination)
**Assemblies, Estimate Templates, Scope Change Orders, Subcontractor Work Orders, Measurement Books** — columns, filters, cell renderers, row-click routes and `canCreate`-gated New buttons preserved. Computed columns / KPI strips that need the full set (SCO KPIs, WO % billed, MB entry counts) kept via small cached aux fetches; the main list paginates on the server.

## Left on DeskList (still paginated client-side)
Where `DocTypeListView` can't serve the UI:
- **Subcontractors** (Contact/Phone from a joined Contact) and **Subcontractor Bills** (payment-status badge derived from the linked PI's outstanding) — per-row cross-doctype joins a plain doctype list can't supply.
- **BoqView** (tree + create modal), **RateMasterView** (inline-edit rows), **Machinery / Machinery Usage** (Equipment reports with server-resolved names), **Task Progress Entries** (KPI strip needs the full set).

All keep DeskList's built-in client-side pagination (10/page), so **every entity list paginates**.

## Follow-ups (your call)
- **Bills** and **Subcontractors** are convertible to server pagination if their join-derived columns (payment-status badge / Contact) are computed via small aux fetches like WO % billed.

Verified: `yarn build` passes. (Cypress can't run in the dev sandbox — SIGILL.)