### PR TITLE
feat: Project Finance workspace uses our own P&L everywhere

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
@@ -98,36 +98,15 @@ _SEED = {
 
 
 def _project_finance_tiles():
-	"""Project Finance tiles, computed per-site. Receivables & Payables, Financial Position,
-	Petty Cash, Expense Summary and Cash & Bank are all bespoke in-app Vue views (real data,
-	prototype layout). Only Profit & Loss stays an ERPNext report, shown through the IN-APP
-	renderer pre-filled with this site's company and a rolling last-12-months period so it opens
-	populated; the in-app filter bar lets a user change the dates."""
-	from urllib.parse import quote
-
-	from frappe.utils import add_years, nowdate
-
-	from buildsuite_core.utils.project import default_company
-
-	company = default_company()
-	to_date = nowdate()
-	from_date = add_years(to_date, -1)
-
-	pnl_parts = []
-	if company:
-		pnl_parts.append(f"company={quote(company)}")
-	pnl_parts += [
-		f"filter_based_on={quote('Date Range')}",
-		f"period_start_date={from_date}",
-		f"period_end_date={to_date}",
-		"periodicity=Yearly",
-	]
-	pnl_route = "/reports/view/" + quote("Profit and Loss Statement") + "?" + "&".join(pnl_parts)
+	"""Project Finance tiles — all six are bespoke in-app Vue views (real data via
+	api.finance_report / api.expense_entry, prototype layout). Profit & Loss is now our own
+	account-tree P&L (api.finance_report.profit_and_loss), not the stock ERPNext report, so the
+	whole workspace uses our variant; its own filter bar carries project + period."""
 	return (
 		{
 			"label": "Profit & Loss",
 			"icon": "chart-line",
-			"route": pnl_route,
+			"route": "/project-finance/report/pnl",
 			"description": "Income vs direct costs and overheads, by project and period.",
 		},
 		{

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -34,3 +34,4 @@ buildsuite_core.patches.fix_stage_planning_workflow_roles # 2026-08-20
 buildsuite_core.patches.reseed_procurement_bespoke_reports # 2026-08-20
 buildsuite_core.patches.grant_child_table_read_access # 2026-08-21
 buildsuite_core.patches.resync_director_permission_matrix # 2026-08-24
+buildsuite_core.patches.repoint_pnl_to_bespoke # 2026-08-25

--- a/buildsuite_core/patches/repoint_pnl_to_bespoke.py
+++ b/buildsuite_core/patches/repoint_pnl_to_bespoke.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Point the Project Finance workspace's Profit & Loss tile at our own account-tree P&L
+(/project-finance/report/pnl, backed by api.finance_report.profit_and_loss) instead of the
+stock ERPNext "Profit and Loss Statement". The whole workspace now uses our variant. The
+seeder is idempotent per workspace (it leaves a workspace that already has rows untouched), so
+this repoints the project-finance tiles explicitly on sites seeded before the change."""
+
+import frappe
+
+from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import (
+	_project_finance_tiles,
+)
+
+
+def execute():
+	if not frappe.db.exists("DocType", "Workspace Setting"):
+		return
+	settings = frappe.get_single("Workspace Setting")
+	# Keep every other workspace's rows; rebuild only the project-finance tiles from the seeder.
+	kept = [
+		{
+			"workspace": r.workspace,
+			"label": r.label,
+			"report": r.report,
+			"route": r.route,
+			"icon": r.icon,
+			"description": r.description,
+		}
+		for r in settings.reports
+		if r.workspace != "project-finance"
+	]
+	settings.set("reports", [])
+	for row in kept:
+		settings.append("reports", row)
+	for row in _project_finance_tiles():
+		settings.append("reports", {"workspace": "project-finance", **row})
+	settings.flags.ignore_permissions = True
+	settings.save()


### PR DESCRIPTION
## Summary
Follow-up to #205. The Project Finance workspace's **Profit & Loss** tile still opened ERPNext's stock *"Profit and Loss Statement"* (a pre-filled GL route). This repoints it to **our own account-tree P&L** (`/project-finance/report/pnl`, backed by `api.finance_report.profit_and_loss`), so the **entire Project Finance workspace now uses our bespoke views** — no ERPNext report left in the tile set.

- `seed_workspace_reports._project_finance_tiles`: P&L route → `/project-finance/report/pnl` (drops the ERPNext report-view URL + the pre-filled company/date query params — our P&L has its own project + period filter bar).
- **`repoint_pnl_to_bespoke` patch**: rebuilds the project-finance tiles on already-seeded sites. The seeder is idempotent per workspace (it won't touch a workspace that already has rows), so existing sites need the patch to pick up the new route.

## Verified on bs.local
After the patch, all six tiles point at our views:
```
Profit & Loss          -> /project-finance/report/pnl
Receivables & Payables -> /project-finance/report/aged
Financial Position     -> /project-finance/report/position
Petty Cash             -> /project-finance/report/petty
Expense Summary        -> /project-finance/report/expenses
Cash & Bank Statement  -> /project-finance/report/cashbank
```