### PR TITLE
fix: home dashboard 500s for personas lacking Task Progress Entry read

### DIFF
--- a/buildsuite_core/api/home.py
+++ b/buildsuite_core/api/home.py
@@ -6,9 +6,13 @@ fields the denser Desk overview (`/dashboard`) still renders.
 
 One aggregate read. It resolves the logged-in user's role (their Persona) and returns that
 role's four snapshot tiles, a primary CTA, and three alert cards — the same per-role content
-as the prototype's HomeWorkspaceView. All project/task/SCO reads go through get_list, so the
-permission query conditions apply: a team-scoped user (QS, Site Engineer, …) sees only their
-own projects/tasks; admins/PMs see the whole company. Single-company for now."""
+as the prototype's HomeWorkspaceView. The *project* rows go through get_list, so the permission
+query conditions apply (a team-scoped user sees only their own projects; admins/PMs see the
+whole company). Every aggregate metric, by contrast, is an elevated, exception-safe count/sum
+(`_count`/`_sum`) gated by which tiles the role gets — NOT by the caller's doctype permissions.
+Keep it that way: a permission-respecting get_list on a metric doctype hard-throws for any
+persona lacking read on it and 500s the whole landing page (it did, for Task Progress Entry).
+Single-company for now."""
 
 import json
 
@@ -323,11 +327,7 @@ def get_home_dashboard():
 	overdue_tasks = _count(
 		"Task", {**proj_in, "status": ["not in", _OPEN_TASK], "exp_end_date": ["<", str(today)]}
 	)
-	progress_today = len(
-		frappe.get_list(
-			"Task Progress Entry", filters={"entry_date": str(today)}, pluck="name", limit_page_length=0
-		)
-	)
+	progress_today = _count("Task Progress Entry", {"entry_date": str(today)})
 	users = _count("User", {"enabled": 1, "name": ["not in", ["Administrator", "Guest"]]})
 	stage_pending = _count("Stage Planning", {**proj_in, "workflow_state": "Pending Approval"})
 	pending_scos_ct = _count("Scope Change Order", {**proj_in, "status": "Pending Approval"})
@@ -366,14 +366,7 @@ def get_home_dashboard():
 	my_open = _my()
 	my_overdue = _my({"exp_end_date": ["<", str(today)]})
 	my_due_week = _my({"exp_end_date": ["between", [str(today), str(add_days(today, 7))]]})
-	my_progress_today = len(
-		frappe.get_list(
-			"Task Progress Entry",
-			filters={"entry_date": str(today), "owner": user},
-			pluck="name",
-			limit_page_length=0,
-		)
-	)
+	my_progress_today = _count("Task Progress Entry", {"entry_date": str(today), "owner": user})
 
 	# --- lazily-computed heavier metrics (only used by some roles) ---
 	def boqs():


### PR DESCRIPTION
## The bug
The `/home` landing page returns **500 Insufficient Permission for Task Progress Entry** for any persona that lacks read/select on that doctype.

```
File "buildsuite_core/api/home.py", line 327, in get_home_dashboard
    frappe.get_list("Task Progress Entry", filters={"entry_date": ...}, ...)
frappe.exceptions.PermissionError: Insufficient Permission for Task Progress Entry
```

## Root cause
`get_home_dashboard()` mixes two read styles:
- **Elevated, exception-safe** — `_count()` (`frappe.db.count`) / `_sum()` (`frappe.get_all`), used for ~every metric. Never throw on permissions.
- **Permission-respecting** — `frappe.get_list(...)`, which **hard-throws** `PermissionError` when the caller can't read the doctype.

Two progress counts used `get_list("Task Progress Entry")` **unconditionally, before the per-role branch**, so a single missing permission 500s the entire landing page for that persona. The persona gating in this endpoint is done in Python (which tiles each role gets), *not* at the data layer — so a metric read must never hard-depend on the caller's doctype permission.

Reproduced locally: **store-keeper** and **procurement** personas (no Task Progress Entry read) crash. On staging the "Admin" persona hits it too — its DocPerms are stale (permission setup is install-only), which is exactly why the code must not depend on that permission being present.

## Fix
Bring the two progress counts onto the same elevated `_count` pattern as every other metric. No behaviour change for personas that *did* have the permission; the crash is gone for those that don't.

The remaining `get_list` calls (Project rows) are intentional and safe — every persona has Project `read`, and project-level permission scoping there is by design.

## Verification
- As **store-keeper** and **procurement** (both lacking Task Progress Entry read): `get_home_dashboard()` now returns cleanly (4 tiles each) — previously a hard `PermissionError`.