### PR TITLE
feat: Insights — first layer (ask-a-question reporting, rules-based, live data)

### DIFF
--- a/frontend/src/composables/useInsightsData.js
+++ b/frontend/src/composables/useInsightsData.js
@@ -1,0 +1,106 @@
+// Live-data context for Insights (first layer). Fetches the Core-5 datasets —
+// Projects, Tasks, Stages, Subcontractor Bills, Purchase Orders — and shapes them
+// into the `store`-like object the engine (data/insightEngine.js) reads. Only the
+// datasets the persona may read are fetched (auto is gated on canRead), so the
+// surface never asks for data the role can't see. Browser-side crunching: the
+// engine runs over these arrays in memory.
+import { computed } from "vue";
+
+import { useDataStore } from "@/stores";
+import { createDataAdapter } from "@/data/adapters";
+import { usePermissions } from "@/composables/usePermissions";
+
+const toArr = (res) =>
+	Array.isArray(res.data) ? res.data : Array.isArray(res.data?.value) ? res.data.value : [];
+
+export function useInsightsData() {
+	const store = useDataStore();
+	const adapter = createDataAdapter(store);
+	const { canRead } = usePermissions();
+
+	const can = {
+		projects: canRead("project"),
+		tasks: canRead("task"),
+		stages: canRead("stagePlanning"),
+		subBills: canRead("subcontractorBill"),
+		purchaseOrders: canRead("purchaseOrder"),
+	};
+
+	// pageLength 0 = all rows (the engine crunches the full set in-browser).
+	const projectsRes = adapter.list("Project", {
+		fields: [
+			"name",
+			"project_name",
+			"custom_project_id",
+			"parent_project",
+			"project_status",
+			"company",
+			"expected_start_date",
+		],
+		pageLength: 0,
+		orderBy: "modified desc",
+		auto: can.projects,
+	});
+	const tasksRes = adapter.list("Task", {
+		fields: ["name", "subject", "project", "task_status", "status", "progress", "priority", "exp_end_date"],
+		pageLength: 0,
+		orderBy: "modified desc",
+		auto: can.tasks,
+	});
+	const stagesRes = adapter.list("Stage Planning", {
+		fields: ["name", "stage_name", "project", "workflow_state", "planned_end", "planned_start"],
+		pageLength: 0,
+		orderBy: "modified desc",
+		auto: can.stages,
+	});
+	const subBillsRes = adapter.list("Subcontractor Bill", {
+		fields: ["name", "project", "subcontractor", "subcontractor_name", "date", "status", "gross"],
+		filters: { docstatus: ["<", 2] }, // exclude cancelled
+		pageLength: 0,
+		orderBy: "modified desc",
+		auto: can.subBills,
+	});
+	const poRes = adapter.list("Purchase Order", {
+		fields: ["name", "supplier", "supplier_name", "status", "grand_total", "transaction_date", "project"],
+		filters: { docstatus: ["<", 2] },
+		pageLength: 0,
+		orderBy: "modified desc",
+		auto: can.purchaseOrders,
+	});
+
+	const projects = computed(() =>
+		toArr(projectsRes).map((p) => ({
+			...p,
+			id: p.name,
+			name: p.project_name || p.name,
+			code: p.custom_project_id || "",
+			parentId: p.parent_project || null,
+		}))
+	);
+	const projectMap = computed(() => {
+		const m = {};
+		for (const p of projects.value) m[p.id] = p;
+		return m;
+	});
+
+	// The engine's `store`: live rows + project helpers + per-dataset read gates.
+	const ctx = computed(() => ({
+		projects: projects.value,
+		rootProjects: projects.value.filter((p) => !p.parentId),
+		projectById: (id) => projectMap.value[id] || null,
+		tasks: toArr(tasksRes),
+		stagePlannings: toArr(stagesRes),
+		subBills: toArr(subBillsRes),
+		purchaseOrders: toArr(poRes),
+		canReadProjects: can.projects,
+		canReadTasks: can.tasks,
+		canReadStages: can.stages,
+		canReadSubBills: can.subBills,
+		canReadPurchaseOrders: can.purchaseOrders,
+	}));
+
+	const resources = [projectsRes, tasksRes, stagesRes, subBillsRes, poRes];
+	const loading = computed(() => resources.some((r) => r.loading));
+
+	return { ctx, loading };
+}

