### PR TITLE
feat: printable workspace reports + no shortcut subtext in Site Execution

### DIFF
--- a/frontend/src/components/desk/DeskPage.vue
+++ b/frontend/src/components/desk/DeskPage.vue
@@ -20,7 +20,17 @@ const props = defineProps({
 	// Accepts a single status string OR an array of status strings (each rendered as a
 	// StatusBadge inline with the title — useful for status + priority pairs).
 	status: { type: [String, Array], default: "" },
+	// Puts a Print / PDF button in the actions row and marks the page as a print
+	// root, so the shared @media print rules in style.css hide the desk chrome and
+	// scale the type down. Kept on the primitive rather than pasted into each report
+	// so every report surface prints the same way and none are silently missing it.
+	printable: { type: Boolean, default: false },
 });
+
+// window is not in template scope, so this cannot be an inline handler.
+function printPage() {
+	window.print();
+}
 
 const statusList = computed(() => {
 	if (!props.status) return [];
@@ -29,7 +39,7 @@ const statusList = computed(() => {
 </script>
 
 <template>
-	<div class="desk-page">
+	<div class="desk-page" :class="printable ? 'report-root report-content' : ''">
 		<nav
 			v-if="breadcrumbs.length"
 			class="text-[11px] text-ink-500 flex items-center gap-1.5 flex-wrap mb-1.5"
@@ -55,8 +65,36 @@ const statusList = computed(() => {
 				</div>
 				<p v-if="subtitle" class="text-xs text-ink-500 mt-0.5">{{ subtitle }}</p>
 			</div>
-			<div data-test="page-actions" class="flex items-center gap-2 flex-shrink-0">
+			<div
+				data-test="page-actions"
+				class="flex items-center gap-2 flex-shrink-0 print:hidden"
+			>
 				<slot name="actions" />
+				<button
+					v-if="printable"
+					type="button"
+					class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 flex items-center gap-1.5"
+					style="border-radius: 6px"
+					title="Print, or save as PDF from the print dialog"
+					@click="printPage"
+				>
+					<svg
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.8"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						class="w-3.5 h-3.5 text-ink-400"
+					>
+						<path d="M6 9V2h12v7" />
+						<path
+							d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"
+						/>
+						<path d="M6 14h12v8H6z" />
+					</svg>
+					Print
+				</button>
 			</div>
 		</div>
 

--- a/frontend/src/views/DelayAnalysisReportView.vue
+++ b/frontend/src/views/DelayAnalysisReportView.vue
@@ -101,10 +101,6 @@ const TABS = [
 	["trend", "Weekly trend"],
 ];
 
-function printReport() {
-	window.print();
-}
-
 const breadcrumbs = [
 	{ label: "BuildSuite Core", to: "/" },
 	{ label: "Site Execution", to: "/site-execution" },
@@ -113,18 +109,7 @@ const breadcrumbs = [
 </script>
 
 <template>
-	<DeskPage title="Delay Analysis" :breadcrumbs="breadcrumbs">
-		<template #actions>
-			<button
-				type="button"
-				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
-				style="border-radius: 6px"
-				@click="printReport"
-			>
-				Print
-			</button>
-		</template>
-
+	<DeskPage title="Delay Analysis" :breadcrumbs="breadcrumbs" printable>
 		<p class="text-xs text-ink-500 mb-3">
 			Stages slipping, what sits downstream, silent tasks and the weekly completion trend.
 		</p>

--- a/frontend/src/views/ReportView.vue
+++ b/frontend/src/views/ReportView.vue
@@ -22,7 +22,7 @@ const breadcrumbs = computed(() => {
 </script>
 
 <template>
-	<DeskPage :title="report" subtitle="Report" :breadcrumbs="breadcrumbs">
+	<DeskPage :title="report" subtitle="Report" :breadcrumbs="breadcrumbs" printable>
 		<FrappeReport :report="report" />
 	</DeskPage>
 </template>

--- a/frontend/src/views/finance/reports/AgedReport.vue
+++ b/frontend/src/views/finance/reports/AgedReport.vue
@@ -89,7 +89,7 @@ const shownCount = computed(
 </script>
 
 <template>
-	<DeskPage title="Receivables & Payables" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Receivables & Payables" :breadcrumbs="breadcrumbs" printable>
 		<div v-if="loading" class="text-sm text-ink-500 italic py-10 text-center">Loading…</div>
 		<div v-else-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
 		<div v-else class="space-y-6">

--- a/frontend/src/views/finance/reports/CashBankStatementReport.vue
+++ b/frontend/src/views/finance/reports/CashBankStatementReport.vue
@@ -66,7 +66,7 @@ const closing = computed(() => statement.value?.closing || 0);
 </script>
 
 <template>
-	<DeskPage title="Cash & Bank Statement" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Cash & Bank Statement" :breadcrumbs="breadcrumbs" printable>
 		<div v-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
 		<div v-else class="space-y-4">
 			<ReportFilters

--- a/frontend/src/views/finance/reports/ExpenseSummaryReport.vue
+++ b/frontend/src/views/finance/reports/ExpenseSummaryReport.vue
@@ -133,7 +133,7 @@ function toggle(k) {
 </script>
 
 <template>
-	<DeskPage title="Expense Summary" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Expense Summary" :breadcrumbs="breadcrumbs" printable>
 		<div v-if="loading" class="text-sm text-ink-500 italic py-10 text-center">Loading…</div>
 		<div v-else-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
 		<div v-else class="space-y-4">

--- a/frontend/src/views/finance/reports/FinancialPositionReport.vue
+++ b/frontend/src/views/finance/reports/FinancialPositionReport.vue
@@ -48,7 +48,7 @@ const net = computed(() => totalHave.value - totalOwe.value);
 </script>
 
 <template>
-	<DeskPage title="Financial Position" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Financial Position" :breadcrumbs="breadcrumbs" printable>
 		<div v-if="loading" class="text-sm text-ink-500 italic py-10 text-center">Loading…</div>
 		<div v-else-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
 		<div v-else class="space-y-4">

--- a/frontend/src/views/finance/reports/PettyCashReport.vue
+++ b/frontend/src/views/finance/reports/PettyCashReport.vue
@@ -152,7 +152,7 @@ function exportCsv() {
 </script>
 
 <template>
-	<DeskPage title="Petty Cash Statement" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Petty Cash Statement" :breadcrumbs="breadcrumbs" printable>
 		<div class="space-y-4">
 			<!-- Holder picker -->
 			<div class="flex items-end gap-3 flex-wrap">

--- a/frontend/src/views/finance/reports/PnlReport.vue
+++ b/frontend/src/views/finance/reports/PnlReport.vue
@@ -146,7 +146,7 @@ function indentStyle(level) {
 </script>
 
 <template>
-	<DeskPage title="Profit &amp; Loss" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Profit &amp; Loss" :breadcrumbs="breadcrumbs" printable>
 		<div v-if="error" class="text-sm text-danger-600 py-10 text-center">{{ error }}</div>
 		<div v-else>
 			<ReportFilters :active="anyFilter" :shown="leafCount" noun="accounts" @clear="clearFilters">

--- a/frontend/src/views/procurement/reports/ProcurementReportView.vue
+++ b/frontend/src/views/procurement/reports/ProcurementReportView.vue
@@ -295,6 +295,7 @@ const inr = (n) => (n || n === 0 ? Number(n).toLocaleString("en-IN") : n);
 		:title="meta ? meta.title : 'Report not found'"
 		:subtitle="meta ? meta.desc : `No report registered for '${slug}'`"
 		:breadcrumbs="breadcrumbs"
+		:printable="!!meta"
 	>
 		<div
 			v-if="!meta"

--- a/frontend/src/views/workspaces/SiteExecutionWorkspace.vue
+++ b/frontend/src/views/workspaces/SiteExecutionWorkspace.vue
@@ -41,24 +41,6 @@ const today = computed(() => {
 	return d.toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
 });
 
-// Short descriptions for each shortcut tile, keyed by route_path. Kept as a
-// local map (not on the Workspace Structure Settings DocType schema yet) per
-// the same exploratory-mockup framing that owns the Reports group below — a
-// schema migration to add `description` to the WSST child table is straight-
-// forward but out of scope for this UX tweak.
-const SHORTCUT_DESCRIPTIONS = {
-	"/projects": "Plan, track, and manage construction projects.",
-	"/work-packages": "Cost-and-control boundaries within a project.",
-	"/tasks": "Day-to-day execution items with progress tracking.",
-	"/stage-plannings": "Time-phased delivery stages and dependencies.",
-	"/progress-entries": "Daily task progress, labour, and blockers.",
-	"/sco": "Scope change orders and BOQ revision tie-ins.",
-	"/schedule": "Gantt view across projects and stages.",
-};
-function descriptionFor(routePath) {
-	return SHORTCUT_DESCRIPTIONS[routePath] || "";
-}
-
 // --- Session 35 additive: Project Dashboard tile -------------------------
 // "Owner" roles that should see the portfolio dashboard tile. Hardcoded
 // here per the exploratory-visualisation framing; production would put this
@@ -169,13 +151,14 @@ onMounted(async () => {
 				v-if="shortcuts.length"
 				class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3"
 			>
+				<!-- Per the prototype (S50), DocType shortcut tiles render WITHOUT a
+				     description — only the Reports group below carries subtext. -->
 				<WorkspaceShortcut
 					v-for="sc in shortcuts"
 					:key="sc.id"
 					:to="sc.route_path"
 					:icon="sc.icon"
 					:label="sc.label"
-					:description="descriptionFor(sc.route_path)"
 				/>
 			</div>
 


### PR DESCRIPTION
Two prototype-alignment tweaks the user asked for.

## 1. Print feature on all workspace reports
`DeskPage` gains a `printable` prop. When set it:
- renders a **Print / PDF** button in the page actions row (`window.print()`), and
- marks the page as a print root (`report-root report-content`) so the shared `@media print` rules in `style.css` hide the desk chrome (sidebar + topbar) and print only the report.

Kept on the primitive rather than pasted into each report, so no report surface is silently missing it. `:printable` is now set on:
- the generic `ReportView`
- `DelayAnalysisReportView` (Site Execution) — its bespoke Print button was removed in favour of the shared one (was rendering twice)
- the six Project Finance reports (P&L, Financial Position, Aged, Petty Cash, Expense Summary, Cash & Bank)
- the Procurement `ProcurementReportView` (gated on a valid report slug)

`ProgressReportView` already had its own print button and is left as-is.

## 2. Site Execution shortcuts drop their subtext
Per the prototype (S50), DocType **shortcut** tiles render *without* a description — only the **Reports** group carries subtext. The app's Site Execution workspace was passing a description to shortcuts; removed. (Estimation intentionally keeps shortcut descriptions — it matches the prototype, so it's untouched.)

## Verification
- `yarn build` clean.
- Playwright (director): Site Execution shortcuts show no subtext, Reports still do; Delay Analysis and P&L reports each show exactly one Print button.