### PR TITLE
fix: Financial Position report — match the prototype layout

### DIFF
--- a/frontend/src/views/finance/reports/FinancialPositionReport.vue
+++ b/frontend/src/views/finance/reports/FinancialPositionReport.vue
@@ -1,4 +1,8 @@
 <script setup>
+// Financial Position — two columns (what we have / what we owe) + an emphasised
+// net position. Matches the prototype layout (full-width, the whole-company
+// subtext, coloured net panel); figures come live from the real ledger via
+// getFinancialPosition().
 import { computed, ref, onMounted } from "vue";
 
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -24,91 +28,112 @@ onMounted(async () => {
 	}
 });
 
-const have = computed(() => [
+const haveRows = computed(() => [
 	{ label: "Bank balance", value: fp.value.have.bank },
 	{ label: "Cash in hand", value: fp.value.have.cash },
-	{ label: "Petty cash with holders", value: fp.value.have.pettyCashOut },
 	{ label: "Customers owe us", value: fp.value.have.customersOwe },
+	{ label: "Petty cash with holders", value: fp.value.have.pettyCashOut },
 	{ label: "Advances paid to suppliers", value: fp.value.have.advancesPaid },
 ]);
-const owe = computed(() => [
+const oweRows = computed(() => [
 	{ label: "Suppliers", value: fp.value.owe.suppliers },
 	{ label: "Subcontractors", value: fp.value.owe.subcontractors },
 	{ label: "Retention held", value: fp.value.owe.retention },
 	{ label: "Advances received from customers", value: fp.value.owe.advancesReceived },
 	{ label: "To reimburse (own-pocket)", value: fp.value.owe.toReimburse },
 ]);
-const haveTotal = computed(() => have.value.reduce((s, r) => s + (Number(r.value) || 0), 0));
-const oweTotal = computed(() => owe.value.reduce((s, r) => s + (Number(r.value) || 0), 0));
+const totalHave = computed(() => haveRows.value.reduce((s, r) => s + (Number(r.value) || 0), 0));
+const totalOwe = computed(() => oweRows.value.reduce((s, r) => s + (Number(r.value) || 0), 0));
+const net = computed(() => totalHave.value - totalOwe.value);
 </script>
 
 <template>
 	<DeskPage title="Financial Position" :breadcrumbs="breadcrumbs">
 		<div v-if="loading" class="text-sm text-ink-500 italic py-10 text-center">Loading…</div>
 		<div v-else-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
-		<template v-else>
-			<div class="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-3xl">
+		<div v-else class="space-y-4">
+			<!-- Financial Position is a live whole-company snapshot with no project or
+			     date dimension, so it deliberately carries no filter row. -->
+			<p class="text-[11px] text-ink-500 mb-3 print:hidden">
+				Whole company, as it stands right now — this one has no period or project filter.
+			</p>
+			<div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+				<!-- Have -->
 				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-					<div class="bg-success-50 px-4 py-2 border-b border-ink-200">
-						<h3
-							class="text-xs uppercase tracking-wider font-semibold text-success-800"
-						>
+					<div class="px-4 py-2.5 bg-success-50 border-b border-success-100">
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-success-700">
 							What we have
 						</h3>
 					</div>
-					<table class="w-full text-sm">
-						<tbody>
-							<tr v-for="r in have" :key="r.label" class="border-t border-ink-100">
-								<td class="px-4 py-2 text-ink-700">{{ r.label }}</td>
-								<td class="px-4 py-2 text-right tabular-nums">
-									{{ fmtINR(r.value) }}
-								</td>
-							</tr>
-							<tr class="border-t-2 border-ink-200 font-semibold">
-								<td class="px-4 py-2">Total assets</td>
-								<td class="px-4 py-2 text-right tabular-nums">
-									{{ fmtINR(haveTotal) }}
-								</td>
-							</tr>
-						</tbody>
-					</table>
+					<div class="divide-y divide-ink-100">
+						<div
+							v-for="r in haveRows"
+							:key="r.label"
+							class="px-4 py-2.5 flex items-center justify-between text-sm"
+						>
+							<span class="text-ink-600">{{ r.label }}</span>
+							<span class="tabular-nums text-ink-900">{{ fmtINR(r.value) }}</span>
+						</div>
+					</div>
+					<div
+						class="px-4 py-2.5 bg-ink-50 border-t border-ink-200 flex items-center justify-between text-sm font-semibold"
+					>
+						<span class="text-ink-700">Total assets</span>
+						<span class="tabular-nums text-ink-900">{{ fmtINR(totalHave) }}</span>
+					</div>
 				</section>
+
+				<!-- Owe -->
 				<section class="bg-white border border-ink-200 rounded-lg overflow-hidden">
-					<div class="bg-danger-50 px-4 py-2 border-b border-ink-200">
-						<h3 class="text-xs uppercase tracking-wider font-semibold text-danger-800">
+					<div class="px-4 py-2.5 bg-danger-50 border-b border-danger-100">
+						<h3 class="text-xs uppercase tracking-wider font-semibold text-danger-700">
 							What we owe
 						</h3>
 					</div>
-					<table class="w-full text-sm">
-						<tbody>
-							<tr v-for="r in owe" :key="r.label" class="border-t border-ink-100">
-								<td class="px-4 py-2 text-ink-700">{{ r.label }}</td>
-								<td class="px-4 py-2 text-right tabular-nums">
-									{{ fmtINR(r.value) }}
-								</td>
-							</tr>
-							<tr class="border-t-2 border-ink-200 font-semibold">
-								<td class="px-4 py-2">Total liabilities</td>
-								<td class="px-4 py-2 text-right tabular-nums">
-									{{ fmtINR(oweTotal) }}
-								</td>
-							</tr>
-						</tbody>
-					</table>
+					<div class="divide-y divide-ink-100">
+						<div
+							v-for="r in oweRows"
+							:key="r.label"
+							class="px-4 py-2.5 flex items-center justify-between text-sm"
+						>
+							<span class="text-ink-600">{{ r.label }}</span>
+							<span class="tabular-nums text-ink-900">{{ fmtINR(r.value) }}</span>
+						</div>
+					</div>
+					<div
+						class="px-4 py-2.5 bg-ink-50 border-t border-ink-200 flex items-center justify-between text-sm font-semibold"
+					>
+						<span class="text-ink-700">Total liabilities</span>
+						<span class="tabular-nums text-ink-900">{{ fmtINR(totalOwe) }}</span>
+					</div>
 				</section>
 			</div>
-			<div
-				class="mt-4 bg-white border border-ink-200 rounded-lg px-4 py-3 max-w-3xl flex items-center justify-between"
+
+			<!-- Net -->
+			<section
+				class="rounded-lg px-5 py-4 flex items-center justify-between"
+				:class="
+					net >= 0
+						? 'bg-brand-50 border border-brand-200'
+						: 'bg-danger-50 border border-danger-200'
+				"
 			>
-				<span class="text-sm font-semibold text-ink-900">Net position</span>
-				<span class="text-lg font-bold tabular-nums text-brand-700">{{
-					fmtINR(haveTotal - oweTotal)
-				}}</span>
-			</div>
-			<p class="text-[11px] text-ink-400 mt-2 max-w-3xl">
+				<div>
+					<div
+						class="text-[11px] uppercase tracking-wider font-medium"
+						:class="net >= 0 ? 'text-brand-700' : 'text-danger-700'"
+					>
+						Net position
+					</div>
+					<div class="text-[11px] text-ink-500">Assets − liabilities</div>
+				</div>
+				<div class="text-2xl font-semibold tabular-nums text-ink-900">{{ fmtINR(net) }}</div>
+			</section>
+
+			<p class="text-[11px] text-ink-400 print:hidden">
 				Supplier/customer advances and own-pocket reimbursements aren't broken out yet —
 				shown as ₹0 until modelled.
 			</p>
-		</template>
+		</div>
 	</DeskPage>
 </template>


### PR DESCRIPTION
## Summary
The **Financial Position** report had drifted from the prototype:
- the whole-company subtext (*"…no period or project filter"*) was gone,
- it was boxed to `max-w-3xl` (squeezed to the left instead of full-width), and
- the net position was a plain white box.

Restored the prototype look — the subtext, a **full-width** two-column grid with *Total assets* / *Total liabilities* footers, and the **coloured Net-position panel** ("Assets − liabilities", brand/red by sign). Real-data wiring (`getFinancialPosition`) unchanged.

## Note on the other finance reports
I audited the rest against the prototype (Aged / Cash-Bank / Petty Cash / Expense): they **already match** — same layout, subtexts, labels, filters and full-width. The earlier line-count gap was prettier formatting + the real-data wiring, not UI. So no changes were needed there.

The **P&L** (custom variant with real data + the "Profit" label) is a separate, larger build and will land in its own PR.

Frontend builds clean.