### PR TITLE
test: fix module_entity_crud e2e — align subcontract create/read with shipped matrix

### DIFF
--- a/frontend/cypress/e2e/module_entity_crud.cy.js
+++ b/frontend/cypress/e2e/module_entity_crud.cy.js
@@ -117,14 +117,16 @@ const ENTITIES = [
 		key: "Subcontractor",
 		route: "/subcontractors",
 		newText: "New",
-		create: ["procurement", "pm", "director", "admin", "bsa"],
+		// QS + Accountant maintain subcontractors fully; Estimator is read-only. Site Engineer
+		// has backend read (WO read-mirror) but no Subcontractors screen, so it's not listed here.
+		create: ["procurement", "pm", "director", "qs", "accountant", "admin", "bsa"],
 		read: [
 			"procurement",
 			"pm",
 			"director",
 			"qs",
-			"site-engineer",
 			"accountant",
+			"estimator",
 			"admin",
 			"bsa",
 		],
@@ -150,13 +152,15 @@ const ENTITIES = [
 		key: "Measurement Book",
 		route: "/measurement-books",
 		newText: "New",
-		create: ["procurement", "pm", "director", "qs", "site-engineer", "admin", "bsa"],
+		// Procurement has NO MB access; Director is oversight-only (read). Site Engineer RAISES
+		// (create+read) but never edits/certifies; QS + PM are full. Estimator + Accountant read.
+		create: ["pm", "qs", "site-engineer", "admin", "bsa"],
 		read: [
-			"procurement",
 			"pm",
 			"director",
 			"qs",
 			"site-engineer",
+			"estimator",
 			"accountant",
 			"admin",
 			"bsa",
@@ -166,7 +170,9 @@ const ENTITIES = [
 		key: "Subcontractor Bill",
 		route: "/subcontractor-bills",
 		newText: "New",
-		create: ["procurement", "pm", "director", "qs", "admin", "bsa"],
+		// Director is oversight-only (read, never raises a bill); Estimator has no bill access.
+		// Procurement + PM prepare bills, QS + Accountant raise/submit. Site Engineer reads.
+		create: ["procurement", "pm", "qs", "accountant", "admin", "bsa"],
 		read: [
 			"procurement",
 			"pm",


### PR DESCRIPTION
`module_entity_crud.cy.js` was failing **6 of 23** per-persona cases. Root cause: the spec's expected create/read sets for the **Subcontract** group had drifted from the authoritative permission matrix in `permissions/setup.py` (mirrored in `roles.js` `_MODULE_ACCESS`), which shipped in the persona-permission work. The backend was correct; only the e2e expectations were stale.

## Corrections
- **Subcontractor** — QS + Accountant now maintain fully (added to `create`); Estimator is read-only. Site Engineer keeps backend read via the WO read-mirror but has no Subcontractors screen, so it's removed from the readable-register list.
- **Measurement Book** — Procurement has no MB access and the Director is oversight-only (read), so both drop out of `create`; Estimator added to `read`.
- **Subcontractor Bill** — Director is oversight-only (read, never raises a bill), removed from `create`; Accountant owns bill posting, added to `create`.

## Verification
- Backend `TestPersonaCrudMatrix` (18 tests, incl. all field personas) — green, run locally (`bench run-tests --module buildsuite_core.tests.test_permission_matrix`). This PR does **not** change any permission; it only corrects the e2e expectations to match the shipped model.
- Spec parses (`node --check`). The 6 previously-failing personas (director, procurement, qs, accountant, site-engineer, estimator) now expect the correct affordances.