### PR TITLE
fix: stale Project Finance reseed patch aborts migrate (KeyError: 'project-finance')

### DIFF
--- a/buildsuite_core/patches/reseed_project_finance_reports.py
+++ b/buildsuite_core/patches/reseed_project_finance_reports.py
@@ -1,26 +1,23 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
 
-"""The Project Finance report tiles were reworked: Profit & Loss / Petty Cash / Expense Summary
-/ Cash & Bank now ride the ERPNext reports (Desk query-report route), and Receivables & Payables
-and Financial Position are bespoke Script Reports (buildsuite_core/report/) shown in-app —
-replacing the six mock-data Vue stubs. This patch syncs the two Script Reports and repoints the
-Project Finance workspace tiles on sites seeded before the change (the seeder is idempotent and
-would otherwise leave the old tiles in place)."""
+"""The Project Finance report tiles were reworked several times. This early patch originally
+synced two bespoke Script Reports (receivables_and_payables / financial_position) and repointed
+the tiles from a static _SEED["project-finance"] list. Both are gone now: those reports became
+in-app Vue views, and the tile set moved to _project_finance_tiles(). A site that migrates for
+the first time after those changes hit `KeyError: 'project-finance'` here, which aborted the whole
+migration. Repoint the Project Finance tiles from the current source instead — the later PF
+patches rebuild the same set idempotently, so this stays consistent with them."""
 
 import frappe
 
-from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import _SEED
-
-MODULES = ("receivables_and_payables", "financial_position")
+from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import (
+	_project_finance_tiles,
+)
 
 
 def execute():
-	# 1) Ensure the two bespoke Script Reports are synced from their module files.
-	for module in MODULES:
-		frappe.reload_doc("buildsuite_core", "report", module, force=True)
-
-	# 2) Repoint the Project Finance workspace tiles to the new set (keep other workspaces).
+	# Repoint only the project-finance tiles; leave the other workspaces' rows untouched.
 	settings = frappe.get_single("Workspace Setting")
 	kept = [
 		{
@@ -37,7 +34,7 @@ def execute():
 	settings.set("reports", [])
 	for row in kept:
 		settings.append("reports", row)
-	for row in _SEED["project-finance"]:
+	for row in _project_finance_tiles():
 		settings.append("reports", {"workspace": "project-finance", **row})
 	settings.flags.ignore_permissions = True
 	settings.save()


### PR DESCRIPTION
## The failure
`bench migrate` aborts on a remote site inside `reseed_project_finance_reports`:

```
File ".../patches/reseed_project_finance_reports.py", line 40, in execute
    for row in _SEED["project-finance"]:
KeyError: 'project-finance'
```

(Preceded by two non-fatal warnings — `receivables_and_payables.json missing` and `financial_position.json missing`.)

## Root cause
The patch (2026-08-18) was written against an older seeder. Later reworks:
- moved the Project Finance tile set out of the static `_SEED` dict into a function, **`_project_finance_tiles()`** — so `_SEED` now only has `subcontract` and `procurement` keys, and `_SEED["project-finance"]` raises `KeyError`;
- replaced the two bespoke Script Reports (`receivables_and_payables`, `financial_position`) with in-app **Vue views**, so the patch's `reload_doc` of those modules now prints "missing" (harmless).

The sibling patches — `reseed_project_finance_bespoke` (#31), `reseed_project_finance_bespoke_views` (#32), `repoint_pnl_to_bespoke` (#37) — were all updated to use `_project_finance_tiles()`. This one was missed. Because it runs *before* them in `patches.txt`, its crash aborts the migration before the corrected patches can run. Any site that hadn't yet applied this patch when the rework landed hits it (fresh sites, or ones behind on migrations).

## Fix
Repoint the Project Finance tiles from `_project_finance_tiles()` (identical to the sibling patches) and drop the obsolete reload of the now-deleted Script Reports. Patches only run once, so this is a no-op on sites that already applied the old version; sites still pending get the corrected, non-crashing version.

## Verification
Ran `execute()` on a local site — completes without error and yields the expected 6 tiles: Profit & Loss, Receivables & Payables, Financial Position, Petty Cash, Expense Summary, Cash & Bank Statement.