### PR TITLE
feat: Cost vs Budget by Cost Code report from the project overview

### DIFF
--- a/buildsuite_core/api/cost_report.py
+++ b/buildsuite_core/api/cost_report.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Cost vs Budget by Cost Code — the project cost-control report launched from the project
+overview. Per BOQ cost code, grouped by cost type, it reconciles three figures computed live:
+
+  • Planned   — Σ BOQ Item.planned_amount over the project's Approved BOQ(s), by group code.
+  • Committed — submitted Subcontractor Work Order lines by cost-code group
+                (subcontract.committed_by_cost_code) — scope already promised to subcontractors.
+  • Actual    — recognised spend by cost code across every rail (material issues, subcontractor
+                bills, overheads) via boq_actuals.get_actuals_summary. Cost is recognised at
+                consumption, not purchase, so this never double-counts a PO.
+
+Variance = Actual − Planned (over budget is positive), mirroring the report prototype; Committed
+is shown alongside but is deliberately NOT folded into Variance. A code's cost type is its group's
+dominant BOQ Item.cost_head (by planned amount), so rows group by the same vocabulary Planned is
+expressed in — sidestepping the Planned/Actual cost-head vocabulary mismatch.
+
+Only Approved BOQs count (a draft/superseded revision must never be costed against). The endpoint
+returns flat rows; the view groups by cost type and filters (variance threshold, cost type, search)
+client-side, exactly like the sibling bespoke reports.
+"""
+
+import frappe
+from frappe.utils import flt
+
+from buildsuite_core.api import boq_actuals, subcontract
+
+
+@frappe.whitelist()
+def cost_vs_budget_by_cost_code(project: str):
+	"""Planned / Committed / Actual / Variance per BOQ cost code for a project.
+
+	Returns ``{project, boq, rows: [{key, code, name, costType, planned, committed, actual,
+	variance, variancePct}]}``. ``rows`` is empty (and ``boq`` is ``None``) when the project has
+	no Approved BOQ — there is nothing to measure cost against yet.
+	"""
+	if not project:
+		return {"project": project, "boq": None, "rows": []}
+
+	# Only Approved BOQs are authoritative for costing (mirrors get_project_cost_codes).
+	boqs = frappe.get_all("BOQ", filters={"project": project, "status": "Approved"}, pluck="name")
+
+	# Committed + Actual are project-scoped and keyed by the group cost-code string, so Planned is
+	# aggregated by that same string below — the three maps line up on the group code.
+	committed = subcontract.committed_by_cost_code(project) or {}
+	actual_by_group = (boq_actuals.get_actuals_summary(project) or {}).get("by_group", {})
+
+	rows = []
+	if boqs:
+		groups = frappe.get_all(
+			"BOQ Group",
+			filters={"boq": ["in", boqs]},
+			fields=["name", "code", "group_name"],
+		)
+		items = frappe.get_all(
+			"BOQ Item",
+			filters={"boq": ["in", boqs]},
+			fields=["boq_group", "planned_amount", "cost_head"],
+		)
+		items_by_group = {}
+		for it in items:
+			items_by_group.setdefault(it.boq_group, []).append(it)
+
+		# Aggregate Planned by group code. Codes are stable across BOQ revisions, so combining is
+		# correct if two Approved revisions share one — and Committed/Actual already key on the code.
+		agg = {}  # code -> {name, planned, heads{cost_head: planned}}
+		for g in groups:
+			code = g.code or ""
+			if not code:
+				continue
+			bucket = agg.setdefault(code, {"name": g.group_name, "planned": 0.0, "heads": {}})
+			for it in items_by_group.get(g.name, []):
+				amt = flt(it.planned_amount)
+				bucket["planned"] += amt
+				if it.cost_head:
+					bucket["heads"][it.cost_head] = bucket["heads"].get(it.cost_head, 0) + amt
+
+		for code, b in agg.items():
+			planned = b["planned"]
+			cost_type = max(b["heads"], key=b["heads"].get) if b["heads"] else "Unclassified"
+			committed_amt = flt(committed.get(code, 0))
+			actual_amt = flt((actual_by_group.get(code) or {}).get("actual", 0))
+			variance = actual_amt - planned
+			rows.append(
+				{
+					"key": code,
+					"code": code,
+					"name": b["name"],
+					"costType": cost_type,
+					"planned": planned,
+					"committed": committed_amt,
+					"actual": actual_amt,
+					"variance": variance,
+					"variancePct": (variance / planned * 100) if planned else 0,
+				}
+			)
+
+	rows.sort(key=lambda r: r["code"])
+	return {"project": project, "boq": boqs[0] if boqs else None, "rows": rows}

--- a/buildsuite_core/tests/test_cost_report.py
+++ b/buildsuite_core/tests/test_cost_report.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+"""Cost vs Budget by Cost Code — Planned aggregation per cost code, dominant-cost-type grouping,
+variance, and the Approved-BOQ gate. Committed/Actual are covered by the subcontract + boq_actuals
+suites; here they are 0 (no work orders / bills), so variance = −planned."""
+
+import frappe
+
+from buildsuite_core.api import boq as boq_api
+from buildsuite_core.api.cost_report import cost_vs_budget_by_cost_code
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestCostVsBudget(BuildSuiteTestCase):
+	def _boq(self, project):
+		return frappe.get_doc(
+			{"doctype": "BOQ", "project": project, "title": "UAT BOQ", "margin_rate": 0, "tax_rate": 0}
+		).insert(ignore_permissions=True)
+
+	def _group(self, boq, code="A", name="Civil"):
+		return frappe.get_doc(
+			{"doctype": "BOQ Group", "boq": boq, "code": code, "group_name": name}
+		).insert(ignore_permissions=True)
+
+	def _item(self, boq, group, qty, rate, code=None, cost_head=None):
+		return frappe.get_doc(
+			{
+				"doctype": "BOQ Item",
+				"boq": boq,
+				"boq_group": group,
+				"code": code or f"A.{frappe.generate_hash(length=3)}",
+				"description": "x",
+				"unit": "Nos",
+				"planned_qty": qty,
+				"rate": rate,
+				"cost_head": cost_head,
+			}
+		).insert(ignore_permissions=True)
+
+	def test_no_project_returns_empty(self):
+		res = cost_vs_budget_by_cost_code("")
+		self.assertIsNone(res["boq"])
+		self.assertEqual(res["rows"], [])
+
+	def test_draft_boq_is_not_measured(self):
+		# Only Approved BOQs count — a Draft revision must never be costed against.
+		p = self._make_project(company=self.company)
+		b = self._boq(p.name)  # left Draft
+		self._item(b.name, self._group(b.name).name, qty=10, rate=100, cost_head="Labour")
+		res = cost_vs_budget_by_cost_code(p.name)
+		self.assertIsNone(res["boq"])
+		self.assertEqual(res["rows"], [])
+
+	def test_planned_dominant_cost_type_and_variance(self):
+		p = self._make_project(company=self.company)
+		b = self._boq(p.name)
+		g = self._group(b.name, code="A", name="Civil")
+		# Labour (1000) dominates Material (200) → the group's cost type is Labour.
+		labour = self._item(b.name, g.name, qty=10, rate=100, cost_head="Labour")
+		material = self._item(b.name, g.name, qty=2, rate=100, cost_head="Material")
+		boq_api.approve_boq(b.name)
+
+		expected_planned = frappe.db.get_value(
+			"BOQ Item", labour.name, "planned_amount"
+		) + frappe.db.get_value("BOQ Item", material.name, "planned_amount")
+
+		res = cost_vs_budget_by_cost_code(p.name)
+		self.assertEqual(res["boq"], b.name)
+		self.assertEqual(len(res["rows"]), 1)
+
+		row = res["rows"][0]
+		self.assertEqual(row["code"], "A")
+		self.assertEqual(row["name"], "Civil")
+		self.assertEqual(row["costType"], "Labour")
+		self.assertEqual(row["planned"], expected_planned)
+		self.assertEqual(row["committed"], 0)
+		self.assertEqual(row["actual"], 0)
+		# No commitments/actuals yet, so the whole budget is unspent: variance = actual − planned.
+		self.assertEqual(row["variance"], -expected_planned)
+		self.assertAlmostEqual(row["variancePct"], -100.0)
+
+	def test_unclassified_when_no_cost_head(self):
+		p = self._make_project(company=self.company)
+		b = self._boq(p.name)
+		g = self._group(b.name, code="B", name="MEP")
+		self._item(b.name, g.name, qty=5, rate=50)  # no cost_head
+		boq_api.approve_boq(b.name)
+
+		res = cost_vs_budget_by_cost_code(p.name)
+		self.assertEqual(len(res["rows"]), 1)
+		self.assertEqual(res["rows"][0]["costType"], "Unclassified")

--- a/frontend/src/data/costReportApi.js
+++ b/frontend/src/data/costReportApi.js
@@ -1,0 +1,16 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Cost vs Budget by Cost Code — planned / committed / actual / variance per BOQ cost code for a
+// project, grouped by cost type. Backed by buildsuite_core.api.cost_report. Returns flat rows;
+// the view groups + filters client-side.
+export async function getCostVsBudget(project) {
+	try {
+		return await frappeRequest({
+			url: "buildsuite_core.api.cost_report.cost_vs_budget_by_cost_code",
+			params: { project: project || "" },
+		});
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Failed to load Cost vs Budget.");
+	}
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -315,6 +315,13 @@ const routes = [
 				component: () => import("@/views/DelayAnalysisReportView.vue"),
 			},
 			{
+				// Bespoke project cost-control report — Planned/Committed/Actual/Variance per BOQ
+				// cost code. Launched from the project overview with ?project=<id>.
+				path: "reports/cost-vs-budget",
+				name: "report-cost-vs-budget",
+				component: () => import("@/views/CostVsBudgetReportView.vue"),
+			},
+			{
 				path: "reports/:slug",
 				name: "report-stub",
 				component: () => import("@/views/workspaces/ReportStubView.vue"),

--- a/frontend/src/views/CostVsBudgetReportView.vue
+++ b/frontend/src/views/CostVsBudgetReportView.vue
@@ -1,0 +1,287 @@
+<script setup>
+// Cost vs Budget by Cost Code — the project cost-control report, launched from the project
+// overview (?project=). Per BOQ cost code, grouped by cost type: Planned (Approved BOQ),
+// Committed (submitted subcontractor work orders) and Actual (recognised spend across every
+// rail), with Variance = Actual − Planned. The server computes the full set
+// (buildsuite_core.api.cost_report); the filters here narrow it client-side (variance
+// threshold, cost type, search) with a live "N of M" count.
+import { computed, reactive, ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { getCostVsBudget } from "@/data/costReportApi";
+import { showToast } from "@/utils/appToast";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import ReportFilters from "@/components/reports/ReportFilters.vue";
+import { fmtINR, fmtCompactINR } from "@/utils/format";
+
+const route = useRoute();
+const router = useRouter();
+
+const projectId = ref(route.query.project || "");
+const loading = ref(false);
+const rows = ref([]); // flat rows from the server
+const boq = ref(null); // the Approved BOQ name, or null when there is none
+
+// --- filters (client-side, over the loaded set) ---
+const BLANK = { q: "", costType: "" };
+const f = reactive({ ...BLANK });
+const varianceThreshold = ref("0"); // % — doubles as the overrun filter
+function clearFilters() {
+	Object.assign(f, BLANK);
+	varianceThreshold.value = "0";
+}
+const anyFilter = computed(
+	() => f.q !== "" || f.costType !== "" || varianceThreshold.value !== "0"
+);
+const hit = (hay, needle) =>
+	!needle ||
+	String(hay || "")
+		.toLowerCase()
+		.includes(needle.trim().toLowerCase());
+
+// Cost types present on this project, so the picker never offers an empty one.
+const costTypeOptions = computed(() =>
+	[...new Set(rows.value.map((r) => r.costType))].sort().map((v) => ({ value: v, label: v }))
+);
+
+// Threshold-filtered, grouped by cost type. Kept separate from the search/type filter below so
+// the bar can report "N of M" and the Total line stay honest about the threshold set.
+const grouped = computed(() => {
+	const t = Number(varianceThreshold.value) || 0;
+	const kept = t > 0 ? rows.value.filter((r) => r.variancePct >= t) : rows.value;
+	const byType = {};
+	for (const r of kept) (byType[r.costType] ||= []).push(r);
+	return Object.entries(byType)
+		.sort((a, b) => a[0].localeCompare(b[0]))
+		.map(([type, list]) => ({
+			type,
+			rows: list,
+			planned: list.reduce((a, r) => a + r.planned, 0),
+			committed: list.reduce((a, r) => a + r.committed, 0),
+			actual: list.reduce((a, r) => a + r.actual, 0),
+		}));
+});
+// What actually renders — the threshold set narrowed by cost type + search.
+const costGroups = computed(() => {
+	if (!f.costType && !f.q) return grouped.value;
+	return grouped.value
+		.filter((g) => !f.costType || g.type === f.costType)
+		.map((g) => ({ ...g, rows: g.rows.filter((r) => hit(r.code, f.q) || hit(r.name, f.q)) }))
+		.filter((g) => g.rows.length);
+});
+const shownCount = computed(() => costGroups.value.reduce((a, g) => a + g.rows.length, 0));
+// Total reflects the threshold set (not the search) — the same convention as the prototype.
+const totals = computed(() =>
+	grouped.value.reduce(
+		(a, g) => ({
+			planned: a.planned + g.planned,
+			committed: a.committed + g.committed,
+			actual: a.actual + g.actual,
+		}),
+		{ planned: 0, committed: 0, actual: 0 }
+	)
+);
+
+// Over budget (actual > planned) reads red; under reads green.
+function tone(v) {
+	return v > 0 ? "text-danger-700" : v < 0 ? "text-success-700" : "text-ink-500";
+}
+
+async function load(pid) {
+	if (!pid) {
+		rows.value = [];
+		boq.value = null;
+		return;
+	}
+	loading.value = true;
+	try {
+		const res = (await getCostVsBudget(pid)) || {};
+		rows.value = res.rows || [];
+		boq.value = res.boq || null;
+	} catch (err) {
+		showToast(err.message || "Failed to load Cost vs Budget", "error");
+		rows.value = [];
+		boq.value = null;
+	} finally {
+		loading.value = false;
+	}
+}
+watch(projectId, (id) => {
+	clearFilters(); // a filter from the previous project shouldn't leak onto the next
+	router.replace({ path: route.path, query: { ...route.query, project: id || undefined } });
+	load(id);
+});
+load(projectId.value);
+
+function printReport() {
+	window.print();
+}
+
+const breadcrumbs = [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: "Cost vs Budget by Cost Code" },
+];
+</script>
+
+<template>
+	<DeskPage title="Cost vs Budget by Cost Code" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
+				style="border-radius: 6px"
+				@click="printReport"
+			>
+				Print
+			</button>
+		</template>
+
+		<p class="text-xs text-ink-500 mb-3">
+			Planned, committed, actual and variance per cost code, grouped by cost type.
+		</p>
+
+		<!-- Scope + filters -->
+		<ReportFilters
+			:active="anyFilter"
+			:shown="shownCount"
+			:total="rows.length"
+			noun="cost codes"
+			@clear="clearFilters"
+		>
+			<label class="flex items-center gap-1.5">
+				<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+					>Project</span
+				>
+				<span class="w-56 inline-block">
+					<DeskLinkPicker
+						v-model="projectId"
+						doctype="Project"
+						label-field="project_name"
+						value-field="name"
+						:search-fields="['project_name', 'name']"
+						placeholder="Pick a project…"
+					/>
+				</span>
+			</label>
+
+			<template v-if="projectId">
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Find</span
+					>
+					<DeskInput v-model="f.q" placeholder="Code or description…" class="!w-52" />
+				</label>
+
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Cost type</span
+					>
+					<span class="w-44 inline-block">
+						<DeskSearchableSelect
+							v-model="f.costType"
+							:options="costTypeOptions"
+							allow-clear
+							placeholder="All types"
+							search-placeholder="Search…"
+						/>
+					</span>
+				</label>
+
+				<label class="flex items-center gap-1.5">
+					<span class="text-[11px] uppercase tracking-wider text-ink-500 font-medium"
+						>Variance over</span
+					>
+					<DeskSelect v-model="varianceThreshold" class="!w-24">
+						<option value="0">All</option>
+						<option value="5">5%</option>
+						<option value="10">10%</option>
+						<option value="20">20%</option>
+					</DeskSelect>
+				</label>
+			</template>
+		</ReportFilters>
+
+		<div v-if="!projectId" class="text-sm text-ink-500 italic py-10 text-center">
+			Pick a project to run this report.
+		</div>
+
+		<template v-else>
+			<div v-if="!costGroups.length" class="text-sm text-ink-500 italic py-10 text-center">
+				<template v-if="!boq"
+					>No approved BOQ on this project — there is nothing to measure cost against
+					yet.</template
+				>
+				<template v-else>No cost codes exceed the selected variance threshold.</template>
+			</div>
+			<div v-else class="space-y-4">
+				<div
+					v-for="g in costGroups"
+					:key="g.type"
+					class="bg-white border border-ink-200 rounded-lg overflow-hidden"
+				>
+					<div
+						class="px-3 py-2 bg-ink-50 border-b border-ink-200 flex items-center justify-between"
+					>
+						<span class="text-[11px] font-semibold uppercase tracking-wider text-ink-700">{{
+							g.type
+						}}</span>
+						<span class="text-[11px] text-ink-500 tabular-nums"
+							>{{ fmtCompactINR(g.actual) }} of {{ fmtCompactINR(g.planned) }}</span
+						>
+					</div>
+					<div class="overflow-x-auto">
+						<table class="w-full text-xs">
+							<thead class="text-ink-500 uppercase tracking-wider text-[10px]">
+								<tr>
+									<th class="text-left px-3 py-2">Cost code</th>
+									<th class="text-right px-3 py-2">Planned</th>
+									<th class="text-right px-3 py-2">Committed</th>
+									<th class="text-right px-3 py-2">Actual</th>
+									<th class="text-right px-3 py-2">Variance</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr v-for="r in g.rows" :key="r.key" class="border-t border-ink-100">
+									<td class="px-3 py-2 text-ink-900">
+										<span class="font-mono text-[11px] text-ink-500 mr-1.5">{{
+											r.code
+										}}</span
+										>{{ r.name }}
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-700">
+										{{ fmtINR(r.planned) }}
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-info-700">
+										{{ r.committed ? fmtINR(r.committed) : "—" }}
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums text-ink-900">
+										{{ fmtINR(r.actual) }}
+									</td>
+									<td class="px-3 py-2 text-right tabular-nums" :class="tone(r.variance)">
+										{{ r.variance > 0 ? "+" : "" }}{{ fmtINR(r.variance) }}
+										<span class="text-[10px] ml-1"
+											>({{ r.variancePct > 0 ? "+" : ""
+											}}{{ r.variancePct.toFixed(0) }}%)</span
+										>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+				<div
+					class="bg-ink-50 border border-ink-200 rounded-lg px-3 py-2 flex items-center justify-between text-xs"
+				>
+					<span class="font-medium text-ink-900">Total</span>
+					<span class="tabular-nums text-ink-700">
+						Planned {{ fmtINR(totals.planned) }} · Committed
+						{{ fmtINR(totals.committed) }} · Actual {{ fmtINR(totals.actual) }}
+					</span>
+				</div>
+			</div>
+		</template>
+	</DeskPage>
+</template>

--- a/frontend/src/views/project-detail/projectDetailConfig.js
+++ b/frontend/src/views/project-detail/projectDetailConfig.js
@@ -62,9 +62,9 @@ export const TEAM_COLS = [
 // carrying `?project=<id>` — OverviewTab.reportLink() injects the project from the current
 // record. `to` is a project-independent route location; the project query is added there.
 // The report pages consume it: the Frappe report renderer (report-view) seeds filter values
-// from the URL query, Delay Analysis reads route.query.project, and the finance P&L is
-// project-scoped. cost-vs-budget has no report yet, so it falls through to the /reports/<slug>
-// stub (still project-carrying).
+// from the URL query, while Delay Analysis and Cost vs Budget read route.query.project and the
+// finance P&L is project-scoped. A tile with neither `to` nor `routeName` falls through to the
+// /reports/<slug> stub (still project-carrying).
 export const PROJECT_REPORTS = [
 	{
 		slug: "progress-report",
@@ -85,6 +85,7 @@ export const PROJECT_REPORTS = [
 		slug: "cost-vs-budget",
 		icon: "chart-bar",
 		label: "Cost vs budget by cost code",
+		to: { name: "report-cost-vs-budget" },
 		desc: "Planned, committed, actual and variance per cost code, grouped by cost type.",
 	},
 	{


### PR DESCRIPTION
Wires the project overview's **Cost vs budget by cost code** tile — previously a stub with no route — to a real, live report that mirrors the prototype: Planned / Committed / Actual / Variance per BOQ cost code, grouped by cost type.

## Backend — `api/cost_report.py`
Whitelisted `cost_vs_budget_by_cost_code(project)` composing the app's existing aggregation primitives:
- **Planned** = Σ `BOQ Item.planned_amount` over the project's **Approved** BOQ(s), by group code.
- **Committed** = `subcontract.committed_by_cost_code` (submitted Subcontractor Work Order lines).
- **Actual** = `boq_actuals.get_actuals_summary` (recognised spend across every rail — material issues, subcontractor bills, overheads; cost is recognised at consumption, so no PO double-count).
- **Variance** = Actual − Planned. A code's **cost type** = its group's dominant `BOQ Item.cost_head`, so rows group by the same vocabulary Planned is expressed in (sidesteps the Planned/Actual cost-head vocabulary mismatch). Only Approved BOQs are measured; returns flat rows for client-side grouping.

## Frontend
- **`CostVsBudgetReportView.vue`** — grouped-by-cost-type tables with a Total line; project picker + variance-threshold / cost-type / search filters, all client-side (mirrors the Delay Analysis pattern). Over-budget variance reads red.
- **`costReportApi.js`** data helper → `frappeRequest`.
- **`reports/cost-vs-budget`** route; the project tile now sets `to` at it (`reportLink()` injects `?project=`).

## Verification
- Backend `test_cost_report.py` — 4 tests green: planned aggregation, dominant-cost-type grouping, variance, the Approved-BOQ gate, and the Unclassified fallback.
- `yarn build` clean.
- Live check (director, PROJ-0260): tile links to `/core/reports/cost-vs-budget?project=…`; report renders the cost-code row with correct Planned/Actual/Variance and Total line.

Note: this branch is off `develop`, whose `DeskPage` predates the `printable` prop (PR #211). The view uses the current `window.print()` button convention; it can adopt `printable` once #211 lands.