### PR TITLE
fix: Work Order list — correct submit/cancel status + stop the 417

### DIFF
--- a/frontend/src/components/doctype/DocTypeListView.vue
+++ b/frontend/src/components/doctype/DocTypeListView.vue
@@ -101,6 +101,19 @@ const configuredColumns = computed(() => {
 	return props.columns.filter((column) => column?.key);
 });
 
+// Standard/system fields aren't in a doctype's `fields` meta, so the validity filter below
+// would silently drop them — including `docstatus`, which a status column derives its state
+// from (drop it and every row reads as Draft). Keep them permitted.
+const STANDARD_FIELDS = new Set([
+	"name",
+	"owner",
+	"creation",
+	"modified",
+	"modified_by",
+	"docstatus",
+	"idx",
+]);
+
 const resolvedFields = computed(() => {
 	const candidates = configuredColumns.value
 		? configuredColumns.value.flatMap((column) => {
@@ -110,7 +123,7 @@ const resolvedFields = computed(() => {
 		: props.fieldOrder;
 
 	const valid = meta.value
-		? candidates.filter((fieldname) => fieldMetaMap.value.has(fieldname))
+		? candidates.filter((fieldname) => fieldMetaMap.value.has(fieldname) || STANDARD_FIELDS.has(fieldname))
 		: candidates;
 	const withName = valid.includes("name") ? valid : ["name", ...valid];
 	return Array.from(new Set(withName));

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -57,6 +57,11 @@ const FIELDS = [
 	"docstatus",
 ];
 
+// DocTypeListView fetches each column's `fields` (falling back to its `key`), so DERIVED
+// columns must name the real fields they read — otherwise their key is queried as a field:
+// "percent" 417s (no such field) and "status" (a stale, unqueryable legacy column) would too,
+// while `docstatus` — which drives the real status — never gets fetched, so every row reads
+// as Draft. `percent` is computed from total_value + the bills fetch; `status` from docstatus.
 const columns = computed(() => [
 	{ key: "name", label: "WO ID" },
 	{ key: "subcontractor_name", label: "Subcontractor" },
@@ -65,8 +70,10 @@ const columns = computed(() => [
 	{ key: "delivery_type", label: "Type" },
 	{ key: "total_value", label: "Value", align: "right" },
 	// "% Billed" is hidden for personas that can't read Subcontractor Bills (no bill fetch).
-	...(canReadBills.value ? [{ key: "percent", label: "% Billed", align: "right" }] : []),
-	{ key: "status", label: "Status" },
+	...(canReadBills.value
+		? [{ key: "percent", label: "% Billed", align: "right", fields: ["total_value"] }]
+		: []),
+	{ key: "status", label: "Status", fields: ["docstatus"] },
 ]);
 
 const breadcrumbs = [


### PR DESCRIPTION
## Symptoms
1. Submitted / cancelled Work Orders showed as **Draft** in the Vue list (correct in ERPNext Desk).
2. The list intermittently failed to load with **`417 Field not permitted in query: percent`** (not a permission issue).

## Root cause — one bug, in `DocTypeListView` field resolution
`DocTypeListView` builds its query fields from each column's `fields` (falling back to the column `key`). The WO list's **derived** columns named no `fields`, so their keys were queried as fields:
- `percent` isn't a real field → **417**.
- `status` on this doctype is a **stale legacy DB column** (the WO moved to native submittable; `status` isn't in the meta anymore).
- `docstatus` — the actual source of truth — was in `FIELDS` but **not a column**, and column keys (not `FIELDS`) drive the fetch, so it was **never queried** → `woStatus()` fell through to "Draft".

It was intermittent because the invalid-field filter only runs once the doctype **meta has loaded**: before that the bad key reached the server and 417'd; after, it was dropped and every row read as Draft. And even declaring `fields: ["docstatus"]` didn't help at first — `docstatus` is a **standard/system field, not in the doctype's `fields` meta**, so the validity filter silently stripped it.

## Fixes
- **`DocTypeListView`**: exempt standard/system fields (`docstatus`, `modified`, `owner`, …) from the meta-based validity filter — they're never in a doctype's `fields`, so it was dropping a legitimate `docstatus` (and any status column derived from it). This hardens *every* list view.
- **WO list**: declare each derived column's real backing fields — `percent` → `total_value`, `status` → `docstatus` — so the query is valid and `docstatus` is actually fetched.

The **detail** view was already correct (backend derives status from `docstatus` via `_wo_state`).

## Verified on bs.local
List loads with **no 417**; `SWO-2026-00006` shows **Cancelled** (docstatus 2), the rest **Submitted** (docstatus 1) — matching each WO's `docstatus`. `% Billed` still populates. Frontend builds clean.