### PR TITLE
fix: correct Director/Owner permission matrix + authoritative re-sync

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -33,3 +33,4 @@ buildsuite_core.patches.reseed_project_finance_bespoke_views # 2026-08-20
 buildsuite_core.patches.fix_stage_planning_workflow_roles # 2026-08-20
 buildsuite_core.patches.reseed_procurement_bespoke_reports # 2026-08-20
 buildsuite_core.patches.grant_child_table_read_access # 2026-08-21
+buildsuite_core.patches.resync_director_permission_matrix # 2026-08-24

--- a/buildsuite_core/patches/resync_director_permission_matrix.py
+++ b/buildsuite_core/patches/resync_director_permission_matrix.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Authoritatively re-apply the BuildSuite permission matrices on existing sites.
+
+The per-persona DocPerm matrices in buildsuite_core.permissions.setup are the single
+source of truth, but they are only applied on after_install (and via individual
+patches) — never re-applied wholesale on migrate. So sites that installed at an older
+matrix drift from the code: the Director/Owner review surfaced this across ~13 doctypes
+(Measurement Book / Subcontractor Bill / Machinery showing more than read, Customer /
+Supplier / Field Employee showing less, Purchase Invoice missing entirely).
+
+This patch heals that drift in one shot by re-running the authoritative setup, which:
+  * applies the corrected Director/Owner matrix (Measurement Book + Subcontractor Bill
+    down to read-only; Supplier Bill / Purchase Invoice up to full CRWDSX), and
+  * re-converges every other doctype's matrix to the code (fixing the stale grants that
+    predate this migrate), then re-mirrors child-table / link-target reads last.
+
+setup_record_permissions() is idempotent, so this is safe to re-run."""
+
+from buildsuite_core.permissions.setup import setup_record_permissions
+
+
+def execute():
+	setup_record_permissions()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -159,7 +159,9 @@ PURCHASE_RECEIPT_ROLE_PERMS = {
 }
 PURCHASE_INVOICE_ROLE_PERMS = {
 	"BuildSuite Administrator": _FULL_SUB,
-	"BuildSuite Director": _READ,
+	# Supplier Bill — the Director/Owner owns supplier invoicing end to end, so full CRWDSX
+	# (not read-only): raise, edit, submit, cancel + amend a supplier invoice.
+	"BuildSuite Director": _FULL_SUB,
 	"BuildSuite PM": _READ,
 	"BuildSuite Procurement Officer": _READ,
 	"BuildSuite Accountant": _FULL_SUB,  # Accountant owns invoicing
@@ -557,19 +559,26 @@ SUBCONTRACT_MASTER_ROLE_PERMS = {
 	"BuildSuite Administrator": _FULL,
 }
 # Measurement Book — the QS + Site Engineer record and certify site measurements,
-# so they get full CRUD here (they only read the WO/Subcontractor masters).
+# so they get full CRUD here (they only read the WO/Subcontractor masters). The
+# Director is oversight-only on the MB (per the Director/Owner ruling): read, not
+# data entry — so it's pulled out of the full roles down to _READ below.
 _MB_FULL_ROLES = _SUBCONTRACT_FULL_ROLES + ("BuildSuite QS", "BuildSuite Site Engineer")
 MEASUREMENT_BOOK_ROLE_PERMS = {
 	**{role: _FULL for role in _MB_FULL_ROLES},
+	"BuildSuite Director": _READ,  # oversight only — read, never edit
 	"BuildSuite Accountant": _READ,
 }
 # Subcontractor Bill (RA Bill) — submittable. The QS + subcontract full roles raise and
 # submit progress bills; the Accountant + Site Engineer + Estimator read them. Every role that
 # can read a Work Order reads Bills too — the WO list shows a "% billed" column sourced from
 # them, so a WO reader without Bill read would 403 the whole list.
+# NOTE: `_BILL_FULL_ROLES` is shared with the Work Order matrix (where the Director stays
+# full CRWDSX). On the Bill, the Director is oversight-only — the explicit `_READ` below wins
+# over the `_FULL_SUB` spread, so the Director reads bills but never raises/submits them.
 _BILL_FULL_ROLES = _SUBCONTRACT_FULL_ROLES + ("BuildSuite QS",)
 SUBCONTRACT_BILL_ROLE_PERMS = {
 	**{role: _FULL_SUB for role in _BILL_FULL_ROLES},
+	"BuildSuite Director": _READ,  # oversight only — read, never raise/submit a bill
 	"BuildSuite Accountant": _READ,
 	"BuildSuite Site Engineer": _READ,
 	"BuildSuite Estimator": _READ,

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -553,6 +553,8 @@ SUBCONTRACT_ROLE_PERMS = {
 	**{role: _READ for role in _SUBCONTRACT_READ_ROLES},
 	"BuildSuite PM": _CRW,  # PM maintains subcontractors (edit) but does not delete them
 	"BuildSuite QS": _FULL,  # QS maintains subcontractors fully (per the QS ruling), not read-only
+	"BuildSuite Accountant": _FULL,  # Accountant maintains subcontractors fully (per the Accountant ruling)
+	"BuildSuite Estimator": _READ,  # Estimator reads subcontractors (per the Estimator ruling)
 }
 # Trade / Delivery Type masters — read for everyone in the module, write for
 # procurement + admins (they're resolved by the WO link pickers).
@@ -574,6 +576,7 @@ MEASUREMENT_BOOK_ROLE_PERMS = {
 	**{role: _FULL for role in _MB_FULL_ROLES},
 	"BuildSuite Site Engineer": _RAISE,  # raise only — create + read, never edit/delete/certify
 	"BuildSuite Director": _READ,  # oversight only — read, never edit
+	"BuildSuite Estimator": _READ,  # read-only (per the Estimator ruling)
 	"BuildSuite Accountant": _READ,
 }
 # Subcontractor Bill (RA Bill) — submittable. The QS + subcontract full roles raise and
@@ -589,9 +592,10 @@ SUBCONTRACT_BILL_ROLE_PERMS = {
 	"BuildSuite Director": _READ,  # oversight only — read, never raise/submit a bill
 	"BuildSuite PM": _CRW,  # PM prepares bills (create/edit) but the QS submits them
 	"BuildSuite Procurement Officer": _CRW,  # prepares bills (create/edit); QS submits, so no S/X
-	"BuildSuite Accountant": _READ,
+	"BuildSuite Accountant": _FULL_SUB,  # Accountant owns bill posting fully (per the Accountant ruling)
 	"BuildSuite Site Engineer": _READ,
-	"BuildSuite Estimator": _READ,
+	# Estimator has NO Subcontractor Bill access (per the Estimator ruling) — omitted, so
+	# _apply_role_perms revokes any prior grant.
 }
 # Subcontractor Work Order — the commitment document is natively submittable (Draft →
 # Submitted → Cancelled + Amend), so the full roles get CRWDSX, not just CRWD. QS prepares
@@ -640,6 +644,8 @@ PETTY_CASH_ROLE_PERMS = {
 	"BuildSuite Foreman": _PETTY_CASH_SITE,
 	"BuildSuite Store Keeper": _RAISE,  # raises petty-cash requests (create + read); no edit/disburse
 	"BuildSuite Procurement Officer": _RAISE,  # raises petty-cash requests (create + read)
+	"BuildSuite Estimator": _RAISE,  # raises petty-cash requests (create + read)
+	"BuildSuite HR Manager": _RAISE,  # raises petty-cash requests (create + read)
 	"BuildSuite QS": _READ,
 }
 PETTY_CASH_DISBURSE_ROLES = (
@@ -664,6 +670,8 @@ EXPENSE_ENTRY_ROLE_PERMS = {
 	"BuildSuite Store Keeper": _RAISE,  # raises expense entries (create + read); finance approves/submits
 	"BuildSuite Procurement Officer": _RAISE,  # raises expense entries (create + read)
 	"BuildSuite QS": _RAISE,  # raises expense entries (create + read), per the QS ruling
+	"BuildSuite Estimator": _RAISE,  # raises expense entries (create + read)
+	"BuildSuite HR Manager": _RAISE,  # raises expense entries (create + read)
 }
 
 
@@ -818,6 +826,7 @@ SALES_INVOICE_ROLE_PERMS = {
 	"BuildSuite Accountant": _FULL_SUB,
 	"BuildSuite PM": _READ,
 	"BuildSuite QS": _READ,
+	"BuildSuite Estimator": _READ,  # read-only billing context (per the Estimator ruling)
 }
 # Payment Entry (money movement) — Accountant + admin tier create and submit; it is
 # created from the document being settled, never a blank form. Director + PM +
@@ -828,6 +837,7 @@ PAYMENT_ENTRY_ROLE_PERMS = {
 	"BuildSuite Director": _READ,
 	"BuildSuite PM": _READ,
 	"BuildSuite Procurement Officer": _READ,
+	"BuildSuite Estimator": _READ,  # read-only (customer advances context, per the Estimator ruling)
 }
 
 

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -560,18 +560,18 @@ SUBCONTRACT_MASTER_ROLE_PERMS = {
 	"BuildSuite Procurement Officer": _FULL,
 	"BuildSuite Administrator": _FULL,
 }
-# Measurement Book — the QS + Site Engineer record and certify site measurements,
-# so they get full CRUD here (they only read the WO/Subcontractor masters). The
-# Director is oversight-only on the MB (per the Director/Owner ruling): read, not
-# data entry — so it's pulled out of the full roles down to _READ below. The
-# Procurement Officer has NO MB access at all (per the Procurement ruling), so it is
-# excluded from the full roles here and gets no grant (revoked by _apply_role_perms).
+# Measurement Book — the QS records + certifies site measurements (full CRUD). The
+# Site Engineer only RAISES measurement books (create + read; no edit/delete/certify,
+# per the Site Engineer ruling), so it's create-only below, not full. The Director is
+# oversight-only (read, per the Director/Owner ruling). The Procurement Officer has NO
+# MB access at all (per the Procurement ruling), so it is excluded from the full roles
+# and gets no grant (revoked by _apply_role_perms).
 _MB_FULL_ROLES = tuple(r for r in _SUBCONTRACT_FULL_ROLES if r != "BuildSuite Procurement Officer") + (
 	"BuildSuite QS",
-	"BuildSuite Site Engineer",
 )
 MEASUREMENT_BOOK_ROLE_PERMS = {
 	**{role: _FULL for role in _MB_FULL_ROLES},
+	"BuildSuite Site Engineer": _RAISE,  # raise only — create + read, never edit/delete/certify
 	"BuildSuite Director": _READ,  # oversight only — read, never edit
 	"BuildSuite Accountant": _READ,
 }

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -164,6 +164,7 @@ PURCHASE_INVOICE_ROLE_PERMS = {
 	"BuildSuite Director": _FULL_SUB,
 	"BuildSuite PM": _CRW,  # PM raises + edits supplier bills; the Accountant submits/cancels them
 	"BuildSuite Procurement Officer": _READ,
+	"BuildSuite Store Keeper": _READ,  # reads supplier bills (custody/receipt context), never edits
 	"BuildSuite Accountant": _FULL_SUB,  # Accountant owns invoicing
 }
 STOCK_ENTRY_ROLE_PERMS = {
@@ -630,6 +631,7 @@ PETTY_CASH_ROLE_PERMS = {
 	"BuildSuite Accountant": _FULL,
 	"BuildSuite Site Engineer": _PETTY_CASH_SITE,
 	"BuildSuite Foreman": _PETTY_CASH_SITE,
+	"BuildSuite Store Keeper": _RAISE,  # raises petty-cash requests (create + read); no edit/disburse
 	"BuildSuite QS": _READ,
 }
 PETTY_CASH_DISBURSE_ROLES = (
@@ -651,6 +653,7 @@ EXPENSE_ENTRY_ROLE_PERMS = {
 	"BuildSuite Accountant": _FULL_SUB,
 	"BuildSuite Site Engineer": _EXPENSE_ENTRY_DRAFT,
 	"BuildSuite Foreman": _EXPENSE_ENTRY_DRAFT,
+	"BuildSuite Store Keeper": _RAISE,  # raises expense entries (create + read); finance approves/submits
 	"BuildSuite QS": _READ,
 }
 

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -552,6 +552,7 @@ SUBCONTRACT_ROLE_PERMS = {
 	**{role: _FULL for role in _SUBCONTRACT_FULL_ROLES},
 	**{role: _READ for role in _SUBCONTRACT_READ_ROLES},
 	"BuildSuite PM": _CRW,  # PM maintains subcontractors (edit) but does not delete them
+	"BuildSuite QS": _FULL,  # QS maintains subcontractors fully (per the QS ruling), not read-only
 }
 # Trade / Delivery Type masters — read for everyone in the module, write for
 # procurement + admins (they're resolved by the WO link pickers).
@@ -662,7 +663,7 @@ EXPENSE_ENTRY_ROLE_PERMS = {
 	"BuildSuite Foreman": _EXPENSE_ENTRY_DRAFT,
 	"BuildSuite Store Keeper": _RAISE,  # raises expense entries (create + read); finance approves/submits
 	"BuildSuite Procurement Officer": _RAISE,  # raises expense entries (create + read)
-	"BuildSuite QS": _READ,
+	"BuildSuite QS": _RAISE,  # raises expense entries (create + read), per the QS ruling
 }
 
 

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -162,7 +162,7 @@ PURCHASE_INVOICE_ROLE_PERMS = {
 	# Supplier Bill — the Director/Owner owns supplier invoicing end to end, so full CRWDSX
 	# (not read-only): raise, edit, submit, cancel + amend a supplier invoice.
 	"BuildSuite Director": _FULL_SUB,
-	"BuildSuite PM": _READ,
+	"BuildSuite PM": _CRW,  # PM raises + edits supplier bills; the Accountant submits/cancels them
 	"BuildSuite Procurement Officer": _READ,
 	"BuildSuite Accountant": _FULL_SUB,  # Accountant owns invoicing
 }
@@ -550,6 +550,7 @@ _SUBCONTRACT_READ_ROLES = ("BuildSuite QS", "BuildSuite Site Engineer", "BuildSu
 SUBCONTRACT_ROLE_PERMS = {
 	**{role: _FULL for role in _SUBCONTRACT_FULL_ROLES},
 	**{role: _READ for role in _SUBCONTRACT_READ_ROLES},
+	"BuildSuite PM": _CRW,  # PM maintains subcontractors (edit) but does not delete them
 }
 # Trade / Delivery Type masters — read for everyone in the module, write for
 # procurement + admins (they're resolved by the WO link pickers).
@@ -579,6 +580,7 @@ _BILL_FULL_ROLES = _SUBCONTRACT_FULL_ROLES + ("BuildSuite QS",)
 SUBCONTRACT_BILL_ROLE_PERMS = {
 	**{role: _FULL_SUB for role in _BILL_FULL_ROLES},
 	"BuildSuite Director": _READ,  # oversight only — read, never raise/submit a bill
+	"BuildSuite PM": _CRW,  # PM prepares bills (create/edit) but the QS/Procurement submit them
 	"BuildSuite Accountant": _READ,
 	"BuildSuite Site Engineer": _READ,
 	"BuildSuite Estimator": _READ,

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -563,8 +563,13 @@ SUBCONTRACT_MASTER_ROLE_PERMS = {
 # Measurement Book — the QS + Site Engineer record and certify site measurements,
 # so they get full CRUD here (they only read the WO/Subcontractor masters). The
 # Director is oversight-only on the MB (per the Director/Owner ruling): read, not
-# data entry — so it's pulled out of the full roles down to _READ below.
-_MB_FULL_ROLES = _SUBCONTRACT_FULL_ROLES + ("BuildSuite QS", "BuildSuite Site Engineer")
+# data entry — so it's pulled out of the full roles down to _READ below. The
+# Procurement Officer has NO MB access at all (per the Procurement ruling), so it is
+# excluded from the full roles here and gets no grant (revoked by _apply_role_perms).
+_MB_FULL_ROLES = tuple(r for r in _SUBCONTRACT_FULL_ROLES if r != "BuildSuite Procurement Officer") + (
+	"BuildSuite QS",
+	"BuildSuite Site Engineer",
+)
 MEASUREMENT_BOOK_ROLE_PERMS = {
 	**{role: _FULL for role in _MB_FULL_ROLES},
 	"BuildSuite Director": _READ,  # oversight only — read, never edit
@@ -581,7 +586,8 @@ _BILL_FULL_ROLES = _SUBCONTRACT_FULL_ROLES + ("BuildSuite QS",)
 SUBCONTRACT_BILL_ROLE_PERMS = {
 	**{role: _FULL_SUB for role in _BILL_FULL_ROLES},
 	"BuildSuite Director": _READ,  # oversight only — read, never raise/submit a bill
-	"BuildSuite PM": _CRW,  # PM prepares bills (create/edit) but the QS/Procurement submit them
+	"BuildSuite PM": _CRW,  # PM prepares bills (create/edit) but the QS submits them
+	"BuildSuite Procurement Officer": _CRW,  # prepares bills (create/edit); QS submits, so no S/X
 	"BuildSuite Accountant": _READ,
 	"BuildSuite Site Engineer": _READ,
 	"BuildSuite Estimator": _READ,
@@ -632,6 +638,7 @@ PETTY_CASH_ROLE_PERMS = {
 	"BuildSuite Site Engineer": _PETTY_CASH_SITE,
 	"BuildSuite Foreman": _PETTY_CASH_SITE,
 	"BuildSuite Store Keeper": _RAISE,  # raises petty-cash requests (create + read); no edit/disburse
+	"BuildSuite Procurement Officer": _RAISE,  # raises petty-cash requests (create + read)
 	"BuildSuite QS": _READ,
 }
 PETTY_CASH_DISBURSE_ROLES = (
@@ -654,6 +661,7 @@ EXPENSE_ENTRY_ROLE_PERMS = {
 	"BuildSuite Site Engineer": _EXPENSE_ENTRY_DRAFT,
 	"BuildSuite Foreman": _EXPENSE_ENTRY_DRAFT,
 	"BuildSuite Store Keeper": _RAISE,  # raises expense entries (create + read); finance approves/submits
+	"BuildSuite Procurement Officer": _RAISE,  # raises expense entries (create + read)
 	"BuildSuite QS": _READ,
 }
 

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -304,6 +304,22 @@ PERSONA_CRUD_MATRIX = {
 		"Machinery Usage": "crw",  # not submittable — CRW is full; the ruling's S is N/A
 		"Project": "r",  # must read Project or the project-field selector is empty
 	},
+	"Project Manager": {
+		"Supplier": "crw",  # Subcontractor — maintain, but no delete
+		"Subcontractor Work Order": "crwdsx",  # full — PM owns the commitment doc
+		"Subcontractor Bill": "crw",  # prepare bills; QS/Procurement submit, so no D/S/X
+		"Purchase Invoice": "crw",  # Supplier Bill — raise + edit; Accountant submits
+		"Payment Entry": "r",  # Supplier / Customer advances — read-only
+		"Sales Invoice": "r",  # read-only (billing context, not raising)
+		"Employee": "crwd",  # Field Employee — full master maintenance
+		"Field Attendance": "crwdsx",  # full
+		"Crew": "crwd",  # full
+		"Labour Attendance Register": "r",  # derived register — read-only
+		"Overtime Attendance Register": "r",  # derived register — read-only
+		"Machinery": "crw",  # register — maintain, no delete
+		"Machinery Type": "r",  # must read the type master or the selector is empty
+		"Customer": "crw",  # maintain, no delete
+	},
 }
 
 
@@ -357,3 +373,6 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_foreman_matrix(self):
 		self._assert_persona_matrix("Foreman / Supervisor", PERSONA_CRUD_MATRIX["Foreman / Supervisor"])
+
+	def test_pm_matrix(self):
+		self._assert_persona_matrix("Project Manager", PERSONA_CRUD_MATRIX["Project Manager"])

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -340,6 +340,24 @@ PERSONA_CRUD_MATRIX = {
 		"Expense Entry": "cr",  # raises expenses — create + read only
 		"Payment Entry": "r",  # advances/payments — read-only
 	},
+	# Supplier + Purchase Invoice are intentionally OMITTED for the Site Engineer: it reads the
+	# Subcontractor Work Order / Bill, which Link to Supplier / Purchase Invoice, so the read-mirror
+	# grants a bare read on those targets (to resolve the WO/Bill's party + invoice). A hard "no
+	# access" therefore can't be asserted at the DocPerm layer; the Subcontractors / Supplier-Bill
+	# SCREENS are hidden at the Vue layer (roles.js) instead.
+	"Site Engineer": {
+		"Measurement Book": "cr",  # raise only — create + read, no edit/delete/certify
+		"Payment Entry": "",  # advances — no access
+		"Employee": "crw",  # Field Employee — create + edit, no delete
+		"Crew": "crwd",  # full
+		"Field Attendance": "crwdsx",  # the muster — full
+		"Labour Attendance Register": "r",  # derived register — read-only
+		"Overtime Attendance Register": "r",  # derived register — read-only
+		"Machinery": "r",  # register — read-only
+		"Machinery Usage": "crwd",  # usage log — full (not submittable, so the ruling's S/X are N/A)
+		"Expense Entry": "crw",  # raise + edit own draft; satisfies the "create + read" ruling
+		"Project": "r",  # must read Project or the project-field selector is empty
+	},
 }
 
 
@@ -402,3 +420,6 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_procurement_officer_matrix(self):
 		self._assert_persona_matrix("Procurement Officer", PERSONA_CRUD_MATRIX["Procurement Officer"])
+
+	def test_site_engineer_matrix(self):
+		self._assert_persona_matrix("Site Engineer", PERSONA_CRUD_MATRIX["Site Engineer"])

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -249,3 +249,89 @@ class TestReportAccessMatrix(_PersonaBase):
 						expected,
 						f"{persona} {'should' if expected else 'should NOT'} be able to run {report!r}",
 					)
+
+
+# --- Director / Owner CRUD matrix --------------------------------------------
+# The permission letters, mapped to the Frappe DocPerm ptypes they represent. "X"
+# is cancel+amend (they always move together on a submittable doctype).
+_LETTER_PTYPES = {
+	"c": ("create",),
+	"r": ("read",),
+	"w": ("write",),
+	"d": ("delete",),
+	"s": ("submit",),
+	"x": ("cancel", "amend"),
+}
+# The full ptype universe to check, by submittability: on a submittable doctype we
+# assert all of CRWDSX; on a plain master, only CRWD (submit/cancel/amend don't exist).
+_SUB_UNIVERSE = "crwdsx"
+_NONSUB_UNIVERSE = "crwd"
+
+# The Director/Owner permission matrix, transcribed from the ruling. Each doctype maps
+# to the letters the Director SHOULD hold; every other letter in that doctype's universe
+# must be DENIED. This encodes both the grants and the non-grants, so an over-grant
+# (Measurement Book / Subcontractor Bill regaining write) or a lost grant (Purchase
+# Invoice / Supplier Bill losing submit) both fail the test.
+#   Petty Cash Request is a plain master (not submittable), so its "full" is CRWD — the
+#   ruling's "S/X" don't exist for it. Payment Entry backs the Supplier/Customer
+#   "advances" (there is no Advance doctype); the Director is read-only there.
+DIRECTOR_MATRIX = {
+	"Subcontractor Work Order": "crwdsx",
+	"Measurement Book": "r",
+	"Subcontractor Bill": "r",
+	"Purchase Invoice": "crwdsx",  # Supplier Bill
+	"Payment Entry": "r",  # Supplier / Customer advances
+	"Sales Invoice": "crwdsx",
+	"Employee": "r",  # Field Employee
+	"Crew": "r",
+	"Field Attendance": "r",
+	"Machinery": "r",
+	"Machinery Usage": "r",
+	"Customer": "crwd",
+	"Supplier": "crwd",
+	"Expense Entry": "crwdsx",
+	"Petty Cash Request": "crwd",
+}
+
+
+class TestDirectorPermissionMatrix(_PersonaBase):
+	"""The Director/Owner DocPerm matrix, asserted end to end: re-apply the authoritative
+	setup (so the test reflects the CURRENT perm maps, not whatever the site drifted to),
+	then check a Director user's effective has_permission per ptype per doctype."""
+
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# Re-converge every matrix to the code — same call the resync patch runs — so the
+		# assertions test the maps, independent of the site's migration history.
+		from buildsuite_core.permissions.setup import setup_record_permissions
+
+		setup_record_permissions()
+		frappe.clear_cache()
+
+	def _allowed(self, email, doctype, ptype):
+		return bool(frappe.has_permission(doctype, ptype=ptype, user=email))
+
+	def test_director_matrix(self):
+		email = self._make_user("Director / Owner")
+		# Sanity: the persona granted exactly the Director role (no stray System Manager
+		# that would mask a missing grant behind super-admin access).
+		roles = self._roles(email)
+		self.assertIn("BuildSuite Director", roles)
+		self.assertNotIn("System Manager", roles)
+
+		for doctype, expected in DIRECTOR_MATRIX.items():
+			if not frappe.db.exists("DocType", doctype):
+				self.skipTest(f"DocType {doctype!r} not installed on this site")
+			submittable = frappe.db.get_value("DocType", doctype, "is_submittable")
+			universe = _SUB_UNIVERSE if submittable else _NONSUB_UNIVERSE
+			for letter in universe:
+				should = letter in expected
+				for ptype in _LETTER_PTYPES[letter]:
+					with self.subTest(doctype=doctype, ptype=ptype):
+						self.assertEqual(
+							self._allowed(email, doctype, ptype),
+							should,
+							f"Director {'should' if should else 'should NOT'} have "
+							f"{ptype!r} on {doctype!r} (wanted {expected!r})",
+						)

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -251,7 +251,7 @@ class TestReportAccessMatrix(_PersonaBase):
 					)
 
 
