### PR TITLE
fix: gate the WO detail's cross-entity create buttons by target create right

### DIFF
--- a/buildsuite_core/api/cypress_setup.py
+++ b/buildsuite_core/api/cypress_setup.py
@@ -74,3 +74,52 @@ def ensure_cypress_users(password: str = "Cypress-Suite-2026!"):
 	# explicit commit persists the provisioned users.
 	frappe.db.commit()  # nosemgrep
 	return summary
+
+
+@frappe.whitelist()
+def ensure_cypress_work_order():
+	"""Return the name of a SUBMITTED Subcontractor Work Order, for detail-page e2e tests that
+	need a real record (e.g. the cross-entity create-button gating spec). Reuses any existing
+	submitted WO; otherwise provisions one (demo project + subcontractor + a line, then submit).
+	Idempotent. Returns the WO name, or None if it couldn't provision one (spec skips)."""
+	if not (frappe.conf.developer_mode or frappe.flags.in_test):
+		frappe.throw(frappe._("ensure_cypress_work_order is only available in developer / test mode"))
+
+	existing = frappe.db.get_value("Subcontractor Work Order", {"docstatus": 1}, "name")
+	if existing:
+		return existing
+
+	try:
+		from buildsuite_core.api import subcontract as sc
+
+		company = frappe.db.get_single_value("Global Defaults", "default_company") or frappe.db.get_value(
+			"Company", {}, "name"
+		)
+		project = frappe.db.get_value("Project", {"company": company}, "name")
+		if not project:
+			project = frappe.get_doc(
+				{"doctype": "Project", "project_name": "Cypress WO Project", "company": company}
+			).insert(ignore_permissions=True).name
+		sub = frappe.db.get_value("Supplier", {"supplier_group": "Subcontractor"}, "name")
+		if not sub:
+			grp = frappe.db.get_value("Supplier Group", {"supplier_group_name": "Subcontractor"}, "name")
+			sub = frappe.get_doc(
+				{
+					"doctype": "Supplier",
+					"supplier_name": "Cypress Subcontractor",
+					"supplier_group": grp or "Subcontractor",
+				}
+			).insert(ignore_permissions=True).name
+
+		out = sc.save_work_order(
+			subcontractor=sub,
+			project=project,
+			lines=frappe.as_json([{"scope": "Tiling", "uom": "Nos", "qty": 10, "rate": 100}]),
+		)
+		doc = frappe.get_doc("Subcontractor Work Order", out["name"])
+		doc.submit()
+		frappe.db.commit()  # nosemgrep
+		return doc.name
+	except Exception:
+		frappe.db.rollback()
+		return None

--- a/frontend/cypress/e2e/cross_entity_create_buttons.cy.js
+++ b/frontend/cypress/e2e/cross_entity_create_buttons.cy.js
@@ -1,0 +1,64 @@
+// A detail page that creates OTHER entities via "link" buttons must gate each button on the
+// TARGET entity's create right — not the host's. A Director/Owner is full on the Work Order but
+// read-only on Measurement Book + Subcontractor Bill, so on a (submitted) WO they must NOT see
+// "+ Record measurement" or "+ Bill progress". Same rule for every such cross-entity button:
+// if you can't CREATE the target, you don't see the button.
+//
+// Data-driven from PERSONA_CAPS (the same table usePermissions() reads), so it stays correct as
+// caps change. A persona that CAN create the target must see the button; one that can't must not.
+//
+// Requires the persona test users + a submitted WO:
+//   bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
+// (the spec itself provisions the WO via ensure_cypress_work_order.)
+
+import { PERSONA_CAPS } from "../../src/data/roles";
+
+// Cross-entity link buttons on the Work Order detail → the PERSONA_CAPS key each gates on.
+const WO_LINK_BUTTONS = [
+	{ text: "Record measurement", cap: "measurementBook" },
+	{ text: "Bill progress", cap: "subcontractorBill" },
+];
+
+// Personas that can READ a Work Order (so the detail page renders). No-WO-read personas
+// (foreman, store-keeper, hr-manager) can't reach it and are covered by permissions.cy.js.
+const WO_READERS = [
+	"director",
+	"pm",
+	"qs",
+	"estimator",
+	"site-engineer",
+	"procurement",
+	"accountant",
+	"admin",
+	"bsa",
+];
+
+describe("Cross-entity create buttons follow the target entity's create right", () => {
+	let woName;
+
+	before(() => {
+		cy.loginAs("admin");
+		cy.request("/api/method/buildsuite_core.api.cypress_setup.ensure_cypress_work_order").then((res) => {
+			woName = res.body.message;
+		});
+	});
+
+	WO_READERS.forEach((persona) => {
+		it(`${persona}: WO detail shows each link button only if it can create the target`, function () {
+			if (!woName) this.skip(); // no submitted WO to test against on this site
+			cy.loginAs(persona);
+			cy.visitApp(`/subcontractor-work-orders/${woName}`);
+			cy.dt("page-title").should("be.visible"); // the WO detail is readable
+
+			WO_LINK_BUTTONS.forEach(({ text, cap }) => {
+				const canCreateTarget = PERSONA_CAPS[persona]?.[cap]?.c === true;
+				if (canCreateTarget) {
+					cy.contains("button", text).should("exist");
+				} else {
+					// The Director/Owner case: full on the WO, read-only on the target → no button.
+					cy.contains("button", text).should("not.exist");
+				}
+			});
+		});
+	});
+});

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -8,6 +8,7 @@ import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { showToast } from "@/utils/appToast";
 import { createDataAdapter } from "@/data/adapters";
 import { useDocTypeList } from "@/composables/useDocTypeList";
