### PR TITLE
feat: Purchase Order print format (prototype S234)

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/subcontractor/seed_print_assets.py
+++ b/buildsuite_core/buildsuite_core/doctype/subcontractor/seed_print_assets.py
@@ -10,6 +10,7 @@ import frappe
 
 LETTER_HEAD = "BuildSuite Standard"
 WO_PRINT_FORMAT = "Subcontractor Work Order"
+PO_PRINT_FORMAT = "Purchase Order"
 
 _LETTER_HEAD_HTML = """
 <div style="display:flex; align-items:center; gap:12px; padding:4px 0;">
@@ -151,9 +152,140 @@ _WO_PRINT_HTML = """
 """
 
 
+# Jinja/HTML body for the Purchase Order (S234 in the prototype). The letter head is
+# prepended by the print engine (company branding); this is the document body only.
+# ERPNext Purchase Order fields — header-level `project` is set by save_purchase_order.
+_PO_PRINT_HTML = """
+<style>
+	.po-print { font-family: -apple-system, "Segoe UI", Roboto, sans-serif; color:#1e293b; font-size:12px; }
+	.po-print .muted { color:#64748b; }
+	.po-print .label { font-size:10px; text-transform:uppercase; letter-spacing:0.06em; color:#64748b; }
+	.po-print .right { text-align:right; }
+	.po-title-row { display:flex; justify-content:space-between; align-items:flex-start;
+		border-bottom:2px solid #cbd5e1; padding-bottom:12px; margin-bottom:16px; }
+	.po-title { font-size:20px; font-weight:700; letter-spacing:1px; }
+	.parties { display:flex; gap:16px; margin-bottom:16px; }
+	.party { flex:1; border:1px solid #e2e8f0; border-radius:8px; padding:12px; }
+	.meta { display:flex; gap:16px; margin-bottom:16px; }
+	.meta > div { flex:1; }
+	table.items { width:100%; border-collapse:collapse; font-size:11px; margin-bottom:16px; }
+	table.items th, table.items td { border:1px solid #e2e8f0; padding:6px 8px; vertical-align:top; }
+	table.items thead th { background:#f8fafc; text-transform:uppercase; font-size:9px;
+		letter-spacing:0.06em; color:#64748b; text-align:left; }
+	h3.sec { font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:#334155; margin:16px 0 6px; }
+	.terms { font-size:11px; color:#475569; margin-bottom:20px; }
+	.terms ul { margin:0; padding-left:16px; }
+	.terms li { margin-bottom:4px; }
+	.sign { display:flex; gap:32px; margin-top:24px; }
+	.sign > div { flex:1; }
+	.sign .line { border-top:1px solid #94a3b8; padding-top:6px; margin-top:40px; font-size:11px; }
+	.footer { text-align:center; font-size:9px; color:#94a3b8; border-top:1px solid #f1f5f9; padding-top:8px; margin-top:16px; }
+</style>
+
+{% set sup = frappe.db.get_value("Supplier", doc.supplier, ["supplier_primary_contact", "mobile_no", "email_id", "tax_id"], as_dict=True) if doc.supplier else None %}
+{% set proj = frappe.db.get_value("Project", doc.project, ["project_name", "custom_project_id", "location"], as_dict=True) if doc.project else None %}
+{% set currency = frappe.db.get_value("Company", doc.company, "default_currency") if doc.company else None %}
+
+<div class="po-print">
+	<div class="po-title-row">
+		<div>
+			<div class="po-title">PURCHASE ORDER</div>
+			<div class="muted" style="font-size:11px;">{{ doc.name }}</div>
+		</div>
+		<div class="right">
+			<div class="muted">{{ frappe.utils.format_date(doc.transaction_date) }}</div>
+		</div>
+	</div>
+
+	<div class="parties">
+		<div class="party">
+			<div class="label">Ordered by</div>
+			<div style="font-weight:600; margin-top:4px;">{{ doc.company or "&mdash;" }}</div>
+		</div>
+		<div class="party">
+			<div class="label">To &mdash; Supplier</div>
+			<div style="font-weight:600; margin-top:4px;">{{ doc.supplier_name or doc.supplier }}</div>
+			{% if sup %}
+				{% if sup.supplier_primary_contact %}<div class="muted">Attn: {{ sup.supplier_primary_contact }}</div>{% endif %}
+				{% if sup.mobile_no or sup.email_id %}<div class="muted">{{ sup.mobile_no or "" }}{% if sup.mobile_no and sup.email_id %} &middot; {% endif %}{{ sup.email_id or "" }}</div>{% endif %}
+				{% if sup.tax_id %}<div class="muted">Tax ID: {{ sup.tax_id }}</div>{% endif %}
+			{% endif %}
+		</div>
+	</div>
+
+	<div class="meta">
+		<div>
+			<div class="label">Deliver to project</div>
+			<div style="font-weight:500;">{{ proj.project_name if proj else doc.project or "&mdash;" }}</div>
+			{% if proj and proj.custom_project_id %}<div class="muted">{{ proj.custom_project_id }}{% if proj.location %} &middot; {{ proj.location }}{% endif %}</div>{% endif %}
+		</div>
+		<div><div class="label">Required by</div><div style="font-weight:500;">{{ frappe.utils.format_date(doc.schedule_date) if doc.schedule_date else "&mdash;" }}</div></div>
+		<div><div class="label">Order date</div><div style="font-weight:500;">{{ frappe.utils.format_date(doc.transaction_date) }}</div></div>
+	</div>
+
+	<h3 class="sec">Order items</h3>
+	<table class="items">
+		<thead>
+			<tr>
+				<th style="width:24px;">#</th>
+				<th>Item</th>
+				<th class="right">Qty</th>
+				<th>UOM</th>
+				<th class="right">Rate</th>
+				<th class="right">Amount</th>
+			</tr>
+		</thead>
+		<tbody>
+			{% for line in doc.items %}
+			<tr>
+				<td class="muted">{{ loop.index }}</td>
+				<td>
+					{{ line.item_name or line.item_code }}
+					{% if line.description and line.description != line.item_name %}<div class="muted" style="font-size:10px; margin-top:2px;">{{ line.description }}</div>{% endif %}
+				</td>
+				<td class="right">{{ line.qty }}</td>
+				<td>{{ line.uom or "" }}</td>
+				<td class="right">{{ frappe.utils.fmt_money(line.rate, currency=currency) }}</td>
+				<td class="right" style="font-weight:500;">{{ frappe.utils.fmt_money(line.amount, currency=currency) }}</td>
+			</tr>
+			{% endfor %}
+		</tbody>
+		<tfoot>
+			<tr>
+				<td colspan="5" class="right" style="background:#f8fafc; font-weight:600; text-transform:uppercase; font-size:9px;">Total order value</td>
+				<td class="right" style="background:#f8fafc; font-weight:600;">{{ frappe.utils.fmt_money(doc.grand_total, currency=currency) }}</td>
+			</tr>
+		</tfoot>
+	</table>
+
+	<h3 class="sec">Terms &amp; conditions</h3>
+	<div class="terms">
+		{% if doc.terms %}
+			{{ doc.terms }}
+		{% else %}
+		<ul>
+			<li>Deliver to the project site named above{% if doc.schedule_date %} on or before {{ frappe.utils.format_date(doc.schedule_date) }}{% endif %}. Part deliveries are accepted against this order.</li>
+			<li>Each delivery must carry a challan quoting this PO number; quantities are confirmed at site on receipt.</li>
+			<li>Material not conforming to the ordered specification may be rejected at site at the supplier's cost.</li>
+			<li>Invoices must reference this PO and the site-acknowledged receipt quantities.</li>
+		</ul>
+		{% endif %}
+	</div>
+
+	<div class="sign">
+		<div><div class="line">For {{ doc.company or "&mdash;" }}</div><div class="muted" style="font-size:9px;">Authorised signatory &middot; Date</div></div>
+		<div><div class="line">For {{ doc.supplier_name or doc.supplier }}</div><div class="muted" style="font-size:9px;">Acknowledged &middot; Date</div></div>
+	</div>
+
+	<div class="footer">{{ doc.name }} &middot; Generated {{ frappe.utils.format_date(frappe.utils.nowdate()) }}</div>
+</div>
+"""
+
+
 def seed_print_assets():
 	_seed_letter_head()
 	_seed_wo_print_format()
+	_seed_po_print_format()
 
 
 def _seed_letter_head():
@@ -185,6 +317,25 @@ def _seed_wo_print_format():
 			"print_format_type": "Jinja",
 			"custom_format": 1,
 			"html": _WO_PRINT_HTML,
+			"disabled": 0,
+		}
+	).insert(ignore_permissions=True)
+
+
+def _seed_po_print_format():
+	if frappe.db.exists("Print Format", PO_PRINT_FORMAT):
+		# Keep the body in sync on migrate.
+		frappe.db.set_value("Print Format", PO_PRINT_FORMAT, "html", _PO_PRINT_HTML)
+		return
+	frappe.get_doc(
+		{
+			"doctype": "Print Format",
+			"name": PO_PRINT_FORMAT,
+			"doc_type": "Purchase Order",
+			"module": "BuildSuite Core",
+			"print_format_type": "Jinja",
+			"custom_format": 1,
+			"html": _PO_PRINT_HTML,
 			"disabled": 0,
 		}
 	).insert(ignore_permissions=True)

--- a/frontend/src/views/procurement/PurchaseOrderDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseOrderDetailView.vue
@@ -48,6 +48,16 @@ const canReceive = computed(() => isSubmitted.value && (po.value?.per_received |
 function onEdit() {
 	router.push(`/procurement/purchase-orders/${po.value.name}/edit`);
 }
+function onPrint() {
+	// Opens ERPNext's native print view in a new tab, applying the seeded
+	// "Purchase Order" Print Format + "BuildSuite Standard" letter head.
+	window.open(
+		`/printview?doctype=Purchase%20Order&name=${encodeURIComponent(
+			po.value.name
+		)}&format=Purchase%20Order&letterhead=BuildSuite%20Standard&trigger_print=1`,
+		"_blank"
+	);
+}
 function onCreateReceipt() {
 	router.push(`/procurement/receipts/new?po=${po.value.name}`);
 }
@@ -135,6 +145,23 @@ const breadcrumbs = computed(() => [
 	>
 		<template #actions>
 			<ProcurementStatusPill :status="po.status" class="self-center mr-1" />
+			<button
+				type="button"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 flex items-center gap-1.5"
+				style="border-radius: 6px"
+				title="Open the printable purchase order (Save as PDF from the print dialog)"
+				@click="onPrint"
+			>
+				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="1.75"
+						d="M17 17h2a2 2 0 002-2v-4a2 2 0 00-2-2H5a2 2 0 00-2 2v4a2 2 0 002 2h2m2 4h6a2 2 0 002-2v-4a2 2 0 00-2-2H9a2 2 0 00-2 2v4a2 2 0 002 2zm8-12V5a2 2 0 00-2-2H9a2 2 0 00-2 2v4h10z"
+					/>
+				</svg>
+				Print / PDF
+			</button>
 			<button
 				v-if="isDraft && canEdit('purchaseOrder')"
 				type="button"


### PR DESCRIPTION
## What
Implements the Purchase Order print/PDF in the live app, matching the prototype's **S234 `PurchaseOrderPrintView`** layout.

- **Seeded `Purchase Order` Frappe Print Format** (Jinja, module `BuildSuite Core`) rendering the prototype's sections: letterhead title, party blocks (Ordered by / To — Supplier with contact + tax id), meta strip (project / required-by / order date), order-lines table with total, terms (doc terms or the standard site-delivery boilerplate fallback), signatures, footer. Uses the seeded **`BuildSuite Standard`** letter head for company branding.
- **`Print / PDF` button on the PO detail** — opens Frappe's native `/printview` in a new tab applying that format + letter head, the same workflow the Supplier Bill uses. Available in every lifecycle state.

## How it's wired
`_seed_po_print_format()` added to `seed_print_assets.py` alongside the existing Work Order format; called from `seed_print_assets()` → `seed_subcontract_masters()`, which runs on both `after_install` and `after_migrate`. Idempotent: creates the format if missing, otherwise keeps the HTML body in sync.

## Verification
- Seeder run on `bs.local`; `Purchase Order` Print Format present (Jinja, not disabled).
- Rendered against a real PO (`PUR-ORD-2026-00010`) — all sections present, no template errors.
- Frontend build clean.