-# --- Director / Owner CRUD matrix --------------------------------------------
+# --- Per-persona CRUD matrix -------------------------------------------------
 # The permission letters, mapped to the Frappe DocPerm ptypes they represent. "X"
 # is cancel+amend (they always move together on a submittable doctype).
 _LETTER_PTYPES = {
@@ -267,60 +267,76 @@ _LETTER_PTYPES = {
 _SUB_UNIVERSE = "crwdsx"
 _NONSUB_UNIVERSE = "crwd"
 
-# The Director/Owner permission matrix, transcribed from the ruling. Each doctype maps
-# to the letters the Director SHOULD hold; every other letter in that doctype's universe
-# must be DENIED. This encodes both the grants and the non-grants, so an over-grant
-# (Measurement Book / Subcontractor Bill regaining write) or a lost grant (Purchase
-# Invoice / Supplier Bill losing submit) both fail the test.
-#   Petty Cash Request is a plain master (not submittable), so its "full" is CRWD — the
-#   ruling's "S/X" don't exist for it. Payment Entry backs the Supplier/Customer
-#   "advances" (there is no Advance doctype); the Director is read-only there.
-DIRECTOR_MATRIX = {
-	"Subcontractor Work Order": "crwdsx",
-	"Measurement Book": "r",
-	"Subcontractor Bill": "r",
-	"Purchase Invoice": "crwdsx",  # Supplier Bill
-	"Payment Entry": "r",  # Supplier / Customer advances
-	"Sales Invoice": "crwdsx",
-	"Employee": "r",  # Field Employee
-	"Crew": "r",
-	"Field Attendance": "r",
-	"Machinery": "r",
-	"Machinery Usage": "r",
-	"Customer": "crwd",
-	"Supplier": "crwd",
-	"Expense Entry": "crwdsx",
-	"Petty Cash Request": "crwd",
+# Per-persona permission matrices, transcribed from the persona rulings. Each doctype maps
+# to the letters the persona SHOULD hold; every OTHER letter in that doctype's universe must
+# be DENIED. So both an over-grant (a read-only doctype regaining write) and a lost grant (a
+# full doctype losing submit) fail the test. An empty string = NO access (every ptype denied,
+# read included) — e.g. the Foreman must not even see Supplier Bill.
+#   Submittability caveats: Petty Cash Request and Machinery Usage are plain masters (not
+#   submittable), so their "full" is CRWD — a ruling's "S/X" simply don't exist for them.
+#   Payment Entry backs the Supplier/Customer "advances" (there is no Advance doctype).
+PERSONA_CRUD_MATRIX = {
+	"Director / Owner": {
+		"Subcontractor Work Order": "crwdsx",
+		"Measurement Book": "r",
+		"Subcontractor Bill": "r",
+		"Purchase Invoice": "crwdsx",  # Supplier Bill
+		"Payment Entry": "r",  # Supplier / Customer advances
+		"Sales Invoice": "crwdsx",
+		"Employee": "r",  # Field Employee
+		"Crew": "r",
+		"Field Attendance": "r",
+		"Machinery": "r",
+		"Machinery Usage": "r",
+		"Customer": "crwd",
+		"Supplier": "crwd",
+		"Expense Entry": "crwdsx",
+		"Petty Cash Request": "crwd",
+	},
+	"Foreman / Supervisor": {
+		"Purchase Invoice": "",  # Supplier Bill — no access at all (not even read)
+		"Employee": "r",  # Field Employee — read-only
+		"Crew": "crw",  # maintain membership; no delete
+		"Field Attendance": "crwdsx",  # the muster — full
+		"Labour Attendance Register": "r",  # derived register — read-only
+		"Overtime Attendance Register": "r",  # derived register — read-only
+		"Machinery": "r",
+		"Machinery Usage": "crw",  # not submittable — CRW is full; the ruling's S is N/A
+		"Project": "r",  # must read Project or the project-field selector is empty
+	},
 }
 
 
-class TestDirectorPermissionMatrix(_PersonaBase):
-	"""The Director/Owner DocPerm matrix, asserted end to end: re-apply the authoritative
-	setup (so the test reflects the CURRENT perm maps, not whatever the site drifted to),
-	then check a Director user's effective has_permission per ptype per doctype."""
+class TestPersonaCrudMatrix(_PersonaBase):
+	"""Per-persona DocPerm matrices, asserted end to end: re-apply the authoritative setup
+	(so the test reflects the CURRENT perm maps, not whatever the site drifted to), then check
+	each persona user's effective has_permission per ptype per doctype."""
 
 	@classmethod
 	def setUpClass(cls):
 		super().setUpClass()
 		# Re-converge every matrix to the code — same call the resync patch runs — so the
-		# assertions test the maps, independent of the site's migration history.
+		# assertions test the maps, independent of the site's migration history. Commit it
+		# (it's idempotent site config, not test data) so it survives the per-test rollback
+		# and both persona tests see the same applied perms.
 		from buildsuite_core.permissions.setup import setup_record_permissions
 
 		setup_record_permissions()
+		frappe.db.commit()
 		frappe.clear_cache()
 
 	def _allowed(self, email, doctype, ptype):
 		return bool(frappe.has_permission(doctype, ptype=ptype, user=email))
 
-	def test_director_matrix(self):
-		email = self._make_user("Director / Owner")
-		# Sanity: the persona granted exactly the Director role (no stray System Manager
-		# that would mask a missing grant behind super-admin access).
+	def _assert_persona_matrix(self, persona, matrix):
+		email = self._make_user(persona)
+		# Sanity: the persona granted exactly its managed role (no stray System Manager that
+		# would mask a missing grant behind super-admin access).
 		roles = self._roles(email)
-		self.assertIn("BuildSuite Director", roles)
+		self.assertIn(PERSONA_ROLE[persona], roles)
 		self.assertNotIn("System Manager", roles)
 
-		for doctype, expected in DIRECTOR_MATRIX.items():
+		for doctype, expected in matrix.items():
 			if not frappe.db.exists("DocType", doctype):
 				self.skipTest(f"DocType {doctype!r} not installed on this site")
 			submittable = frappe.db.get_value("DocType", doctype, "is_submittable")
@@ -328,10 +344,16 @@ class TestDirectorPermissionMatrix(_PersonaBase):
 			for letter in universe:
 				should = letter in expected
 				for ptype in _LETTER_PTYPES[letter]:
-					with self.subTest(doctype=doctype, ptype=ptype):
+					with self.subTest(persona=persona, doctype=doctype, ptype=ptype):
 						self.assertEqual(
 							self._allowed(email, doctype, ptype),
 							should,
-							f"Director {'should' if should else 'should NOT'} have "
-							f"{ptype!r} on {doctype!r} (wanted {expected!r})",
+							f"{persona} {'should' if should else 'should NOT'} have "
+							f"{ptype!r} on {doctype!r} (wanted {expected or 'no access'!r})",
 						)
+
+	def test_director_matrix(self):
+		self._assert_persona_matrix("Director / Owner", PERSONA_CRUD_MATRIX["Director / Owner"])
+
+	def test_foreman_matrix(self):
+		self._assert_persona_matrix("Foreman / Supervisor", PERSONA_CRUD_MATRIX["Foreman / Supervisor"])

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -329,6 +329,17 @@ PERSONA_CRUD_MATRIX = {
 		"Petty Cash Request": "cr",  # raises requests — create + read only
 		"Expense Entry": "cr",  # raises expenses — create + read only
 	},
+	"Procurement Officer": {
+		"Subcontractor Work Order": "crwdsx",  # full — Procurement owns the commitment doc
+		"Measurement Book": "",  # no access at all
+		"Subcontractor Bill": "crw",  # prepares bills; QS submits, so no D/S/X
+		"Machinery": "crwd",  # register — full (buys/hires plant)
+		"Machinery Usage": "r",  # read-only (usage is the basis for hire bills)
+		"Supplier": "crwd",  # full — maintains the subcontractor/supplier master
+		"Petty Cash Request": "cr",  # raises requests — create + read only
+		"Expense Entry": "cr",  # raises expenses — create + read only
+		"Payment Entry": "r",  # advances/payments — read-only
+	},
 }
 
 
@@ -388,3 +399,6 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_store_keeper_matrix(self):
 		self._assert_persona_matrix("Store Keeper", PERSONA_CRUD_MATRIX["Store Keeper"])
+
+	def test_procurement_officer_matrix(self):
+		self._assert_persona_matrix("Procurement Officer", PERSONA_CRUD_MATRIX["Procurement Officer"])

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -320,6 +320,15 @@ PERSONA_CRUD_MATRIX = {
 		"Machinery Type": "r",  # must read the type master or the selector is empty
 		"Customer": "crw",  # maintain, no delete
 	},
+	"Store Keeper": {
+		"Supplier": "r",  # read-only (granted via the read-mirror, not a bespoke map)
+		"Purchase Invoice": "r",  # Supplier Bill — read-only, no create
+		"Payment Entry": "",  # advances — no access at all
+		"Machinery": "crwd",  # register — full custody maintenance
+		"Project": "r",  # must read Project or the project-field selector is empty
+		"Petty Cash Request": "cr",  # raises requests — create + read only
+		"Expense Entry": "cr",  # raises expenses — create + read only
+	},
 }
 
 
@@ -376,3 +385,6 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_pm_matrix(self):
 		self._assert_persona_matrix("Project Manager", PERSONA_CRUD_MATRIX["Project Manager"])
+
+	def test_store_keeper_matrix(self):
+		self._assert_persona_matrix("Store Keeper", PERSONA_CRUD_MATRIX["Store Keeper"])

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -345,6 +345,17 @@ PERSONA_CRUD_MATRIX = {
 	# grants a bare read on those targets (to resolve the WO/Bill's party + invoice). A hard "no
 	# access" therefore can't be asserted at the DocPerm layer; the Subcontractors / Supplier-Bill
 	# SCREENS are hidden at the Vue layer (roles.js) instead.
+	"Quantity Surveyor": {
+		"Supplier": "crwd",  # full — QS maintains subcontractors (per the QS ruling)
+		"Subcontractor Work Order": "crwdsx",  # full
+		"Subcontractor Bill": "crwdsx",  # full — QS raises + submits progress bills
+		"Measurement Book": "crwd",  # full — QS records + certifies measurements
+		"Labour Attendance Register": "r",  # derived register — read-only
+		"Overtime Attendance Register": "r",  # derived register — read-only
+		"Expense Entry": "cr",  # raises expenses — create + read
+		"Sales Invoice": "r",  # read-only (billing context, not raising)
+		"Project": "r",  # must read Project or the project-field selector is empty
+	},
 	"Site Engineer": {
 		"Measurement Book": "cr",  # raise only — create + read, no edit/delete/certify
 		"Payment Entry": "",  # advances — no access
@@ -423,3 +434,6 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_site_engineer_matrix(self):
 		self._assert_persona_matrix("Site Engineer", PERSONA_CRUD_MATRIX["Site Engineer"])
+
+	def test_qs_matrix(self):
+		self._assert_persona_matrix("Quantity Surveyor", PERSONA_CRUD_MATRIX["Quantity Surveyor"])

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -369,6 +369,52 @@ PERSONA_CRUD_MATRIX = {
 		"Expense Entry": "crw",  # raise + edit own draft; satisfies the "create + read" ruling
 		"Project": "r",  # must read Project or the project-field selector is empty
 	},
+	"Estimator": {
+		"Supplier": "r",  # read-only
+		"Subcontractor Work Order": "r",  # read-only
+		"Measurement Book": "r",  # read-only
+		"Subcontractor Bill": "",  # no access at all
+		"Sales Invoice": "r",  # read-only (billing context)
+		"Payment Entry": "r",  # customer advances — read-only
+		"Petty Cash Request": "cr",  # create + read
+		"Expense Entry": "cr",  # create + read
+		"Project": "r",
+	},
+	# Customer + Supplier are OMITTED for HR Manager: both survive as a bare read via the
+	# linked-master read-mirror (HR reads Project/Employee), so a hard "no access" can't be
+	# asserted at the DocPerm layer — the Customer/Supplier SCREENS are hidden at the Vue layer.
+	"HR Manager": {
+		"Employee": "crwd",  # Field Employee — full
+		"Crew": "crwd",  # full
+		"Labour Attendance Register": "r",  # read-only
+		"Overtime Attendance Register": "r",  # read-only
+		"Petty Cash Request": "cr",  # create + read
+		"Expense Entry": "cr",  # create + read
+		"Payment Entry": "",  # advances — no access
+		"Sales Invoice": "",  # no access
+		"Purchase Invoice": "",  # supplier bill — no access
+		"Machinery": "",  # equipment — no access
+		"Subcontractor Work Order": "",  # subcontract — no access
+	},
+	"Accountant": {
+		"Supplier": "crwd",  # full — maintains subcontractors
+		"Subcontractor Work Order": "r",  # read-only
+		"Measurement Book": "r",  # read-only
+		"Subcontractor Bill": "crwdsx",  # full — owns bill posting
+		"Purchase Invoice": "crwdsx",  # Supplier Bill — full
+		"Customer": "crwd",  # full
+		"Sales Invoice": "crwdsx",  # full
+		"Payment Entry": "crwdsx",  # full (customer/supplier advances + payments)
+		"Petty Cash Request": "crwd",  # full (not submittable, so S/X are N/A)
+		"Expense Entry": "crwdsx",  # full
+		"Employee": "r",  # Field Employee — read-only
+		"Field Attendance": "r",  # read-only
+		"Crew": "",  # no access
+		"Machinery": "r",  # read-only
+		"Machinery Usage": "r",  # read-only
+		"Machinery Type": "r",  # read (selector)
+		"Project": "r",
+	},
 }
 
 
@@ -437,3 +483,12 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_qs_matrix(self):
 		self._assert_persona_matrix("Quantity Surveyor", PERSONA_CRUD_MATRIX["Quantity Surveyor"])
+
+	def test_estimator_matrix(self):
+		self._assert_persona_matrix("Estimator", PERSONA_CRUD_MATRIX["Estimator"])
+
+	def test_hr_manager_matrix(self):
+		self._assert_persona_matrix("HR Manager", PERSONA_CRUD_MATRIX["HR Manager"])
+
+	def test_accountant_matrix(self):
+		self._assert_persona_matrix("Accountant", PERSONA_CRUD_MATRIX["Accountant"])

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -632,8 +632,9 @@ const _MODULE_ACCESS = {
 		// Site Engineer has no Subcontractors screen (per the Site Engineer ruling). Its bare
 		// read on Supplier survives at the backend via the read-mirror (the Work Order it can
 		// read links to Supplier), but that only resolves the WO's supplier name — no screen.
-		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
-		read: ["procurement", "pm", "director", "qs", "accountant", "admin", "bsa"],
+		// Accountant + QS maintain subcontractors fully; Estimator is read-only.
+		create: ["procurement", "pm", "director", "qs", "accountant", "admin", "bsa"],
+		read: ["procurement", "pm", "director", "qs", "accountant", "estimator", "admin", "bsa"],
 	},
 	subcontractorWorkOrder: {
 		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
@@ -656,10 +657,11 @@ const _MODULE_ACCESS = {
 		create: ["pm", "qs", "site-engineer", "admin", "bsa"],
 		edit: ["pm", "qs", "admin", "bsa"],
 		del: ["pm", "qs", "admin", "bsa"],
-		read: ["pm", "director", "qs", "site-engineer", "accountant", "admin", "bsa"],
+		read: ["pm", "director", "qs", "site-engineer", "estimator", "accountant", "admin", "bsa"],
 	},
 	subcontractorBill: {
-		create: ["procurement", "pm", "qs", "admin", "bsa"],  // Director is read-only on bills
+		// Director is read-only; Estimator has no bill access (omitted). Accountant is full.
+		create: ["procurement", "pm", "qs", "accountant", "admin", "bsa"],
 		read: [
 			"procurement",
 			"pm",
@@ -727,7 +729,7 @@ const _MODULE_ACCESS = {
 	// show only for personas whose DocPerm would actually allow the insert.
 	supplier: {
 		// Supplier (SUBCONTRACT_ROLE_PERMS) — same doctype the Suppliers panel creates
-		create: ["procurement", "pm", "director", "admin", "bsa"],
+		create: ["procurement", "pm", "director", "qs", "accountant", "admin", "bsa"],
 		read: [
 			"procurement",
 			"pm",
@@ -736,14 +738,16 @@ const _MODULE_ACCESS = {
 			"site-engineer",
 			"accountant",
 			"store-keeper",
+			"estimator",
 			"admin",
 			"bsa",
 		],
 	},
 	customer: {
-		// Customer (CUSTOMER_WRITE_ROLE_PERMS); read is the linked-master mirror = everyone
+		// Customer (CUSTOMER_WRITE_ROLE_PERMS); read is the linked-master mirror = every persona
+		// EXCEPT HR Manager, which has no Customer screen (per the HR ruling).
 		create: ["director", "pm", "accountant", "admin", "bsa"],
-		read: _ALL_PERSONAS,
+		read: _ALL_PERSONAS.filter((p) => p !== "hr-manager"),
 	},
 	supplierBill: {
 		// Purchase Invoice (PURCHASE_INVOICE_ROLE_PERMS)
@@ -753,16 +757,16 @@ const _MODULE_ACCESS = {
 	salesInvoice: {
 		// Sales Invoice (SALES_INVOICE_ROLE_PERMS)
 		create: ["director", "accountant", "admin", "bsa"],
-		read: ["director", "pm", "qs", "accountant", "admin", "bsa"],
+		read: ["director", "pm", "qs", "accountant", "estimator", "admin", "bsa"],
 	},
 	advance: {
 		// Payment Entry (PAYMENT_ENTRY_ROLE_PERMS) — supplier/customer advances + payments
 		create: ["accountant", "admin", "bsa"],
-		read: ["director", "pm", "procurement", "accountant", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "accountant", "estimator", "admin", "bsa"],
 	},
 	pettyCash: {
 		// Petty Cash Request (PETTY_CASH_ROLE_PERMS)
-		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "admin", "bsa"],
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "estimator", "hr-manager", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",
@@ -771,6 +775,8 @@ const _MODULE_ACCESS = {
 			"foreman",
 			"store-keeper",
 			"procurement",
+			"estimator",
+			"hr-manager",
 			"qs",
 			"admin",
 			"bsa",
@@ -778,7 +784,7 @@ const _MODULE_ACCESS = {
 	},
 	expense: {
 		// Expense Entry (EXPENSE_ENTRY_ROLE_PERMS)
-		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "qs", "admin", "bsa"],
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "qs", "estimator", "hr-manager", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",
@@ -788,6 +794,8 @@ const _MODULE_ACCESS = {
 			"store-keeper",
 			"procurement",
 			"qs",
+			"estimator",
+			"hr-manager",
 			"admin",
 			"bsa",
 		],

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -632,7 +632,7 @@ const _MODULE_ACCESS = {
 		// Site Engineer has no Subcontractors screen (per the Site Engineer ruling). Its bare
 		// read on Supplier survives at the backend via the read-mirror (the Work Order it can
 		// read links to Supplier), but that only resolves the WO's supplier name — no screen.
-		create: ["procurement", "pm", "director", "admin", "bsa"],
+		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
 		read: ["procurement", "pm", "director", "qs", "accountant", "admin", "bsa"],
 	},
 	subcontractorWorkOrder: {
@@ -778,7 +778,7 @@ const _MODULE_ACCESS = {
 	},
 	expense: {
 		// Expense Entry (EXPENSE_ENTRY_ROLE_PERMS)
-		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "admin", "bsa"],
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "qs", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -629,17 +629,11 @@ const _MODULE_ACCESS = {
 	},
 	// Subcontract
 	subcontractor: {
+		// Site Engineer has no Subcontractors screen (per the Site Engineer ruling). Its bare
+		// read on Supplier survives at the backend via the read-mirror (the Work Order it can
+		// read links to Supplier), but that only resolves the WO's supplier name — no screen.
 		create: ["procurement", "pm", "director", "admin", "bsa"],
-		read: [
-			"procurement",
-			"pm",
-			"director",
-			"qs",
-			"site-engineer",
-			"accountant",
-			"admin",
-			"bsa",
-		],
+		read: ["procurement", "pm", "director", "qs", "accountant", "admin", "bsa"],
 	},
 	subcontractorWorkOrder: {
 		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
@@ -656,8 +650,12 @@ const _MODULE_ACCESS = {
 		],
 	},
 	measurementBook: {
-		// Procurement Officer has no MB access (per the Procurement ruling); Director is read-only
+		// Procurement Officer has no MB access (per the Procurement ruling); Director is read-only.
+		// Site Engineer RAISES books (create) but does NOT edit/delete/certify them (edit/del below
+		// exclude it), so the detail view's Edit/Certify/Delete buttons hide for the Site Engineer.
 		create: ["pm", "qs", "site-engineer", "admin", "bsa"],
+		edit: ["pm", "qs", "admin", "bsa"],
+		del: ["pm", "qs", "admin", "bsa"],
 		read: ["pm", "director", "qs", "site-engineer", "accountant", "admin", "bsa"],
 	},
 	subcontractorBill: {
@@ -796,10 +794,20 @@ const _MODULE_ACCESS = {
 	},
 };
 
-for (const [entity, { create, read }] of Object.entries(_MODULE_ACCESS)) {
+// edit/del default to the create set (the common case: whoever can create can edit +
+// delete). Provide them explicitly only when they diverge — e.g. a role that may CREATE
+// a record but not EDIT or DELETE it (Site Engineer raises a Measurement Book but the QS
+// edits/certifies it). read defaults to (create ∪ read).
+for (const [entity, access] of Object.entries(_MODULE_ACCESS)) {
+	const { create, read, edit = create, del = create } = access;
 	for (const persona of _ALL_PERSONAS) {
 		const c = create.includes(persona);
 		const r = c || read.includes(persona);
-		PERSONA_CAPS[persona][entity] = { c, r, e: c, d: c };
+		PERSONA_CAPS[persona][entity] = {
+			c,
+			r,
+			e: edit.includes(persona),
+			d: del.includes(persona),
+		};
 	}
 }

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -656,17 +656,9 @@ const _MODULE_ACCESS = {
 		],
 	},
 	measurementBook: {
-		create: ["procurement", "pm", "qs", "site-engineer", "admin", "bsa"],
-		read: [
-			"procurement",
-			"pm",
-			"director",
-			"qs",
-			"site-engineer",
-			"accountant",
-			"admin",
-			"bsa",
-		],
+		// Procurement Officer has no MB access (per the Procurement ruling); Director is read-only
+		create: ["pm", "qs", "site-engineer", "admin", "bsa"],
+		read: ["pm", "director", "qs", "site-engineer", "accountant", "admin", "bsa"],
 	},
 	subcontractorBill: {
 		create: ["procurement", "pm", "qs", "admin", "bsa"],  // Director is read-only on bills
@@ -772,7 +764,7 @@ const _MODULE_ACCESS = {
 	},
 	pettyCash: {
 		// Petty Cash Request (PETTY_CASH_ROLE_PERMS)
-		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "admin", "bsa"],
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",
@@ -780,6 +772,7 @@ const _MODULE_ACCESS = {
 			"site-engineer",
 			"foreman",
 			"store-keeper",
+			"procurement",
 			"qs",
 			"admin",
 			"bsa",
@@ -787,7 +780,7 @@ const _MODULE_ACCESS = {
 	},
 	expense: {
 		// Expense Entry (EXPENSE_ENTRY_ROLE_PERMS)
-		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "admin", "bsa"],
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",
@@ -795,6 +788,7 @@ const _MODULE_ACCESS = {
 			"site-engineer",
 			"foreman",
 			"store-keeper",
+			"procurement",
 			"qs",
 			"admin",
 			"bsa",

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -656,7 +656,7 @@ const _MODULE_ACCESS = {
 		],
 	},
 	measurementBook: {
-		create: ["procurement", "pm", "director", "qs", "site-engineer", "admin", "bsa"],
+		create: ["procurement", "pm", "qs", "site-engineer", "admin", "bsa"],
 		read: [
 			"procurement",
 			"pm",
@@ -669,7 +669,7 @@ const _MODULE_ACCESS = {
 		],
 	},
 	subcontractorBill: {
-		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
+		create: ["procurement", "pm", "qs", "admin", "bsa"],  // Director is read-only on bills
 		read: [
 			"procurement",
 			"pm",
@@ -728,6 +728,74 @@ const _MODULE_ACCESS = {
 			"procurement",
 			"store-keeper",
 			"accountant",
+			"admin",
+			"bsa",
+		],
+	},
+	// Project Finance — the create/read sets mirror the backend perm maps in
+	// buildsuite_core/permissions/setup.py, so the finance panels' "+ New" buttons
+	// show only for personas whose DocPerm would actually allow the insert.
+	supplier: {
+		// Supplier (SUBCONTRACT_ROLE_PERMS) — same doctype the Suppliers panel creates
+		create: ["procurement", "pm", "director", "admin", "bsa"],
+		read: [
+			"procurement",
+			"pm",
+			"director",
+			"qs",
+			"site-engineer",
+			"accountant",
+			"store-keeper",
+			"admin",
+			"bsa",
+		],
+	},
+	customer: {
+		// Customer (CUSTOMER_WRITE_ROLE_PERMS); read is the linked-master mirror = everyone
+		create: ["director", "pm", "accountant", "admin", "bsa"],
+		read: _ALL_PERSONAS,
+	},
+	supplierBill: {
+		// Purchase Invoice (PURCHASE_INVOICE_ROLE_PERMS)
+		create: ["director", "pm", "accountant", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
+	},
+	salesInvoice: {
+		// Sales Invoice (SALES_INVOICE_ROLE_PERMS)
+		create: ["director", "accountant", "admin", "bsa"],
+		read: ["director", "pm", "qs", "accountant", "admin", "bsa"],
+	},
+	advance: {
+		// Payment Entry (PAYMENT_ENTRY_ROLE_PERMS) — supplier/customer advances + payments
+		create: ["accountant", "admin", "bsa"],
+		read: ["director", "pm", "procurement", "accountant", "admin", "bsa"],
+	},
+	pettyCash: {
+		// Petty Cash Request (PETTY_CASH_ROLE_PERMS)
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"accountant",
+			"site-engineer",
+			"foreman",
+			"store-keeper",
+			"qs",
+			"admin",
+			"bsa",
+		],
+	},
+	expense: {
+		// Expense Entry (EXPENSE_ENTRY_ROLE_PERMS)
+		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "admin", "bsa"],
+		read: [
+			"director",
+			"pm",
+			"accountant",
+			"site-engineer",
+			"foreman",
+			"store-keeper",
+			"qs",
 			"admin",
 			"bsa",
 		],

--- a/frontend/src/views/MeasurementBookDetailView.vue
+++ b/frontend/src/views/MeasurementBookDetailView.vue
@@ -18,12 +18,16 @@ import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+// The Site Engineer only raises MBs (create + read); edit/certify/delete are QS/PM actions.
+// canEdit/canDelete resolve the persona's measurementBook caps (see roles.js).
+const { canEdit, canDelete, canCreate } = usePermissions();
 
 const mb = ref(null);
 const woLines = ref([]);
@@ -134,7 +138,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('measurementBook')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -143,7 +147,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('measurementBook')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-success-200 bg-success-50 hover:bg-success-100 text-success-700 font-medium"
 				style="border-radius: 6px"
@@ -153,7 +157,7 @@ const breadcrumbs = computed(() => [
 				Certify
 			</button>
 			<button
-				v-if="!isDraft"
+				v-if="!isDraft && canEdit('measurementBook')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -163,7 +167,7 @@ const breadcrumbs = computed(() => [
 				Revert to Draft
 			</button>
 			<button
-				v-if="!isDraft && mb.work_order"
+				v-if="!isDraft && mb.work_order && canCreate('subcontractorBill')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -173,6 +177,7 @@ const breadcrumbs = computed(() => [
 				+ Create Subcontractor bill
 			</button>
 			<button
+				v-if="canDelete('measurementBook')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -14,7 +14,11 @@ import { fmtDate, fmtCompactINR } from "@/utils/format";
 
 const router = useRouter();
 const { projectName } = useProjectNames();
-const { canCreate } = usePermissions();
+const { canCreate, canRead } = usePermissions();
+
+// The "% Billed" column is sourced from Subcontractor Bills. A persona without Bill read
+// (e.g. Estimator) neither fetches them (which would 403) nor sees the column.
+const canReadBills = computed(() => canRead("subcontractorBill"));
 
 // Billed-to-date per work order (sum of non-cancelled Subcontractor Bill gross) → % billed.
 // Kept as a lightweight full fetch feeding the derived "% Billed" cell.
@@ -23,6 +27,7 @@ const billsRes = useDocTypeList("Subcontractor Bill", {
 	orderBy: "modified desc",
 	pageLength: 0,
 	cache: "buildsuite-subcontractor-bills-all",
+	auto: canReadBills.value, // skip the fetch (and its 403) when the persona can't read bills
 });
 const billedByWO = computed(() => {
 	const map = {};
@@ -52,16 +57,17 @@ const FIELDS = [
 	"docstatus",
 ];
 
-const columns = [
+const columns = computed(() => [
 	{ key: "name", label: "WO ID" },
 	{ key: "subcontractor_name", label: "Subcontractor" },
 	{ key: "project", label: "Project" },
 	{ key: "date", label: "Date" },
 	{ key: "delivery_type", label: "Type" },
 	{ key: "total_value", label: "Value", align: "right" },
-	{ key: "percent", label: "% Billed", align: "right" },
+	// "% Billed" is hidden for personas that can't read Subcontractor Bills (no bill fetch).
+	...(canReadBills.value ? [{ key: "percent", label: "% Billed", align: "right" }] : []),
 	{ key: "status", label: "Status" },
-];
+]);
 
 const breadcrumbs = [
 	{ label: "BuildSuite Core", to: "/" },

--- a/frontend/src/views/finance/FinanceBillsPanel.vue
+++ b/frontend/src/views/finance/FinanceBillsPanel.vue
@@ -24,10 +24,15 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Bills" }];
 const router = useRouter();
+const { canCreate } = usePermissions();
+// "+ New bill" opens a chooser for a Supplier bill (Purchase Invoice) or a Subcontractor
+// bill; show the entry point only if the persona can create at least one of them.
+const canNewBill = computed(() => canCreate("supplierBill") || canCreate("subcontractorBill"));
 const { projectName } = useProjectNames();
 
 const payables = ref([]);
@@ -283,13 +288,14 @@ async function saveAdvance() {
 		<template #actions>
 			<div class="flex items-center gap-2">
 				<button
+					v-if="canCreate('advance')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
 					@click="openAdvance"
 				>
 					Record advance
 				</button>
-				<button type="button" class="desk-save-btn" @click="newOpen = true">
+				<button v-if="canNewBill" type="button" class="desk-save-btn" @click="newOpen = true">
 					+ New bill
 				</button>
 			</div>
@@ -522,6 +528,7 @@ async function saveAdvance() {
 				</header>
 				<div class="px-4 py-4 space-y-2">
 					<button
+						v-if="canCreate('supplierBill')"
 						type="button"
 						class="w-full text-left border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-4 py-3 transition-colors"
 						@click="newSupplierBill"
@@ -533,6 +540,7 @@ async function saveAdvance() {
 						</div>
 					</button>
 					<button
+						v-if="canCreate('subcontractorBill')"
 						type="button"
 						class="w-full text-left border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-4 py-3 transition-colors"
 						@click="newSubcontractorBill"

--- a/frontend/src/views/finance/FinanceCustomersPanel.vue
+++ b/frontend/src/views/finance/FinanceCustomersPanel.vue
@@ -11,10 +11,14 @@ import DeskList from "@/components/desk/DeskList.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
 import PartyFormModal from "./PartyFormModal.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const store = useDataStore();
-const canManage = computed(() => store.isAdmin);
+const { canCreate } = usePermissions();
+// Customers are created AND edited from this panel; the create and write role-sets
+// coincide (Director / PM / Accountant / admin tier), so one capability gates both.
+const canManage = computed(() => canCreate("customer"));
 
 const TYPE_OPTIONS = ["Company", "Individual", "Partnership"];
 

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -25,7 +25,10 @@ import CostCodePicker from "@/components/CostCodePicker.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { activeCompanyFilter } from "@/composables/useActiveCompany";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
+
+const { canCreate } = usePermissions();
 
 // Every account/project/employee picker is scoped to the active (default) company. This is
 // the single-company seam — see useActiveCompany. Empty pre-boot → picker unfiltered, but
@@ -297,10 +300,10 @@ const expenseAccountFilters = computed(() => [
 		<div class="space-y-4">
 			<div class="flex items-center justify-between gap-3">
 				<div class="text-sm text-ink-600">Log site spend. It hits balances &amp; reports once <span class="font-medium">Submitted</span>.</div>
-				<button v-if="canLog" type="button" class="text-xs desk-save-btn whitespace-nowrap" @click="openNew">+ New expense</button>
+				<button v-if="canCreate('expense') && canLog" type="button" class="text-xs desk-save-btn whitespace-nowrap" @click="openNew">+ New expense</button>
 			</div>
 
-			<div v-if="!canLog" class="bg-warning-50 border border-warning-200 rounded-lg px-4 py-3 text-sm text-warning-700">
+			<div v-if="canCreate('expense') && !canLog" class="bg-warning-50 border border-warning-200 rounded-lg px-4 py-3 text-sm text-warning-700">
 				Your user account isn't linked to an Employee, so spend can't be logged. Ask an administrator to set the Employee's User ID.
 			</div>
 

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -22,10 +22,12 @@ import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { useActiveCompany } from "@/composables/useActiveCompany";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Invoices" }];
 const router = useRouter();
+const { canCreate } = usePermissions();
 const { projectName } = useProjectNames();
 const activeCompany = useActiveCompany();
 const baseFilters = computed(() =>
@@ -229,13 +231,14 @@ async function saveAdvance() {
 		<template #actions>
 			<div class="flex items-center gap-2">
 				<button
+					v-if="canCreate('advance')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
 					@click="openAdvance"
 				>
 					Record advance
 				</button>
-				<button type="button" class="desk-save-btn" @click="openNew">+ New invoice</button>
+				<button v-if="canCreate('salesInvoice')" type="button" class="desk-save-btn" @click="openNew">+ New invoice</button>
 			</div>
 		</template>
 

--- a/frontend/src/views/finance/FinanceOverviewPanel.vue
+++ b/frontend/src/views/finance/FinanceOverviewPanel.vue
@@ -10,10 +10,12 @@ import { useRouter } from "vue-router";
 import { useFinanceMock } from "@/data/financeMock";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR, fmtCompactINR } from "@/utils/format";
 
 const fin = useFinanceMock();
 const router = useRouter();
+const { canCreate } = usePermissions();
 const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { label: "Overview" }];
 
 function go(section) {
@@ -92,11 +94,15 @@ const topPayables = computed(() =>
 const recentMovements = computed(() => fin.allPayments.slice(0, 5));
 
 const quickActions = [
-	{ key: "new-expense", section: "expenses", icon: "receipt", label: "New Expense" },
-	{ key: "req-petty", section: "petty-cash", icon: "hand-coins", label: "Request Petty Cash" },
-	{ key: "new-invoice", section: "invoices", icon: "file-text", label: "New Invoice" },
-	{ key: "new-bill", section: "bills", icon: "banknote", label: "New Bill" },
+	{ key: "new-expense", section: "expenses", icon: "receipt", label: "New Expense", caps: ["expense"] },
+	{ key: "req-petty", section: "petty-cash", icon: "hand-coins", label: "Request Petty Cash", caps: ["pettyCash"] },
+	{ key: "new-invoice", section: "invoices", icon: "file-text", label: "New Invoice", caps: ["salesInvoice"] },
+	{ key: "new-bill", section: "bills", icon: "banknote", label: "New Bill", caps: ["supplierBill", "subcontractorBill"] },
 ];
+// Only surface a quick action the persona can actually act on (its create capability).
+const visibleQuickActions = computed(() =>
+	quickActions.filter((qa) => qa.caps.some((c) => canCreate(c)))
+);
 
 const toneDot = {
 	danger: "bg-danger-500",
@@ -316,7 +322,10 @@ const toneDot = {
 				</section>
 
 				<!-- Quick actions -->
-				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<section
+					v-if="visibleQuickActions.length"
+					class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+				>
 					<div class="px-4 py-2.5 bg-ink-50 border-b border-ink-200">
 						<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">
 							Quick actions
@@ -324,7 +333,7 @@ const toneDot = {
 					</div>
 					<div class="p-3 grid grid-cols-2 gap-2">
 						<button
-							v-for="qa in quickActions"
+							v-for="qa in visibleQuickActions"
 							:key="qa.key"
 							type="button"
 							class="border border-ink-200 hover:border-brand-400 hover:shadow-sm p-2.5 rounded-lg text-left transition-all group flex items-center gap-2"

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -28,9 +28,11 @@ import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { useUserNames } from "@/composables/useUserNames";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const session = useSessionStore();
+const { canCreate } = usePermissions();
 const { userName } = useUserNames();
 const confirmDialog = useConfirm();
 const router = useRouter();
@@ -318,6 +320,7 @@ const rowsForTab = computed(() => {
 					+ Issue directly
 				</button>
 				<button
+					v-if="canCreate('pettyCash')"
 					type="button"
 					class="text-xs desk-save-btn whitespace-nowrap"
 					@click="openRequest"

--- a/frontend/src/views/finance/FinanceSuppliersPanel.vue
+++ b/frontend/src/views/finance/FinanceSuppliersPanel.vue
@@ -15,11 +15,15 @@ import DeskList from "@/components/desk/DeskList.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
 import PartyFormModal from "./PartyFormModal.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const router = useRouter();
 const store = useDataStore();
-const canManage = computed(() => store.isAdmin);
+const { canCreate } = usePermissions();
+// Regular suppliers are created AND edited here; create and write role-sets coincide
+// (Procurement / PM / Director / admin tier), so one capability gates both.
+const canManage = computed(() => canCreate("supplier"));
 
 // The real supplier_type options (subcontractors are managed in the Subcontract module).
 const TYPE_OPTIONS = ["Company", "Individual", "Partnership", "Subcontractor"];


### PR DESCRIPTION
## Summary

A Director/Owner permission review found **three real DocPerm-map defects** plus a class of **stale-perm drift** on already-migrated sites (the per-persona matrices only apply on `after_install`, never wholesale on migrate — so sites diverge from the code over time).

### Code fixes (`permissions/setup.py`)
| Doctype | Before (Director) | After | Why |
|---|---|---|---|
| **Measurement Book** | `CRWD` | `R` | Director is oversight-only — reads, never edits |
| **Subcontractor Bill** | `CRWDSX` | `R` | Reads bills, never raises/submits. `_BILL_FULL_ROLES` is shared with the Work Order, where Director stays full `CRWDSX` |
| **Purchase Invoice** (Supplier Bill) | `R` | `CRWDSX` | Director owns supplier invoicing end to end |

### Re-sync patch
Every other doctype the review flagged (Machinery, Customer, Supplier, Field Employee, Crew, Field Attendance, Sales Invoice, Payment Entry/advances, Expense, Petty Cash) was **already correct in code** — the reported symptoms were stale perms on the site. `resync_director_permission_matrix` re-runs the authoritative `setup_record_permissions()` once, converging every matrix to the code in a single shot.

### Notes
- **Petty Cash Request** is not submittable, so its "full" is `CRWD` (S/X are N/A).
- There is **no Advance doctype** — Supplier/Customer advances are `Payment Entry`, where the Director is (and remains) read-only. Any "creation happening" there was native-role bleed / stale perms, healed by the re-sync.

## Tests
New `TestDirectorPermissionMatrix` asserts the **full Director CRUD matrix per doctype end to end**: it re-applies the authoritative setup, then checks effective `has_permission` for **every** ptype in each doctype's universe — so both an over-grant (MB/Bill regaining write) and a lost grant (PI losing submit) fail the test.

```
Ran 9 tests in 186.411s
OK
```

Live `bs.local` after the patch — `CURRENT == REQUIRED` for all 14 doctypes.