### PR TITLE
fix: gate Subcontractor Bill lifecycle buttons by capability (+ the e2e that catches it)

### DIFF
--- a/buildsuite_core/api/cypress_setup.py
+++ b/buildsuite_core/api/cypress_setup.py
@@ -138,3 +138,59 @@ def ensure_cypress_bills():
 		"draft": frappe.db.get_value("Subcontractor Bill", {"docstatus": 0}, "name"),
 		"submitted": frappe.db.get_value("Subcontractor Bill", {"docstatus": 1}, "name"),
 	}
+
+
+@frappe.whitelist()
+def ensure_cypress_records():
+	"""Return existing record names (reusing demo data) for the comprehensive detail-page
+	action-gating e2e (detail_action_gating.cy.js). One key per entity, matching the manifest
+	in that spec. A submittable doctype returns a `draft` (docstatus 0) + `submitted`
+	(docstatus 1) slot; a master returns a single `one` slot. Any slot with no record comes
+	back None so the spec skips it rather than fail. Read-only; dev/test only.
+
+	Shape, e.g.:
+	    {"purchaseOrder": {"draft": "...", "submitted": "..."},
+	     "machinery": {"one": "..."}, ...}
+	"""
+	if not (frappe.conf.developer_mode or frappe.flags.in_test):
+		frappe.throw(frappe._("ensure_cypress_records is only available in developer / test mode"))
+
+	def one(doctype, filters=None):
+		return frappe.db.get_value(doctype, filters or {}, "name")
+
+	def draft_submitted(doctype, base=None):
+		base = dict(base or {})
+		return {
+			"draft": one(doctype, {**base, "docstatus": 0}),
+			"submitted": one(doctype, {**base, "docstatus": 1}),
+		}
+
+	return {
+		# Subcontract
+		"subcontractorWorkOrder": draft_submitted("Subcontractor Work Order"),
+		# A Draft measurement book so its Edit/Certify buttons render (Certify hides once
+		# certified); None → the spec skips rather than open a certified book with no Edit.
+		"measurementBook": {"one": one("Measurement Book", {"status": "Draft"})},
+		"subcontractor": {"one": one("Supplier", {"supplier_group": "Subcontractor"})},
+		# Procurement
+		"materialRequest": draft_submitted("Material Request"),
+		"purchaseOrder": draft_submitted("Purchase Order"),
+		"purchaseReceipt": draft_submitted("Purchase Receipt"),
+		# Material Consumption is a Stock Entry of type "Material Issue".
+		"materialConsumption": draft_submitted("Stock Entry", {"stock_entry_type": "Material Issue"}),
+		# Equipment
+		"machinery": {"one": one("Machinery")},
+		"machineryUsage": {"one": one("Machinery Usage")},
+		# Estimation
+		"boq": {"one": one("BOQ")},
+		"assembly": {"one": one("Assembly")},
+		"estimateTemplate": {"one": one("Estimate Template")},
+		"rateMaster": {"one": one("Construction Rate Master")},
+		# Workforce
+		"fieldEmployee": {"one": one("Employee", {"is_labour": 1})},
+		"crew": {"one": one("Crew")},
+		"fieldAttendance": draft_submitted("Field Attendance"),
+		# Project Finance
+		"salesInvoice": draft_submitted("Sales Invoice"),
+		"supplierBill": draft_submitted("Purchase Invoice"),
+	}

--- a/buildsuite_core/api/cypress_setup.py
+++ b/buildsuite_core/api/cypress_setup.py
@@ -123,3 +123,18 @@ def ensure_cypress_work_order():
 	except Exception:
 		frappe.db.rollback()
 		return None
+
+
+@frappe.whitelist()
+def ensure_cypress_bills():
+	"""Return one draft + one submitted Subcontractor Bill name, for the detail-page action-gating
+	e2e (Edit/Submit/Delete on a draft, Cancel on a submitted one). Reuses existing bills — the demo
+	carries many — and returns None for a slot that has no record so the spec skips that half rather
+	than fail. Read-only; dev/test only."""
+	if not (frappe.conf.developer_mode or frappe.flags.in_test):
+		frappe.throw(frappe._("ensure_cypress_bills is only available in developer / test mode"))
+
+	return {
+		"draft": frappe.db.get_value("Subcontractor Bill", {"docstatus": 0}, "name"),
+		"submitted": frappe.db.get_value("Subcontractor Bill", {"docstatus": 1}, "name"),
+	}