--- a/frontend/src/data/insightEngine.js
+++ b/frontend/src/data/insightEngine.js
@@ -1,0 +1,700 @@
+// Insights — the query model behind the prompt box (first layer).
+//
+// HONESTY NOTE, read before extending. There is no model call. A prompt is
+// matched LOCALLY — synonyms → a QuerySpec — and the spec is executed against
+// live data fed in as `store` (see composables/useInsightsData.js). Every number
+// a chart shows is a real record, and an unrecognised prompt says so.
+//
+// In production this same spec is what an LLM would emit: prompt → model →
+// QuerySpec → the executor below, unchanged. Parser and executor are kept apart
+// precisely so the half that gets replaced later (AI understanding) is one
+// function. This file is ported almost verbatim from the prototype's engine; the
+// only thing that changed for the live product is each dataset's rows/can/
+// accessors, which now read real Frappe data instead of the mock store.
+//
+// QuerySpec:
+//   { source, mode:'aggregate'|'list', measure, dimension,
+//     filters:{project,from,to,values,min,max}, viz, sort, limit }
+
+// ---------------------------------------------------------------------------
+// Helpers shared by the dataset definitions
+// ---------------------------------------------------------------------------
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+function monthOf(iso) {
+	if (!iso) return "—";
+	const [y, m] = String(iso).slice(0, 7).split("-");
+	return m ? `${MONTHS[Number(m) - 1]} ${y}` : "—";
+}
+const n = (v) => Number(v) || 0;
+const pName = (s, id) => s.projectById(id)?.name || id || "—";
+
+// ---------------------------------------------------------------------------
+// Datasets — the first-layer cut: Projects, Tasks, Stages, Subcontractor Bills,
+// Purchase Orders. Each declares can(store) so the surface only offers what the
+// signed-in role may read. `rows(store)` returns live records; accessors read
+// their real Frappe fields.
+// ---------------------------------------------------------------------------
+export const DATASETS = {
+	projects: {
+		label: "Projects",
+		can: (s) => s.canReadProjects,
+		words: ["project", "projects", "job", "jobs"],
+		rows: (s) => s.rootProjects,
+		date: (r) => r.expected_start_date,
+		amount: () => 0,
+		qty: () => 0,
+		project: (r) => r.name,
+		measures: ["count"],
+		dims: {
+			status: { label: "Status", get: (r) => r.project_status || "—" },
+			company: { label: "Company", get: (r) => r.company || "—" },
+		},
+		list: {
+			columns: [
+				{ key: "name", label: "Project" },
+				{ key: "code", label: "ID" },
+				{ key: "status", label: "Status" },
+			],
+			row: (r) => ({
+				name: r.project_name || r.name,
+				code: r.custom_project_id || r.name,
+				status: r.project_status || "—",
+			}),
+		},
+	},
+	tasks: {
+		label: "Tasks",
+		can: (s) => s.canReadTasks,
+		words: ["task", "tasks", "activity", "activities"],
+		rows: (s) => s.tasks,
+		date: (r) => r.exp_end_date,
+		amount: () => 0,
+		qty: () => 0,
+		project: (r) => r.project,
+		measures: ["count"],
+		dims: {
+			project: { label: "Project", get: (r, s) => pName(s, r.project) },
+			status: { label: "Status", get: (r) => r.task_status || r.status || "—" },
+			priority: { label: "Priority", get: (r) => r.priority || "—" },
+			month: { label: "Month", get: (r) => monthOf(r.exp_end_date) },
+		},
+		list: {
+			columns: [
+				{ key: "name", label: "Task" },
+				{ key: "project", label: "Project" },
+				{ key: "status", label: "Status" },
+				{ key: "progress", label: "Progress", align: "right" },
+			],
+			row: (r, s) => ({
+				name: r.subject || r.name,
+				project: pName(s, r.project),
+				status: r.task_status || r.status || "—",
+				progress: `${n(r.progress)}%`,
+			}),
+		},
+	},
+	stages: {
+		label: "Stages",
+		can: (s) => s.canReadStages,
+		words: ["stage", "stages", "stage plan", "stage planning"],
+		rows: (s) => s.stagePlannings,
+		date: (r) => r.planned_end,
+		amount: () => 0,
+		qty: () => 0,
+		project: (r) => r.project,
+		measures: ["count"],
+		dims: {
+			state: { label: "Approval state", get: (r) => r.workflow_state || "—" },
+			project: { label: "Project", get: (r, s) => pName(s, r.project) },
+			month: { label: "Month", get: (r) => monthOf(r.planned_end) },
+		},
+		list: {
+			columns: [
+				{ key: "name", label: "Stage" },
+				{ key: "project", label: "Project" },
+				{ key: "end", label: "Planned end" },
+				{ key: "state", label: "State" },
+			],
+			row: (r, s) => ({
+				name: r.stage_name || r.name,
+				project: pName(s, r.project),
+				end: r.planned_end || "—",
+				state: r.workflow_state || "—",
+			}),
+		},
+	},
+	subBills: {
+		label: "Subcontractor bills",
+		can: (s) => s.canReadSubBills,
+		words: ["subcontractor bill", "subcontractor bills", "ra bill", "ra bills", "sub bill", "sub bills"],
+		rows: (s) => s.subBills,
+		date: (r) => r.date,
+		amount: (r) => n(r.gross),
+		qty: () => 0,
+		project: (r) => r.project,
+		measures: ["amount", "count"],
+		dims: {
+			subcontractor: { label: "Subcontractor", get: (r) => r.subcontractor_name || r.subcontractor || "—" },
+			project: { label: "Project", get: (r, s) => pName(s, r.project) },
+			status: { label: "Status", get: (r) => r.status || "—" },
+			month: { label: "Month", get: (r) => monthOf(r.date) },
+		},
+		list: {
+			columns: [
+				{ key: "name", label: "Bill" },
+				{ key: "subcontractor", label: "Subcontractor" },
+				{ key: "project", label: "Project" },
+				{ key: "gross", label: "Gross", align: "right", money: true },
+			],
+			row: (r, s) => ({
+				name: r.name,
+				subcontractor: r.subcontractor_name || r.subcontractor || "—",
+				project: pName(s, r.project),
+				gross: n(r.gross),
+			}),
+		},
+	},
+	purchaseOrders: {
+		label: "Purchase orders",
+		can: (s) => s.canReadPurchaseOrders,
+		words: ["purchase order", "purchase orders"],
+		rows: (s) => s.purchaseOrders,
+		date: (r) => r.transaction_date,
+		amount: (r) => n(r.grand_total),
+		qty: () => 0,
+		project: (r) => r.project,
+		measures: ["amount", "count"],
+		dims: {
+			supplier: { label: "Supplier", get: (r) => r.supplier_name || r.supplier || "—" },
+			status: { label: "Status", get: (r) => r.status || "—" },
+			project: { label: "Project", get: (r, s) => pName(s, r.project) },
+			month: { label: "Month", get: (r) => monthOf(r.transaction_date) },
+		},
+		list: {
+			columns: [
+				{ key: "name", label: "PO" },
+				{ key: "supplier", label: "Supplier" },
+				{ key: "status", label: "Status" },
+				{ key: "total", label: "Total", align: "right", money: true },
+			],
+			row: (r) => ({
+				name: r.name,
+				supplier: r.supplier_name || r.supplier || "—",
+				status: r.status || "—",
+				total: n(r.grand_total),
+			}),
+		},
+	},
+};
+
+export function availableDatasets(store) {
+	return Object.entries(DATASETS).filter(([, ds]) => {
+		try {
+			return ds.can(store);
+		} catch {
+			return false;
+		}
+	});
+}
+
+export const MEASURE_LABEL = { count: "Count", amount: "Value", mandays: "Man-days", qty: "Quantity" };
+export const VIZ = ["bar", "column", "line", "donut", "table", "kpi"];
+
+// ---------------------------------------------------------------------------
+// Parser — prompt → spec. Replaced by a model call in production. (verbatim)
+// ---------------------------------------------------------------------------
+const DIM_WORDS = {
+	project: ["project", "projects", "site", "sites", "job"],
+	status: ["status", "state"],
+	state: ["approval", "approval state", "workflow", "state"],
+	month: ["month", "monthly", "over time", "trend", "date", "timeline"],
+	priority: ["priority"],
+	supplier: ["supplier", "suppliers", "vendor", "vendors"],
+	subcontractor: ["subcontractor", "subcontractors"],
+	company: ["company"],
+	type: ["type"],
+};
+const VIZ_WORDS = {
+	donut: ["pie", "donut", "doughnut", "share", "split", "breakdown", "proportion"],
+	line: ["line", "trend", "over time", "timeline"],
+	column: ["column", "vertical bar"],
+	bar: ["bar", "chart", "graph", "ranked"],
+	table: ["table", "grid"],
+	kpi: ["total", "how many", "how much", "number of", "sum"],
+};
+const MEASURE_WORDS = {
+	amount: ["value", "amount", "cost", "spend", "spent", "worth", "rupees", "money"],
+	mandays: ["man-days", "mandays", "man days", "manpower", "days worked"],
+	qty: ["quantity", "qty", "volume", "hours", "how much of"],
+	count: ["count", "how many", "number of", "no of"],
+};
+const LIST_WORDS = ["list", "show me the", "which ", "what were", "detail", "details", "log of", "register of", "itemised", "itemized", "line by line"];
+
+function hit(text, words) {
+	return words.some((w) => text.includes(w));
+}
+
+function editDistance(a, b) {
+	if (Math.abs(a.length - b.length) > 2) return 99;
+	const prev = Array.from({ length: b.length + 1 }, (_, j) => j);
+	for (let i = 1; i <= a.length; i++) {
+		let diag = prev[0];
+		prev[0] = i;
+		for (let j = 1; j <= b.length; j++) {
+			const tmp = prev[j];
+			prev[j] = Math.min(prev[j] + 1, prev[j - 1] + 1, diag + (a[i - 1] === b[j - 1] ? 0 : 1));
+			diag = tmp;
+		}
+	}
+	return prev[b.length];
+}
+function tolerance(w) {
+	return w.length >= 6 ? 2 : w.length >= 5 ? 1 : 0;
+}
+function tokenMatches(token, word) {
+	if (token === word) return true;
+	const t = tolerance(word);
+	return t > 0 && editDistance(token, word) <= t;
+}
+function fuzzyIncludes(tokens, phrase) {
+	return phrase
+		.split(" ")
+		.filter(Boolean)
+		.every((w) => tokens.some((tk) => tokenMatches(tk, w)));
+}
+
+export function parsePrompt(prompt, store, base = null) {
+	const text = ` ${String(prompt || "").toLowerCase().trim()} `;
+	if (!text.trim()) return null;
+	const spec = base
+		? JSON.parse(JSON.stringify(base))
+		: { source: null, mode: "aggregate", measure: "count", dimension: null, filters: {}, viz: "bar", sort: "desc", limit: null };
+	const understood = [];
+	const allowed = availableDatasets(store);
+
+	const forSource = text.replace(/\b(?:group by|split by|by)\s+[a-z\s-]{2,20}/g, " ");
+	const tokens = forSource.split(/[^a-z0-9-]+/).filter(Boolean);
+	let best = null;
+	for (const [key, ds] of allowed) {
+		for (const w of ds.words) {
+			const exact = forSource.includes(w);
+			const fuzzy = !exact && fuzzyIncludes(tokens, w);
+			if (!exact && !fuzzy) continue;
+			const score = w.length - (fuzzy ? 0.5 : 0);
+			if (!best || score > best.len) best = { key, len: score, label: ds.label };
+		}
+	}
+	if (!best) return null;
+	spec.source = best.key;
+	understood.push(best.label);
+
+	const ds = DATASETS[spec.source];
+
+	if (hit(text, LIST_WORDS)) {
+		spec.mode = "list";
+		understood.push("as a list");
+	}
+
+	let measured = false;
+	for (const m of ["mandays", "qty", "amount", "count"]) {
+		if (ds.measures.includes(m) && hit(text, MEASURE_WORDS[m])) {
+			spec.measure = m;
+			measured = true;
+			understood.push(MEASURE_LABEL[m]);
+			break;
+		}
+	}
+	if (!measured || !ds.measures.includes(spec.measure)) spec.measure = ds.measures[0];
+
+	const byMatch = text.match(/\bby ([a-z\s-]{2,20})/);
+	let dim = null;
+	if (byMatch) {
+		const phrase = byMatch[1].trim();
+		for (const k of Object.keys(ds.dims)) {
+			if ((DIM_WORDS[k] || []).some((w) => phrase.startsWith(w))) {
+				dim = k;
+				break;
+			}
+		}
+	}
+	if (!dim) {
+		for (const k of Object.keys(ds.dims)) {
+			if ((DIM_WORDS[k] || []).some((w) => text.includes(` ${w} `))) {
+				dim = k;
+				break;
+			}
+		}
+	}
+	if (dim) {
+		spec.dimension = dim;
+		understood.push(`by ${ds.dims[dim].label}`);
+	}
+	if (!spec.dimension || !ds.dims[spec.dimension]) spec.dimension = Object.keys(ds.dims)[0];
+
+	for (const [v, words] of Object.entries(VIZ_WORDS)) {
+		if (v === "kpi" && dim) continue;
+		if (hit(text, words)) {
+			spec.viz = v;
+			understood.push(v);
+			break;
+		}
+	}
+	if (spec.dimension === "month" && spec.viz === "bar") spec.viz = "line";
+
+	for (const p of store.projects) {
+		const code = (p.code || "").toLowerCase();
+		const words = (p.name || "").toLowerCase().split(/\s+/).filter((w) => w.length > 2);
+		const opener = words.slice(0, 2).join(" ");
+		if ((code.length > 2 && text.includes(code)) || (opener.length > 4 && text.includes(opener))) {
+			spec.filters.project = p.id;
+			understood.push(p.name);
+			break;
+		}
+	}
+
+	const now = new Date();
+	const iso = (d) => d.toISOString().slice(0, 10);
+	const back = (days) => iso(new Date(now.getTime() - days * 86400000));
+	if (text.includes("today")) {
+		spec.filters.from = iso(now);
+		understood.push("today");
+	} else if (text.includes("last 7") || text.includes("this week") || text.includes("past week")) {
+		spec.filters.from = back(7);
+		understood.push("last 7 days");
+	} else if (text.includes("last month") || text.includes("last 30") || text.includes("this month") || text.includes("past month")) {
+		spec.filters.from = back(30);
+		understood.push("last 30 days");
+	} else if (text.includes("last 90") || text.includes("quarter")) {
+		spec.filters.from = back(90);
+		understood.push("last 90 days");
+	} else if (text.includes("this year") || text.includes("ytd")) {
+		spec.filters.from = `${now.getFullYear()}-01-01`;
+		understood.push("year to date");
+	}
+
+	const topMatch = text.match(/\btop (\d{1,2})/);
+	if (topMatch) {
+		spec.limit = Number(topMatch[1]);
+		understood.push(`top ${spec.limit}`);
+	}
+	if (text.includes("ascending") || text.includes("lowest") || text.includes("smallest")) spec.sort = "asc";
+	if (text.includes("descending") || text.includes("highest") || text.includes("largest")) spec.sort = "desc";
+	if (text.includes("alphabetical") || text.includes("a-z")) spec.sort = "label";
+
+	applyValueFilters(spec, text, store, understood);
+
+	spec.understood = understood;
+	return spec;
+}
+
+function applyValueFilters(spec, text, store, understood) {
+	spec.filters.values = spec.filters.values || {};
+	const num = (raw) => {
+		const v = Number(String(raw).replace(/[,]/g, ""));
+		if (!Number.isFinite(v)) return null;
+		if (/\blakh|\bl\b/.test(text) && v < 1000) return v * 100000;
+		if (/\bcrore|\bcr\b/.test(text) && v < 1000) return v * 10000000;
+		return v;
+	};
+	const over = text.match(/\b(?:over|above|more than|greater than|exceeding)\s+₹?\s*([\d,]+)/);
+	if (over) {
+		const v = num(over[1]);
+		if (v != null) {
+			spec.filters.min = v;
+			understood.push(`over ${over[1]}`);
+		}
+	}
+	const under = text.match(/\b(?:under|below|less than|up to)\s+₹?\s*([\d,]+)/);
+	if (under) {
+		const v = num(under[1]);
+		if (v != null) {
+			spec.filters.max = v;
+			understood.push(`under ${under[1]}`);
+		}
+	}
+
+	const dv = dimensionValues(spec.source, store);
+	let bestVal = null;
+	for (const [k, d] of Object.entries(dv)) {
+		for (const v of d.values) {
+			const lv = v.toLowerCase();
+			if (lv.length < 4) continue;
+			if (text.includes(lv) && (!bestVal || lv.length > bestVal.len)) bestVal = { k, v, len: lv.length, label: d.label };
+		}
+	}
+	if (bestVal && !(bestVal.k === "project" && spec.filters.project)) {
+		spec.filters.values[bestVal.k] = bestVal.v;
+		understood.push(`${bestVal.label} = ${bestVal.v}`);
+	}
+	if (!Object.keys(spec.filters.values).length) delete spec.filters.values;
+}
+
+export function refineSpec(spec, prompt) {
+	const text = ` ${String(prompt || "").toLowerCase().trim()} `;
+	const next = JSON.parse(JSON.stringify(spec));
+	const applied = [];
+	const ds = DATASETS[next.source];
+
+	if (hit(text, LIST_WORDS)) {
+		next.mode = "list";
+		applied.push("as a list");
+	}
+	if (text.includes("summar") || text.includes("roll up") || text.includes("rollup") || text.includes("group it")) {
+		next.mode = "aggregate";
+		applied.push("summarised");
+	}
+	for (const [v, words] of Object.entries(VIZ_WORDS)) {
+		if (hit(text, words)) {
+			next.viz = v;
+			next.mode = "aggregate";
+			applied.push(`shown as ${v}`);
+			break;
+		}
+	}
+	const byMatch = text.match(/\b(?:by|group by|split by) ([a-z\s-]{2,20})/);
+	if (byMatch) {
+		const phrase = byMatch[1].trim();
+		for (const k of Object.keys(ds.dims)) {
+			if ((DIM_WORDS[k] || []).some((w) => phrase.startsWith(w))) {
+				next.dimension = k;
+				next.mode = "aggregate";
+				applied.push(`grouped by ${ds.dims[k].label}`);
+				break;
+			}
+		}
+	}
+	for (const m of ["mandays", "qty", "amount", "count"]) {
+		if (ds.measures.includes(m) && hit(text, MEASURE_WORDS[m])) {
+			next.measure = m;
+			applied.push(MEASURE_LABEL[m]);
+			break;
+		}
+	}
+	const topMatch = text.match(/\btop (\d{1,2})/);
+	if (topMatch) {
+		next.limit = Number(topMatch[1]);
+		applied.push(`top ${next.limit}`);
+	}
+	if (text.includes("show all") || text.includes("all rows") || text.includes("remove limit")) {
+		next.limit = null;
+		applied.push("all rows");
+	}
+	if (text.includes("ascending") || text.includes("lowest")) {
+		next.sort = "asc";
+		applied.push("ascending");
+	}
+	if (text.includes("descending") || text.includes("highest")) {
+		next.sort = "desc";
+		applied.push("descending");
+	}
+	if (text.includes("alphabetical") || text.includes("a-z")) {
+		next.sort = "label";
+		applied.push("alphabetical");
+	}
+	if (text.includes("all projects") || text.includes("every project")) {
+		delete next.filters.project;
+		applied.push("all projects");
+	}
+	if (text.includes("all time") || text.includes("no date") || text.includes("remove date")) {
+		delete next.filters.from;
+		delete next.filters.to;
+		applied.push("all dates");
+	}
+	if (text.includes("clear filter") || text.includes("remove filter") || text.includes("no filter")) {
+		next.filters = {};
+		applied.push("filters cleared");
+	}
+
+	if (!applied.length) return null;
+	next.understood = applied;
+	return next;
+}
+
+export function refineWithStore(spec, prompt, store) {
+	const text = ` ${String(prompt || "").toLowerCase().trim()} `;
+	const base = refineSpec(spec, prompt);
+	const next = base || JSON.parse(JSON.stringify(spec));
+	const applied = base ? [...(base.understood || [])] : [];
+	const before = JSON.stringify(next.filters);
+	applyValueFilters(next, text, store, applied);
+	if (!base && JSON.stringify(next.filters) === before) return null;
+	next.understood = applied;
+	return next;
+}
+
+// ---------------------------------------------------------------------------
+// Executor — spec → result, straight off the live rows. (verbatim)
+// ---------------------------------------------------------------------------
+export function filteredRows(spec, store) {
+	const ds = DATASETS[spec.source];
+	if (!ds || !ds.can(store)) return [];
+	const f = spec.filters || {};
+
+	const scope = f.project
+		? new Set([f.project, ...store.projects.filter((p) => p.parentId === f.project).map((p) => p.id)])
+		: null;
+	const q = (f.q || "").trim().toLowerCase();
+	const values = f.values || {};
+	const dimEntries = Object.entries(values).filter(([, v]) => v);
+
+	return ds.rows(store).filter((r) => {
+		if (scope) {
+			const pid = ds.project(r, store);
+			if (!pid || !scope.has(pid)) return false;
+		}
+		const d = ds.date(r);
+		if (f.from && (!d || d < f.from)) return false;
+		if (f.to && (!d || d > f.to)) return false;
+		if (f.min != null || f.max != null) {
+			const v = measureOf(ds, r, spec.measure);
+			if (f.min != null && v < f.min) return false;
+			if (f.max != null && v > f.max) return false;
+		}
+		for (const [k, want] of dimEntries) {
+			const dim = ds.dims[k];
+			if (dim && String(dim.get(r, store)) !== String(want)) return false;
+		}
+		if (q) {
+			const hay = Object.values(ds.list.row(r, store)).join(" ").toLowerCase();
+			if (!hay.includes(q)) return false;
+		}
+		return true;
+	});
+}
+
+export function dimensionValues(source, store, cap = 60) {
+	const ds = DATASETS[source];
+	if (!ds || !ds.can(store)) return {};
+	const rows = ds.rows(store);
+	const out = {};
+	for (const [k, dim] of Object.entries(ds.dims)) {
+		const set = new Set();
+		for (const r of rows) {
+			const v = dim.get(r, store);
+			if (v && v !== "—") set.add(String(v));
+			if (set.size > cap) break;
+		}
+		out[k] = { label: dim.label, values: [...set].sort((a, b) => a.localeCompare(b)) };
+	}
+	return out;
+}
+
+export function runSpec(spec, store, window = null) {
+	const ds = DATASETS[spec.source];
+	if (!ds || !ds.can(store)) return null;
+
+	const rows = filteredRows(spec, store);
+	const base = {
+		recordCount: rows.length,
+		datasetLabel: ds.label,
+		measure: spec.measure,
+		measureLabel: MEASURE_LABEL[spec.measure],
+	};
+
+	if (spec.mode === "list") {
+		const dateOf = (r) => ds.date(r) || "";
+		const sorted = rows.slice().sort((a, b) => String(dateOf(b)).localeCompare(String(dateOf(a))));
+		const offset = Math.max(0, window?.offset || 0);
+		const size = window?.pageSize || sorted.length;
+		const page = sorted.slice(offset, offset + size);
+		return {
+			...base,
+			mode: "list",
+			columns: ds.list.columns,
+			records: page.map((r, i) => ({ _k: r._key || r.name || `${offset + i}`, ...ds.list.row(r, store) })),
+			offset,
+			pageSize: size,
+			total: +rows.reduce((a, r) => a + measureOf(ds, r, spec.measure), 0).toFixed(2),
+			truncated: 0,
+			dimensionLabel: "",
+		};
+	}
+
+	const dim = ds.dims[spec.dimension] || Object.values(ds.dims)[0];
+	const buckets = new Map();
+	for (const r of rows) {
+		const key = dim.get(r, store) || "—";
+		buckets.set(key, (buckets.get(key) || 0) + measureOf(ds, r, spec.measure));
+	}
+
+	let out = [...buckets.entries()].map(([label, value]) => ({ label, value: +value.toFixed(2) }));
+	if (spec.dimension === "month") out.sort((a, b) => monthKey(a.label) - monthKey(b.label));
+	else if (spec.sort === "label") out.sort((a, b) => a.label.localeCompare(b.label));
+	else if (spec.sort === "asc") out.sort((a, b) => a.value - b.value);
+	else out.sort((a, b) => b.value - a.value);
+
+	let truncated = 0;
+	if (spec.limit && out.length > spec.limit) {
+		truncated = out.length - spec.limit;
+		out = out.slice(0, spec.limit);
+	}
+
+	return {
+		...base,
+		mode: "aggregate",
+		rows: out,
+		total: +out.reduce((a, r) => a + r.value, 0).toFixed(2),
+		truncated,
+		dimensionLabel: dim.label,
+	};
+}
+
+function measureOf(ds, r, measure) {
+	if (measure === "amount") return ds.amount(r);
+	if (measure === "qty") return ds.qty(r);
+	if (measure === "mandays") return r.status === "Half Day" ? 0.5 : r.status === "Absent" ? 0 : 1;
+	return 1;
+}
+
+function monthKey(label) {
+	if (!label || label === "—") return 0;
+	const [m, y] = label.split(" ");
+	return Number(y) * 12 + MONTHS.indexOf(m);
+}
+
+export function describeSpec(spec) {
+	const ds = DATASETS[spec.source];
+	if (!ds) return "";
+	if (spec.mode === "list") return `${ds.label} — detail`;
+	const dim = ds.dims[spec.dimension];
+	const bits = [`${MEASURE_LABEL[spec.measure]} of ${ds.label.toLowerCase()}`];
+	if (dim) bits.push(`by ${dim.label.toLowerCase()}`);
+	return bits.join(" ");
+}
+
+// ---------------------------------------------------------------------------
+// Presets + suggestions — Core-5 cut. A preset is the same spec shape, so it is
+// refinable like anything else.
+// ---------------------------------------------------------------------------
+const P = (source, measure, dimension, viz, extra = {}) => ({
+	source,
+	mode: "aggregate",
+	measure,
+	dimension,
+	filters: {},
+	viz,
+	sort: "desc",
+	limit: null,
+	...extra,
+});
+
+export const ALL_PRESETS = [
+	{ id: "sub-billing", title: "Subcontractor billing", prompt: "subcontractor bill value by subcontractor", spec: P("subBills", "amount", "subcontractor", "bar") },
+	{ id: "po-by-supplier", title: "Spend by supplier", prompt: "purchase order value by supplier, top 8", spec: P("purchaseOrders", "amount", "supplier", "bar", { limit: 8 }) },
+	{ id: "po-by-status", title: "POs by status", prompt: "purchase order value by status", spec: P("purchaseOrders", "amount", "status", "donut") },
+	{ id: "tasks-by-status", title: "Tasks by status", prompt: "tasks by status as a pie", spec: P("tasks", "count", "status", "donut") },
+	{ id: "tasks-by-project", title: "Tasks by project", prompt: "tasks by project", spec: P("tasks", "count", "project", "bar") },
+	{ id: "stages-by-state", title: "Stages by approval", prompt: "stages by approval state", spec: P("stages", "count", "state", "donut") },
+];
+
+export function availablePresets(store) {
+	return ALL_PRESETS.filter((p) => DATASETS[p.spec.source]?.can(store));
+}
+
+export const SUGGESTIONS = [
+	"Subcontractor bill value by subcontractor",
+	"Purchase order value by supplier, top 5",
+	"Tasks by status as a pie",
+	"Stages by approval state",
+	"Purchase orders by month",
+];

