### PR TITLE
fix: in-app Purchase Order print view (no new-tab redirect)

### DIFF
--- a/buildsuite_core/api/procurement_docs.py
+++ b/buildsuite_core/api/procurement_docs.py
@@ -260,6 +260,51 @@ def get_purchase_order(name):
 	return out
 
 
+def _supplier_detail(supplier):
+	"""Party block for the PO print view — tax id on the Supplier, contact
+	person/phone/email on its native Contact (mirrors _subcontractor_detail)."""
+	if not supplier or not frappe.db.exists("Supplier", supplier):
+		return None
+	detail = {"tax_id": frappe.db.get_value("Supplier", supplier, "tax_id")}
+	contact = frappe.get_all(
+		"Contact",
+		filters=[
+			["Dynamic Link", "link_doctype", "=", "Supplier"],
+			["Dynamic Link", "link_name", "=", supplier],
+		],
+		fields=["first_name", "email_id", "mobile_no", "phone"],
+		limit=1,
+	)
+	if contact:
+		c = contact[0]
+		detail["contact_person"] = c.first_name
+		detail["email"] = c.email_id
+		detail["phone"] = c.mobile_no or c.phone
+	return detail
+
+
+@frappe.whitelist()
+def get_po_print_data(name):
+	"""A Purchase Order enriched with the party/project detail the in-app print view
+	needs (supplier contact + tax id, project code/location). Single fetch so the Vue
+	print page mirrors the seeded Frappe Print Format from one payload."""
+	doc = frappe.get_doc(PURCHASE_ORDER, name)
+	doc.check_permission("read")
+	out = _serialize_po(doc)
+	out["supplier_detail"] = _supplier_detail(doc.supplier)
+	out["project_detail"] = (
+		frappe.db.get_value(
+			"Project",
+			doc.project,
+			["custom_project_id", "customer", "location"],
+			as_dict=True,
+		)
+		if doc.project
+		else None
+	)
+	return out
+
+
 @frappe.whitelist()
 def get_mr_for_po(material_request):
 	"""Prefill payload for a PO raised from an approved Material Request — the

--- a/frontend/src/data/procurementApi.js
+++ b/frontend/src/data/procurementApi.js
@@ -38,6 +38,7 @@ export const deleteMaterialRequest = (name) => docCall("delete_material_request"
 
 // Purchase Order
 export const getPurchaseOrder = (name) => docCall("get_purchase_order", { name });
+export const getPoPrintData = (name) => docCall("get_po_print_data", { name });
 export const getMrForPo = (materialRequest) =>
 	docCall("get_mr_for_po", { material_request: materialRequest });
 export const savePurchaseOrder = (payload) =>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -385,6 +385,12 @@ const routes = [
 				component: () => import("@/views/procurement/NewPurchaseOrderView.vue"),
 			},
 			{
+				path: "procurement/purchase-orders/:id/print",
+				name: "purchase-order-print",
+				component: () => import("@/views/procurement/PurchaseOrderPrintView.vue"),
+				props: true,
+			},
+			{
 				path: "procurement/receipts",
 				name: "purchase-receipts",
 				component: () => import("@/views/procurement/PurchaseReceiptsListView.vue"),

--- a/frontend/src/views/procurement/PurchaseOrderDetailView.vue
+++ b/frontend/src/views/procurement/PurchaseOrderDetailView.vue
@@ -49,14 +49,9 @@ function onEdit() {
 	router.push(`/procurement/purchase-orders/${po.value.name}/edit`);
 }
 function onPrint() {
-	// Opens ERPNext's native print view in a new tab, applying the seeded
-	// "Purchase Order" Print Format + "BuildSuite Standard" letter head.
-	window.open(
-		`/printview?doctype=Purchase%20Order&name=${encodeURIComponent(
-			po.value.name
-		)}&format=Purchase%20Order&letterhead=BuildSuite%20Standard&trigger_print=1`,
-		"_blank"
-	);
+	// In-app print view (mirrors the Work Order workflow) — no new tab. The Vue
+	// page is the visual twin of the seeded Frappe "Purchase Order" Print Format.
+	router.push(`/procurement/purchase-orders/${po.value.name}/print`);
 }
 function onCreateReceipt() {
 	router.push(`/procurement/receipts/new?po=${po.value.name}`);

--- a/frontend/src/views/procurement/PurchaseOrderPrintView.vue
+++ b/frontend/src/views/procurement/PurchaseOrderPrintView.vue
@@ -1,0 +1,287 @@
+<script setup>
+// Purchase Order — printable document rendered inside the SPA (prototype S234).
+//
+// Mirrors the Subcontractor Work Order print workflow: the PO detail's "Print /
+// PDF" button routes here; a sticky control bar (Back + Export PDF, both hidden
+// in print) sits above a Vue-styled document surface. PDF export is
+// `window.print()` + the global @media print rules in style.css, which hide the
+// DeskShell chrome (.print:hidden / aside / header.h-12), force a white page and
+// set A4. The browser's own "Save as PDF" does the export — no new dependency.
+//
+// The layout is the visual twin of the seeded Frappe "Purchase Order" Print
+// Format + "BuildSuite Standard" Letter Head (used for Desk/server PDF).
+
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import { getPoPrintData } from "@/data/procurementApi";
+import { showToast } from "@/utils/appToast";
+import { fmtINR, fmtDate } from "@/utils/format";
+
+const props = defineProps({ id: { type: String, required: true } });
+const router = useRouter();
+
+const po = ref(null);
+const loading = ref(true);
+
+const sup = computed(() => po.value?.supplier_detail || null);
+const proj = computed(() => po.value?.project_detail || null);
+const company = computed(() => po.value?.company || null);
+
+function generatedOnLabel() {
+	return new Date().toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" });
+}
+
+function printDoc() {
+	window.print();
+}
+function backToPo() {
+	router.push(`/procurement/purchase-orders/${props.id}`);
+}
+
+async function load() {
+	loading.value = true;
+	try {
+		po.value = await getPoPrintData(props.id);
+	} catch (err) {
+		showToast(err.message || "Failed to load purchase order", "error");
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.id, load, { immediate: true });
+</script>
+
+<template>
+	<div class="bg-white min-h-full report-root">
+		<!-- ===== Control bar (hidden in print) ===== -->
+		<header class="border-b border-ink-200 bg-white sticky top-0 z-10 print:hidden">
+			<div class="max-w-4xl mx-auto px-6 py-3 flex items-center gap-3">
+				<button
+					@click="backToPo"
+					class="text-xs text-ink-600 hover:text-ink-900 flex items-center gap-1"
+				>
+					<span>←</span><span>Back to purchase order</span>
+				</button>
+				<button
+					v-if="po"
+					@click="printDoc"
+					class="ml-auto text-xs px-3 py-1.5 rounded bg-ink-900 text-white hover:bg-ink-800 flex items-center gap-1.5"
+					title="Opens the browser print dialog. Pick 'Save as PDF' to export."
+				>
+					<svg
+						class="w-3.5 h-3.5"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="1.75"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<polyline points="6 9 6 2 18 2 18 9" />
+						<path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2" />
+						<rect x="6" y="14" width="12" height="8" />
+					</svg>
+					<span>Export PDF</span>
+				</button>
+			</div>
+		</header>
+
+		<!-- ===== Document ===== -->
+		<main v-if="po" class="report-content max-w-4xl mx-auto px-6 py-8 text-ink-900">
+			<!-- Letterhead -->
+			<section
+				class="report-section flex items-start justify-between gap-6 pb-4 mb-6 border-b-2 border-ink-300"
+			>
+				<div class="min-w-0">
+					<div class="flex items-center gap-3">
+						<div
+							class="w-12 h-12 rounded border border-dashed border-ink-300 flex items-center justify-center text-[9px] text-ink-400 flex-shrink-0"
+						>
+							LOGO
+						</div>
+						<div class="min-w-0">
+							<div class="text-lg font-semibold truncate">{{ company || "—" }}</div>
+							<div class="text-[11px] text-ink-400 italic">
+								Registered address · GSTIN — to be configured (Letter Head)
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="text-right flex-shrink-0">
+					<div class="text-xl font-bold tracking-wide">PURCHASE ORDER</div>
+					<div class="text-sm font-medium text-ink-700 mt-0.5">{{ po.name }}</div>
+					<div class="text-xs text-ink-500 mt-0.5">{{ fmtDate(po.transaction_date) }}</div>
+				</div>
+			</section>
+
+			<!-- Party blocks -->
+			<section class="report-section grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+				<div class="border border-ink-200 rounded-lg p-4">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 mb-1.5">
+						Ordered by
+					</div>
+					<div class="text-sm font-semibold">{{ company || "—" }}</div>
+					<div class="text-xs text-ink-400 italic mt-0.5">Address — to be configured</div>
+				</div>
+				<div class="border border-ink-200 rounded-lg p-4">
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 mb-1.5">
+						To — Supplier
+					</div>
+					<div class="text-sm font-semibold">{{ po.supplier_name || po.supplier }}</div>
+					<div v-if="sup" class="text-xs text-ink-600 mt-1 space-y-0.5">
+						<div v-if="sup.contact_person">Attn: {{ sup.contact_person }}</div>
+						<div v-if="sup.phone || sup.email">
+							<span v-if="sup.phone">{{ sup.phone }}</span>
+							<span v-if="sup.phone && sup.email"> · </span>
+							<span v-if="sup.email">{{ sup.email }}</span>
+						</div>
+						<div v-if="sup.tax_id" class="text-ink-500">Tax ID: {{ sup.tax_id }}</div>
+					</div>
+				</div>
+			</section>
+
+			<!-- Meta strip -->
+			<section class="report-section grid grid-cols-2 md:grid-cols-3 gap-3 mb-6 text-xs">
+				<div>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">
+						Deliver to project
+					</div>
+					<div class="font-medium mt-0.5">{{ po.project_name || po.project }}</div>
+					<div class="text-ink-500">
+						{{ proj?.custom_project_id
+						}}<span v-if="proj?.location"> · {{ proj.location }}</span>
+					</div>
+				</div>
+				<div>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Required by</div>
+					<div class="font-medium mt-0.5">
+						{{ po.schedule_date ? fmtDate(po.schedule_date) : "—" }}
+					</div>
+				</div>
+				<div>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500">Order date</div>
+					<div class="font-medium mt-0.5">{{ fmtDate(po.transaction_date) }}</div>
+				</div>
+			</section>
+
+			<!-- Order lines -->
+			<section class="report-section mb-6">
+				<h2 class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2">
+					Order items
+				</h2>
+				<table class="w-full text-xs border border-ink-200 rounded-lg overflow-hidden">
+					<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+						<tr>
+							<th class="text-left px-3 py-2 w-8">#</th>
+							<th class="text-left px-3 py-2">Item</th>
+							<th class="text-right px-3 py-2">Qty</th>
+							<th class="text-left px-3 py-2">UOM</th>
+							<th class="text-right px-3 py-2">Rate</th>
+							<th class="text-right px-3 py-2">Amount</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr
+							v-for="(line, idx) in po.items"
+							:key="line.name || idx"
+							class="border-t border-ink-100 align-top"
+						>
+							<td class="px-3 py-2 text-ink-500">{{ idx + 1 }}</td>
+							<td class="px-3 py-2">
+								{{ line.item_name || line.item_code }}
+								<div
+									v-if="line.description && line.description !== line.item_name"
+									class="text-[10px] text-ink-500 mt-0.5"
+								>
+									{{ line.description }}
+								</div>
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums">{{ line.qty }}</td>
+							<td class="px-3 py-2">{{ line.uom }}</td>
+							<td class="px-3 py-2 text-right tabular-nums">{{ fmtINR(line.rate) }}</td>
+							<td class="px-3 py-2 text-right tabular-nums font-medium">
+								{{ fmtINR(line.amount) }}
+							</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr class="border-t-2 border-ink-200 bg-ink-50">
+							<td
+								colspan="5"
+								class="px-3 py-2 text-right text-[11px] font-semibold uppercase tracking-wider text-ink-700"
+							>
+								Total order value
+							</td>
+							<td class="px-3 py-2 text-right tabular-nums text-sm font-semibold">
+								{{ fmtINR(po.grand_total) }}
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</section>
+
+			<!-- Terms — the PO's own terms print when set; the generic boilerplate is
+			     the no-terms fallback. -->
+			<section class="report-section mb-8 text-xs text-ink-600">
+				<h3 class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-1.5">
+					Terms &amp; conditions
+				</h3>
+				<div v-if="po.terms" class="whitespace-pre-line leading-relaxed">{{ po.terms }}</div>
+				<ul v-else class="list-disc pl-4 space-y-1 leading-relaxed">
+					<li>
+						Deliver to the project site named above{{
+							po.schedule_date ? ` on or before ${fmtDate(po.schedule_date)}` : ""
+						}}. Part deliveries are accepted against this order.
+					</li>
+					<li>
+						Each delivery must carry a challan quoting this PO number; quantities are
+						confirmed at site on receipt.
+					</li>
+					<li>
+						Material not conforming to the ordered specification may be rejected at site at
+						the supplier's cost.
+					</li>
+					<li>Invoices must reference this PO and the site-acknowledged receipt quantities.</li>
+				</ul>
+			</section>
+
+			<!-- Signatures -->
+			<section class="report-section grid grid-cols-2 gap-8 mb-6">
+				<div>
+					<div class="border-t border-ink-400 pt-1.5 mt-10 text-xs text-ink-600">
+						For {{ company || "—" }}
+					</div>
+					<div class="text-[10px] text-ink-400 mt-0.5">Authorised signatory · Date</div>
+				</div>
+				<div>
+					<div class="border-t border-ink-400 pt-1.5 mt-10 text-xs text-ink-600">
+						For {{ po.supplier_name || po.supplier }}
+					</div>
+					<div class="text-[10px] text-ink-400 mt-0.5">Acknowledged · Date</div>
+				</div>
+			</section>
+
+			<!-- Footer -->
+			<div class="text-[10px] text-ink-400 text-center pt-3 border-t border-ink-100">
+				Generated on {{ generatedOnLabel() }} · {{ po.name }}
+			</div>
+		</main>
+
+		<!-- Loading / not found -->
+		<main
+			v-else-if="loading"
+			class="max-w-4xl mx-auto px-6 py-16 text-center text-sm text-ink-500"
+		>
+			Loading…
+		</main>
+		<main v-else class="max-w-4xl mx-auto px-6 py-16 text-center">
+			<div class="text-sm text-ink-700 mb-2">
+				No purchase order with id <span class="font-mono">{{ id }}</span>.
+			</div>
+			<button @click="backToPo" class="text-xs text-brand-700 hover:underline">
+				← Back to purchase order
+			</button>
+		</main>
+	</div>
+</template>


### PR DESCRIPTION
## Why
The PO print (merged in #222) opened ERPNext's server-rendered `/printview` in a **new browser tab**, leaving the SPA. That's inconsistent with how the **Subcontractor Work Order** prints — an in-app Vue print page, no redirect. This aligns the PO with that workflow (and with the prototype's S234 `PurchaseOrderPrintView`).

## What
- **New `PurchaseOrderPrintView.vue`** — a printable document rendered inside the SPA, structured exactly like `SubcontractorWorkOrderPrintView.vue`: sticky control bar (Back + Export PDF, both `print:hidden`), then the document surface. PDF export is `window.print()` + the shared `@media print` rules. Layout ports the prototype S234 (letterhead, party blocks, meta strip, order-lines, terms + boilerplate fallback, signatures, footer).
- **`onPrint` now routes in-app** — `router.push('/procurement/purchase-orders/<name>/print')` instead of `window.open('/printview', '_blank')`.
- **New route** `procurement/purchase-orders/:id/print`.
- **New `get_po_print_data` endpoint** — enriches the PO with supplier contact + project detail in one fetch (mirrors `get_wo_print_data`).

The seeded Frappe **Purchase Order** Print Format (from #222) stays as the Desk/server-PDF twin — same arrangement as the Work Order.

## Verification
- `get_po_print_data` returns the enriched payload against a real PO (`PUR-ORD-2026-00010`).
- Frontend build clean; the print view degrades gracefully when supplier contact / project detail are absent.