--- a/frontend/cypress/e2e/detail_action_gating.cy.js
+++ b/frontend/cypress/e2e/detail_action_gating.cy.js
@@ -1,0 +1,289 @@
+// Comprehensive companion to submittable_action_gating.cy.js.
+//
+// Every entity's DETAIL page renders its action buttons (Edit / Submit / Cancel / Delete, plus
+// cross-entity "+ Create X" buttons) behind a persona CAPABILITY — not just the document's
+// docstatus. The bug this guards against: a read-only persona opens a record and sees Edit /
+// Submit / Delete that the backend then 403s, because the view gated them on the record's state
+// alone. Each detail view (now fixed) imports usePermissions() and ANDs a cap into every button's
+// v-if; this spec asserts, per persona, that each button appears iff that cap is true.
+//
+// This is the surface the other specs miss: module_entity_crud covers the LIST "+ New" (create)
+// affordance and cross_entity_create_buttons covers cross-entity CREATE buttons from a fixed
+// record — neither opens EVERY entity's detail to check its own edit/submit/delete/cancel
+// buttons. submittable_action_gating.cy.js stays as the dedicated Subcontractor Bill lifecycle
+// spec; this file is the broad, data-driven sweep over the rest.
+//
+// Data-driven from PERSONA_CAPS (the same table usePermissions() reads) + a MANIFEST describing
+// each entity's detail route, fixture slot, and buttons — so it stays correct as the caps change.
+// Fixture record names come from ensure_cypress_records (reuses demo data); a null slot skips.
+//
+// Modelling notes / known caveats:
+//   * Buttons are matched with `cy.contains("button", text)` inside [data-test="page-actions"]
+//     (the DeskPage #actions slot). Buttons rendered ELSEWHERE are intentionally NOT modelled:
+//       - BOQ's actions live in a DeskActionBar menu (inside DeskForm), not page-actions — so BOQ
+//         carries no buttons here and only gets a readability check.
+//       - RateMaster's Edit/Delete live in the record drawer; only its page-actions "+ New rate"
+//         (canCreate) is modelled.
+//       - Machinery's "+ Log usage" is a RouterLink (<a>), not a <button>, so it is omitted.
+//   * A cross-entity "+ Create X" button gates on the TARGET entity's create cap — modelled as
+//     { capEntity: '<target>', cap: 'c' }. Its `when` opens the record in the state that also
+//     satisfies the button's non-cap condition (e.g. a submitted PO not yet fully received, a
+//     submitted invoice with outstanding > 0). A freshly-submitted demo record satisfies these;
+//     if demo data is fully received/paid the positive assertion may under-fire — negatives
+//     (a non-capable persona never sees the button) are always exact.
+//   * Assumes the plain docstatus lifecycle (no active Frappe Workflow on Stock Entry / Field
+//     Attendance / Sales Invoice / Purchase Invoice) — the app's default. An active workflow
+//     replaces Submit/Cancel with its transitions and these assertions would need revisiting.
+//
+// Requires the persona test users + demo records:
+//   bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
+
+import { PERSONA_CAPS } from "../../src/data/roles";
+
+// Per entity: `base` (detail route is `${base}/${name}`), the fixture key (defaults to `entity`),
+// and the page-actions buttons. Each button: { text, cap: 'e'|'d'|'x'|'c', when, capEntity? }.
+//   cap  — the PERSONA_CAPS key the button's v-if ANDs in: e(dit)/d(elete)/x(submit·cancel)/c(reate)
+//   when — 'draft' | 'submitted' (which fixture slot renders the button) | 'any' (master; uses 'one')
+//   capEntity — for cross-entity create buttons, the TARGET entity the cap lives under (else = entity)
+const MANIFEST = [
+	// ---- Subcontract ----
+	{
+		entity: "subcontractorWorkOrder",
+		base: "/subcontractor-work-orders",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			// cross-entity: raise a Measurement Book / Subcontractor Bill from a submitted WO
+			{ text: "+ Record measurement", capEntity: "measurementBook", cap: "c", when: "submitted" },
+			{ text: "+ Bill progress", capEntity: "subcontractorBill", cap: "c", when: "submitted" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	{
+		entity: "measurementBook",
+		base: "/measurement-books",
+		// Non-submittable (status field). Fixture is a Draft book, so Edit + Certify render;
+		// Delete has no status gate. Revert / "+ Create bill" need a certified book — out of scope.
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Certify", cap: "x", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	{
+		entity: "subcontractor",
+		base: "/subcontractors",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	// ---- Procurement ----
+	{
+		entity: "materialRequest",
+		base: "/procurement/material-requests",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "+ Create Purchase Order", capEntity: "purchaseOrder", cap: "c", when: "submitted" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	{
+		entity: "purchaseOrder",
+		base: "/procurement/purchase-orders",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "+ Create Receipt", capEntity: "purchaseReceipt", cap: "c", when: "submitted" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	{
+		entity: "purchaseReceipt",
+		base: "/procurement/receipts",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	{
+		entity: "materialConsumption",
+		base: "/material-consumption",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	// ---- Equipment ----
+	{
+		entity: "machinery",
+		base: "/machinery",
+		// "+ Log usage" is a RouterLink, not a <button> — omitted (see header caveats).
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	{
+		entity: "machineryUsage",
+		base: "/machinery-usage",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	// ---- Estimation ----
+	{
+		entity: "boq",
+		base: "/boq",
+		// Actions live in the DeskActionBar menu, not page-actions — readability check only.
+		buttons: [],
+	},
+	{
+		entity: "assembly",
+		base: "/assembly",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	{
+		entity: "estimateTemplate",
+		base: "/estimate-template",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	{
+		entity: "rateMaster",
+		base: "/rate-master",
+		// Edit/Delete live in the record drawer; only the page-actions create button is here.
+		buttons: [{ text: "+ New rate", cap: "c", when: "any" }],
+	},
+	// ---- Workforce ----
+	{
+		entity: "fieldEmployee",
+		base: "/field-employees",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	{
+		entity: "crew",
+		base: "/crews",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "any" },
+			{ text: "Delete", cap: "d", when: "any" },
+		],
+	},
+	{
+		entity: "fieldAttendance",
+		base: "/field-attendance",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	// ---- Project Finance ----
+	{
+		entity: "salesInvoice",
+		base: "/project-finance/invoices",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			// "Receive payment" posts a Payment Entry (advance) — gates on advance create.
+			{ text: "Receive payment", capEntity: "advance", cap: "c", when: "submitted" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+	{
+		entity: "supplierBill",
+		base: "/project-finance/supplier-bills",
+		buttons: [
+			{ text: "Edit", cap: "e", when: "draft" },
+			{ text: "Delete", cap: "d", when: "draft" },
+			{ text: "Submit", cap: "x", when: "draft" },
+			// "Pay" posts a Payment Entry (advance) — gates on advance create.
+			{ text: "Pay", capEntity: "advance", cap: "c", when: "submitted" },
+			{ text: "Cancel", cap: "x", when: "submitted" },
+		],
+	},
+];
+
+const ALL_PERSONAS = Object.keys(PERSONA_CAPS);
+
+// Caps are plain booleans (module entities carry no own-scope), so `=== true` mirrors usePermissions.
+const has = (persona, entity, key) => PERSONA_CAPS[persona]?.[entity]?.[key] === true;
+const canRead = (persona, entity) => PERSONA_CAPS[persona]?.[entity]?.r === true;
+
+// which fixture slot renders a button of this `when`.
+const slotOf = (when) => (when === "draft" ? "draft" : when === "submitted" ? "submitted" : "one");
+// pick the id for a slot, tolerating a master's single "one" slot for readability checks.
+const idForSlot = (rec, slot) =>
+	slot === "__any__" ? rec.one || rec.draft || rec.submitted : rec[slot];
+
+MANIFEST.forEach((row) => {
+	const fixtureKey = row.fixture || row.entity;
+	// Personas that can READ the record (so its detail renders). Non-readers land on the
+	// forbidden route and are covered by the CRUD specs.
+	const readers = ALL_PERSONAS.filter((p) => canRead(p, row.entity));
+	// Distinct fixture slots this entity exercises; entities with no buttons still get one
+	// readability pass so a reader is proven able to open the detail at all.
+	const slots = [...new Set(row.buttons.map((b) => slotOf(b.when)))];
+	const slotList = slots.length ? slots : ["__any__"];
+
+	describe(`${row.entity} detail — action buttons follow the persona's capability`, () => {
+		let records;
+
+		before(() => {
+			cy.loginAs("admin");
+			cy.request(
+				"/api/method/buildsuite_core.api.cypress_setup.ensure_cypress_records"
+			).then((res) => {
+				records = res.body.message;
+			});
+		});
+
+		readers.forEach((persona) => {
+			slotList.forEach((slot) => {
+				const buttons = row.buttons.filter((b) => slotOf(b.when) === slot);
+				const label = slot === "__any__" ? "detail opens" : `${slot} buttons`;
+
+				it(`${persona}: ${row.entity} — ${label} match the caps`, function () {
+					const rec = records[fixtureKey] || {};
+					const id = idForSlot(rec, slot);
+					if (!id) this.skip(); // no fixture for this slot on this site
+
+					cy.loginAs(persona);
+					cy.visitApp(`${row.base}/${id}`);
+					cy.dt("page-title").should("be.visible"); // the record is readable
+
+					buttons.forEach((b) => {
+						const capEntity = b.capEntity || row.entity;
+						cy.dt("page-actions").within(() => {
+							if (has(persona, capEntity, b.cap)) {
+								cy.contains("button", b.text).should("exist");
+							} else {
+								// The lapse: a persona without the right must NOT see the button.
+								cy.contains("button", b.text).should("not.exist");
+							}
+						});
+					});
+				});
+			});
+		});
+	});
+});

--- a/frontend/cypress/e2e/submittable_action_gating.cy.js
+++ b/frontend/cypress/e2e/submittable_action_gating.cy.js
@@ -1,0 +1,91 @@
+// A detail page's own lifecycle buttons (Edit / Submit / Delete / Cancel) must be gated on the
+// persona's CAPABILITY, not just the document's docstatus. The bug this guards against: a
+// read-only Director opens a draft Subcontractor Bill and sees Edit/Submit/Delete — all of which
+// the backend then 403s — because the view gated them on `isDraft` alone. It also covers the
+// subtler case: PM + Procurement may RAISE and edit a bill (create + write) but NOT delete or
+// submit it (backend _CRW vs the QS/Accountant _FULL_SUB), so they see Edit but not Submit/Delete.
+//
+// Data-driven from PERSONA_CAPS (the same table usePermissions() reads), so it stays correct as the
+// caps change. This is the surface the existing specs miss: module_entity_crud covers the LIST
+// "+ New" (create) affordance, and cross_entity_create_buttons covers cross-entity CREATE buttons —
+// neither opens a record to check its own edit/submit/delete/cancel buttons.
+//
+// Requires the persona test users + at least one draft and one submitted Subcontractor Bill:
+//   bench --site <site> execute buildsuite_core.api.cypress_setup.ensure_cypress_users
+// (the spec fetches the bill names via ensure_cypress_bills; a missing slot skips that half.)
+//
+// NOTE: assumes the plain docstatus lifecycle (no active workflow on the bill) — the app's default.
+
+import { PERSONA_CAPS } from "../../src/data/roles";
+
+const ENTITY = "subcontractorBill";
+
+// Personas that can READ a Subcontractor Bill (so the detail renders). Non-readers (estimator,
+// foreman, store-keeper, hr-manager) can't reach it and are covered by the CRUD specs.
+const BILL_READERS = [
+	"director",
+	"pm",
+	"qs",
+	"site-engineer",
+	"procurement",
+	"accountant",
+	"admin",
+	"bsa",
+];
+
+// Lifecycle buttons on the bill detail → the PERSONA_CAPS key each must be gated on.
+const DRAFT_BUTTONS = [
+	{ text: "Edit", cap: "e" }, // canEdit
+	{ text: "Submit", cap: "x" }, // canSubmit
+	{ text: "Delete", cap: "d" }, // canDelete
+];
+const SUBMITTED_BUTTONS = [
+	{ text: "Cancel", cap: "x" }, // canSubmit (cancel is part of the submit right)
+];
+
+// subcontractorBill caps are plain booleans (no own-scope), so `=== true` mirrors usePermissions.
+const capable = (persona, key) => PERSONA_CAPS[persona]?.[ENTITY]?.[key] === true;
+
+function assertButtons(persona, buttons) {
+	buttons.forEach(({ text, cap }) => {
+		cy.dt("page-actions").within(() => {
+			if (capable(persona, cap)) {
+				cy.contains("button", text).should("exist");
+			} else {
+				// The lapse: a persona without the right must NOT see the button.
+				cy.contains("button", text).should("not.exist");
+			}
+		});
+	});
+}
+
+describe("Subcontractor Bill detail — lifecycle buttons follow the persona's capability", () => {
+	let draft;
+	let submitted;
+
+	before(() => {
+		cy.loginAs("admin");
+		cy.request("/api/method/buildsuite_core.api.cypress_setup.ensure_cypress_bills").then((res) => {
+			draft = res.body.message.draft;
+			submitted = res.body.message.submitted;
+		});
+	});
+
+	BILL_READERS.forEach((persona) => {
+		it(`${persona}: draft bill shows Edit/Submit/Delete only where capable`, function () {
+			if (!draft) this.skip(); // no draft bill on this site
+			cy.loginAs(persona);
+			cy.visitApp(`/subcontractor-bills/${draft}`);
+			cy.dt("page-title").should("be.visible"); // the bill is readable
+			assertButtons(persona, DRAFT_BUTTONS);
+		});
+
+		it(`${persona}: submitted bill shows Cancel only if it can submit/cancel`, function () {
+			if (!submitted) this.skip();
+			cy.loginAs(persona);
+			cy.visitApp(`/subcontractor-bills/${submitted}`);
+			cy.dt("page-title").should("be.visible");
+			assertButtons(persona, SUBMITTED_BUTTONS);
+		});
+	});
+});

--- a/frontend/src/components/ItemFormModal.vue
+++ b/frontend/src/components/ItemFormModal.vue
@@ -7,6 +7,7 @@ import { createDataAdapter } from "@/data/adapters";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useConfirm } from "@/composables/useConfirm";
 import { useFormErrors } from "@/composables/useFormErrors";
+import { usePermissions } from "@/composables/usePermissions";
 import { showToast } from "@/utils/appToast";
 import { fmtINR } from "@/utils/format";
 import DeskField from "@/components/desk/DeskField.vue";
@@ -23,6 +24,7 @@ const emit = defineEmits(["close", "saved"]);
 
 const adapter = createDataAdapter(useDataStore());
 const confirmDialog = useConfirm();
+const { canEdit, canDelete, canCreate } = usePermissions();
 const { errors, applyServerErrors, setErrors, clearError } = useFormErrors({
 	item_code: "item_code",
 	item_group: "item_group",
@@ -44,6 +46,7 @@ function blank() {
 const saving = ref(false);
 const form = ref(blank());
 const editing = computed(() => !!props.item?.name);
+const canSaveForm = computed(() => (editing.value ? canEdit("item") : canCreate("item")));
 
 // Same options block and cache key as the estimation views — frappe-ui dedupes
 // on the key, so this adds no request.
@@ -290,7 +293,7 @@ async function onDelete() {
 					class="px-5 py-3 border-t border-ink-200 flex items-center justify-between gap-2"
 				>
 					<button
-						v-if="editing"
+						v-if="editing && canDelete('item')"
 						type="button"
 						class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 						style="border-radius: 6px"
@@ -312,7 +315,7 @@ async function onDelete() {
 						<button
 							type="button"
 							class="desk-save-btn !text-xs"
-							:disabled="saving"
+							:disabled="saving || !canSaveForm"
 							@click="save"
 						>
 							{{ saving ? "Saving…" : editing ? "Save changes" : "Create item" }}

--- a/frontend/src/composables/usePermissions.js
+++ b/frontend/src/composables/usePermissions.js
@@ -55,6 +55,9 @@ export function usePermissions() {
 		// list-level affordances; prefer the record-aware variants on detail pages.
 		canEdit: (doctype) => cap(doctype, "e") !== false,
 		canDelete: (doctype) => cap(doctype, "d") !== false,
+		// Submit/cancel a submittable doctype (backend S/X). Distinct from create: a role may
+		// raise a draft but not submit it. Unconditional persona capability, like create.
+		canSubmit: (doctype) => cap(doctype, "x") === true,
 		// Precise (record in hand) — own-scope resolves against the creator.
 		canEditRecord,
 		canDeleteRecord,

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -661,7 +661,12 @@ const _MODULE_ACCESS = {
 	},
 	subcontractorBill: {
 		// Director is read-only; Estimator has no bill access (omitted). Accountant is full.
+		// PM + Procurement RAISE and prepare bills (create + write) but the QS + Accountant
+		// DELETE and SUBMIT them (backend _CRW vs _FULL_SUB) — so del + submit are narrower
+		// than create, and edit defaults to create (everyone who raises may also write).
 		create: ["procurement", "pm", "qs", "accountant", "admin", "bsa"],
+		del: ["qs", "accountant", "admin", "bsa"],
+		submit: ["qs", "accountant", "admin", "bsa"],
 		read: [
 			"procurement",
 			"pm",
@@ -807,7 +812,11 @@ const _MODULE_ACCESS = {
 // a record but not EDIT or DELETE it (Site Engineer raises a Measurement Book but the QS
 // edits/certifies it). read defaults to (create ∪ read).
 for (const [entity, access] of Object.entries(_MODULE_ACCESS)) {
-	const { create, read, edit = create, del = create } = access;
+	// submit defaults to del (both are the "full control" set on a submittable doctype);
+	// provide it explicitly when a role may CREATE/EDIT but not SUBMIT (e.g. PM prepares a
+	// bill, the QS submits it). Non-submittable entities never render a submit button, so
+	// the default is harmless there.
+	const { create, read, edit = create, del = create, submit = del } = access;
 	for (const persona of _ALL_PERSONAS) {
 		const c = create.includes(persona);
 		const r = c || read.includes(persona);
@@ -816,6 +825,7 @@ for (const [entity, access] of Object.entries(_MODULE_ACCESS)) {
 			r,
 			e: edit.includes(persona),
 			d: del.includes(persona),
+			x: submit.includes(persona),
 		};
 	}
 }

--- a/frontend/src/data/roles.js
+++ b/frontend/src/data/roles.js
@@ -562,7 +562,12 @@ const _ALL_PERSONAS = Object.keys(PERSONA_CAPS);
 const _MODULE_ACCESS = {
 	// Procurement
 	materialRequest: {
+		// Site Engineer + Foreman RAISE only (create+read, no write/delete/submit); PM authors +
+		// submits (_CRWS, no delete); Procurement is full (backend MATERIAL_REQUEST_ROLE_PERMS).
 		create: ["pm", "site-engineer", "foreman", "procurement", "admin", "bsa"],
+		edit: ["pm", "procurement", "admin", "bsa"],
+		del: ["procurement", "admin", "bsa"],
+		submit: ["pm", "procurement", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",
@@ -584,7 +589,11 @@ const _MODULE_ACCESS = {
 		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
 	},
 	materialConsumption: {
+		// Stock Entry (Material Issue). Site Engineer posts + submits (_CRWS, no delete);
+		// Procurement + Store Keeper are full (backend STOCK_ENTRY_ROLE_PERMS).
 		create: ["site-engineer", "procurement", "store-keeper", "admin", "bsa"],
+		del: ["procurement", "store-keeper", "admin", "bsa"],
+		submit: ["site-engineer", "procurement", "store-keeper", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",
@@ -755,8 +764,11 @@ const _MODULE_ACCESS = {
 		read: _ALL_PERSONAS.filter((p) => p !== "hr-manager"),
 	},
 	supplierBill: {
-		// Purchase Invoice (PURCHASE_INVOICE_ROLE_PERMS)
+		// Purchase Invoice (PURCHASE_INVOICE_ROLE_PERMS). Director + Accountant own invoicing
+		// (_FULL_SUB); PM raises + edits (_CRW) but the Accountant deletes/submits.
 		create: ["director", "pm", "accountant", "admin", "bsa"],
+		del: ["director", "accountant", "admin", "bsa"],
+		submit: ["director", "accountant", "admin", "bsa"],
 		read: ["director", "pm", "procurement", "store-keeper", "accountant", "admin", "bsa"],
 	},
 	salesInvoice: {
@@ -788,8 +800,13 @@ const _MODULE_ACCESS = {
 		],
 	},
 	expense: {
-		// Expense Entry (EXPENSE_ENTRY_ROLE_PERMS)
+		// Expense Entry (EXPENSE_ENTRY_ROLE_PERMS). Director/PM/Accountant own it (_FULL_SUB);
+		// Site Engineer + Foreman create+edit drafts (no delete/submit); Store Keeper/Procurement/
+		// QS/Estimator/HR RAISE only (create+read, no write/delete/submit). Finance submits.
 		create: ["director", "pm", "accountant", "site-engineer", "foreman", "store-keeper", "procurement", "qs", "estimator", "hr-manager", "admin", "bsa"],
+		edit: ["director", "pm", "accountant", "site-engineer", "foreman", "admin", "bsa"],
+		del: ["director", "pm", "accountant", "admin", "bsa"],
+		submit: ["director", "pm", "accountant", "admin", "bsa"],
 		read: [
 			"director",
 			"pm",

--- a/frontend/src/views/AssemblyDetailView.vue
+++ b/frontend/src/views/AssemblyDetailView.vue
@@ -5,6 +5,7 @@ import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { showToast } from "@/utils/appToast";
@@ -27,6 +28,7 @@ const { errors, applyServerErrors, setErrors } = useFormErrors({
 	uom: "uom",
 });
 const adapter = createDataAdapter(useDataStore());
+const { canEdit, canDelete } = usePermissions();
 
 const resource = adapter.read("Assembly", props.id, { fields: ["*"] });
 const doc = computed(() => resource?.doc || null);
@@ -229,6 +231,7 @@ async function removeComponent(index) {
 	>
 		<template #actions>
 			<button
+				v-if="canEdit('assembly')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -237,6 +240,7 @@ async function removeComponent(index) {
 				Edit
 			</button>
 			<button
+				v-if="canDelete('assembly')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -287,7 +291,7 @@ async function removeComponent(index) {
 					· linked to Rate Master · coefficient × rate
 				</div>
 				<button
-					v-if="!addingRow"
+					v-if="!addingRow && canEdit('assembly')"
 					type="button"
 					class="desk-save-btn"
 					:disabled="savingComponents"
@@ -347,6 +351,7 @@ async function removeComponent(index) {
 					</div>
 					<div class="px-2 py-1 text-right">
 						<button
+							v-if="canEdit('assembly')"
 							type="button"
 							class="text-ink-400 hover:text-danger-700 text-base leading-none"
 							title="Remove"
@@ -404,6 +409,7 @@ async function removeComponent(index) {
 					</div>
 					<div class="px-2 py-2 flex items-center gap-1 justify-end">
 						<button
+							v-if="canEdit('assembly')"
 							type="button"
 							class="desk-save-btn !px-2 !py-1 !text-[11px]"
 							:disabled="savingComponents"
@@ -528,6 +534,7 @@ async function removeComponent(index) {
 							Cancel
 						</button>
 						<button
+							v-if="canEdit('assembly')"
 							type="button"
 							class="desk-save-btn"
 							:disabled="saving"

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -12,6 +12,7 @@ import { useDataStore } from "@/stores";
 import { createDataAdapter } from "@/data/adapters";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { showToast } from "@/utils/appToast";
 import { parseFrappeError } from "@/utils/frappeError";
 import * as boqApi from "@/utils/boqApi";
@@ -34,6 +35,14 @@ const props = defineProps({ id: { type: String, required: true } });
 const router = useRouter();
 const adapter = createDataAdapter(useDataStore());
 const confirmDialog = useConfirm();
+// Gate BOQ mutations by the persona's capability, not just docstatus. `canSubmit` is
+// aliased to canSubmitCap to avoid colliding with the local draft-status computed below.
+const {
+	canEdit,
+	canDelete,
+	canCreate,
+	canSubmit: canSubmitCap,
+} = usePermissions();
 
 // === Data load: BOQ header + the three child levels ===
 const boqResource = adapter.read("BOQ", props.id, { fields: ["*"] });
@@ -1056,7 +1065,9 @@ async function deleteSubItemConfirm(si) {
 }
 
 // Primary action dispatcher — Submit when Draft, Approve when Submitted.
-const showPrimary = computed(() => canSubmit.value || canApprove.value);
+const showPrimary = computed(
+	() => (canSubmit.value || canApprove.value) && canSubmitCap("boq")
+);
 const primaryLabel = computed(() =>
 	canSubmit.value ? "Submit for approval" : canApprove.value ? "Approve" : ""
 );
@@ -1129,6 +1140,7 @@ const breadcrumbs = computed(() => {
 						</button>
 
 						<button
+							v-if="canEdit('boq')"
 							type="button"
 							class="text-xs px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50"
 							style="border-radius: 2px"
@@ -1138,6 +1150,7 @@ const breadcrumbs = computed(() => {
 						</button>
 
 						<button
+							v-if="canCreate('boq')"
 							type="button"
 							class="text-xs px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50"
 							style="border-radius: 2px"
@@ -1156,7 +1169,7 @@ const breadcrumbs = computed(() => {
 						</button>
 
 						<button
-							v-if="isEditable"
+							v-if="isEditable && canEdit('boq')"
 							type="button"
 							class="text-xs px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50"
 							style="border-radius: 2px"
@@ -1166,6 +1179,7 @@ const breadcrumbs = computed(() => {
 						</button>
 
 						<button
+							v-if="canCreate('boq')"
 							type="button"
 							class="text-xs px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50"
 							style="border-radius: 2px"
@@ -1175,7 +1189,7 @@ const breadcrumbs = computed(() => {
 						</button>
 
 						<button
-							v-if="!isLocked"
+							v-if="!isLocked && canDelete('boq')"
 							type="button"
 							class="text-xs px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50"
 							style="border-radius: 2px; color: #b91c1c"
@@ -1327,13 +1341,18 @@ const breadcrumbs = computed(() => {
 				<div class="ml-auto flex items-center gap-2">
 					<span v-if="!isEditable" class="text-[11px] text-ink-400 italic">
 						{{ boq.status }} — read-only · use
-						<button type="button" @click="createRevision" class="desk-link">
+						<button
+							v-if="canCreate('boq')"
+							type="button"
+							@click="createRevision"
+							class="desk-link"
+						>
 							+ Revision
 						</button>
 						to make changes
 					</span>
 					<button
-						v-if="isEditable"
+						v-if="isEditable && canEdit('boq')"
 						type="button"
 						class="desk-save-btn"
 						@click="openAddGroup"
@@ -1448,7 +1467,7 @@ const breadcrumbs = computed(() => {
 
 						<!-- Edit / Delete (hover-visible, only when BOQ is Draft) -->
 						<div
-							v-if="isEditable"
+							v-if="isEditable && canEdit('boq')"
 							class="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover/row:opacity-100 transition-opacity flex bg-white border border-ink-200 shadow-fp-sm"
 							style="border-radius: 2px"
 						>
@@ -1504,7 +1523,7 @@ const breadcrumbs = computed(() => {
 							>
 								<!-- Edit / Delete (hover-visible, only when BOQ is Draft) -->
 								<div
-									v-if="isEditable"
+									v-if="isEditable && canEdit('boq')"
 									class="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover/row:opacity-100 transition-opacity flex bg-white border border-ink-200 shadow-fp-sm z-10"
 									style="border-radius: 2px"
 								>
@@ -1749,7 +1768,7 @@ const breadcrumbs = computed(() => {
 
 									<!-- Edit / Delete (hover-visible) -->
 									<div
-										v-if="isEditable"
+										v-if="isEditable && canEdit('boq')"
 										class="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover/row:opacity-100 transition-opacity flex bg-white border border-ink-200 shadow-fp-sm z-10"
 										style="border-radius: 2px"
 									>
@@ -1815,7 +1834,7 @@ const breadcrumbs = computed(() => {
 
 								<!-- Inline "+ Add Sub-item" affordance (hidden while searching) -->
 								<div
-									v-if="isEditable && !searching"
+									v-if="isEditable && !searching && canEdit('boq')"
 									class="grid items-center border-b border-dashed border-ink-200 bg-ink-50/40 cursor-pointer hover:bg-brand-50"
 									:style="treeGridStyle"
 									@click="openAddSubItem(item)"
@@ -1843,7 +1862,7 @@ const breadcrumbs = computed(() => {
 
 						<!-- Inline "+ Add Item" affordance — at the bottom of the expanded group (hidden while searching) -->
 						<div
-							v-if="isEditable && !searching"
+							v-if="isEditable && !searching && canEdit('boq')"
 							class="grid items-center border-b border-dashed border-ink-200 cursor-pointer hover:bg-brand-50"
 							:style="treeGridStyle"
 							@click="openAddItem(g.id)"
@@ -1870,7 +1889,7 @@ const breadcrumbs = computed(() => {
 				<div v-if="!groups.length" class="px-4 py-12 text-center text-sm text-ink-400">
 					This BOQ has no groups yet.
 					<button
-						v-if="isEditable"
+						v-if="isEditable && canEdit('boq')"
 						type="button"
 						class="desk-link ml-1"
 						@click="openAddGroup"
@@ -1939,7 +1958,7 @@ const breadcrumbs = computed(() => {
 						>
 							Cancel
 						</button>
-						<button type="button" @click="saveGroup" class="desk-save-btn">
+						<button v-if="canEdit('boq')" type="button" @click="saveGroup" class="desk-save-btn">
 							{{ groupModal.mode === "add" ? "Create group" : "Save changes" }}
 						</button>
 					</div>
@@ -2093,7 +2112,7 @@ const breadcrumbs = computed(() => {
 						>
 							Cancel
 						</button>
-						<button type="button" @click="saveItem" class="desk-save-btn">
+						<button v-if="canEdit('boq')" type="button" @click="saveItem" class="desk-save-btn">
 							{{ itemModal.mode === "add" ? "Create item" : "Save changes" }}
 						</button>
 					</div>
@@ -2199,7 +2218,7 @@ const breadcrumbs = computed(() => {
 						>
 							Cancel
 						</button>
-						<button type="button" @click="saveSubItem" class="desk-save-btn">
+						<button v-if="canEdit('boq')" type="button" @click="saveSubItem" class="desk-save-btn">
 							{{ subItemModal.mode === "add" ? "Create sub-item" : "Save changes" }}
 						</button>
 					</div>
@@ -2282,6 +2301,7 @@ const breadcrumbs = computed(() => {
 							Cancel
 						</button>
 						<button
+							v-if="canCreate('boq')"
 							type="button"
 							class="desk-save-btn"
 							:disabled="revisionTitleConflict"
@@ -2340,7 +2360,12 @@ const breadcrumbs = computed(() => {
 						>
 							Cancel
 						</button>
-						<button type="button" @click="doImport" class="desk-save-btn">
+						<button
+							v-if="canEdit('boq')"
+							type="button"
+							@click="doImport"
+							class="desk-save-btn"
+						>
 							Import
 						</button>
 					</div>
@@ -2423,7 +2448,14 @@ const breadcrumbs = computed(() => {
 						>
 							Cancel
 						</button>
-						<button type="button" @click="doClone" class="desk-save-btn">Clone</button>
+						<button
+							v-if="canCreate('boq')"
+							type="button"
+							@click="doClone"
+							class="desk-save-btn"
+						>
+							Clone
+						</button>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/views/ConsumptionDetailView.vue
+++ b/frontend/src/views/ConsumptionDetailView.vue
@@ -23,11 +23,13 @@ import DeskPage from "@/components/desk/DeskPage.vue";
 import AccessDenied from "@/components/AccessDenied.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
+import { usePermissions } from "@/composables/usePermissions";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { canEdit, canDelete, canSubmit, canCreate } = usePermissions();
 const { projectLabel } = useProjectOptions();
 const {
 	active: wfActive,
@@ -166,7 +168,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('materialConsumption')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -175,7 +177,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft || isCancelled"
+				v-if="(isDraft || isCancelled) && canDelete('materialConsumption')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -185,7 +187,7 @@ const breadcrumbs = computed(() => [
 			</button>
 
 			<button
-				v-if="!wfActive && isDraft"
+				v-if="!wfActive && isDraft && canSubmit('materialConsumption')"
 				type="button"
 				class="desk-save-btn !text-xs"
 				:disabled="busy"
@@ -194,7 +196,7 @@ const breadcrumbs = computed(() => [
 				Submit
 			</button>
 			<button
-				v-if="!wfActive && isSubmitted"
+				v-if="!wfActive && isSubmitted && canSubmit('materialConsumption')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -204,7 +206,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="!wfActive && isCancelled"
+				v-if="!wfActive && isCancelled && canCreate('materialConsumption')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/CrewDetailView.vue
+++ b/frontend/src/views/CrewDetailView.vue
@@ -10,6 +10,7 @@ import { useFormErrors } from "@/composables/useFormErrors";
 import { showToast } from "@/utils/appToast";
 import { isPermissionDenied } from "@/utils/frappeError";
 import { createDataAdapter } from "@/data/adapters";
+import { usePermissions } from "@/composables/usePermissions";
 import { saveCrew } from "@/data/crewApi";
 import { validateCrew } from "@/utils/workforceForms";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -24,6 +25,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { canEdit, canDelete } = usePermissions();
 const { workerName } = useFieldEmployeeOptions();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	crew_name: "crew_name",
@@ -136,7 +138,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="!editing"
+				v-if="!editing && canEdit('crew')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -145,7 +147,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="!editing"
+				v-if="!editing && canDelete('crew')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/EstimateTemplateDetailView.vue
+++ b/frontend/src/views/EstimateTemplateDetailView.vue
@@ -6,6 +6,7 @@ import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
 import { useDocTypeList } from "@/composables/useDocTypeList";
@@ -29,6 +30,7 @@ const router = useRouter();
 const confirmDialog = useConfirm();
 const { errors, applyServerErrors, setErrors } = useFormErrors({ template_name: "templateName" });
 const adapter = createDataAdapter(useDataStore());
+const { canEdit, canDelete } = usePermissions();
 
 const groupKeyOf = (row) => (row?.group_name || "").trim().toLowerCase();
 
@@ -444,6 +446,7 @@ async function removeRow(name) {
 	>
 		<template #actions>
 			<button
+				v-if="canEdit('estimateTemplate')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -452,6 +455,7 @@ async function removeRow(name) {
 				Edit
 			</button>
 			<button
+				v-if="canDelete('estimateTemplate')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -495,7 +499,7 @@ async function removeRow(name) {
 					BOQ. Assembly-driven rows auto-explode into snapshot sub-items when imported.
 				</div>
 				<button
-					v-if="!addingGroup"
+					v-if="!addingGroup && canEdit('estimateTemplate')"
 					type="button"
 					class="desk-save-btn !text-xs flex-shrink-0"
 					:disabled="savingRows"
@@ -526,6 +530,7 @@ async function removeRow(name) {
 					Cancel
 				</button>
 				<button
+					v-if="canEdit('estimateTemplate')"
 					type="button"
 					class="desk-save-btn !text-xs"
 					:disabled="savingRows"
@@ -579,6 +584,7 @@ async function removeRow(name) {
 										Cancel
 									</button>
 									<button
+										v-if="canEdit('estimateTemplate')"
 										type="button"
 										class="desk-save-btn !text-xs"
 										:disabled="savingRows"
@@ -619,6 +625,7 @@ async function removeRow(name) {
 							>
 								<template v-if="group.real && editingGroupKey !== group.key">
 									<button
+										v-if="canEdit('estimateTemplate')"
 										type="button"
 										class="text-ink-400 hover:text-brand-700 disabled:opacity-40"
 										title="Rename group"
@@ -643,6 +650,7 @@ async function removeRow(name) {
 										</svg>
 									</button>
 									<button
+										v-if="canEdit('estimateTemplate')"
 										type="button"
 										class="text-ink-400 hover:text-danger-700 disabled:opacity-40"
 										title="Delete group"
@@ -737,6 +745,7 @@ async function removeRow(name) {
 								</div>
 								<div class="px-2 py-1 text-right">
 									<button
+										v-if="canEdit('estimateTemplate')"
 										type="button"
 										class="text-ink-400 hover:text-danger-700 text-base leading-none"
 										title="Remove"
@@ -816,6 +825,7 @@ async function removeRow(name) {
 										Cancel
 									</button>
 									<button
+										v-if="canEdit('estimateTemplate')"
 										type="button"
 										class="desk-save-btn !text-xs"
 										:disabled="savingRows"
@@ -828,6 +838,7 @@ async function removeRow(name) {
 
 							<div v-else class="border-t border-ink-100 px-3 py-1.5 bg-white">
 								<button
+									v-if="canEdit('estimateTemplate')"
 									type="button"
 									class="text-[11px] text-ink-500 hover:text-brand-700"
 									@click="startAddRow(group)"
@@ -875,7 +886,12 @@ async function removeRow(name) {
 				<div class="text-xs text-ink-500 mb-3">
 					Create a group first, then map items under it — same as a BOQ.
 				</div>
-				<button type="button" class="desk-save-btn !text-xs" @click="startAddGroup">
+				<button
+					v-if="canEdit('estimateTemplate')"
+					type="button"
+					class="desk-save-btn !text-xs"
+					@click="startAddGroup"
+				>
 					+ Add group
 				</button>
 			</div>
@@ -960,6 +976,7 @@ async function removeRow(name) {
 							Cancel
 						</button>
 						<button
+							v-if="canEdit('estimateTemplate')"
 							type="button"
 							class="desk-save-btn"
 							:disabled="saving"

--- a/frontend/src/views/FieldAttendanceDetailView.vue
+++ b/frontend/src/views/FieldAttendanceDetailView.vue
@@ -7,6 +7,7 @@ import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
 import { useWorkflow } from "@/composables/useWorkflow";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useProjectOptions } from "@/composables/useProjectOptions";
 import { useAttendanceSheet } from "@/composables/useAttendanceSheet";
@@ -40,6 +41,7 @@ const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
 const { projectLabel } = useProjectOptions();
+const { canEdit, canDelete, canSubmit, canCreate } = usePermissions();
 const {
 	active: wfActive,
 	state: wfState,
@@ -254,7 +256,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="!editing && isDraft"
+				v-if="!editing && isDraft && canEdit('fieldAttendance')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -263,7 +265,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="!editing && isDraft"
+				v-if="!editing && isDraft && canDelete('fieldAttendance')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -272,7 +274,7 @@ const breadcrumbs = computed(() => [
 				Delete
 			</button>
 			<button
-				v-if="!editing && !wfActive && isDraft"
+				v-if="!editing && !wfActive && isDraft && canSubmit('fieldAttendance')"
 				type="button"
 				class="desk-save-btn !text-xs"
 				:disabled="busy"
@@ -281,7 +283,7 @@ const breadcrumbs = computed(() => [
 				Submit
 			</button>
 			<button
-				v-if="!editing && !wfActive && isSubmitted"
+				v-if="!editing && !wfActive && isSubmitted && canSubmit('fieldAttendance')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -291,7 +293,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="!editing && !wfActive && isCancelled"
+				v-if="!editing && !wfActive && isCancelled && canCreate('fieldAttendance')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/FieldEmployeeDetailView.vue
+++ b/frontend/src/views/FieldEmployeeDetailView.vue
@@ -11,6 +11,7 @@ import { useFormErrors } from "@/composables/useFormErrors";
 import { showToast } from "@/utils/appToast";
 import { isPermissionDenied } from "@/utils/frappeError";
 import { createDataAdapter } from "@/data/adapters";
+import { usePermissions } from "@/composables/usePermissions";
 import { saveFieldEmployee } from "@/data/fieldEmployeeApi";
 import { fmtINR, fmtDate } from "@/utils/format";
 import { validateFieldEmployee } from "@/utils/workforceForms";
@@ -27,6 +28,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { canEdit, canDelete } = usePermissions();
 const { contractorName } = useContractorOptions();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	first_name: "first_name",
@@ -143,7 +145,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="!editing"
+				v-if="!editing && canEdit('fieldEmployee')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -152,7 +154,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="!editing"
+				v-if="!editing && canDelete('fieldEmployee')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/MachineryDetailView.vue
+++ b/frontend/src/views/MachineryDetailView.vue
@@ -5,6 +5,7 @@ import { computed, ref, watch } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
@@ -24,6 +25,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { canCreate, canEdit, canDelete } = usePermissions();
 const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
 	machinery_name: "machinery_name",
@@ -153,7 +155,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<RouterLink
-				v-if="!editing"
+				v-if="!editing && canCreate('machineryUsage')"
 				:to="`/machinery-usage/new?machine=${doc.name}`"
 				class="text-xs px-2.5 py-1 border border-info-200 bg-info-50 hover:bg-info-100 text-info-700 font-medium"
 				style="border-radius: 6px"
@@ -161,7 +163,7 @@ const breadcrumbs = computed(() => [
 				+ Log usage
 			</RouterLink>
 			<button
-				v-if="!editing"
+				v-if="!editing && canEdit('machinery')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -170,7 +172,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="!editing"
+				v-if="!editing && canDelete('machinery')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -188,7 +190,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="editing"
+				v-if="editing && canEdit('machinery')"
 				type="button"
 				class="desk-save-btn"
 				:disabled="saving"

--- a/frontend/src/views/MachineryUsageDetailView.vue
+++ b/frontend/src/views/MachineryUsageDetailView.vue
@@ -5,6 +5,7 @@ import { computed, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
@@ -24,6 +25,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
+const { canEdit, canDelete } = usePermissions();
 const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({ machine: "machine" });
 
@@ -163,7 +165,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="!editing"
+				v-if="!editing && canEdit('machineryUsage')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -172,7 +174,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="!editing"
+				v-if="!editing && canDelete('machineryUsage')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -190,7 +192,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="editing"
+				v-if="editing && canEdit('machineryUsage')"
 				type="button"
 				class="desk-save-btn"
 				:disabled="saving"

--- a/frontend/src/views/MeasurementBookDetailView.vue
+++ b/frontend/src/views/MeasurementBookDetailView.vue
@@ -27,7 +27,7 @@ const confirmDialog = useConfirm();
 const adapter = createDataAdapter(useDataStore());
 // The Site Engineer only raises MBs (create + read); edit/certify/delete are QS/PM actions.
 // canEdit/canDelete resolve the persona's measurementBook caps (see roles.js).
-const { canEdit, canDelete, canCreate } = usePermissions();
+const { canEdit, canDelete, canCreate, canSubmit } = usePermissions();
 
 const mb = ref(null);
 const woLines = ref([]);
@@ -147,7 +147,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft && canEdit('measurementBook')"
+				v-if="isDraft && canSubmit('measurementBook')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-success-200 bg-success-50 hover:bg-success-100 text-success-700 font-medium"
 				style="border-radius: 6px"
@@ -157,7 +157,7 @@ const breadcrumbs = computed(() => [
 				Certify
 			</button>
 			<button
-				v-if="!isDraft && canEdit('measurementBook')"
+				v-if="!isDraft && canSubmit('measurementBook')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/NewAssemblyView.vue
+++ b/frontend/src/views/NewAssemblyView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useDataStore } from '@/stores'
 import { showToast } from '@/utils/appToast'
 import { useFormErrors } from '@/composables/useFormErrors'
+import { usePermissions } from '@/composables/usePermissions'
 import { createDataAdapter } from '@/data/adapters'
 import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskForm from '@/components/desk/DeskForm.vue'
@@ -17,6 +18,7 @@ import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
 const router = useRouter()
 const store = useDataStore()
 const adapter = createDataAdapter(store)
+const { canCreate } = usePermissions()
 
 const form = reactive({ assemblyCode: '', assemblyName: '', uom: '', category: '', notes: '' })
 const { errors, applyServerErrors, setErrors } = useFormErrors({
@@ -68,7 +70,14 @@ const breadcrumbs = [
 
 <template>
   <DeskPage title="New Assembly" subtitle="Rate-analysis recipe priced per unit" :breadcrumbs="breadcrumbs">
-    <DeskForm>
+    <div
+      v-if="!canCreate('assembly')"
+      class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+      style="border-radius: 6px"
+    >
+      You don't have permission to create an assembly.
+    </div>
+    <DeskForm v-else>
       <template #action-bar>
         <DeskActionBar :save-label="saving ? 'Creating…' : 'Create assembly'" :saving="saving" @save="onSave"
           @cancel="onCancel" />

--- a/frontend/src/views/NewConsumptionView.vue
+++ b/frontend/src/views/NewConsumptionView.vue
@@ -19,12 +19,17 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import CostCodePicker from "@/components/CostCodePicker.vue";
+import { usePermissions } from "@/composables/usePermissions";
 
 const props = defineProps({ id: { type: String, default: "" } });
 const router = useRouter();
 const { projectOptions } = useProjectOptions();
+const { canEdit, canCreate } = usePermissions();
 
 const editing = computed(() => !!props.id);
+const canSaveForm = computed(() =>
+	editing.value ? canEdit("materialConsumption") : canCreate("materialConsumption")
+);
 const form = reactive({ project: "", cost_code: null, lines: [] });
 const saving = ref(false);
 const warehouse = ref("");
@@ -171,7 +176,14 @@ const breadcrumbs = computed(() => [
 		subtitle="Issues site material out of stock. Cost-code it against the BOQ if you want it costed."
 		:breadcrumbs="breadcrumbs"
 	>
-		<DeskForm>
+		<div
+			v-if="!canSaveForm"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ editing ? "edit this" : "record a" }} consumption.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="

--- a/frontend/src/views/NewCrewView.vue
+++ b/frontend/src/views/NewCrewView.vue
@@ -7,6 +7,7 @@ import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useActiveCompany } from "@/composables/useActiveCompany";
+import { usePermissions } from "@/composables/usePermissions";
 import { saveCrew } from "@/data/crewApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -16,6 +17,7 @@ import CrewMembersTable from "@/components/CrewMembersTable.vue";
 import { validateCrew } from "@/utils/workforceForms";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 const activeCompany = useActiveCompany();
 
 const form = reactive({
@@ -73,7 +75,14 @@ const breadcrumbs = [
 
 <template>
 	<DeskPage title="New Crew" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canCreate('crew')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to create a crew.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Creating…' : 'Create crew'"

--- a/frontend/src/views/NewEstimateTemplateView.vue
+++ b/frontend/src/views/NewEstimateTemplateView.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useDataStore } from '@/stores'
 import { showToast } from '@/utils/appToast'
 import { useFormErrors } from '@/composables/useFormErrors'
+import { usePermissions } from '@/composables/usePermissions'
 import { createDataAdapter } from '@/data/adapters'
 import DeskPage from '@/components/desk/DeskPage.vue'
 import DeskForm from '@/components/desk/DeskForm.vue'
@@ -17,6 +18,7 @@ import DeskLinkPicker from '@/components/desk/DeskLinkPicker.vue'
 const router = useRouter()
 const store = useDataStore()
 const adapter = createDataAdapter(store)
+const { canCreate } = usePermissions()
 
 const form = reactive({ templateCode: '', templateName: '', projectType: '', description: '' })
 const { errors, applyServerErrors, setErrors } = useFormErrors({
@@ -66,7 +68,14 @@ const breadcrumbs = [
 <template>
   <DeskPage title="New Estimate Template" subtitle="A reusable BOQ skeleton — add rows after creating"
     :breadcrumbs="breadcrumbs">
-    <DeskForm>
+    <div
+      v-if="!canCreate('estimateTemplate')"
+      class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+      style="border-radius: 6px"
+    >
+      You don't have permission to create an estimate template.
+    </div>
+    <DeskForm v-else>
       <template #action-bar>
         <DeskActionBar :save-label="saving ? 'Creating…' : 'Create template'" :saving="saving" @save="onSave"
           @cancel="onCancel" />

--- a/frontend/src/views/NewFieldAttendanceView.vue
+++ b/frontend/src/views/NewFieldAttendanceView.vue
@@ -9,6 +9,7 @@ import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useProjectOptions } from "@/composables/useProjectOptions";
 import { useAttendanceSheet } from "@/composables/useAttendanceSheet";
+import { usePermissions } from "@/composables/usePermissions";
 import { saveFieldAttendance } from "@/data/fieldAttendanceApi";
 import { ATTENDANCE_STATUSES, validateFieldAttendance } from "@/utils/workforceForms";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -20,6 +21,7 @@ import AttendanceEmployeeTable from "@/components/AttendanceEmployeeTable.vue";
 import AttendanceBulkSelectModal from "@/components/AttendanceBulkSelectModal.vue";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 const { projectLabel } = useProjectOptions();
 
 const form = reactive({
@@ -85,7 +87,14 @@ const breadcrumbs = [
 
 <template>
 	<DeskPage title="New Field Attendance" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canCreate('fieldAttendance')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to create a field attendance sheet.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Creating…' : 'Create'"

--- a/frontend/src/views/NewFieldEmployeeView.vue
+++ b/frontend/src/views/NewFieldEmployeeView.vue
@@ -8,6 +8,7 @@ import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useActiveCompany } from "@/composables/useActiveCompany";
+import { usePermissions } from "@/composables/usePermissions";
 import { saveFieldEmployee } from "@/data/fieldEmployeeApi";
 import { validateFieldEmployee } from "@/utils/workforceForms";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -17,6 +18,7 @@ import FieldEmployeeFormFields from "@/components/FieldEmployeeFormFields.vue";
 import AllocatedProjectsTable from "@/components/AllocatedProjectsTable.vue";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 // `company` is mandatory on Employee and has no doctype default, so pre-fill it
 // with the site's default company. The user can still pick a different one.
 const activeCompany = useActiveCompany();
@@ -90,7 +92,14 @@ const breadcrumbs = [
 
 <template>
 	<DeskPage title="New Field Employee" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canCreate('fieldEmployee')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to create a field employee.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Creating…' : 'Create'"

--- a/frontend/src/views/NewMachineryUsageView.vue
+++ b/frontend/src/views/NewMachineryUsageView.vue
@@ -6,6 +6,7 @@ import { useRouter, useRoute } from "vue-router";
 import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
+import { usePermissions } from "@/composables/usePermissions";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { createDataAdapter } from "@/data/adapters";
 import { fmtINR } from "@/utils/format";
@@ -22,6 +23,7 @@ import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 const router = useRouter();
 const route = useRoute();
 const adapter = createDataAdapter(useDataStore());
+const { canCreate } = usePermissions();
 
 const machineryRes = useDocTypeList("Machinery", {
 	fields: ["name", "machinery_name", "machinery_type", "ownership", "rate", "rate_unit"],
@@ -135,7 +137,14 @@ const breadcrumbs = [
 
 <template>
 	<DeskPage title="Log Machinery Usage" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canCreate('machineryUsage')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to log machinery usage.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Saving…' : 'Log usage'"

--- a/frontend/src/views/NewMachineryView.vue
+++ b/frontend/src/views/NewMachineryView.vue
@@ -6,6 +6,7 @@ import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
+import { usePermissions } from "@/composables/usePermissions";
 import { createDataAdapter } from "@/data/adapters";
 import { getActiveCompany } from "@/data/companyApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
@@ -19,6 +20,7 @@ import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 
 const router = useRouter();
 const adapter = createDataAdapter(useDataStore());
+const { canCreate } = usePermissions();
 
 const form = reactive({
 	machinery_name: "",
@@ -91,7 +93,14 @@ const breadcrumbs = [
 
 <template>
 	<DeskPage title="New Machinery" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canCreate('machinery')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to create machinery.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Creating…' : 'Create machinery'"

--- a/frontend/src/views/NewMeasurementBookView.vue
+++ b/frontend/src/views/NewMeasurementBookView.vue
@@ -8,6 +8,7 @@
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
+import { usePermissions } from "@/composables/usePermissions";
 import { getWorkOrder, getMeasurementBook, saveMeasurementBook } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -20,9 +21,14 @@ import CostCodePicker from "@/components/CostCodePicker.vue";
 
 const route = useRoute();
 const router = useRouter();
+const { canCreate, canEdit } = usePermissions();
 
 const editingId = computed(() => route.params.id || null);
 const isEdit = computed(() => !!editingId.value);
+// Edit mode needs edit rights; create mode needs create rights.
+const canSaveForm = computed(() =>
+	isEdit.value ? canEdit("measurementBook") : canCreate("measurementBook")
+);
 
 function emptyEntry() {
 	return {
@@ -298,7 +304,14 @@ const breadcrumbs = computed(() => [
 
 <template>
 	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canSaveForm"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this" : "create a" }} measurement book.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saveLabel"

--- a/frontend/src/views/NewSubcontractorView.vue
+++ b/frontend/src/views/NewSubcontractorView.vue
@@ -7,6 +7,7 @@ import { reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
+import { usePermissions } from "@/composables/usePermissions";
 import { createSubcontractor } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -18,6 +19,7 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import TradePicker from "@/components/TradePicker.vue";
 
 const router = useRouter();
+const { canCreate } = usePermissions();
 
 const form = reactive({
 	subcontractor_name: "",
@@ -77,7 +79,14 @@ const breadcrumbs = [
 
 <template>
 	<DeskPage title="New Subcontractor" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canCreate('subcontractor')"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to create a subcontractor.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saving ? 'Creating…' : 'Create subcontractor'"

--- a/frontend/src/views/NewSubcontractorWorkOrderView.vue
+++ b/frontend/src/views/NewSubcontractorWorkOrderView.vue
@@ -10,6 +10,7 @@ import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { frappeRequest } from "frappe-ui-frappe-request";
 import { showToast } from "@/utils/appToast";
+import { usePermissions } from "@/composables/usePermissions";
 import { getWorkOrder, saveWorkOrder } from "@/data/subcontractApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
@@ -24,9 +25,14 @@ import { fmtINR } from "@/utils/format";
 
 const route = useRoute();
 const router = useRouter();
+const { canCreate, canEdit } = usePermissions();
 
 const editingId = computed(() => route.params.id || null);
 const isEdit = computed(() => !!editingId.value);
+// Edit mode needs edit rights; create mode needs create rights.
+const canSaveForm = computed(() =>
+	isEdit.value ? canEdit("subcontractorWorkOrder") : canCreate("subcontractorWorkOrder")
+);
 
 function emptyLine() {
 	return { scope: "", cost_code: null, uom: "", qty: 0, rate: 0 };
@@ -199,7 +205,14 @@ const saveLabel = computed(() =>
 
 <template>
 	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canSaveForm"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this" : "create a" }} work order.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saveLabel"

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -1551,6 +1551,7 @@ usePageTitle(() => project.value?.name);
 							</div>
 							<div v-if="templateSummary" class="flex items-center gap-2 flex-wrap">
 								<button
+									v-if="canCreate('stagePlanning')"
 									type="button"
 									class="desk-save-btn"
 									@click="seedFromTemplate"
@@ -1558,6 +1559,7 @@ usePageTitle(() => project.value?.name);
 									+ Seed from {{ project.type }} template
 								</button>
 								<RouterLink
+									v-if="canCreate('stagePlanning')"
 									:to="{
 										name: 'stage-planning-new',
 										query: { projectId: project.id },
@@ -1573,6 +1575,7 @@ usePageTitle(() => project.value?.name);
 							</div>
 							<div v-else class="flex items-center gap-2 flex-wrap">
 								<RouterLink
+									v-if="canCreate('stagePlanning')"
 									:to="{
 										name: 'stage-planning-new',
 										query: { projectId: project.id },
@@ -1693,7 +1696,7 @@ usePageTitle(() => project.value?.name);
 				>
 					<template #actions>
 						<RouterLink
-							v-if="canCreate('project')"
+							v-if="canCreate('sco')"
 							:to="`/sco/new?project=${resolvedProjectId}`"
 							class="desk-save-btn"
 							>+ Raise SCO</RouterLink

--- a/frontend/src/views/RateMasterView.vue
+++ b/frontend/src/views/RateMasterView.vue
@@ -25,7 +25,7 @@ const router = useRouter();
 const store = useDataStore();
 const adapter = createDataAdapter(store);
 const confirmDialog = useConfirm();
-const { canCreate } = usePermissions();
+const { canCreate, canEdit, canDelete } = usePermissions();
 const { selectOptions } = useDoctypeMeta("Construction Rate Master");
 
 const breadcrumbs = [
@@ -507,7 +507,13 @@ async function removeRate() {
 					>
 						Cancel
 					</button>
-					<button type="button" :disabled="saving" @click="save" class="desk-save-btn">
+					<button
+						v-if="editing === 'new' ? canCreate('rateMaster') : canEdit('rateMaster')"
+						type="button"
+						:disabled="saving"
+						@click="save"
+						class="desk-save-btn"
+					>
 						{{
 							saving ? "Saving…" : editing === "new" ? "Create rate" : "Save changes"
 						}}
@@ -638,6 +644,7 @@ async function removeRate() {
 						</div>
 						<div class="flex items-center gap-2 flex-shrink-0">
 							<button
+								v-if="canDelete('rateMaster')"
 								type="button"
 								class="text-xs px-2 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 								style="border-radius: 6px"
@@ -645,7 +652,12 @@ async function removeRate() {
 							>
 								Delete
 							</button>
-							<button type="button" class="desk-save-btn" @click="editRate">
+							<button
+								v-if="canEdit('rateMaster')"
+								type="button"
+								class="desk-save-btn"
+								@click="editRate"
+							>
 								Edit
 							</button>
 						</div>

--- a/frontend/src/views/ScheduleView.vue
+++ b/frontend/src/views/ScheduleView.vue
@@ -1279,6 +1279,7 @@ onBeforeUnmount(() => {
 							@keydown.enter="onSaveRevision"
 						/>
 						<button
+							v-if="canEditAny"
 							class="text-xs px-2.5 py-1 rounded bg-ink-900 text-white hover:bg-ink-800 disabled:opacity-50"
 							:disabled="snapBusy || !newRevisionLabel.trim()"
 							@click="onSaveRevision"
@@ -1308,6 +1309,7 @@ onBeforeUnmount(() => {
 								</div>
 							</div>
 							<button
+								v-if="canEditAny"
 								class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 rounded"
 								:disabled="snapBusy"
 								@click="onRestoreRevision(rev)"
@@ -1315,6 +1317,7 @@ onBeforeUnmount(() => {
 								Restore
 							</button>
 							<button
+								v-if="canEditAny"
 								class="text-[11px] px-1.5 py-0.5 text-ink-400 hover:text-danger-600"
 								title="Delete revision"
 								@click="onDeleteRevision(rev)"

--- a/frontend/src/views/ScoDetailView.vue
+++ b/frontend/src/views/ScoDetailView.vue
@@ -27,7 +27,7 @@ const props = defineProps({ id: String });
 const router = useRouter();
 const session = useSessionStore();
 const confirmDialog = useConfirm();
-const { canEditRecord, canDeleteRecord } = usePermissions();
+const { canEditRecord, canDeleteRecord, canCreate } = usePermissions();
 const adapter = createDataAdapter(useDataStore());
 const { errors, applyServerErrors, setErrors } = useFormErrors({ title: "title" });
 
@@ -251,7 +251,12 @@ const breadcrumbs = computed(() => [
 					Reject
 				</button>
 				<button
-					v-if="isApproved && !sco.boq_revision && canEditRecord('sco', sco)"
+					v-if="
+						isApproved &&
+						!sco.boq_revision &&
+						canEditRecord('sco', sco) &&
+						canCreate('boq')
+					"
 					type="button"
 					class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 					style="border-radius: 6px"

--- a/frontend/src/views/StagePlanningDetailView.vue
+++ b/frontend/src/views/StagePlanningDetailView.vue
@@ -15,6 +15,7 @@ import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { createDataAdapter } from "@/data/adapters";
 import { useProjectNames } from "@/composables/useProjectNames";
+import { usePermissions } from "@/composables/usePermissions";
 import { outOfParentBoundsError } from "@/utils/dateBounds";
 import { fetchProjectBounds } from "@/utils/projectBounds";
 
@@ -365,6 +366,10 @@ const canEdit = computed(() => {
 	const editRoles = STATE_EDIT_ROLES[state] || [];
 	return editRoles.some((r) => userRoles.value.includes(r));
 });
+
+// DocPerm capability gate (separate from the workflow/role gate above) — used to
+// AND the persona's edit permission into the task-list controls.
+const { canEdit: canEditPerm } = usePermissions();
 
 const canDelete = computed(() => {
 	const state = stage.value?.workflowState || "Draft";
@@ -1157,7 +1162,7 @@ usePageTitle(() => stage.value?.stageName);
 						>Locked — stage is approved</span
 					>
 					<button
-						v-else
+						v-else-if="canEditPerm('stagePlanning')"
 						type="button"
 						class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 dark:bg-ink-800 dark:border-ink-700 dark:text-ink-100 dark:hover:bg-ink-700"
 						style="border-radius: 6px"
@@ -1214,7 +1219,7 @@ usePageTitle(() => stage.value?.stageName);
 									max="100"
 									step="1"
 									class="!text-xs !text-right !py-1"
-									:disabled="tasksLocked"
+									:disabled="tasksLocked || !canEditPerm('stagePlanning')"
 									@update:model-value="onPlannedQtyChange(row, $event)"
 								/>
 								<span class="text-[11px] text-ink-500">%</span>

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -33,11 +33,15 @@ import DeskLink from "@/components/desk/DeskLink.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import FrappeUserBadge from "@/components/FrappeUserBadge.vue";
 import { useWorkflow } from "@/composables/useWorkflow";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+// Gate the lifecycle actions by the persona's capability, not just docstatus — otherwise a
+// read-only viewer (e.g. Director) sees Edit/Submit/Delete that the backend then 403s.
+const { canEdit, canDelete, canSubmit, canCreate } = usePermissions();
 const adapter = createDataAdapter(useDataStore());
 
 // Defer to an active Frappe Workflow on Subcontractor Bill when configured; the
@@ -570,7 +574,7 @@ const accountFilters = computed(() =>
 	>
 		<template #actions>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('subcontractorBill')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -581,7 +585,7 @@ const accountFilters = computed(() =>
 			</button>
 			<!-- Plain docstatus lifecycle (no workflow configured) -->
 			<button
-				v-if="!wfActive && isDraft"
+				v-if="!wfActive && isDraft && canSubmit('subcontractorBill')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -591,7 +595,7 @@ const accountFilters = computed(() =>
 				Submit
 			</button>
 			<button
-				v-if="isSubmitted && payment.status !== 'Paid'"
+				v-if="isSubmitted && payment.status !== 'Paid' && canCreate('advance')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -600,7 +604,7 @@ const accountFilters = computed(() =>
 				Make Payment
 			</button>
 			<button
-				v-if="!wfActive && isSubmitted"
+				v-if="!wfActive && isSubmitted && canSubmit('subcontractorBill')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -622,7 +626,7 @@ const accountFilters = computed(() =>
 				{{ t.action }}
 			</button>
 			<button
-				v-if="isCancelled"
+				v-if="isCancelled && canCreate('subcontractorBill')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -633,7 +637,7 @@ const accountFilters = computed(() =>
 				Amend
 			</button>
 			<button
-				v-if="!isSubmitted"
+				v-if="!isSubmitted && canDelete('subcontractorBill')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/SubcontractorDetailView.vue
+++ b/frontend/src/views/SubcontractorDetailView.vue
@@ -8,6 +8,7 @@ import { computed, ref, watch } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { useDataStore } from "@/stores";
 import { useConfirm } from "@/composables/useConfirm";
+import { usePermissions } from "@/composables/usePermissions";
 import { useFormErrors } from "@/composables/useFormErrors";
 import { useDocTypeList } from "@/composables/useDocTypeList";
 import { useProjectNames } from "@/composables/useProjectNames";
@@ -27,6 +28,7 @@ import StatusBadge from "@/components/StatusBadge.vue";
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canEdit, canDelete, canCreate } = usePermissions();
 const adapter = createDataAdapter(useDataStore()); // delete only
 const { projectName } = useProjectNames();
 const { errors, applyServerErrors, setErrors } = useFormErrors({
@@ -183,7 +185,7 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="!editing"
+				v-if="!editing && canEdit('subcontractor')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -192,7 +194,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="!editing"
+				v-if="!editing && canDelete('subcontractor')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -210,7 +212,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="editing"
+				v-if="editing && canEdit('subcontractor')"
 				type="button"
 				class="desk-save-btn"
 				:disabled="saving"
@@ -266,6 +268,7 @@ const breadcrumbs = computed(() => [
 						Work orders ({{ linkedWOs.length }})
 					</h3>
 					<RouterLink
+						v-if="canCreate('subcontractorWorkOrder')"
 						:to="`/subcontractor-work-orders/new?subcontractor=${sub.name}`"
 						class="text-xs text-brand-700 hover:underline"
 						>+ Raise new work order</RouterLink

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -27,7 +27,7 @@ import { fmtDate, fmtINR } from "@/utils/format";
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
-const { canCreate } = usePermissions();
+const { canCreate, canEdit, canDelete, canSubmit } = usePermissions();
 // These buttons create OTHER entities from the WO, so each follows that entity's create
 // rights — not the WO's. A WO-full persona that is read-only on Measurement Book / on
 // Subcontractor Bill (e.g. Director/Owner) can open + submit the WO but must not see the
@@ -216,7 +216,7 @@ const tabs = computed(() => [
 	>
 		<template #actions>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('subcontractorWorkOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -225,7 +225,7 @@ const tabs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canSubmit('subcontractorWorkOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -255,7 +255,7 @@ const tabs = computed(() => [
 				+ Bill progress
 			</button>
 			<button
-				v-if="isSubmitted"
+				v-if="isSubmitted && canSubmit('subcontractorWorkOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -265,7 +265,7 @@ const tabs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="isCancelled"
+				v-if="isCancelled && canCreate('subcontractorWorkOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -285,7 +285,7 @@ const tabs = computed(() => [
 				Print / PDF
 			</button>
 			<button
-				v-if="!isSubmitted"
+				v-if="!isSubmitted && canDelete('subcontractorWorkOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"
@@ -584,7 +584,7 @@ const tabs = computed(() => [
 					Terms &amp; conditions
 				</h3>
 				<button
-					v-if="isDraft"
+					v-if="isDraft && canEdit('subcontractorWorkOrder')"
 					type="button"
 					class="text-xs text-brand-700 hover:underline"
 					@click="onEdit"

--- a/frontend/src/views/TaskProgressEntryDetailView.vue
+++ b/frontend/src/views/TaskProgressEntryDetailView.vue
@@ -731,6 +731,7 @@ usePageTitle(() => task.value?.name || entry.value?.id);
 									</div>
 									<div class="px-1 py-2 flex justify-center">
 										<button
+											v-if="canEditEntry"
 											type="button"
 											class="text-xs px-1 py-0.5 border border-ink-200 bg-white hover:bg-danger-50 text-danger-700"
 											style="border-radius: 4px"
@@ -750,6 +751,7 @@ usePageTitle(() => task.value?.name || entry.value?.id);
 								@change="onAttachFilesPicked"
 							/>
 							<button
+								v-if="canEditEntry"
 								type="button"
 								class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 								style="border-radius: 6px"

--- a/frontend/src/views/finance/FinanceBillsPanel.vue
+++ b/frontend/src/views/finance/FinanceBillsPanel.vue
@@ -455,7 +455,11 @@ async function saveAdvance() {
 							<td class="px-3 py-2"><StatusBadge :status="r.status" size="xs" /></td>
 							<td class="px-3 py-2 text-right whitespace-nowrap">
 								<button
-									v-if="r.kind === 'supplier' && r.outstanding > 0.01"
+									v-if="
+										r.kind === 'supplier' &&
+										r.outstanding > 0.01 &&
+										canCreate('advance')
+									"
 									type="button"
 									class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded"
 									@click.stop="openPay(r)"

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -28,7 +28,7 @@ import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
-const { canCreate } = usePermissions();
+const { canCreate, canEdit, canDelete } = usePermissions();
 
 // Every account/project/employee picker is scoped to the active (default) company. This is
 // the single-company seam — see useActiveCompany. Empty pre-boot → picker unfiltered, but
@@ -449,11 +449,11 @@ const expenseAccountFilters = computed(() => [
 					</div>
 					<footer class="px-4 py-3 border-t border-ink-200 flex items-center justify-between gap-2 flex-shrink-0">
 						<div class="flex items-center gap-2">
-							<button v-if="detail.status === 'Draft' || (detail.status === 'Cancelled' && canVerify)" type="button" class="text-xs px-2.5 py-1.5 text-danger-600 hover:underline" @click="onDelete(detail)">Delete</button>
+							<button v-if="(detail.status === 'Draft' || (detail.status === 'Cancelled' && canVerify)) && canDelete('expense')" type="button" class="text-xs px-2.5 py-1.5 text-danger-600 hover:underline" @click="onDelete(detail)">Delete</button>
 						</div>
 						<div class="flex items-center gap-2">
 							<button type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="closeDetail">Close</button>
-							<button v-if="detail.status === 'Draft'" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="openEdit(detail)">Edit</button>
+							<button v-if="detail.status === 'Draft' && canEdit('expense')" type="button" class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md" @click="openEdit(detail)">Edit</button>
 							<button v-if="detail.status === 'Draft' && canVerify" type="button" class="text-xs desk-save-btn" @click="onSubmit(detail)">Submit</button>
 							<button v-if="detail.status === 'Submitted' && canVerify" type="button" class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md" @click="onCancel(detail)">Cancel</button>
 						</div>

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -26,11 +26,13 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { useWorkflow } from "@/composables/useWorkflow";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, required: true } });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canEdit, canDelete, canSubmit, canCreate } = usePermissions();
 
 // If a site configures an active Frappe Workflow for Sales Invoice, the lifecycle
 // buttons below defer to it: Submit/Cancel are replaced by the workflow's allowed
@@ -348,7 +350,7 @@ async function unlinkAdvance(row) {
 					Print / PDF
 				</button>
 				<button
-					v-if="isDraft"
+					v-if="isDraft && canDelete('salesInvoice')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md"
 					:disabled="busy"
@@ -357,7 +359,7 @@ async function unlinkAdvance(row) {
 					Delete
 				</button>
 				<button
-					v-if="isDraft"
+					v-if="isDraft && canEdit('salesInvoice')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
 					@click="router.push(`/project-finance/invoices/${inv.name}/edit`)"
@@ -366,7 +368,7 @@ async function unlinkAdvance(row) {
 				</button>
 				<!-- Plain docstatus lifecycle (no workflow configured) -->
 				<button
-					v-if="!wfActive && isDraft"
+					v-if="!wfActive && isDraft && canSubmit('salesInvoice')"
 					type="button"
 					class="text-xs desk-save-btn"
 					:disabled="busy"
@@ -375,7 +377,7 @@ async function unlinkAdvance(row) {
 					Submit
 				</button>
 				<button
-					v-if="isSubmitted && payment.outstanding > 0.01"
+					v-if="isSubmitted && payment.outstanding > 0.01 && canCreate('advance')"
 					type="button"
 					class="text-xs desk-save-btn"
 					:disabled="busy"
@@ -384,7 +386,7 @@ async function unlinkAdvance(row) {
 					Receive payment
 				</button>
 				<button
-					v-if="!wfActive && isSubmitted"
+					v-if="!wfActive && isSubmitted && canSubmit('salesInvoice')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md"
 					:disabled="busy"
@@ -436,7 +438,12 @@ async function unlinkAdvance(row) {
 
 			<!-- unlinked-advance suggestion -->
 			<div
-				v-if="canLink && availableAdvances.length && remainingOutstanding > 0.01"
+				v-if="
+					canLink &&
+					availableAdvances.length &&
+					remainingOutstanding > 0.01 &&
+					canCreate('advance')
+				"
 				class="px-4 py-2.5 bg-info-50 border border-info-200 rounded-md text-xs text-ink-700 flex items-center justify-between gap-3 flex-wrap"
 			>
 				<span>
@@ -592,7 +599,7 @@ async function unlinkAdvance(row) {
 								>Advance Payments</span
 							>
 							<button
-								v-if="canLink && availableAdvances.length"
+								v-if="canLink && availableAdvances.length && canCreate('advance')"
 								type="button"
 								class="text-xs text-brand-700 hover:underline"
 								@click="openLinkAdvance"
@@ -616,7 +623,7 @@ async function unlinkAdvance(row) {
 										fmtINR(row.allocated)
 									}}</span>
 									<button
-										v-if="canLink"
+										v-if="canLink && canCreate('advance')"
 										type="button"
 										class="text-ink-400 hover:text-danger-600 text-xs"
 										:title="`Unlink ${row.payment_entry}`"
@@ -849,6 +856,7 @@ async function unlinkAdvance(row) {
 									class="flex-1 text-sm px-2.5 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
 								/>
 								<button
+									v-if="canCreate('advance')"
 									type="button"
 									class="text-xs px-3 py-1.5 bg-brand-600 hover:bg-brand-700 text-white font-medium rounded-md flex-shrink-0 disabled:opacity-60"
 									:disabled="adv.saving === a.payment_entry"

--- a/frontend/src/views/finance/FinanceInvoiceFormView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceFormView.vue
@@ -22,16 +22,21 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import { activeCompanyFilter, useActiveCompany } from "@/composables/useActiveCompany";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, default: "" } });
 const router = useRouter();
 const companyFilter = activeCompanyFilter();
 const activeCompany = useActiveCompany();
+const { canEdit, canCreate } = usePermissions();
 // Tax account heads: non-group accounts in the active (default) company only — so a tax
 // template / row can't pull an account from another company (which the Sales Invoice rejects).
 const accountFilters = computed(() => [["is_group", "=", 0], ...companyFilter.value]);
 const isEdit = computed(() => !!props.id);
+const canSaveInvoice = computed(() =>
+	isEdit.value ? canEdit("salesInvoice") : canCreate("salesInvoice")
+);
 
 function blankLine() {
 	return { description: "", qty: 1, rate: null };
@@ -227,7 +232,14 @@ async function save() {
 		:breadcrumbs="breadcrumbs"
 		subtitle="Bills the customer — Submit posts it as a receivable."
 	>
-		<DeskForm>
+		<div
+			v-if="!canSaveInvoice"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this invoice" : "create an invoice" }}.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="isEdit ? 'Save invoice' : 'Create invoice'"

--- a/frontend/src/views/finance/FinanceInvoicesPanel.vue
+++ b/frontend/src/views/finance/FinanceInvoicesPanel.vue
@@ -389,7 +389,7 @@ async function saveAdvance() {
 				</template>
 				<template #cell-actions="{ row }">
 					<button
-						v-if="canReceive(row)"
+						v-if="canReceive(row) && canCreate('advance')"
 						type="button"
 						class="text-[11px] px-2 py-0.5 border border-brand-300 bg-brand-50 text-brand-700 rounded"
 						@click.stop="openReceive(row)"

--- a/frontend/src/views/finance/FinanceSupplierBillDetailView.vue
+++ b/frontend/src/views/finance/FinanceSupplierBillDetailView.vue
@@ -27,11 +27,13 @@ import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { useWorkflow } from "@/composables/useWorkflow";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, required: true } });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canEdit, canDelete, canSubmit, canCreate } = usePermissions();
 
 // Defer to an active Frappe Workflow on Purchase Invoice when one is configured;
 // otherwise the plain docstatus Submit/Cancel buttons render as before.
@@ -343,7 +345,7 @@ async function unlinkAdvance(row) {
 					Print / PDF
 				</button>
 				<button
-					v-if="isDraft"
+					v-if="isDraft && canDelete('supplierBill')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md"
 					:disabled="busy"
@@ -352,7 +354,7 @@ async function unlinkAdvance(row) {
 					Delete
 				</button>
 				<button
-					v-if="isDraft"
+					v-if="isDraft && canEdit('supplierBill')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
 					@click="router.push(`/project-finance/supplier-bills/${bill.name}/edit`)"
@@ -361,7 +363,7 @@ async function unlinkAdvance(row) {
 				</button>
 				<!-- Plain docstatus lifecycle (no workflow configured) -->
 				<button
-					v-if="!wfActive && isDraft"
+					v-if="!wfActive && isDraft && canSubmit('supplierBill')"
 					type="button"
 					class="text-xs desk-save-btn"
 					:disabled="busy"
@@ -370,7 +372,7 @@ async function unlinkAdvance(row) {
 					Submit
 				</button>
 				<button
-					v-if="isSubmitted && payment.outstanding > 0.01"
+					v-if="isSubmitted && payment.outstanding > 0.01 && canCreate('advance')"
 					type="button"
 					class="text-xs desk-save-btn"
 					:disabled="busy"
@@ -379,7 +381,7 @@ async function unlinkAdvance(row) {
 					Pay
 				</button>
 				<button
-					v-if="!wfActive && isSubmitted"
+					v-if="!wfActive && isSubmitted && canSubmit('supplierBill')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium rounded-md"
 					:disabled="busy"
@@ -429,7 +431,12 @@ async function unlinkAdvance(row) {
 
 			<!-- unlinked-advance suggestion -->
 			<div
-				v-if="canLink && availableAdvances.length && remainingOutstanding > 0.01"
+				v-if="
+					canLink &&
+					availableAdvances.length &&
+					remainingOutstanding > 0.01 &&
+					canCreate('advance')
+				"
 				class="px-4 py-2.5 bg-info-50 border border-info-200 rounded-md text-xs text-ink-700 flex items-center justify-between gap-3 flex-wrap"
 			>
 				<span>
@@ -587,7 +594,7 @@ async function unlinkAdvance(row) {
 								>Advance Payments</span
 							>
 							<button
-								v-if="canLink && availableAdvances.length"
+								v-if="canLink && availableAdvances.length && canCreate('advance')"
 								type="button"
 								class="text-xs text-brand-700 hover:underline"
 								@click="openLinkAdvance"
@@ -611,7 +618,7 @@ async function unlinkAdvance(row) {
 										fmtINR(row.allocated)
 									}}</span>
 									<button
-										v-if="canLink"
+										v-if="canLink && canCreate('advance')"
 										type="button"
 										class="text-ink-400 hover:text-danger-600 text-xs"
 										:title="`Unlink ${row.payment_entry}`"
@@ -844,6 +851,7 @@ async function unlinkAdvance(row) {
 									class="flex-1 text-sm px-2.5 py-1.5 border border-ink-200 rounded-md text-right tabular-nums focus:outline-none focus:ring-2 focus:ring-brand-200 focus:border-brand-400"
 								/>
 								<button
+									v-if="canCreate('advance')"
 									type="button"
 									class="text-xs px-3 py-1.5 bg-brand-600 hover:bg-brand-700 text-white font-medium rounded-md flex-shrink-0 disabled:opacity-60"
 									:disabled="adv.saving === a.payment_entry"

--- a/frontend/src/views/finance/FinanceSupplierBillFormView.vue
+++ b/frontend/src/views/finance/FinanceSupplierBillFormView.vue
@@ -25,6 +25,7 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import { activeCompanyFilter } from "@/composables/useActiveCompany";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, default: "" } });
@@ -32,6 +33,10 @@ const router = useRouter();
 const companyFilter = activeCompanyFilter();
 const accountFilters = computed(() => [["is_group", "=", 0], ...companyFilter.value]);
 const isEdit = computed(() => !!props.id);
+const { canEdit, canCreate } = usePermissions();
+const canSaveBill = computed(() =>
+	isEdit.value ? canEdit("supplierBill") : canCreate("supplierBill")
+);
 
 // 'po' | 'direct'. Locked once editing (the source can't change on a saved bill).
 const mode = ref("po");
@@ -300,7 +305,14 @@ async function save() {
 		:breadcrumbs="breadcrumbs"
 		subtitle="A supplier payable — Submit posts it; then pay from a Bank/Cash account."
 	>
-		<DeskForm>
+		<div
+			v-if="!canSaveBill"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this bill" : "create a supplier bill" }}.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="isEdit ? 'Save bill' : 'Create bill'"

--- a/frontend/src/views/procurement/MaterialRequestDetailView.vue
+++ b/frontend/src/views/procurement/MaterialRequestDetailView.vue
@@ -17,11 +17,13 @@ import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canEdit, canSubmit, canCreate, canDelete } = usePermissions();
 
 const mr = ref(null);
 const loading = ref(true);
@@ -136,7 +138,7 @@ const breadcrumbs = computed(() => [
 		<template #actions>
 			<ProcurementStatusPill :status="mr.status" class="self-center mr-1" />
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('materialRequest')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -145,7 +147,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canSubmit('materialRequest')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -155,7 +157,7 @@ const breadcrumbs = computed(() => [
 				Submit
 			</button>
 			<button
-				v-if="canOrder"
+				v-if="canOrder && canCreate('purchaseOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -165,7 +167,7 @@ const breadcrumbs = computed(() => [
 				+ Create Purchase Order
 			</button>
 			<button
-				v-if="isSubmitted"
+				v-if="isSubmitted && canSubmit('materialRequest')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -175,7 +177,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="isCancelled"
+				v-if="isCancelled && canCreate('materialRequest')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -186,7 +188,7 @@ const breadcrumbs = computed(() => [
 				Amend
 			</button>
 			<button
-				v-if="!isSubmitted"
+				v-if="!isSubmitted && canDelete('materialRequest')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/procurement/NewMaterialRequestView.vue
+++ b/frontend/src/views/procurement/NewMaterialRequestView.vue
@@ -15,13 +15,18 @@ import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const route = useRoute();
 const router = useRouter();
+const { canEdit, canCreate } = usePermissions();
 
 const editingId = computed(() => route.params.id || null);
 const isEdit = computed(() => !!editingId.value);
+const canSaveForm = computed(() =>
+	isEdit.value ? canEdit("materialRequest") : canCreate("materialRequest")
+);
 
 function emptyLine() {
 	return { item_code: "", description: "", qty: null, uom: "", rate: null };
@@ -138,7 +143,14 @@ const saveLabel = computed(() =>
 
 <template>
 	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canSaveForm"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this" : "create a" }} material request.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saveLabel"

--- a/frontend/src/views/procurement/NewPurchaseOrderView.vue
+++ b/frontend/src/views/procurement/NewPurchaseOrderView.vue
@@ -14,13 +14,18 @@ import DeskSection from "@/components/desk/DeskSection.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const route = useRoute();
 const router = useRouter();
+const { canEdit, canCreate } = usePermissions();
 
 const editingId = computed(() => route.params.id || null);
 const isEdit = computed(() => !!editingId.value);
+const canSaveForm = computed(() =>
+	isEdit.value ? canEdit("purchaseOrder") : canCreate("purchaseOrder")
+);
 
 function emptyLine() {
 	return { item_code: "", description: "", qty: null, uom: "", rate: null };
@@ -173,7 +178,14 @@ const saveLabel = computed(() =>
 
 <template>
 	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canSaveForm"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this" : "create a" }} purchase order.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saveLabel"

--- a/frontend/src/views/procurement/NewPurchaseReceiptView.vue
+++ b/frontend/src/views/procurement/NewPurchaseReceiptView.vue
@@ -21,13 +21,18 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const route = useRoute();
 const router = useRouter();
+const { canEdit, canCreate } = usePermissions();
 
 const editingId = computed(() => route.params.id || null);
 const isEdit = computed(() => !!editingId.value);
+const canSaveForm = computed(() =>
+	isEdit.value ? canEdit("purchaseReceipt") : canCreate("purchaseReceipt")
+);
 
 function today() {
 	return new Date().toISOString().slice(0, 10);
@@ -204,7 +209,14 @@ const saveLabel = computed(() =>
 
 <template>
 	<DeskPage :title="pageTitle" :breadcrumbs="breadcrumbs">
-		<DeskForm>
+		<div
+			v-if="!canSaveForm"
+			class="px-3 py-2 bg-warning-50 border border-warning-100 text-xs text-warning-700 dark:bg-ink-800 dark:border-ink-700"
+			style="border-radius: 6px"
+		>
+			You don't have permission to {{ isEdit ? "edit this" : "create a" }} purchase receipt.
+		</div>
+		<DeskForm v-else>
 			<template #action-bar>
 				<DeskActionBar
 					:save-label="saveLabel"

--- a/frontend/src/views/procurement/PurchaseOrderDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseOrderDetailView.vue
@@ -16,11 +16,13 @@ import {
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canEdit, canSubmit, canCreate, canDelete } = usePermissions();
 
 const po = ref(null);
 const loading = ref(true);
@@ -134,7 +136,7 @@ const breadcrumbs = computed(() => [
 		<template #actions>
 			<ProcurementStatusPill :status="po.status" class="self-center mr-1" />
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('purchaseOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -143,7 +145,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canSubmit('purchaseOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -153,7 +155,7 @@ const breadcrumbs = computed(() => [
 				Submit
 			</button>
 			<button
-				v-if="canReceive"
+				v-if="canReceive && canCreate('purchaseReceipt')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -163,7 +165,7 @@ const breadcrumbs = computed(() => [
 				+ Create Receipt
 			</button>
 			<button
-				v-if="isSubmitted"
+				v-if="isSubmitted && canSubmit('purchaseOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -173,7 +175,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="isCancelled"
+				v-if="isCancelled && canCreate('purchaseOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -184,7 +186,7 @@ const breadcrumbs = computed(() => [
 				Amend
 			</button>
 			<button
-				v-if="!isSubmitted"
+				v-if="!isSubmitted && canDelete('purchaseOrder')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/procurement/PurchaseReceiptDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseReceiptDetailView.vue
@@ -16,11 +16,13 @@ import {
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
 import ProcurementStatusPill from "@/components/procurement/ProcurementStatusPill.vue";
+import { usePermissions } from "@/composables/usePermissions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: String });
 const router = useRouter();
 const confirmDialog = useConfirm();
+const { canEdit, canSubmit, canCreate, canDelete } = usePermissions();
 
 const pr = ref(null);
 const loading = ref(true);
@@ -133,7 +135,7 @@ const breadcrumbs = computed(() => [
 		<template #actions>
 			<ProcurementStatusPill :status="pr.status" class="self-center mr-1" />
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canEdit('purchaseReceipt')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700"
 				style="border-radius: 6px"
@@ -142,7 +144,7 @@ const breadcrumbs = computed(() => [
 				Edit
 			</button>
 			<button
-				v-if="isDraft"
+				v-if="isDraft && canSubmit('purchaseReceipt')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -152,7 +154,7 @@ const breadcrumbs = computed(() => [
 				Submit
 			</button>
 			<button
-				v-if="isSubmitted"
+				v-if="isSubmitted && canSubmit('purchaseReceipt')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-warning-300 bg-warning-50 hover:bg-warning-100 text-warning-700 font-medium"
 				style="border-radius: 6px"
@@ -162,7 +164,7 @@ const breadcrumbs = computed(() => [
 				Cancel
 			</button>
 			<button
-				v-if="isCancelled"
+				v-if="isCancelled && canCreate('purchaseReceipt')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
 				style="border-radius: 6px"
@@ -173,7 +175,7 @@ const breadcrumbs = computed(() => [
 				Amend
 			</button>
 			<button
-				v-if="!isSubmitted"
+				v-if="!isSubmitted && canDelete('purchaseReceipt')"
 				type="button"
 				class="text-xs px-2.5 py-1 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700"
 				style="border-radius: 6px"

--- a/frontend/src/views/project-detail/tabs/OverviewTab.vue
+++ b/frontend/src/views/project-detail/tabs/OverviewTab.vue
@@ -6,6 +6,9 @@ import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { fmtDate, fmtCompactINR } from "@/utils/format";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
+import { usePermissions } from "@/composables/usePermissions";
+
+const { canEdit } = usePermissions();
 
 const props = defineProps({
 	project: { type: Object, required: true },
@@ -390,6 +393,7 @@ function deviationColor(pct) {
 						/>
 						<h3 class="text-sm font-semibold text-ink-900">Project details</h3>
 						<button
+							v-if="canEdit('project')"
 							type="button"
 							class="ml-auto text-[11px] text-brand-700 hover:text-brand-800 font-medium"
 							@click="emit('edit')"


### PR DESCRIPTION
## The bug
Logged in as Director/Owner, opening a **draft** Subcontractor Bill showed **Edit / Submit / Delete** — but the backend 403s each (Director is read-only on bills). The detail view gated those buttons on **docstatus alone** (`isDraft` / `isSubmitted`) with **no permission check** — no `usePermissions` import at all. Backend perms were right; the UI just never consulted them.

## Why the e2e kept passing
The suite never tests this surface:
- `module_entity_crud.cy.js` → list-view **"+ New"** (create) + "list opens" (read), per persona. Never opens a record.
- `cross_entity_create_buttons.cy.js` → the WO detail's **cross-entity CREATE** buttons only.
- `TestPersonaCrudMatrix` (backend) → `frappe.has_permission`, which is correct — green, and blind to the UI.

**No test opened a record to assert its own Edit/Submit/Delete/Cancel are gated by capability.** That whole class of detail-view mutation buttons was untested.

## Fix
- Add a **submit** capability (`x`) to `PERSONA_CAPS` (defaults to `del`) + `usePermissions().canSubmit`.
- `subcontractorBill`: set `del` + `submit` explicitly to `[qs, accountant, admin, bsa]`. PM + Procurement *raise/edit* bills (create+write) but the QS/Accountant *delete + submit* them — backend `_CRW` vs `_FULL_SUB` — so these are narrower than `create` (which `del` previously defaulted to, itself a latent mismatch).
- `SubcontractorBillDetailView.vue`: Edit→`canEdit`, Submit/Cancel→`canSubmit`, Delete→`canDelete`, Make Payment→`canCreate('advance')`, Amend→`canCreate`. Each keeps its docstatus condition; capability is ANDed in.

## The refined e2e
`submittable_action_gating.cy.js` — data-driven from `PERSONA_CAPS`, opens a draft + submitted bill per bill-reader persona and asserts each lifecycle button appears **iff** the persona has the matching capability. `cypress_setup.ensure_cypress_bills` supplies the fixtures. This is the coverage that was missing — it fails on the old code and passes on the fixed code.

## Verification
Live (Playwright, draft SB-2026-00009, 6 personas): **director & site-engineer → none**; **pm & procurement → Edit only**; **qs & accountant → Edit/Submit/Delete** — matching the backend exactly. `yarn build` clean.

## Follow-up
Other submittable detail views (Work Order, Measurement Book, Sales/Purchase Invoice, Expense Entry) likely share the same "gated on docstatus only" pattern — worth the same audit + gating in a follow-up.