--- a/frontend/src/layouts/DeskShell.vue
+++ b/frontend/src/layouts/DeskShell.vue
@@ -113,6 +113,12 @@ const ACCESS_HINTS = {
 const navGroups = computed(() => {
 	const HOME_ITEM = { slug: "home", name: "Home", to: "/home", group: "buildsuite", hint: null };
 	const buildsuiteItems = [HOME_ITEM];
+	// Insights — ask-a-question reporting. First layer is leadership-only (Director /
+	// PM / Administrator); it's a standalone feature, not a workspace, so it's pinned
+	// here rather than driven off the workspace-visibility matrix.
+	if (["director", "pm", "admin", "bsa"].includes(store.role)) {
+		buildsuiteItems.push({ slug: "insights", name: "Insights", to: "/insights", icon: "💡", group: "buildsuite", hint: null });
+	}
 	const erpnextItems = [];
 	const otherBuildsuiteItems = [];
 	for (const slug of store.visibleWorkspaces) {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -296,6 +296,12 @@ const routes = [
 				component: () => import("@/views/workspaces/ProjectDashboardView.vue"),
 			},
 			{
+				// Insights — ask-a-question reporting. Leadership-gated in the view.
+				path: "insights",
+				name: "insights",
+				component: () => import("@/views/InsightsView.vue"),
+			},
+			{
 				path: "reports/view/:report",
 				name: "report-view",
 				component: () => import("@/views/ReportView.vue"),

--- a/frontend/src/views/InsightsView.vue
+++ b/frontend/src/views/InsightsView.vue
@@ -1,0 +1,408 @@
+<script setup>
+// Insights (first layer) — ask a plain question, get a report built from live
+// data, then reshape it with a follow-up or the viz switcher.
+//
+// The "AI" here is a LOCAL parser (data/insightEngine.js) that maps a prompt to
+// a QuerySpec, run by an executor over the Core-5 datasets (useInsightsData).
+// No model call, so nothing is invented — every figure is a real record, and an
+// unrecognised prompt says so. In production the parser is the one piece a model
+// replaces, returning the same spec.
+import { ref, computed, onMounted } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import { useDataStore } from "@/stores";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import { fmtINR, fmtCompactINR } from "@/utils/format";
+import { useInsightsData } from "@/composables/useInsightsData";
+import {
+	VIZ,
+	availableDatasets,
+	availablePresets,
+	parsePrompt,
+	refineWithStore,
+	runSpec,
+	describeSpec,
+} from "@/data/insightEngine";
+
+const store = useDataStore();
+const route = useRoute();
+const router = useRouter();
+const { ctx, loading } = useInsightsData();
+
+// First layer: leadership only (Director / PM / Administrator). Each dataset also
+// respects the persona's own read permissions, so users only see allowed numbers.
+const LEADERSHIP = ["director", "pm", "admin", "bsa"];
+const canUseInsights = computed(() => LEADERSHIP.includes(store.role));
+
+const breadcrumbs = [{ label: "BuildSuite Core", to: "/" }, { label: "Insights" }];
+
+const prompt = ref("");
+const refinePrompt = ref("");
+const spec = ref(null);
+const notice = ref("");
+const noticeTone = ref("info");
+const history = ref([]);
+const presetsOpen = ref(true);
+const page = ref(0);
+const PAGE_SIZE = 25;
+
+function setNotice(msg, tone = "info") {
+	notice.value = msg;
+	noticeTone.value = tone;
+}
+
+const PRESETS = computed(() => availablePresets(ctx.value));
+const datasetNames = computed(() => availableDatasets(ctx.value).map(([, d]) => d.label.toLowerCase()));
+const SUGGESTIONS = ["Subcontractor bill value by subcontractor", "Purchase order value by supplier, top 5", "Tasks by status as a pie", "Stages by approval state"];
+
+function ask() {
+	const text = prompt.value.trim();
+	if (!text) return;
+	const s = parsePrompt(text, ctx.value);
+	if (!s) {
+		setNotice(`Couldn't tell which records you mean. Try naming one: ${datasetNames.value.join(", ")}.`, "warn");
+		return;
+	}
+	history.value = [];
+	spec.value = s;
+	page.value = 0;
+	presetsOpen.value = false;
+	setNotice(`Read as: ${(s.understood || []).join(" · ")}`);
+	refinePrompt.value = "";
+}
+
+function refine() {
+	const text = refinePrompt.value.trim();
+	if (!text || !spec.value) return;
+	const next = refineWithStore(spec.value, text, ctx.value);
+	if (!next) {
+		setNotice('Nothing in that changed the report. Try "as a pie", "top 5", "by month", "over 10000", "show all", or "clear filters".', "warn");
+		return;
+	}
+	history.value.push(JSON.parse(JSON.stringify(spec.value)));
+	spec.value = next;
+	page.value = 0;
+	setNotice(`Applied: ${(next.understood || []).join(" · ")}`);
+	refinePrompt.value = "";
+}
+
+function undo() {
+	const prev = history.value.pop();
+	if (prev) {
+		spec.value = prev;
+		page.value = 0;
+		setNotice("Reverted the last change.");
+	}
+}
+
+function runPreset(p) {
+	history.value = [];
+	spec.value = JSON.parse(JSON.stringify(p.spec));
+	prompt.value = p.prompt;
+	page.value = 0;
+	presetsOpen.value = false;
+	setNotice(`Read as: ${describeSpec(p.spec)}`);
+}
+
+function clearReport() {
+	spec.value = null;
+	prompt.value = "";
+	refinePrompt.value = "";
+	presetsOpen.value = true;
+	setNotice("");
+}
+
+function setViz(v) {
+	if (!spec.value) return;
+	spec.value = { ...spec.value, viz: v, mode: v === "table" && spec.value.mode === "list" ? "list" : "aggregate" };
+}
+
+const result = computed(() => {
+	if (!spec.value || loading.value) return null;
+	try {
+		return runSpec(spec.value, ctx.value, { offset: page.value * PAGE_SIZE, pageSize: PAGE_SIZE });
+	} catch {
+		return null;
+	}
+});
+const isMoney = computed(() => spec.value?.measure === "amount");
+function fmtVal(v) {
+	return isMoney.value ? fmtINR(v) : Number(v || 0).toLocaleString();
+}
+function fmtValShort(v) {
+	return isMoney.value ? fmtCompactINR(v) : Number(v || 0).toLocaleString();
+}
+
+// --- chart geometry ---
+const maxVal = computed(() => Math.max(1, ...(result.value?.rows || []).map((r) => r.value)));
+const DONUT_COLORS = ["#16a34a", "#0ea5e9", "#f59e0b", "#8b5cf6", "#ef4444", "#14b8a6", "#ec4899", "#64748b"];
+const donutArcs = computed(() => {
+	const rows = result.value?.rows || [];
+	const total = rows.reduce((a, r) => a + r.value, 0) || 1;
+	let acc = 0;
+	const C = 2 * Math.PI * 42;
+	return rows.map((r, i) => {
+		const frac = r.value / total;
+		const arc = { ...r, color: DONUT_COLORS[i % DONUT_COLORS.length], dash: `${frac * C} ${C}`, offset: -acc * C, pct: frac * 100 };
+		acc += frac;
+		return arc;
+	});
+});
+const linePoints = computed(() => {
+	const rows = result.value?.rows || [];
+	if (rows.length < 2) return "";
+	const w = 640, h = 200, pad = 8;
+	const max = Math.max(1, ...rows.map((r) => r.value));
+	return rows
+		.map((r, i) => {
+			const x = pad + (i * (w - 2 * pad)) / (rows.length - 1);
+			const y = h - pad - (r.value / max) * (h - 2 * pad);
+			return `${x.toFixed(1)},${y.toFixed(1)}`;
+		})
+		.join(" ");
+});
+
+onMounted(() => {
+	if (!canUseInsights.value) {
+		router.replace("/");
+		return;
+	}
+	const q = route.query.q;
+	if (typeof q === "string" && q.trim()) {
+		prompt.value = q.trim();
+		ask();
+	}
+});
+</script>
+
+<template>
+	<DeskPage title="Insights" subtitle="Ask a question of your data" :breadcrumbs="breadcrumbs">
+		<div v-if="!canUseInsights" class="text-sm text-ink-500 py-10 text-center">
+			Insights is available to leadership roles.
+		</div>
+		<div v-else class="space-y-4 max-w-5xl">
+			<!-- Ask box -->
+			<div class="flex items-center gap-2">
+				<input
+					v-model="prompt"
+					type="text"
+					placeholder="e.g. subcontractor bill value by subcontractor, top 8"
+					class="flex-1 border border-ink-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-brand-400"
+					@keyup.enter="ask"
+				/>
+				<button type="button" class="desk-save-btn" @click="ask">Ask</button>
+			</div>
+
+			<!-- Notice -->
+			<div
+				v-if="notice"
+				class="text-xs px-3 py-2 rounded-md border"
+				:class="
+					noticeTone === 'warn'
+						? 'bg-warning-50 border-warning-200 text-warning-700'
+						: 'bg-brand-50/60 border-brand-100 text-brand-700'
+				"
+			>
+				{{ notice }}
+			</div>
+
+			<!-- Suggestions (empty state) -->
+			<div v-if="!spec" class="text-xs text-ink-500 flex flex-wrap items-center gap-1.5">
+				<span class="text-ink-400">Try:</span>
+				<button
+					v-for="s in SUGGESTIONS"
+					:key="s"
+					type="button"
+					class="px-2 py-1 border border-ink-200 rounded-full hover:border-brand-400 hover:bg-brand-50"
+					@click="((prompt = s), ask())"
+				>
+					{{ s }}
+				</button>
+			</div>
+
+			<!-- Presets -->
+			<section v-if="presetsOpen" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="px-4 py-2.5 bg-ink-50 border-b border-ink-200">
+					<h3 class="text-xs uppercase tracking-wider font-semibold text-ink-700">Starter questions</h3>
+				</div>
+				<div class="p-3 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+					<button
+						v-for="p in PRESETS"
+						:key="p.id"
+						type="button"
+						class="border border-ink-200 hover:border-brand-400 hover:bg-brand-50/40 rounded-lg px-3 py-2.5 text-left transition-colors"
+						@click="runPreset(p)"
+					>
+						<div class="text-sm font-medium text-ink-900">{{ p.title }}</div>
+						<div class="text-[11px] text-ink-500 mt-0.5">{{ p.prompt }}</div>
+					</button>
+				</div>
+			</section>
+
+			<div v-if="loading && spec" class="text-sm text-ink-500 italic py-10 text-center">Loading data…</div>
+
+			<!-- Report -->
+			<section v-if="spec && result && !loading" class="bg-white border border-ink-200 rounded-lg overflow-hidden">
+				<div class="px-4 py-2.5 border-b border-ink-200 flex items-center justify-between gap-3 flex-wrap">
+					<div>
+						<h3 class="text-sm font-semibold text-ink-900">{{ describeSpec(spec) }}</h3>
+						<div class="text-[11px] text-ink-500">
+							{{ result.recordCount }} record{{ result.recordCount === 1 ? "" : "s" }} ·
+							{{ result.measureLabel }} total {{ fmtVal(result.total) }}
+						</div>
+					</div>
+					<div class="flex items-center gap-1">
+						<button
+							v-for="v in VIZ"
+							:key="v"
+							type="button"
+							class="text-[11px] px-2 py-1 border rounded-md capitalize"
+							:class="spec.viz === v ? 'bg-brand-600 border-brand-600 text-white' : 'border-ink-200 text-ink-600 hover:bg-ink-50'"
+							@click="setViz(v)"
+						>
+							{{ v }}
+						</button>
+						<button type="button" class="text-[11px] px-2 py-1 border border-ink-200 rounded-md text-ink-600 hover:bg-ink-50 ml-1" @click="clearReport">
+							Clear
+						</button>
+					</div>
+				</div>
+
+				<div class="p-4">
+					<!-- KPI -->
+					<div v-if="spec.viz === 'kpi'" class="py-8 text-center">
+						<div class="text-4xl font-bold tabular-nums text-ink-900">{{ fmtVal(result.total) }}</div>
+						<div class="text-xs text-ink-500 mt-1">{{ result.measureLabel }} · {{ result.datasetLabel }}</div>
+					</div>
+
+					<!-- Bar (horizontal) -->
+					<div v-else-if="spec.viz === 'bar'" class="space-y-1.5">
+						<div v-for="r in result.rows" :key="r.label" class="flex items-center gap-2 text-xs">
+							<span class="w-40 shrink-0 truncate text-ink-600" :title="r.label">{{ r.label }}</span>
+							<div class="flex-1 bg-ink-50 rounded h-5 overflow-hidden">
+								<div class="h-full bg-brand-500 rounded" :style="`width:${Math.max(2, (r.value / maxVal) * 100)}%`"></div>
+							</div>
+							<span class="w-24 shrink-0 text-right tabular-nums text-ink-900">{{ fmtValShort(r.value) }}</span>
+						</div>
+					</div>
+
+					<!-- Column (vertical) -->
+					<div v-else-if="spec.viz === 'column'" class="flex items-end gap-2 h-56 pt-2">
+						<div v-for="r in result.rows" :key="r.label" class="flex-1 flex flex-col items-center gap-1 min-w-0">
+							<span class="text-[10px] tabular-nums text-ink-700">{{ fmtValShort(r.value) }}</span>
+							<div class="w-full bg-brand-500 rounded-t" :style="`height:${Math.max(2, (r.value / maxVal) * 100)}%`"></div>
+							<span class="text-[10px] text-ink-500 truncate w-full text-center" :title="r.label">{{ r.label }}</span>
+						</div>
+					</div>
+
+					<!-- Line -->
+					<svg v-else-if="spec.viz === 'line'" viewBox="0 0 640 200" class="w-full h-56">
+						<polyline :points="linePoints" fill="none" stroke="#16a34a" stroke-width="2" stroke-linejoin="round" />
+						<g v-for="(r, i) in result.rows" :key="r.label">
+							<text :x="8 + (i * 624) / Math.max(1, result.rows.length - 1)" y="196" font-size="9" fill="#94a3b8" text-anchor="middle">{{ r.label }}</text>
+						</g>
+					</svg>
+
+					<!-- Donut -->
+					<div v-else-if="spec.viz === 'donut'" class="flex items-center gap-6 flex-wrap">
+						<svg viewBox="0 0 100 100" class="w-40 h-40 -rotate-90 shrink-0">
+							<circle cx="50" cy="50" r="42" fill="none" stroke="#f1f5f9" stroke-width="12" />
+							<circle
+								v-for="a in donutArcs"
+								:key="a.label"
+								cx="50"
+								cy="50"
+								r="42"
+								fill="none"
+								:stroke="a.color"
+								stroke-width="12"
+								:stroke-dasharray="a.dash"
+								:stroke-dashoffset="a.offset"
+							/>
+						</svg>
+						<div class="flex-1 min-w-[200px] space-y-1">
+							<div v-for="a in donutArcs" :key="a.label" class="flex items-center gap-2 text-xs">
+								<span class="w-2.5 h-2.5 rounded-sm shrink-0" :style="`background:${a.color}`"></span>
+								<span class="flex-1 truncate text-ink-700" :title="a.label">{{ a.label }}</span>
+								<span class="tabular-nums text-ink-900">{{ fmtValShort(a.value) }}</span>
+								<span class="w-10 text-right tabular-nums text-ink-400">{{ a.pct.toFixed(0) }}%</span>
+							</div>
+						</div>
+					</div>
+
+					<!-- Table (aggregate) -->
+					<table v-else-if="result.mode === 'aggregate'" class="w-full text-xs">
+						<thead class="text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-100">
+							<tr>
+								<th class="text-left px-3 py-2">{{ result.dimensionLabel }}</th>
+								<th class="text-right px-3 py-2">{{ result.measureLabel }}</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr v-for="r in result.rows" :key="r.label" class="border-b border-ink-100 last:border-0">
+								<td class="px-3 py-1.5 text-ink-800">{{ r.label }}</td>
+								<td class="px-3 py-1.5 text-right tabular-nums text-ink-900">{{ fmtVal(r.value) }}</td>
+							</tr>
+						</tbody>
+					</table>
+
+					<!-- Table (list / records) -->
+					<div v-else>
+						<table class="w-full text-xs">
+							<thead class="text-ink-500 uppercase tracking-wider text-[10px] border-b border-ink-100">
+								<tr>
+									<th v-for="c in result.columns" :key="c.key" class="px-3 py-2" :class="c.align === 'right' ? 'text-right' : 'text-left'">
+										{{ c.label }}
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr v-for="rec in result.records" :key="rec._k" class="border-b border-ink-100 last:border-0">
+									<td
+										v-for="c in result.columns"
+										:key="c.key"
+										class="px-3 py-1.5"
+										:class="c.align === 'right' ? 'text-right tabular-nums text-ink-900' : 'text-ink-800'"
+									>
+										{{ c.money ? fmtINR(rec[c.key]) : rec[c.key] }}
+									</td>
+								</tr>
+							</tbody>
+						</table>
+						<div v-if="result.recordCount > PAGE_SIZE" class="flex items-center justify-between mt-3 text-xs text-ink-500">
+							<span>{{ page * PAGE_SIZE + 1 }}–{{ Math.min((page + 1) * PAGE_SIZE, result.recordCount) }} of {{ result.recordCount }}</span>
+							<span class="flex gap-2">
+								<button type="button" class="px-2 py-1 border border-ink-200 rounded disabled:opacity-40" :disabled="page === 0" @click="page--">Prev</button>
+								<button
+									type="button"
+									class="px-2 py-1 border border-ink-200 rounded disabled:opacity-40"
+									:disabled="(page + 1) * PAGE_SIZE >= result.recordCount"
+									@click="page++"
+								>
+									Next
+								</button>
+							</span>
+						</div>
+					</div>
+
+					<p v-if="result.truncated" class="text-[11px] text-ink-400 mt-2">
+						+{{ result.truncated }} more not shown — say "show all" to include them.
+					</p>
+				</div>
+
+				<!-- Refine -->
+				<div class="px-4 py-2.5 border-t border-ink-200 bg-ink-50/40 flex items-center gap-2">
+					<input
+						v-model="refinePrompt"
+						type="text"
+						placeholder='Refine: "as a pie", "top 5", "by month", "over 100000", "clear filters"…'
+						class="flex-1 border border-ink-200 rounded-md px-2.5 py-1.5 text-xs bg-white focus:outline-none focus:border-brand-400"
+						@keyup.enter="refine"
+					/>
+					<button type="button" class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md bg-white hover:bg-ink-50" @click="refine">Refine</button>
+					<button v-if="history.length" type="button" class="text-xs px-2.5 py-1.5 border border-ink-200 rounded-md bg-white hover:bg-ink-50" @click="undo">Undo</button>
+				</div>
+			</section>
+		</div>
+	</DeskPage>
+</template>


### PR DESCRIPTION
## Summary
The **first layer of the Insights feature** from the research brief (Phase 1 MVP): rules-based understanding + browser-side crunching over **live data**, gated to leadership. Ask a plain question, get a chart/table; reshape with a follow-up or the viz switcher.

### Architecture (matches the brief's two-halves design)
- **`data/insightEngine.js`** — the query model. `parsePrompt` (synonyms + fuzzy typo tolerance, list-vs-aggregate, project/date/threshold/named-value filters) → `QuerySpec`, run by an executor (`runSpec`/`filteredRows`) over datasets. Ported ~verbatim from the prototype; **parser and executor are data-agnostic**, so an AI model can replace the parser later without touching the rest. No model call here — nothing is invented, and an unrecognised prompt says so.
- **Core-5 datasets on real Frappe data**: Projects, Tasks, Stages, Subcontractor Bills, Purchase Orders. Each declares `can(store)` so the surface only offers what the persona may read.
- **`composables/useInsightsData.js`** — fetches the Core-5 (all rows, browser-side) via the data adapter; fetches gated on `canRead` per dataset.
- **`views/InsightsView.vue`** — ask box, starter questions, "read as…" notice, six viz (bar/column/line/donut/table/kpi) + list detail with paging, refine box.
- **Route `/core/insights` + leadership-gated nav item** (Director / PM / Admin).

### Verified on bs.local (live data)
"purchase order value by supplier, top 8" parses to **Purchase orders · Value · by Supplier · top 8** and renders the real bar chart (Summit Traders 262.8K, Zuckerman 193.8K, MA Inc. 95.7K). Frontend builds clean.

### Follow-on phases (per the brief, additive/low-risk)
More data areas, server-side crunching for heavy datasets, and an AI (Claude) fallback for "ask anything" — none require rebuilding this layer.