@@ -26,6 +27,13 @@ import { fmtDate, fmtINR } from "@/utils/format";
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canCreate } = usePermissions();
+// These buttons create OTHER entities from the WO, so each follows that entity's create
+// rights — not the WO's. A WO-full persona that is read-only on Measurement Book / on
+// Subcontractor Bill (e.g. Director/Owner) can open + submit the WO but must not see the
+// "+ Record measurement" / "+ Bill progress" buttons.
+const canRecordMeasurement = computed(() => canCreate("measurementBook"));
+const canRaiseBill = computed(() => canCreate("subcontractorBill"));
 const adapter = createDataAdapter(useDataStore());
 
 const wo = ref(null);
@@ -227,7 +235,7 @@ const tabs = computed(() => [
 				Submit
 			</button>
 			<button
-				v-if="isSubmitted"
+				v-if="isSubmitted && canRecordMeasurement"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-info-200 bg-info-50 hover:bg-info-100 text-info-700 font-medium"
 				style="border-radius: 6px"
@@ -237,7 +245,7 @@ const tabs = computed(() => [
 				+ Record measurement
 			</button>
 			<button
-				v-if="isSubmitted"
+				v-if="isSubmitted && canRaiseBill"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium inline-flex items-center"
 				style="border-radius: 6px"
@@ -458,7 +466,7 @@ const tabs = computed(() => [
 					Measurement books ({{ mbs.length }})
 				</h3>
 				<button
-					v-if="isSubmitted"
+					v-if="isSubmitted && canRecordMeasurement"
 					type="button"
 					class="text-xs text-brand-700 hover:underline"
 					@click="onRecordMeasurement"
@@ -518,7 +526,7 @@ const tabs = computed(() => [
 					Bills ({{ bills.length }})
 				</h3>
 				<button
-					v-if="isSubmitted"
+					v-if="isSubmitted && canRaiseBill"
 					type="button"
 					class="text-xs text-brand-700 hover:underline"
 					@click="onRaiseBill"


### PR DESCRIPTION
The Subcontractor Work Order detail view exposes cross-entity create buttons — **+ Record measurement** (creates a Measurement Book) and **+ Bill progress** (creates a Subcontractor Bill). These were shown to anyone who could view a submitted WO, even personas with no create right on the target doctype (e.g. Director/Owner has full WO access but read-only on Measurement Book), so clicking would 403.

## Changes
- `SubcontractorWorkOrderDetailView.vue` — gate both button pairs on the target's create capability via `usePermissions()`: `canRecordMeasurement = canCreate("measurementBook")`, `canRaiseBill = canCreate("subcontractorBill")`. Buttons now render only when the WO is submitted **and** the persona can create the target.
- `api/cypress_setup.py` — `ensure_cypress_work_order()` helper (idempotent, dev/test-guarded) returns a submitted WO name for the e2e test, provisioning one if none exists.
- `cypress/e2e/cross_entity_create_buttons.cy.js` (new) — data-driven from `PERSONA_CAPS`: for each WO-reader persona, asserts each cross-entity button is shown **iff** that persona has the create capability.

Mirrors the two-layer permission model — Vue gates only hide buttons that would 403; DocPerms remain authoritative.