### PR TITLE
feat: select (not read) on picker-only reference masters

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -35,3 +35,4 @@ buildsuite_core.patches.reseed_procurement_bespoke_reports # 2026-08-20
 buildsuite_core.patches.grant_child_table_read_access # 2026-08-21
 buildsuite_core.patches.resync_director_permission_matrix # 2026-08-24
 buildsuite_core.patches.repoint_pnl_to_bespoke # 2026-08-25
+buildsuite_core.patches.resync_picker_select_permissions

--- a/buildsuite_core/patches/resync_picker_select_permissions.py
+++ b/buildsuite_core/patches/resync_picker_select_permissions.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Re-apply the BuildSuite permission matrices so the picker-only masters drop to `select`.
+
+Reference masters that a persona only ever resolves in a LINK-FIELD picker (UOM, the tax-template
+masters, Construction Trade, Subcontract Delivery Type) were granted full `read` — which also lets
+those personas list / report / export the master. `frappe.get_list` (the picker's endpoint) honours
+`select`, so the pickers keep working on `select` alone. The setup maps now grant `select` (not
+`read`) for those picker-only roles.
+
+Permission setup is install-only, so this patch re-runs the authoritative setup to converge existing
+sites onto the new grants (clearing the stale `read`, setting `select`). setup_record_permissions()
+is idempotent, so this is safe to re-run."""
+
+from buildsuite_core.permissions.setup import setup_record_permissions
+
+
+def execute():
+	setup_record_permissions()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -115,6 +115,10 @@ _FULL_SUB = {**_FULL, "submit": 1, "cancel": 1, "amend": 1}  # CRWDSX
 _RAISE = {"read": 1, "create": 1, "print": 1}  # CR — raise own records only
 _CRWS = {"read": 1, "write": 1, "create": 1, "submit": 1, "report": 1, "print": 1}  # CRWS
 _CRW = {"read": 1, "write": 1, "create": 1, "report": 1, "print": 1}  # CRW — edit, no delete
+# Select-only: the role may resolve the doctype in a LINK-FIELD PICKER (frappe.get_list honours
+# `select` — verified) but cannot list / report / export it. Used for reference masters a persona
+# only ever picks, never opens a screen for. Applied with _SELECT_PTYPES so read is cleared.
+_SELECT = {"select": 1, "print": 1}  # S — pick in a link field, no read
 
 # Assembly + Estimate Template: full for the estimation roles, hidden for the rest.
 ASSEMBLY_TEMPLATE_ROLE_PERMS = {role: _FULL for role in _ESTIMATION_ROLES}
@@ -336,6 +340,9 @@ _PTYPES = ("read", "write", "create", "delete", "report", "export", "print")
 # Submittable doctypes (Material Request, Purchase Order, Stock Entry, …) also carry
 # the transition ptypes.
 _SUBMIT_PTYPES = _PTYPES + ("submit", "cancel", "amend")
+# Picker-only reference masters carry `select` too — include it so a _SELECT grant sets select=1
+# AND clears read/report/export/print (which are in _PTYPES).
+_SELECT_PTYPES = _PTYPES + ("select",)
 
 
 def _ensure_role(role_name):
@@ -447,7 +454,8 @@ def setup_estimation_master_permissions():
 	for doctype in ("Assembly", "Estimate Template"):
 		_apply_role_perms(doctype, ASSEMBLY_TEMPLATE_ROLE_PERMS)
 	_apply_role_perms("Construction Rate Master", RATE_MASTER_ROLE_PERMS)
-	_apply_role_perms("UOM", {role: _READ for role in _UOM_READ_ROLES})
+	# UOM is a pure link-picker target (unit dropdown on BOQ / Rate Master) — select, not read.
+	_apply_role_perms("UOM", {role: _SELECT for role in _UOM_READ_ROLES}, _SELECT_PTYPES)
 
 
 def setup_purchase_stock_permissions():
@@ -556,10 +564,10 @@ SUBCONTRACT_ROLE_PERMS = {
 	"BuildSuite Accountant": _FULL,  # Accountant maintains subcontractors fully (per the Accountant ruling)
 	"BuildSuite Estimator": _READ,  # Estimator reads subcontractors (per the Estimator ruling)
 }
-# Trade / Delivery Type masters — read for everyone in the module, write for
-# procurement + admins (they're resolved by the WO link pickers).
+# Trade / Delivery Type masters — pure WO link-picker targets (no screen), so everyone in the
+# module only SELECTs them; Procurement + admins maintain the master (full CRWD).
 SUBCONTRACT_MASTER_ROLE_PERMS = {
-	**{role: _READ for role in _SUBCONTRACT_FULL_ROLES + _SUBCONTRACT_READ_ROLES},
+	**{role: _SELECT for role in _SUBCONTRACT_FULL_ROLES + _SUBCONTRACT_READ_ROLES},
 	"BuildSuite Procurement Officer": _FULL,
 	"BuildSuite Administrator": _FULL,
 }
@@ -691,14 +699,18 @@ def setup_subcontract_permissions():
 	_apply_role_perms("Subcontractor Work Order", SUBCONTRACT_WO_ROLE_PERMS, _SUBMIT_PTYPES)
 	_apply_role_perms("Measurement Book", MEASUREMENT_BOOK_ROLE_PERMS)
 	_apply_role_perms("Subcontractor Bill", SUBCONTRACT_BILL_ROLE_PERMS, _SUBMIT_PTYPES)
-	_apply_role_perms("Construction Trade", SUBCONTRACT_MASTER_ROLE_PERMS)
-	_apply_role_perms("Subcontract Delivery Type", SUBCONTRACT_MASTER_ROLE_PERMS)
+	_apply_role_perms("Construction Trade", SUBCONTRACT_MASTER_ROLE_PERMS, _SELECT_PTYPES)
+	_apply_role_perms("Subcontract Delivery Type", SUBCONTRACT_MASTER_ROLE_PERMS, _SELECT_PTYPES)
 	# The bill's billing pickers (expense account, tax template, withholding category) read
 	# ERPNext's accounting masters — grant the finance-facing BuildSuite roles read so the
 	# Vue dropdowns populate for non-admin personas.
-	_billing_read = {role: _READ for role in _BILL_FULL_ROLES + ("BuildSuite Accountant",)}
-	for dt in ("Account", "Purchase Taxes and Charges Template", "Tax Category", "Tax Withholding Category"):
-		_apply_role_perms(dt, _billing_read)
+	_billing_roles = _BILL_FULL_ROLES + ("BuildSuite Accountant",)
+	# Account keeps read (it has a Finance Accounts screen + the disburse/JE context reads it).
+	_apply_role_perms("Account", {role: _READ for role in _billing_roles})
+	# The tax-template masters are pure billing-picker targets (no screen) — select, not read.
+	_billing_select = {role: _SELECT for role in _billing_roles}
+	for dt in ("Purchase Taxes and Charges Template", "Tax Category", "Tax Withholding Category"):
+		_apply_role_perms(dt, _billing_select, _SELECT_PTYPES)
 
 
 # --- M3 — Workforce -----------------------------------------------------------

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -492,3 +492,63 @@ class TestPersonaCrudMatrix(_PersonaBase):
 
 	def test_accountant_matrix(self):
 		self._assert_persona_matrix("Accountant", PERSONA_CRUD_MATRIX["Accountant"])
+
+
+class TestPickerSelectPermissions(_PersonaBase):
+	"""Picker-only reference masters grant `select` (link-field resolution), not `read`.
+
+	The picker (frappe.get_list) honours `select`, so dropdowns keep populating, but the persona
+	can no longer list / report / export the master. Masters with their own screen (Account) keep
+	read; masters that maintain the master (Procurement on Trade) keep full CRWD."""
+
+	def setUp(self):
+		super().setUp()
+		from buildsuite_core.permissions.setup import (
+			setup_estimation_master_permissions,
+			setup_subcontract_permissions,
+		)
+
+		setup_estimation_master_permissions()
+		setup_subcontract_permissions()
+		frappe.clear_cache()
+
+	def test_uom_is_select_only_for_estimation(self):
+		email = self._make_user("Estimator")
+		frappe.set_user(email)
+		try:
+			self.assertFalse(frappe.has_permission("UOM", "read"))
+			self.assertTrue(frappe.has_permission("UOM", "select"))
+			frappe.get_list("UOM", fields=["name"], limit_page_length=1)  # picker: no PermissionError
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_trade_masters_select_only_for_read_roles(self):
+		email = self._make_user("Quantity Surveyor")
+		frappe.set_user(email)
+		try:
+			for dt in ("Construction Trade", "Subcontract Delivery Type"):
+				self.assertFalse(frappe.has_permission(dt, "read"), dt)
+				self.assertTrue(frappe.has_permission(dt, "select"), dt)
+				frappe.get_list(dt, fields=["name"], limit_page_length=1)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_procurement_keeps_full_on_trade(self):
+		email = self._make_user("Procurement Officer")
+		frappe.set_user(email)
+		try:
+			self.assertTrue(frappe.has_permission("Construction Trade", "read"))
+			self.assertTrue(frappe.has_permission("Construction Trade", "write"))
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_tax_templates_select_but_account_keeps_read(self):
+		email = self._make_user("Project Manager")  # a billing-picker role
+		frappe.set_user(email)
+		try:
+			self.assertFalse(frappe.has_permission("Purchase Taxes and Charges Template", "read"))
+			self.assertTrue(frappe.has_permission("Purchase Taxes and Charges Template", "select"))
+			# Account keeps read — it has a Finance Accounts screen + the disburse/JE context reads it.
+			self.assertTrue(frappe.has_permission("Account", "read"))
+		finally:
+			frappe.set_user("Administrator")


### PR DESCRIPTION
Resolves the **select-vs-read over-grant**: reference masters a persona only resolves in a **link-field picker** (UOM, the tax-template masters, Construction Trade, Subcontract Delivery Type) were granted full `read` — which also lets those personas **list / report / export** the master.

## The key finding (no picker rewrite needed)
`frappe.get_list` — the picker's own endpoint (`DeskLinkPicker → linkSearch → frappe.client.get_list`) — **already honours `select`**. Its `DatabaseQuery.check_read_permission` uses `only_has_select_perm`, and a select-only role lists fine. **Verified empirically**: a role with `read=0, select=1` on UOM successfully `get_list`s. So this is a **backend-only** change — no frontend/picker modification.

## Change
- `_SELECT = {select, print}` + `_SELECT_PTYPES` (`= _PTYPES + select`) so a select grant clears `read/report/export/print` and sets `select`.
- Downgraded to `select` for the picker-only roles: **UOM**, **Purchase Taxes and Charges Template**, **Tax Category**, **Tax Withholding Category**, **Construction Trade**, **Subcontract Delivery Type**. Dropdowns still populate; those personas lose list/report/export.
- **Account keeps `read`** (Finance Accounts screen + disburse/JE context). **Procurement keeps full CRWD** on Trade/Delivery (it maintains the master).
- `resync_picker_select_permissions` patch converges existing sites (setup is install-only) — run `bench migrate`.

## Verification
- Live (rolled back): estimator → UOM `read=False, select=True, get_list=2`; QS → Trade same; PM → Account `read=True`.
- `TestPickerSelectPermissions` (4 tests) + the full `test_permission_matrix` module — **22/22 green**.

## Deferred (smaller follow-up)
Masters that are **both** a screen and a picker — `Customer, Employee, Project Category, Persona, Company` — need a per-role read/select split (screen roles keep `read`, picker-only roles get `select`), because their grant currently mirrors Project-read to all project-readable roles.

Full access-control picture: the [Frontend Access-Control Audit](https://claude.ai/code/artifact/222b24f3-ae14-473c-a31f-367184bac911) artifact.