### PR TITLE
feat: custom DocType sections in workspaces (list + form)

### DIFF
--- a/buildsuite_core/api/workspace_setting.py
+++ b/buildsuite_core/api/workspace_setting.py
@@ -338,4 +338,37 @@ def get_doctype_permissions(doctype):
 		"create": bool(frappe.has_permission(doctype, "create")),
 		"delete": bool(frappe.has_permission(doctype, "delete")),
 		"submit": bool(frappe.has_permission(doctype, "submit")),
+		"cancel": bool(frappe.has_permission(doctype, "cancel")),
 	}
+
+
+@frappe.whitelist()
+def submit_record(doctype, name):
+	"""Submit a saved draft of an allow-listed DocType (doc.submit enforces the submit
+	permission + validation server-side)."""
+	_require_allowed(doctype)
+	doc = frappe.get_doc(doctype, name)
+	doc.submit()
+	return {"name": doc.name, "docstatus": doc.docstatus}
+
+
+@frappe.whitelist()
+def cancel_record(doctype, name):
+	"""Cancel a submitted document of an allow-listed DocType."""
+	_require_allowed(doctype)
+	doc = frappe.get_doc(doctype, name)
+	doc.cancel()
+	return {"name": doc.name, "docstatus": doc.docstatus}
+
+
+@frappe.whitelist()
+def amend_record(doctype, name):
+	"""Amend a cancelled document — a fresh draft copy linked via amended_from."""
+	_require_allowed(doctype)
+	src = frappe.get_doc(doctype, name)
+	if src.docstatus != 2:
+		frappe.throw(_("Only a cancelled document can be amended."))
+	new = frappe.copy_doc(src)
+	new.amended_from = name
+	new.insert()
+	return {"name": new.name, "docstatus": new.docstatus}

--- a/buildsuite_core/api/workspace_setting.py
+++ b/buildsuite_core/api/workspace_setting.py
@@ -1,13 +1,17 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
 
-"""Whitelisted read/write for per-workspace **report-style shortcut** tiles
-(Workspace Setting Single). Each live BuildSuite workspace renders an ordered list
-of report tiles; admins configure them per workspace in the Workspace Setting screen.
+"""Whitelisted read/write for the per-workspace shortcut tiles (Workspace Setting Single).
+Two parallel groups, both tagged by workspace slug and configured in the Workspace Setting
+screen:
 
-A tile's destination is either an explicit `route` (an in-app path like
-`/subcontractor-work-orders`, or a Desk URL like `/app/query-report/Stock Balance`)
-or a linked Frappe `Report` (whose Desk route + name are derived when `route` is blank)."""
+- **Reports** — a tile's destination is an explicit `route` (an in-app path like
+  `/subcontractor-work-orders`, or a Desk URL like `/app/query-report/Stock Balance`) or a
+  linked Frappe `Report` (whose Desk route + name are derived when `route` is blank).
+- **Records** — a tile points at an admin-curated DocType; it opens the generic /records
+  list + add/edit form for that DocType. The list config (columns/search/sort) is derived
+  from the DocType's own Frappe meta. The configured DocTypes form an allowlist that gates
+  the generic list/form config endpoints (Frappe permissions still gate each record)."""
 
 from urllib.parse import quote
 
@@ -92,7 +96,7 @@ def get_workspace_reports(workspace):
 
 @frappe.whitelist()
 def get_workspace_settings():
-	"""Every live workspace + its configured report rows, for the admin screen."""
+	"""Every live workspace + its configured report and doctype rows, for the admin screen."""
 	_require_admin()
 	settings = frappe.get_single(SETTINGS)
 	by_ws = {w["slug"]: [] for w in WORKSPACES}
@@ -107,7 +111,18 @@ def get_workspace_settings():
 					"description": row.description or "",
 				}
 			)
-	return {"workspaces": list(WORKSPACES), "reports": by_ws}
+	by_dt = {w["slug"]: [] for w in WORKSPACES}
+	for row in settings.doctypes:
+		if row.workspace in by_dt:
+			by_dt[row.workspace].append(
+				{
+					"label": row.label or "",
+					"doctype": row.document_type or "",
+					"icon": row.icon or "",
+					"description": row.description or "",
+				}
+			)
+	return {"workspaces": list(WORKSPACES), "reports": by_ws, "doctypes": by_dt}
 
 
 @frappe.whitelist()
@@ -154,3 +169,149 @@ def set_workspace_reports(workspace, reports=None):
 	settings.flags.ignore_permissions = True
 	settings.save()
 	return get_workspace_settings()
+
+
+# --------------------------------------------------------------------------- #
+# DocType shortcut tiles — the generic /records list + form for admin-curated
+# DocTypes. Parallel to the report tiles above.
+# --------------------------------------------------------------------------- #
+# List fieldtypes that never belong as a list column even if flagged in_list_view.
+_NON_LIST_FIELDTYPES = {"Table", "Table MultiSelect", "Section Break", "Column Break", "HTML", "Button"}
+
+
+def _resolve_doctype(row):
+	"""A stored doctype row → a renderable tile, or None. Hidden if the DocType is gone
+	or the user can't read it (so a tile never leaks a DocType a persona has no access to)."""
+	dt = (row.get("document_type") or "").strip()
+	if not dt or not frappe.db.exists("DocType", dt):
+		return None
+	if not frappe.has_permission(dt, "read"):
+		return None
+	return {
+		"label": (row.get("label") or "").strip() or dt,
+		"doctype": dt,
+		"route": f"/records/{quote(dt)}",
+		"icon": (row.get("icon") or "file-text").strip() or "file-text",
+		"description": (row.get("description") or "").strip(),
+	}
+
+
+def _allowed_doctypes():
+	"""The allowlist: every DocType an admin has added to any workspace's Records group.
+	The generic list/form config endpoints serve only these — the routes can't be turned
+	into an open browser of arbitrary DocTypes (Frappe perms still gate each row too)."""
+	settings = frappe.get_single(SETTINGS)
+	return {r.document_type for r in settings.doctypes if r.document_type}
+
+
+def _require_allowed(doctype):
+	if doctype not in _allowed_doctypes():
+		frappe.throw(
+			_("{0} is not available here.").format(doctype or "DocType"), frappe.PermissionError
+		)
+
+
+@frappe.whitelist()
+def get_workspace_doctypes(workspace):
+	"""Ordered, renderable DocType tiles for a workspace. Any signed-in user."""
+	if workspace not in _SLUGS:
+		return []
+	settings = frappe.get_single(SETTINGS)
+	out = []
+	for row in settings.doctypes:
+		if row.workspace != workspace:
+			continue
+		tile = _resolve_doctype(row.as_dict())
+		if tile:
+			out.append(tile)
+	return out
+
+
+@frappe.whitelist()
+def set_workspace_doctypes(workspace, doctypes=None):
+	"""Replace one workspace's DocType rows (order preserved), leaving other workspaces'
+	rows untouched. Admin only."""
+	_require_admin()
+	if workspace not in _SLUGS:
+		frappe.throw(_("Unknown workspace: {0}").format(workspace))
+	doctypes = frappe.parse_json(doctypes) or []
+	settings = frappe.get_single(SETTINGS)
+
+	kept = [r for r in settings.doctypes if r.workspace != workspace]
+	settings.set("doctypes", [])
+	for r in kept:
+		settings.append(
+			"doctypes",
+			{
+				"workspace": r.workspace,
+				"label": r.label,
+				"document_type": r.document_type,
+				"icon": r.icon,
+				"description": r.description,
+			},
+		)
+	for row in doctypes:
+		dt = (row.get("doctype") or "").strip()
+		if not dt:
+			continue
+		settings.append(
+			"doctypes",
+			{
+				"workspace": workspace,
+				"label": (row.get("label") or "").strip(),
+				"document_type": dt,
+				"icon": (row.get("icon") or "").strip(),
+				"description": (row.get("description") or "").strip(),
+			},
+		)
+	settings.flags.ignore_permissions = True
+	settings.save()
+	return get_workspace_settings()
+
+
+@frappe.whitelist()
+def get_doctype_list_config(doctype):
+	"""The DocTypeListView props for an allow-listed DocType, derived from its Frappe meta:
+	columns from in_list_view fields, search from search_fields, order from sort_field."""
+	_require_allowed(doctype)
+	meta = frappe.get_meta(doctype)
+
+	list_fields = [
+		df.fieldname
+		for df in meta.fields
+		if df.in_list_view and df.fieldtype not in _NON_LIST_FIELDTYPES
+	]
+	if meta.title_field and meta.title_field not in list_fields:
+		list_fields.insert(0, meta.title_field)
+	field_order = ["name"] + [f for f in list_fields if f != "name"]
+
+	search = [s.strip() for s in (meta.search_fields or "").split(",") if s.strip()]
+	search_fields = ["name"] + [s for s in search if s != "name"]
+	if meta.title_field and meta.title_field not in search_fields:
+		search_fields.append(meta.title_field)
+
+	order_by = f"{meta.sort_field or 'modified'} {(meta.sort_order or 'desc').lower()}"
+
+	return {
+		"doctype": doctype,
+		"label": doctype,
+		"fieldOrder": field_order,
+		"searchFields": search_fields,
+		"initialOrderBy": order_by,
+		"titleField": meta.title_field or "name",
+		"isSubmittable": bool(meta.is_submittable),
+	}
+
+
+@frappe.whitelist()
+def get_doctype_permissions(doctype):
+	"""The current user's action permissions on an allow-listed DocType — for gating the
+	New / Save / Delete buttons. Server-side enforcement is unchanged; this is UI only."""
+	_require_allowed(doctype)
+	return {
+		"read": bool(frappe.has_permission(doctype, "read")),
+		"write": bool(frappe.has_permission(doctype, "write")),
+		"create": bool(frappe.has_permission(doctype, "create")),
+		"delete": bool(frappe.has_permission(doctype, "delete")),
+		"submit": bool(frappe.has_permission(doctype, "submit")),
+	}

--- a/buildsuite_core/api/workspace_setting.py
+++ b/buildsuite_core/api/workspace_setting.py
@@ -177,6 +177,8 @@ def set_workspace_reports(workspace, reports=None):
 # --------------------------------------------------------------------------- #
 # List fieldtypes that never belong as a list column even if flagged in_list_view.
 _NON_LIST_FIELDTYPES = {"Table", "Table MultiSelect", "Section Break", "Column Break", "HTML", "Button"}
+# Fieldtypes that make a usable list filter (discrete/enumerable or a simple text/date match).
+_FILTERABLE_FIELDTYPES = {"Link", "Select", "Check", "Date", "Datetime", "Data", "Small Text"}
 
 
 def _resolve_doctype(row):
@@ -292,6 +294,27 @@ def get_doctype_list_config(doctype):
 
 	order_by = f"{meta.sort_field or 'modified'} {(meta.sort_order or 'desc').lower()}"
 
+	# Filter controls, derived from the DocType's own meta: Frappe's list filters
+	# (in_standard_filter) plus the list columns (in_list_view), of filterable types.
+	filters = []
+	seen = set()
+	for df in meta.fields:
+		if df.fieldname in seen or df.fieldname == "name" or df.hidden:
+			continue
+		if df.fieldtype not in _FILTERABLE_FIELDTYPES:
+			continue
+		if not (df.in_standard_filter or df.in_list_view):
+			continue
+		seen.add(df.fieldname)
+		filters.append(
+			{
+				"fieldname": df.fieldname,
+				"label": df.label or df.fieldname,
+				"fieldtype": df.fieldtype,
+				"options": df.options or "",
+			}
+		)
+
 	return {
 		"doctype": doctype,
 		"label": doctype,
@@ -300,6 +323,7 @@ def get_doctype_list_config(doctype):
 		"initialOrderBy": order_by,
 		"titleField": meta.title_field or "name",
 		"isSubmittable": bool(meta.is_submittable),
+		"filters": filters,
 	}
 
 

--- a/buildsuite_core/buildsuite_core/doctype/workspace_doctype/workspace_doctype.json
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_doctype/workspace_doctype.json
@@ -1,0 +1,62 @@
+{
+ "actions": [],
+ "creation": "2026-08-31 00:00:00.000000",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "workspace",
+  "label",
+  "document_type",
+  "icon",
+  "description"
+ ],
+ "fields": [
+  {
+   "fieldname": "workspace",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Workspace",
+   "reqd": 1
+  },
+  {
+   "description": "Tile title. Falls back to the DocType's own label when blank.",
+   "fieldname": "label",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Label"
+  },
+  {
+   "description": "The DocType whose records this tile lists (rendered via the generic /records route).",
+   "fieldname": "document_type",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "DocType",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "default": "file-text",
+   "fieldname": "icon",
+   "fieldtype": "Data",
+   "label": "Icon"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  }
+ ],
+ "index_web_pages_for_search": 0,
+ "istable": 1,
+ "links": [],
+ "modified": "2026-08-31 00:00:00.000000",
+ "modified_by": "Administrator",
+ "module": "BuildSuite Core",
+ "name": "Workspace Doctype",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "creation",
+ "sort_order": "ASC",
+ "states": []
+}

--- a/buildsuite_core/buildsuite_core/doctype/workspace_doctype/workspace_doctype.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_doctype/workspace_doctype.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+from frappe.model.document import Document
+
+
+class WorkspaceDoctype(Document):
+	# begin: auto-generated types
+	# This code is auto-generated. Do not modify anything in this block.
+
+	from typing import TYPE_CHECKING
+
+	if TYPE_CHECKING:
+		from frappe.types import DF
+
+		description: DF.SmallText | None
+		document_type: DF.Link
+		icon: DF.Data | None
+		label: DF.Data | None
+		parent: DF.Data
+		parentfield: DF.Data
+		parenttype: DF.Data
+		workspace: DF.Data
+	# end: auto-generated types
+
+	pass

--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/workspace_setting.json
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/workspace_setting.json
@@ -5,7 +5,9 @@
  "engine": "InnoDB",
  "field_order": [
   "reports_section",
-  "reports"
+  "reports",
+  "doctypes_section",
+  "doctypes"
  ],
  "fields": [
   {
@@ -19,6 +21,18 @@
    "fieldtype": "Table",
    "label": "Reports",
    "options": "Workspace Report"
+  },
+  {
+   "fieldname": "doctypes_section",
+   "fieldtype": "Section Break",
+   "label": "Workspace Records"
+  },
+  {
+   "description": "DocType shortcut tiles rendered in each workspace, tagged by workspace slug. Each opens the generic /records list + form for that DocType.",
+   "fieldname": "doctypes",
+   "fieldtype": "Table",
+   "label": "DocTypes",
+   "options": "Workspace Doctype"
   }
  ],
  "index_web_pages_for_search": 0,

--- a/frontend/src/components/doctype/DocTypeChildRowModal.vue
+++ b/frontend/src/components/doctype/DocTypeChildRowModal.vue
@@ -1,0 +1,104 @@
+<script setup>
+// Full-detail editor for a single child-table row. The grid shows only the child
+// DocType's in_list_view columns; this modal renders ALL of its fields so rows with
+// more than a few fields are fully editable. Binds straight to the row object, so
+// edits reflect in the grid immediately (the parent form saves the whole doc).
+import { computed } from "vue";
+import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
+import DeskField from "@/components/desk/DeskField.vue";
+import DocTypeFieldControl from "@/components/doctype/DocTypeFieldControl.vue";
+
+const props = defineProps({
+	open: { type: Boolean, default: false },
+	row: { type: Object, default: () => ({}) },
+	doctype: { type: String, required: true },
+	title: { type: String, default: "Row detail" },
+	disabled: { type: Boolean, default: false },
+});
+const emit = defineEmits(["close"]);
+
+const { meta } = useDoctypeMeta(props.doctype);
+
+const SKIP = new Set([
+	"Section Break",
+	"Column Break",
+	"Tab Break",
+	"HTML",
+	"Button",
+	"Image",
+	"Fold",
+	"Heading",
+	"Table",
+	"Table MultiSelect",
+]);
+
+function evalDependsOn(expr) {
+	if (!expr) return true;
+	try {
+		if (expr.startsWith("eval:")) {
+			// eslint-disable-next-line no-new-func
+			return !!Function("doc", `return (${expr.slice(5)});`)(props.row);
+		}
+		return !!props.row[expr];
+	} catch {
+		return true;
+	}
+}
+
+const fields = computed(() =>
+	(meta.value?.fields || []).filter(
+		(f) => !SKIP.has(f.fieldtype) && !f.hidden && evalDependsOn(f.depends_on)
+	)
+);
+</script>
+
+<template>
+	<Teleport to="body">
+		<div
+			v-if="open"
+			class="fixed inset-0 bg-ink-900/40 z-[60] flex items-center justify-center p-6"
+			@click.self="emit('close')"
+		>
+			<div
+				class="bg-white border border-ink-200 w-full max-w-2xl shadow-fp-lg flex flex-col"
+				style="border-radius: 12px; max-height: calc(100vh - 3rem)"
+				@click.stop
+			>
+				<header class="px-5 py-3 border-b border-ink-200 flex items-center justify-between">
+					<h2 class="text-sm font-semibold text-ink-900">{{ title }}</h2>
+					<button
+						type="button"
+						class="text-ink-500 hover:text-ink-900 text-lg leading-none"
+						aria-label="Close"
+						@click="emit('close')"
+					>
+						×
+					</button>
+				</header>
+
+				<div class="p-5 overflow-y-auto min-h-0">
+					<div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+						<DeskField
+							v-for="f in fields"
+							:key="f.fieldname"
+							:label="f.label || f.fieldname"
+							:required="!!f.reqd"
+							:hint="f.description || ''"
+						>
+							<DocTypeFieldControl
+								v-model="row[f.fieldname]"
+								:field="f"
+								:context="row"
+								:disabled="disabled || !!f.read_only"
+							/>
+						</DeskField>
+					</div>
+				</div>
+
+				<footer class="px-5 py-3 border-t border-ink-200 flex justify-end">
+					<button type="button" class="desk-save-btn" @click="emit('close')">Done</button>
+				</footer>
+			</div>
+		</div>
+	</Teleport>
+</template>

--- a/frontend/src/components/doctype/DocTypeChildTable.vue
+++ b/frontend/src/components/doctype/DocTypeChildTable.vue
@@ -4,9 +4,10 @@
 // Dynamic Link, Select, Check, Date and numeric cells all work (a row's Dynamic
 // Link resolves its target from the sibling cell in the same row). Add / remove
 // rows; new rows seed their field defaults.
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
 import DocTypeFieldControl from "./DocTypeFieldControl.vue";
+import DocTypeChildRowModal from "./DocTypeChildRowModal.vue";
 
 const props = defineProps({
 	modelValue: { type: Array, default: () => [] },
@@ -56,6 +57,11 @@ function removeRow(i) {
 	next.splice(i, 1);
 	emit("update:modelValue", next);
 }
+
+// Full-detail modal for a single row (all child fields, not just the grid columns).
+const detailIndex = ref(-1);
+const detailOpen = computed(() => detailIndex.value >= 0);
+const detailRow = computed(() => rows.value[detailIndex.value] || {});
 </script>
 
 <template>
@@ -67,7 +73,7 @@ function removeRow(i) {
 					<th v-for="c in columns" :key="c.fieldname" class="px-2 py-2 text-left font-medium">
 						{{ c.label || c.fieldname }}<span v-if="c.reqd" class="text-danger-600"> *</span>
 					</th>
-					<th class="w-8"></th>
+					<th class="w-16"></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -82,11 +88,19 @@ function removeRow(i) {
 							compact
 						/>
 					</td>
-					<td class="px-2 py-1 text-center pt-2">
+					<td class="px-2 py-1 text-center whitespace-nowrap pt-2">
+						<button
+							type="button"
+							class="text-ink-400 hover:text-ink-700 px-1"
+							title="Open row detail"
+							@click="detailIndex = i"
+						>
+							⤢
+						</button>
 						<button
 							v-if="!disabled"
 							type="button"
-							class="text-ink-400 hover:text-danger-600"
+							class="text-ink-400 hover:text-danger-600 px-1"
 							title="Remove row"
 							@click="removeRow(i)"
 						>
@@ -106,5 +120,15 @@ function removeRow(i) {
 				+ Add row
 			</button>
 		</div>
+
+		<DocTypeChildRowModal
+			:open="detailOpen"
+			:row="detailRow"
+			:doctype="doctype"
+			:title="`Row ${detailIndex + 1} · ${doctype}`"
+			:disabled="disabled"
+			@close="detailIndex = -1"
+		/>
 	</div>
 </template>
+

--- a/frontend/src/components/doctype/DocTypeChildTable.vue
+++ b/frontend/src/components/doctype/DocTypeChildTable.vue
@@ -1,0 +1,110 @@
+<script setup>
+// Editable grid for a child table (Table fieldtype). Columns come from the child
+// DocType's in_list_view fields; each cell is a DocTypeFieldControl, so Link,
+// Dynamic Link, Select, Check, Date and numeric cells all work (a row's Dynamic
+// Link resolves its target from the sibling cell in the same row). Add / remove
+// rows; new rows seed their field defaults.
+import { computed } from "vue";
+import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
+import DocTypeFieldControl from "./DocTypeFieldControl.vue";
+
+const props = defineProps({
+	modelValue: { type: Array, default: () => [] },
+	doctype: { type: String, required: true }, // the child DocType (field.options)
+	disabled: { type: Boolean, default: false },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const { meta } = useDoctypeMeta(props.doctype);
+
+const HARD_SKIP = new Set([
+	"Section Break",
+	"Column Break",
+	"Tab Break",
+	"HTML",
+	"Button",
+	"Table",
+	"Table MultiSelect",
+]);
+
+const columns = computed(() => {
+	const fields = (meta.value?.fields || []).filter(
+		(f) => !HARD_SKIP.has(f.fieldtype) && !f.hidden && !f.read_only
+	);
+	const inList = fields.filter((f) => f.in_list_view);
+	return (inList.length ? inList : fields).slice(0, 8);
+});
+
+const rows = computed(() => props.modelValue || []);
+
+function seededRow() {
+	const row = {};
+	for (const f of meta.value?.fields || []) {
+		if (f.default !== undefined && f.default !== null && f.default !== "") {
+			row[f.fieldname] = f.fieldtype === "Check" ? (Number(f.default) ? 1 : 0) : f.default;
+		} else if (f.fieldtype === "Check") {
+			row[f.fieldname] = 0;
+		}
+	}
+	return row;
+}
+function addRow() {
+	emit("update:modelValue", [...rows.value, seededRow()]);
+}
+function removeRow(i) {
+	const next = rows.value.slice();
+	next.splice(i, 1);
+	emit("update:modelValue", next);
+}
+</script>
+
+<template>
+	<div class="border border-ink-200 rounded-lg overflow-x-auto">
+		<table class="w-full text-xs" style="min-width: 480px">
+			<thead class="bg-ink-50 text-ink-500 uppercase tracking-wider text-[10px]">
+				<tr>
+					<th class="px-2 py-2 w-8 text-left">#</th>
+					<th v-for="c in columns" :key="c.fieldname" class="px-2 py-2 text-left font-medium">
+						{{ c.label || c.fieldname }}<span v-if="c.reqd" class="text-danger-600"> *</span>
+					</th>
+					<th class="w-8"></th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="(row, i) in rows" :key="i" class="border-t border-ink-100 align-top">
+					<td class="px-2 py-1 text-ink-400 tabular-nums pt-2.5">{{ i + 1 }}</td>
+					<td v-for="c in columns" :key="c.fieldname" class="px-2 py-1">
+						<DocTypeFieldControl
+							v-model="row[c.fieldname]"
+							:field="c"
+							:context="row"
+							:disabled="disabled"
+							compact
+						/>
+					</td>
+					<td class="px-2 py-1 text-center pt-2">
+						<button
+							v-if="!disabled"
+							type="button"
+							class="text-ink-400 hover:text-danger-600"
+							title="Remove row"
+							@click="removeRow(i)"
+						>
+							×
+						</button>
+					</td>
+				</tr>
+				<tr v-if="!rows.length">
+					<td :colspan="columns.length + 2" class="px-2 py-3 text-center text-ink-400">
+						No rows yet.
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<div v-if="!disabled" class="px-2 py-1.5 border-t border-ink-100">
+			<button type="button" class="text-xs text-brand-600 hover:underline" @click="addRow">
+				+ Add row
+			</button>
+		</div>
+	</div>
+</template>

--- a/frontend/src/components/doctype/DocTypeFieldControl.vue
+++ b/frontend/src/components/doctype/DocTypeFieldControl.vue
@@ -1,0 +1,111 @@
+<script setup>
+// One meta-driven field control, shared by the main form (DocTypeForm) and the
+// child-table grid (DocTypeChildTable). Picks a Desk control by fieldtype and
+// resolves a Dynamic Link's target DocType from a sibling value in `context`.
+import { computed } from "vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskTextarea from "@/components/desk/DeskTextarea.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+
+const props = defineProps({
+	field: { type: Object, required: true },
+	modelValue: { default: "" },
+	// Sibling field values (the form object or the child row) — for Dynamic Link.
+	context: { type: Object, default: () => ({}) },
+	disabled: { type: Boolean, default: false },
+	compact: { type: Boolean, default: false },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const NUMERIC = new Set(["Int", "Float", "Currency", "Percent"]);
+const TEXTAREA = new Set([
+	"Small Text",
+	"Text",
+	"Long Text",
+	"Code",
+	"Text Editor",
+	"HTML Editor",
+	"Markdown Editor",
+	"JSON",
+]);
+
+const kind = computed(() => {
+	const t = props.field.fieldtype;
+	if (t === "Link" || t === "Dynamic Link") return "link";
+	if (t === "Select") return "select";
+	if (t === "Check") return "check";
+	if (t === "Date") return "date";
+	if (t === "Datetime") return "datetime";
+	if (TEXTAREA.has(t)) return props.compact ? "data" : "textarea";
+	if (NUMERIC.has(t)) return "number";
+	return "data";
+});
+
+// Link → options is the target DocType; Dynamic Link → options names the sibling
+// field that holds the target DocType.
+const linkDoctype = computed(() =>
+	props.field.fieldtype === "Dynamic Link"
+		? props.context[props.field.options] || ""
+		: props.field.options || "DocType"
+);
+const linkDisabled = computed(
+	() => props.disabled || (props.field.fieldtype === "Dynamic Link" && !linkDoctype.value)
+);
+
+const options = computed(() =>
+	(props.field.options || "")
+		.split("\n")
+		.map((o) => o.trim())
+		.filter(Boolean)
+);
+
+const val = computed({
+	get: () => props.modelValue,
+	set: (v) => emit("update:modelValue", v),
+});
+function onNumber(v) {
+	emit("update:modelValue", v === "" || v === null || v === undefined ? null : Number(v));
+}
+function onCheck(e) {
+	emit("update:modelValue", e.target.checked ? 1 : 0);
+}
+</script>
+
+<template>
+	<DeskLinkPicker
+		v-if="kind === 'link'"
+		v-model="val"
+		:doctype="linkDoctype || 'DocType'"
+		value-field="name"
+		:disabled="linkDisabled"
+		:placeholder="field.fieldtype === 'Dynamic Link' && !linkDoctype ? 'Pick type first' : 'Search…'"
+	/>
+	<DeskSelect v-else-if="kind === 'select'" v-model="val" :disabled="disabled">
+		<option value="">—</option>
+		<option v-for="o in options" :key="o" :value="o">{{ o }}</option>
+	</DeskSelect>
+	<label
+		v-else-if="kind === 'check'"
+		class="inline-flex items-center gap-2 text-xs text-ink-700 h-[34px]"
+	>
+		<input type="checkbox" :checked="!!modelValue" :disabled="disabled" @change="onCheck" />
+		<span v-if="!compact">Yes</span>
+	</label>
+	<DeskInput v-else-if="kind === 'date'" v-model="val" type="date" :disabled="disabled" />
+	<DeskInput
+		v-else-if="kind === 'datetime'"
+		v-model="val"
+		type="datetime-local"
+		:disabled="disabled"
+	/>
+	<DeskTextarea v-else-if="kind === 'textarea'" v-model="val" :rows="3" :disabled="disabled" />
+	<DeskInput
+		v-else-if="kind === 'number'"
+		:model-value="modelValue"
+		type="number"
+		:disabled="disabled"
+		@update:model-value="onNumber"
+	/>
+	<DeskInput v-else v-model="val" :disabled="disabled" />
+</template>

--- a/frontend/src/components/doctype/DocTypeForm.vue
+++ b/frontend/src/components/doctype/DocTypeForm.vue
@@ -83,20 +83,44 @@ function isRenderable(f) {
 	return evalDependsOn(f.depends_on);
 }
 
-const sections = computed(() => {
+// Field layout: Tab Break → tabs, Section Break → sections within a tab, then fields.
+// Fields before the first Tab Break form an implicit first tab (Frappe's "Details").
+const activeTab = ref(0);
+
+const tabs = computed(() => {
 	const fields = meta.value?.fields || [];
-	const out = [{ label: "", fields: [], tables: [] }];
+	const mkSection = (label) => ({ label: label || "", fields: [], tables: [] });
+	const mkTab = (label) => ({ label: label || "", sections: [] });
+	const out = [];
+	let tab = mkTab("");
+	let section = mkSection("");
+	tab.sections.push(section);
+	out.push(tab);
 	for (const f of fields) {
+		if (f.fieldtype === "Tab Break") {
+			tab = mkTab(f.label || "");
+			section = mkSection("");
+			tab.sections.push(section);
+			out.push(tab);
+			continue;
+		}
 		if (f.fieldtype === "Section Break") {
-			out.push({ label: f.label || "", fields: [], tables: [] });
+			section = mkSection(f.label || "");
+			tab.sections.push(section);
 			continue;
 		}
 		if (!isRenderable(f)) continue;
-		if (f.fieldtype === "Table") out[out.length - 1].tables.push(f);
-		else out[out.length - 1].fields.push(f);
+		if (f.fieldtype === "Table") section.tables.push(f);
+		else section.fields.push(f);
 	}
-	return out.filter((s) => s.fields.length || s.tables.length);
+	const pruned = out
+		.map((t) => ({ ...t, sections: t.sections.filter((s) => s.fields.length || s.tables.length) }))
+		.filter((t) => t.sections.length);
+	if (pruned.length > 1 && !pruned[0].label) pruned[0].label = "Details";
+	return pruned;
 });
+
+const currentTab = computed(() => tabs.value[activeTab.value] || tabs.value[0] || { sections: [] });
 
 function isReadOnly(f) {
 	if (locked.value) return true;
@@ -166,26 +190,39 @@ function goEdit(name) {
 // --- actions -----------------------------------------------------------------
 function missingRequired() {
 	const missing = [];
-	for (const s of sections.value) {
-		for (const f of s.fields) {
-			if (!f.reqd || isReadOnly(f)) continue;
-			const v = form[f.fieldname];
-			if (v === undefined || v === null || v === "") missing.push(f.label || f.fieldname);
+	let firstTab = null;
+	const flag = (label, ti) => {
+		missing.push(label);
+		if (firstTab === null) firstTab = ti;
+	};
+	tabs.value.forEach((t, ti) => {
+		for (const s of t.sections) {
+			for (const f of s.fields) {
+				if (!f.reqd || isReadOnly(f)) continue;
+				const v = form[f.fieldname];
+				if (v === undefined || v === null || v === "") flag(f.label || f.fieldname, ti);
+			}
+			for (const tb of s.tables) {
+				if (tb.reqd && !(form[tb.fieldname] || []).length) flag(tb.label || tb.fieldname, ti);
+			}
 		}
-		for (const t of s.tables) {
-			if (t.reqd && !(form[t.fieldname] || []).length) missing.push(t.label || t.fieldname);
-		}
+	});
+	return { missing, firstTab };
+}
+
+function guardRequired() {
+	const { missing, firstTab } = missingRequired();
+	if (missing.length) {
+		if (firstTab !== null) activeTab.value = firstTab;
+		formError.value = `Please fill: ${missing.join(", ")}.`;
+		return false;
 	}
-	return missing;
+	return true;
 }
 
 async function onSave() {
 	formError.value = "";
-	const missing = missingRequired();
-	if (missing.length) {
-		formError.value = `Please fill: ${missing.join(", ")}.`;
-		return;
-	}
+	if (!guardRequired()) return;
 	busy.value = true;
 	try {
 		const doc = isEdit.value ? await saveRecord({ ...form }) : await insertRecord({ ...form });
@@ -201,11 +238,7 @@ async function onSave() {
 
 async function onSubmit() {
 	formError.value = "";
-	const missing = missingRequired();
-	if (missing.length) {
-		formError.value = `Please fill: ${missing.join(", ")}.`;
-		return;
-	}
+	if (!guardRequired()) return;
 	busy.value = true;
 	try {
 		await saveRecord({ ...form }); // persist edits before submitting
@@ -305,7 +338,28 @@ const DANGER =
 		</div>
 
 		<form v-else @submit.prevent="onSave">
-			<section v-for="(s, si) in sections" :key="si" class="mb-6">
+			<!-- Tabs (Tab Break fields) -->
+			<div
+				v-if="tabs.length > 1"
+				class="flex items-center gap-1 border-b border-ink-200 mb-5 overflow-x-auto"
+			>
+				<button
+					v-for="(t, ti) in tabs"
+					:key="ti"
+					type="button"
+					class="px-3 py-2 text-sm whitespace-nowrap border-b-2 -mb-px transition-colors"
+					:class="
+						activeTab === ti
+							? 'border-brand-600 text-brand-700 font-medium'
+							: 'border-transparent text-ink-500 hover:text-ink-800'
+					"
+					@click="activeTab = ti"
+				>
+					{{ t.label || "Details" }}
+				</button>
+			</div>
+
+			<section v-for="(s, si) in currentTab.sections" :key="si" class="mb-6">
 				<h3
 					v-if="s.label"
 					class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-3 pb-1.5 border-b border-ink-200"

--- a/frontend/src/components/doctype/DocTypeForm.vue
+++ b/frontend/src/components/doctype/DocTypeForm.vue
@@ -1,0 +1,321 @@
+<script setup>
+// Generic, meta-driven form for an arbitrary DocType (Phase 1: scalar fields).
+//
+// Reads the DocType's Frappe meta (useDoctypeMeta), renders each field by its
+// fieldtype using the shared Desk controls, honouring reqd / read_only / hidden /
+// depends_on, and saves via the standard frappe.client.* endpoints. Child tables
+// (fieldtype "Table") are intentionally NOT rendered yet — that (and Journal
+// Entry's accounts grid) lands in Phase 2. When a DocType has a mandatory child
+// table the server rejects the save and the error surfaces in the banner.
+import { computed, reactive, ref, watch } from "vue";
+import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
+import { getRecord, insertRecord, saveRecord } from "@/data/doctypeRecordApi";
+import { getDoctypePermissions } from "@/data/workspaceSettingApi";
+import { showToast } from "@/utils/appToast";
+import DeskField from "@/components/desk/DeskField.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskTextarea from "@/components/desk/DeskTextarea.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+
+const props = defineProps({
+	doctype: { type: String, required: true },
+	// Present → edit an existing record; absent → new record.
+	name: { type: String, default: "" },
+});
+const emit = defineEmits(["saved", "cancelled"]);
+
+const { meta, loading: metaLoading, selectOptions } = useDoctypeMeta(props.doctype);
+
+const form = reactive({ doctype: props.doctype });
+const loading = ref(false);
+const saving = ref(false);
+const formError = ref("");
+const perms = ref({ read: true, write: true, create: true, delete: true });
+
+const isEdit = computed(() => !!props.name);
+
+// --- fieldtype → control routing ---------------------------------------------
+const NUMERIC = new Set(["Int", "Float", "Currency", "Percent"]);
+const TEXTAREA = new Set([
+	"Small Text",
+	"Text",
+	"Long Text",
+	"Code",
+	"Text Editor",
+	"HTML Editor",
+	"Markdown Editor",
+	"JSON",
+]);
+// Layout / structural / not-yet-supported fieldtypes never rendered as an input.
+const SKIP = new Set([
+	"Section Break",
+	"Column Break",
+	"Tab Break",
+	"HTML",
+	"Button",
+	"Image",
+	"Fold",
+	"Heading",
+	"Table",
+	"Table MultiSelect",
+]);
+
+function evalDependsOn(expr) {
+	if (!expr) return true;
+	try {
+		if (expr.startsWith("eval:")) {
+			// Frappe depends_on expressions are trusted (from the DocType definition).
+			// eslint-disable-next-line no-new-func
+			return !!Function("doc", `return (${expr.slice(5)});`)(form);
+		}
+		return !!form[expr];
+	} catch {
+		return true; // never hide a field because its expression failed to parse
+	}
+}
+
+function isRenderable(f) {
+	if (SKIP.has(f.fieldtype)) return false;
+	if (f.hidden) return false;
+	if (f.fieldname === "naming_series" && !f.reqd) return false;
+	return evalDependsOn(f.depends_on);
+}
+
+// Fields grouped into sections (split on Section Break), for a tidy layout.
+const sections = computed(() => {
+	const fields = meta.value?.fields || [];
+	const out = [{ label: "", fields: [] }];
+	for (const f of fields) {
+		if (f.fieldtype === "Section Break") {
+			out.push({ label: f.label || "", fields: [] });
+			continue;
+		}
+		if (isRenderable(f)) out[out.length - 1].fields.push(f);
+	}
+	return out.filter((s) => s.fields.length);
+});
+
+function controlFor(f) {
+	if (f.fieldtype === "Link" || f.fieldtype === "Dynamic Link") return "link";
+	if (f.fieldtype === "Select") return "select";
+	if (f.fieldtype === "Check") return "check";
+	if (f.fieldtype === "Date") return "date";
+	if (f.fieldtype === "Datetime") return "datetime";
+	if (TEXTAREA.has(f.fieldtype)) return "textarea";
+	if (NUMERIC.has(f.fieldtype)) return "number";
+	return "data";
+}
+
+// Dynamic Link: options names the field that holds the target DocType.
+function linkTarget(f) {
+	if (f.fieldtype === "Dynamic Link") return form[f.options] || "";
+	return f.options || "DocType";
+}
+
+function isReadOnly(f) {
+	return !!f.read_only || (isEdit.value && !perms.value.write) || (!isEdit.value && !perms.value.create);
+}
+
+// --- load --------------------------------------------------------------------
+function seedDefaults() {
+	for (const f of meta.value?.fields || []) {
+		if (SKIP.has(f.fieldtype)) continue;
+		if (f.default !== undefined && f.default !== null && f.default !== "") {
+			form[f.fieldname] = f.fieldtype === "Check" ? Number(f.default) ? 1 : 0 : f.default;
+		} else if (f.fieldtype === "Check" && form[f.fieldname] === undefined) {
+			form[f.fieldname] = 0;
+		}
+	}
+}
+
+async function load() {
+	loading.value = true;
+	formError.value = "";
+	try {
+		perms.value = await getDoctypePermissions(props.doctype).catch(() => perms.value);
+		if (isEdit.value) {
+			const doc = await getRecord(props.doctype, props.name);
+			Object.keys(form).forEach((k) => delete form[k]);
+			Object.assign(form, doc); // full doc incl. child tables (which ride untouched on save)
+		} else {
+			// wait for meta so defaults can seed
+			if (!meta.value) await new Promise((r) => setTimeout(r, 0));
+			seedDefaults();
+		}
+	} catch (err) {
+		formError.value = err.message || "Failed to load record.";
+	} finally {
+		loading.value = false;
+	}
+}
+
+// meta arrives async; seed defaults for a new record once it's here.
+watch(
+	() => meta.value,
+	(m) => {
+		if (m && !isEdit.value && !loading.value) seedDefaults();
+	}
+);
+watch(() => [props.doctype, props.name], load, { immediate: true });
+
+// --- save --------------------------------------------------------------------
+function missingRequired() {
+	const missing = [];
+	for (const s of sections.value) {
+		for (const f of s.fields) {
+			if (!f.reqd || isReadOnly(f)) continue;
+			const v = form[f.fieldname];
+			if (v === undefined || v === null || v === "") missing.push(f.label || f.fieldname);
+		}
+	}
+	return missing;
+}
+
+async function onSave() {
+	formError.value = "";
+	const missing = missingRequired();
+	if (missing.length) {
+		formError.value = `Please fill: ${missing.join(", ")}.`;
+		return;
+	}
+	saving.value = true;
+	try {
+		const doc = isEdit.value ? await saveRecord({ ...form }) : await insertRecord({ ...form });
+		showToast(isEdit.value ? "Saved." : "Created.");
+		emit("saved", doc);
+	} catch (err) {
+		formError.value = err.message || "Save failed.";
+	} finally {
+		saving.value = false;
+	}
+}
+
+const canSave = computed(() => (isEdit.value ? perms.value.write : perms.value.create));
+</script>
+
+<template>
+	<div>
+		<div
+			v-if="formError"
+			class="mb-4 px-4 py-2.5 bg-danger-50 border border-danger-200 rounded-md text-xs text-danger-700"
+		>
+			{{ formError }}
+		</div>
+
+		<div v-if="metaLoading || loading" class="text-sm text-ink-500 py-10 text-center">
+			Loading…
+		</div>
+
+		<form v-else @submit.prevent="onSave">
+			<section v-for="(s, si) in sections" :key="si" class="mb-6">
+				<h3
+					v-if="s.label"
+					class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-3 pb-1.5 border-b border-ink-200"
+				>
+					{{ s.label }}
+				</h3>
+				<div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+					<DeskField
+						v-for="f in s.fields"
+						:key="f.fieldname"
+						:label="f.label || f.fieldname"
+						:required="!!f.reqd"
+						:hint="f.description || ''"
+					>
+						<!-- Link / Dynamic Link -->
+						<DeskLinkPicker
+							v-if="controlFor(f) === 'link'"
+							v-model="form[f.fieldname]"
+							:doctype="linkTarget(f) || 'DocType'"
+							value-field="name"
+							:disabled="isReadOnly(f) || (f.fieldtype === 'Dynamic Link' && !linkTarget(f))"
+							:placeholder="f.fieldtype === 'Dynamic Link' && !linkTarget(f) ? 'Pick the type first' : 'Search…'"
+						/>
+
+						<!-- Select -->
+						<DeskSelect
+							v-else-if="controlFor(f) === 'select'"
+							v-model="form[f.fieldname]"
+							:disabled="isReadOnly(f)"
+						>
+							<option value="">—</option>
+							<option v-for="o in selectOptions(f.fieldname)" :key="o" :value="o">
+								{{ o }}
+							</option>
+						</DeskSelect>
+
+						<!-- Check -->
+						<label
+							v-else-if="controlFor(f) === 'check'"
+							class="inline-flex items-center gap-2 text-xs text-ink-700 h-[34px]"
+						>
+							<input
+								type="checkbox"
+								:checked="!!form[f.fieldname]"
+								:disabled="isReadOnly(f)"
+								@change="form[f.fieldname] = $event.target.checked ? 1 : 0"
+							/>
+							<span>Yes</span>
+						</label>
+
+						<!-- Date / Datetime -->
+						<DeskInput
+							v-else-if="controlFor(f) === 'date'"
+							v-model="form[f.fieldname]"
+							type="date"
+							:disabled="isReadOnly(f)"
+						/>
+						<DeskInput
+							v-else-if="controlFor(f) === 'datetime'"
+							v-model="form[f.fieldname]"
+							type="datetime-local"
+							:disabled="isReadOnly(f)"
+						/>
+
+						<!-- Textarea -->
+						<DeskTextarea
+							v-else-if="controlFor(f) === 'textarea'"
+							v-model="form[f.fieldname]"
+							:rows="3"
+							:disabled="isReadOnly(f)"
+						/>
+
+						<!-- Number -->
+						<DeskInput
+							v-else-if="controlFor(f) === 'number'"
+							v-model.number="form[f.fieldname]"
+							type="number"
+							:disabled="isReadOnly(f)"
+						/>
+
+						<!-- Data / fallback -->
+						<DeskInput
+							v-else
+							v-model="form[f.fieldname]"
+							:disabled="isReadOnly(f)"
+						/>
+					</DeskField>
+				</div>
+			</section>
+
+			<div class="flex items-center gap-2 pt-2 border-t border-ink-200 sticky bottom-0 bg-white py-3">
+				<button
+					v-if="canSave"
+					type="submit"
+					class="text-xs px-3 py-1.5 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium rounded-md"
+					:disabled="saving"
+				>
+					{{ saving ? "Saving…" : isEdit ? "Save" : "Create" }}
+				</button>
+				<button
+					type="button"
+					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+					@click="emit('cancelled')"
+				>
+					Cancel
+				</button>
+			</div>
+		</form>
+	</div>
+</template>

--- a/frontend/src/components/doctype/DocTypeForm.vue
+++ b/frontend/src/components/doctype/DocTypeForm.vue
@@ -2,13 +2,24 @@
 // Generic, meta-driven form for an arbitrary DocType. Renders each field by its
 // fieldtype via the shared DocTypeFieldControl, honouring reqd / read_only /
 // hidden / depends_on, plus full-width child-table grids (DocTypeChildTable) and
-// Dynamic Links. Loads via frappe.client.get (full doc incl. child tables) and
-// saves via frappe.client.insert / save — so untouched child rows round-trip.
+// Dynamic Links. For submittable DocTypes the action bar follows docstatus:
+// Draft → Save / Submit / Delete; Submitted → Cancel; Cancelled → Amend / Delete.
 import { computed, reactive, ref, watch } from "vue";
+import { useRouter } from "vue-router";
 import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
-import { getRecord, insertRecord, saveRecord } from "@/data/doctypeRecordApi";
+import {
+	getRecord,
+	insertRecord,
+	saveRecord,
+	deleteRecord,
+	submitRecord,
+	cancelRecord,
+	amendRecord,
+} from "@/data/doctypeRecordApi";
 import { getDoctypePermissions } from "@/data/workspaceSettingApi";
+import { useConfirm } from "@/composables/useConfirm";
 import { showToast } from "@/utils/appToast";
+import StatusBadge from "@/components/StatusBadge.vue";
 import DeskField from "@/components/desk/DeskField.vue";
 import DocTypeFieldControl from "@/components/doctype/DocTypeFieldControl.vue";
 import DocTypeChildTable from "@/components/doctype/DocTypeChildTable.vue";
@@ -17,19 +28,29 @@ const props = defineProps({
 	doctype: { type: String, required: true },
 	name: { type: String, default: "" },
 });
-const emit = defineEmits(["saved", "cancelled"]);
 
+const router = useRouter();
+const confirmDialog = useConfirm();
 const { meta, loading: metaLoading } = useDoctypeMeta(props.doctype);
 
 const form = reactive({ doctype: props.doctype });
 const loading = ref(false);
-const saving = ref(false);
+const busy = ref(false);
 const formError = ref("");
-const perms = ref({ read: true, write: true, create: true, delete: true });
+const perms = ref({ read: true, write: true, create: true, delete: true, submit: true, cancel: true });
 
 const isEdit = computed(() => !!props.name);
+const docstatus = computed(() => Number(form.docstatus || 0));
+const submittable = computed(() => !!meta.value?.is_submittable);
+const isDraft = computed(() => isEdit.value && docstatus.value === 0);
+const isSubmitted = computed(() => isEdit.value && docstatus.value === 1);
+const isCancelled = computed(() => isEdit.value && docstatus.value === 2);
+// A submitted/cancelled document is not field-editable through this form.
+const locked = computed(() => isSubmitted.value || isCancelled.value);
+const statusLabel = computed(() =>
+	docstatus.value === 1 ? "Submitted" : docstatus.value === 2 ? "Cancelled" : "Draft"
+);
 
-// Structural / not-yet-supported fieldtypes never rendered (Table is handled separately).
 const SKIP = new Set([
 	"Section Break",
 	"Column Break",
@@ -62,7 +83,6 @@ function isRenderable(f) {
 	return evalDependsOn(f.depends_on);
 }
 
-// Sections split on Section Break; scalars render in a 2-col grid, tables full-width.
 const sections = computed(() => {
 	const fields = meta.value?.fields || [];
 	const out = [{ label: "", fields: [], tables: [] }];
@@ -79,11 +99,9 @@ const sections = computed(() => {
 });
 
 function isReadOnly(f) {
-	return (
-		!!f.read_only ||
-		(isEdit.value && !perms.value.write) ||
-		(!isEdit.value && !perms.value.create)
-	);
+	if (locked.value) return true;
+	if (f.read_only) return true;
+	return isEdit.value ? !perms.value.write : !perms.value.create;
 }
 
 // --- load --------------------------------------------------------------------
@@ -93,7 +111,7 @@ function resolveDefault(f) {
 	if (f.fieldtype === "Date" && /^today$/i.test(d)) return new Date().toISOString().slice(0, 10);
 	if (f.fieldtype === "Datetime" && /^(now|today)$/i.test(d))
 		return new Date().toISOString().slice(0, 16);
-	if (/^(user|__user)$/i.test(d)) return undefined; // let the server stamp the session user
+	if (/^(user|__user)$/i.test(d)) return undefined;
 	return f.fieldtype === "Check" ? (Number(d) ? 1 : 0) : d;
 }
 
@@ -137,7 +155,15 @@ watch(
 );
 watch(() => [props.doctype, props.name], load, { immediate: true });
 
-// --- save --------------------------------------------------------------------
+// --- navigation --------------------------------------------------------------
+function goList() {
+	router.push({ name: "records-list", params: { doctype: props.doctype } });
+}
+function goEdit(name) {
+	router.replace({ name: "record-edit", params: { doctype: props.doctype, name } });
+}
+
+// --- actions -----------------------------------------------------------------
 function missingRequired() {
 	const missing = [];
 	for (const s of sections.value) {
@@ -160,23 +186,113 @@ async function onSave() {
 		formError.value = `Please fill: ${missing.join(", ")}.`;
 		return;
 	}
-	saving.value = true;
+	busy.value = true;
 	try {
 		const doc = isEdit.value ? await saveRecord({ ...form }) : await insertRecord({ ...form });
 		showToast(isEdit.value ? "Saved." : "Created.");
-		emit("saved", doc);
+		if (!isEdit.value && doc?.name) goEdit(doc.name);
+		else await load();
 	} catch (err) {
 		formError.value = err.message || "Save failed.";
 	} finally {
-		saving.value = false;
+		busy.value = false;
 	}
 }
 
-const canSave = computed(() => (isEdit.value ? perms.value.write : perms.value.create));
+async function onSubmit() {
+	formError.value = "";
+	const missing = missingRequired();
+	if (missing.length) {
+		formError.value = `Please fill: ${missing.join(", ")}.`;
+		return;
+	}
+	busy.value = true;
+	try {
+		await saveRecord({ ...form }); // persist edits before submitting
+		await submitRecord(props.doctype, props.name);
+		showToast("Submitted.");
+		await load();
+	} catch (err) {
+		formError.value = err.message || "Submit failed.";
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onCancel() {
+	const ok = await confirmDialog({
+		title: `Cancel ${props.name}?`,
+		message: "This cancels the submitted document.",
+		confirmLabel: "Cancel document",
+		destructive: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		await cancelRecord(props.doctype, props.name);
+		showToast("Cancelled.");
+		await load();
+	} catch (err) {
+		formError.value = err.message || "Cancel failed.";
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onAmend() {
+	const ok = await confirmDialog({
+		title: `Amend ${props.name}?`,
+		message: "Creates a fresh editable draft copy; the original stays cancelled.",
+		confirmLabel: "Amend",
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		const res = await amendRecord(props.doctype, props.name);
+		showToast("Amended — a draft was created.");
+		goEdit(res.name);
+	} catch (err) {
+		formError.value = err.message || "Amend failed.";
+	} finally {
+		busy.value = false;
+	}
+}
+
+async function onDelete() {
+	const ok = await confirmDialog({
+		title: `Delete ${props.name}?`,
+		message: "This permanently removes the record.",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	busy.value = true;
+	try {
+		await deleteRecord(props.doctype, props.name);
+		showToast("Deleted.");
+		goList();
+	} catch (err) {
+		formError.value = err.message || "Delete failed.";
+		busy.value = false;
+	}
+}
+
+const SECONDARY =
+	"text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md";
+const DANGER =
+	"text-xs px-3 py-1.5 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700 rounded-md";
 </script>
 
 <template>
 	<div>
+		<div
+			v-if="isEdit && submittable"
+			class="mb-4 flex items-center gap-2"
+		>
+			<StatusBadge :status="statusLabel" />
+			<span v-if="isDraft" class="text-[11px] text-ink-500">Not submitted yet.</span>
+		</div>
+
 		<div
 			v-if="formError"
 			class="mb-4 px-4 py-2.5 bg-danger-50 border border-danger-200 rounded-md text-xs text-danger-700 whitespace-pre-line"
@@ -232,21 +348,77 @@ const canSave = computed(() => (isEdit.value ? perms.value.write : perms.value.c
 			<div
 				class="flex items-center gap-2 pt-2 border-t border-ink-200 sticky bottom-0 bg-white py-3"
 			>
+				<!-- New -->
 				<button
-					v-if="canSave"
+					v-if="!isEdit && perms.create"
 					type="submit"
-					class="text-xs px-3 py-1.5 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium rounded-md"
-					:disabled="saving"
+					class="desk-save-btn"
+					:disabled="busy"
 				>
-					{{ saving ? "Saving…" : isEdit ? "Save" : "Create" }}
+					{{ busy ? "Creating…" : "Create" }}
 				</button>
-				<button
-					type="button"
-					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
-					@click="emit('cancelled')"
-				>
-					Cancel
-				</button>
+
+				<!-- Draft -->
+				<template v-else-if="isDraft">
+					<button v-if="perms.write" type="submit" class="desk-save-btn" :disabled="busy">
+						{{ busy ? "Saving…" : "Save" }}
+					</button>
+					<button
+						v-if="submittable && perms.submit"
+						type="button"
+						:class="SECONDARY"
+						:disabled="busy"
+						@click="onSubmit"
+					>
+						Submit
+					</button>
+					<button
+						v-if="perms.delete"
+						type="button"
+						:class="DANGER"
+						:disabled="busy"
+						@click="onDelete"
+					>
+						Delete
+					</button>
+				</template>
+
+				<!-- Submitted -->
+				<template v-else-if="isSubmitted">
+					<button
+						v-if="perms.cancel"
+						type="button"
+						:class="DANGER"
+						:disabled="busy"
+						@click="onCancel"
+					>
+						Cancel
+					</button>
+				</template>
+
+				<!-- Cancelled -->
+				<template v-else-if="isCancelled">
+					<button
+						v-if="perms.create"
+						type="button"
+						class="desk-save-btn"
+						:disabled="busy"
+						@click="onAmend"
+					>
+						Amend
+					</button>
+					<button
+						v-if="perms.delete"
+						type="button"
+						:class="DANGER"
+						:disabled="busy"
+						@click="onDelete"
+					>
+						Delete
+					</button>
+				</template>
+
+				<button type="button" :class="SECONDARY" @click="goList">Back</button>
 			</div>
 		</form>
 	</div>

--- a/frontend/src/components/doctype/DocTypeForm.vue
+++ b/frontend/src/components/doctype/DocTypeForm.vue
@@ -122,6 +122,17 @@ const tabs = computed(() => {
 
 const currentTab = computed(() => tabs.value[activeTab.value] || tabs.value[0] || { sections: [] });
 
+// Dirty tracking: while a draft has unsaved edits, Save is the primary action;
+// once clean, Submit becomes primary (Frappe's Save-then-Submit behaviour).
+const pristine = ref("");
+function snapshot() {
+	pristine.value = JSON.stringify(form);
+}
+const dirty = computed(() => JSON.stringify(form) !== pristine.value);
+const showSave = computed(
+	() => isDraft.value && perms.value.write && !(submittable.value && !dirty.value)
+);
+
 function isReadOnly(f) {
 	if (locked.value) return true;
 	if (f.read_only) return true;
@@ -164,6 +175,7 @@ async function load() {
 		} else if (meta.value) {
 			seedNew();
 		}
+		snapshot();
 	} catch (err) {
 		formError.value = err.message || "Failed to load record.";
 	} finally {
@@ -174,7 +186,10 @@ async function load() {
 watch(
 	() => meta.value,
 	(m) => {
-		if (m && !isEdit.value && !loading.value) seedNew();
+		if (m && !isEdit.value && !loading.value) {
+			seedNew();
+			snapshot();
+		}
 	}
 );
 watch(() => [props.doctype, props.name], load, { immediate: true });
@@ -222,6 +237,7 @@ function guardRequired() {
 
 async function onSave() {
 	formError.value = "";
+	if (isEdit.value && !dirty.value) return; // nothing to save on a clean draft
 	if (!guardRequired()) return;
 	busy.value = true;
 	try {
@@ -412,15 +428,20 @@ const DANGER =
 					{{ busy ? "Creating…" : "Create" }}
 				</button>
 
-				<!-- Draft -->
+				<!-- Draft: Save is primary while dirty; once clean, Submit takes over. -->
 				<template v-else-if="isDraft">
-					<button v-if="perms.write" type="submit" class="desk-save-btn" :disabled="busy">
+					<button
+						v-if="showSave"
+						type="submit"
+						class="desk-save-btn"
+						:disabled="busy || !dirty"
+					>
 						{{ busy ? "Saving…" : "Save" }}
 					</button>
 					<button
 						v-if="submittable && perms.submit"
 						type="button"
-						:class="SECONDARY"
+						:class="dirty ? SECONDARY : 'desk-save-btn'"
 						:disabled="busy"
 						@click="onSubmit"
 					>

--- a/frontend/src/components/doctype/DocTypeForm.vue
+++ b/frontend/src/components/doctype/DocTypeForm.vue
@@ -1,31 +1,25 @@
 <script setup>
-// Generic, meta-driven form for an arbitrary DocType (Phase 1: scalar fields).
-//
-// Reads the DocType's Frappe meta (useDoctypeMeta), renders each field by its
-// fieldtype using the shared Desk controls, honouring reqd / read_only / hidden /
-// depends_on, and saves via the standard frappe.client.* endpoints. Child tables
-// (fieldtype "Table") are intentionally NOT rendered yet — that (and Journal
-// Entry's accounts grid) lands in Phase 2. When a DocType has a mandatory child
-// table the server rejects the save and the error surfaces in the banner.
+// Generic, meta-driven form for an arbitrary DocType. Renders each field by its
+// fieldtype via the shared DocTypeFieldControl, honouring reqd / read_only /
+// hidden / depends_on, plus full-width child-table grids (DocTypeChildTable) and
+// Dynamic Links. Loads via frappe.client.get (full doc incl. child tables) and
+// saves via frappe.client.insert / save — so untouched child rows round-trip.
 import { computed, reactive, ref, watch } from "vue";
 import { useDoctypeMeta } from "@/composables/useDoctypeMeta";
 import { getRecord, insertRecord, saveRecord } from "@/data/doctypeRecordApi";
 import { getDoctypePermissions } from "@/data/workspaceSettingApi";
 import { showToast } from "@/utils/appToast";
 import DeskField from "@/components/desk/DeskField.vue";
-import DeskInput from "@/components/desk/DeskInput.vue";
-import DeskTextarea from "@/components/desk/DeskTextarea.vue";
-import DeskSelect from "@/components/desk/DeskSelect.vue";
-import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import DocTypeFieldControl from "@/components/doctype/DocTypeFieldControl.vue";
+import DocTypeChildTable from "@/components/doctype/DocTypeChildTable.vue";
 
 const props = defineProps({
 	doctype: { type: String, required: true },
-	// Present → edit an existing record; absent → new record.
 	name: { type: String, default: "" },
 });
 const emit = defineEmits(["saved", "cancelled"]);
 
-const { meta, loading: metaLoading, selectOptions } = useDoctypeMeta(props.doctype);
+const { meta, loading: metaLoading } = useDoctypeMeta(props.doctype);
 
 const form = reactive({ doctype: props.doctype });
 const loading = ref(false);
@@ -35,19 +29,7 @@ const perms = ref({ read: true, write: true, create: true, delete: true });
 
 const isEdit = computed(() => !!props.name);
 
-// --- fieldtype → control routing ---------------------------------------------
-const NUMERIC = new Set(["Int", "Float", "Currency", "Percent"]);
-const TEXTAREA = new Set([
-	"Small Text",
-	"Text",
-	"Long Text",
-	"Code",
-	"Text Editor",
-	"HTML Editor",
-	"Markdown Editor",
-	"JSON",
-]);
-// Layout / structural / not-yet-supported fieldtypes never rendered as an input.
+// Structural / not-yet-supported fieldtypes never rendered (Table is handled separately).
 const SKIP = new Set([
 	"Section Break",
 	"Column Break",
@@ -57,7 +39,6 @@ const SKIP = new Set([
 	"Image",
 	"Fold",
 	"Heading",
-	"Table",
 	"Table MultiSelect",
 ]);
 
@@ -65,13 +46,12 @@ function evalDependsOn(expr) {
 	if (!expr) return true;
 	try {
 		if (expr.startsWith("eval:")) {
-			// Frappe depends_on expressions are trusted (from the DocType definition).
 			// eslint-disable-next-line no-new-func
 			return !!Function("doc", `return (${expr.slice(5)});`)(form);
 		}
 		return !!form[expr];
 	} catch {
-		return true; // never hide a field because its expression failed to parse
+		return true;
 	}
 }
 
@@ -82,50 +62,51 @@ function isRenderable(f) {
 	return evalDependsOn(f.depends_on);
 }
 
-// Fields grouped into sections (split on Section Break), for a tidy layout.
+// Sections split on Section Break; scalars render in a 2-col grid, tables full-width.
 const sections = computed(() => {
 	const fields = meta.value?.fields || [];
-	const out = [{ label: "", fields: [] }];
+	const out = [{ label: "", fields: [], tables: [] }];
 	for (const f of fields) {
 		if (f.fieldtype === "Section Break") {
-			out.push({ label: f.label || "", fields: [] });
+			out.push({ label: f.label || "", fields: [], tables: [] });
 			continue;
 		}
-		if (isRenderable(f)) out[out.length - 1].fields.push(f);
+		if (!isRenderable(f)) continue;
+		if (f.fieldtype === "Table") out[out.length - 1].tables.push(f);
+		else out[out.length - 1].fields.push(f);
 	}
-	return out.filter((s) => s.fields.length);
+	return out.filter((s) => s.fields.length || s.tables.length);
 });
 
-function controlFor(f) {
-	if (f.fieldtype === "Link" || f.fieldtype === "Dynamic Link") return "link";
-	if (f.fieldtype === "Select") return "select";
-	if (f.fieldtype === "Check") return "check";
-	if (f.fieldtype === "Date") return "date";
-	if (f.fieldtype === "Datetime") return "datetime";
-	if (TEXTAREA.has(f.fieldtype)) return "textarea";
-	if (NUMERIC.has(f.fieldtype)) return "number";
-	return "data";
-}
-
-// Dynamic Link: options names the field that holds the target DocType.
-function linkTarget(f) {
-	if (f.fieldtype === "Dynamic Link") return form[f.options] || "";
-	return f.options || "DocType";
-}
-
 function isReadOnly(f) {
-	return !!f.read_only || (isEdit.value && !perms.value.write) || (!isEdit.value && !perms.value.create);
+	return (
+		!!f.read_only ||
+		(isEdit.value && !perms.value.write) ||
+		(!isEdit.value && !perms.value.create)
+	);
 }
 
 // --- load --------------------------------------------------------------------
-function seedDefaults() {
+function resolveDefault(f) {
+	const d = f.default;
+	if (d === undefined || d === null || d === "") return undefined;
+	if (f.fieldtype === "Date" && /^today$/i.test(d)) return new Date().toISOString().slice(0, 10);
+	if (f.fieldtype === "Datetime" && /^(now|today)$/i.test(d))
+		return new Date().toISOString().slice(0, 16);
+	if (/^(user|__user)$/i.test(d)) return undefined; // let the server stamp the session user
+	return f.fieldtype === "Check" ? (Number(d) ? 1 : 0) : d;
+}
+
+function seedNew() {
 	for (const f of meta.value?.fields || []) {
-		if (SKIP.has(f.fieldtype)) continue;
-		if (f.default !== undefined && f.default !== null && f.default !== "") {
-			form[f.fieldname] = f.fieldtype === "Check" ? Number(f.default) ? 1 : 0 : f.default;
-		} else if (f.fieldtype === "Check" && form[f.fieldname] === undefined) {
-			form[f.fieldname] = 0;
+		if (f.fieldtype === "Table") {
+			if (!Array.isArray(form[f.fieldname])) form[f.fieldname] = [];
+			continue;
 		}
+		if (SKIP.has(f.fieldtype)) continue;
+		const dv = resolveDefault(f);
+		if (dv !== undefined) form[f.fieldname] = dv;
+		else if (f.fieldtype === "Check" && form[f.fieldname] === undefined) form[f.fieldname] = 0;
 	}
 }
 
@@ -137,11 +118,9 @@ async function load() {
 		if (isEdit.value) {
 			const doc = await getRecord(props.doctype, props.name);
 			Object.keys(form).forEach((k) => delete form[k]);
-			Object.assign(form, doc); // full doc incl. child tables (which ride untouched on save)
-		} else {
-			// wait for meta so defaults can seed
-			if (!meta.value) await new Promise((r) => setTimeout(r, 0));
-			seedDefaults();
+			Object.assign(form, doc);
+		} else if (meta.value) {
+			seedNew();
 		}
 	} catch (err) {
 		formError.value = err.message || "Failed to load record.";
@@ -150,11 +129,10 @@ async function load() {
 	}
 }
 
-// meta arrives async; seed defaults for a new record once it's here.
 watch(
 	() => meta.value,
 	(m) => {
-		if (m && !isEdit.value && !loading.value) seedDefaults();
+		if (m && !isEdit.value && !loading.value) seedNew();
 	}
 );
 watch(() => [props.doctype, props.name], load, { immediate: true });
@@ -167,6 +145,9 @@ function missingRequired() {
 			if (!f.reqd || isReadOnly(f)) continue;
 			const v = form[f.fieldname];
 			if (v === undefined || v === null || v === "") missing.push(f.label || f.fieldname);
+		}
+		for (const t of s.tables) {
+			if (t.reqd && !(form[t.fieldname] || []).length) missing.push(t.label || t.fieldname);
 		}
 	}
 	return missing;
@@ -198,7 +179,7 @@ const canSave = computed(() => (isEdit.value ? perms.value.write : perms.value.c
 	<div>
 		<div
 			v-if="formError"
-			class="mb-4 px-4 py-2.5 bg-danger-50 border border-danger-200 rounded-md text-xs text-danger-700"
+			class="mb-4 px-4 py-2.5 bg-danger-50 border border-danger-200 rounded-md text-xs text-danger-700 whitespace-pre-line"
 		>
 			{{ formError }}
 		</div>
@@ -215,7 +196,11 @@ const canSave = computed(() => (isEdit.value ? perms.value.write : perms.value.c
 				>
 					{{ s.label }}
 				</h3>
-				<div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4">
+
+				<div
+					v-if="s.fields.length"
+					class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4 mb-4"
+				>
 					<DeskField
 						v-for="f in s.fields"
 						:key="f.fieldname"
@@ -223,83 +208,30 @@ const canSave = computed(() => (isEdit.value ? perms.value.write : perms.value.c
 						:required="!!f.reqd"
 						:hint="f.description || ''"
 					>
-						<!-- Link / Dynamic Link -->
-						<DeskLinkPicker
-							v-if="controlFor(f) === 'link'"
+						<DocTypeFieldControl
 							v-model="form[f.fieldname]"
-							:doctype="linkTarget(f) || 'DocType'"
-							value-field="name"
-							:disabled="isReadOnly(f) || (f.fieldtype === 'Dynamic Link' && !linkTarget(f))"
-							:placeholder="f.fieldtype === 'Dynamic Link' && !linkTarget(f) ? 'Pick the type first' : 'Search…'"
-						/>
-
-						<!-- Select -->
-						<DeskSelect
-							v-else-if="controlFor(f) === 'select'"
-							v-model="form[f.fieldname]"
-							:disabled="isReadOnly(f)"
-						>
-							<option value="">—</option>
-							<option v-for="o in selectOptions(f.fieldname)" :key="o" :value="o">
-								{{ o }}
-							</option>
-						</DeskSelect>
-
-						<!-- Check -->
-						<label
-							v-else-if="controlFor(f) === 'check'"
-							class="inline-flex items-center gap-2 text-xs text-ink-700 h-[34px]"
-						>
-							<input
-								type="checkbox"
-								:checked="!!form[f.fieldname]"
-								:disabled="isReadOnly(f)"
-								@change="form[f.fieldname] = $event.target.checked ? 1 : 0"
-							/>
-							<span>Yes</span>
-						</label>
-
-						<!-- Date / Datetime -->
-						<DeskInput
-							v-else-if="controlFor(f) === 'date'"
-							v-model="form[f.fieldname]"
-							type="date"
-							:disabled="isReadOnly(f)"
-						/>
-						<DeskInput
-							v-else-if="controlFor(f) === 'datetime'"
-							v-model="form[f.fieldname]"
-							type="datetime-local"
-							:disabled="isReadOnly(f)"
-						/>
-
-						<!-- Textarea -->
-						<DeskTextarea
-							v-else-if="controlFor(f) === 'textarea'"
-							v-model="form[f.fieldname]"
-							:rows="3"
-							:disabled="isReadOnly(f)"
-						/>
-
-						<!-- Number -->
-						<DeskInput
-							v-else-if="controlFor(f) === 'number'"
-							v-model.number="form[f.fieldname]"
-							type="number"
-							:disabled="isReadOnly(f)"
-						/>
-
-						<!-- Data / fallback -->
-						<DeskInput
-							v-else
-							v-model="form[f.fieldname]"
+							:field="f"
+							:context="form"
 							:disabled="isReadOnly(f)"
 						/>
 					</DeskField>
 				</div>
+
+				<div v-for="t in s.tables" :key="t.fieldname" class="mb-4">
+					<div class="text-[11px] font-medium text-ink-700 mb-1.5">
+						{{ t.label || t.fieldname }}<span v-if="t.reqd" class="text-danger-600"> *</span>
+					</div>
+					<DocTypeChildTable
+						v-model="form[t.fieldname]"
+						:doctype="t.options"
+						:disabled="isReadOnly(t)"
+					/>
+				</div>
 			</section>
 
-			<div class="flex items-center gap-2 pt-2 border-t border-ink-200 sticky bottom-0 bg-white py-3">
+			<div
+				class="flex items-center gap-2 pt-2 border-t border-ink-200 sticky bottom-0 bg-white py-3"
+			>
 				<button
 					v-if="canSave"
 					type="submit"

--- a/frontend/src/components/workspaces/WorkspaceRecordsSection.vue
+++ b/frontend/src/components/workspaces/WorkspaceRecordsSection.vue
@@ -1,0 +1,45 @@
+<script setup>
+// The "Records" group for a workspace — DocType shortcut tiles configured in
+// Workspace Setting, each opening the generic /records list + form. Server-gated
+// per DocType (a persona who can't read a DocType never gets its tile), so this
+// simply renders whatever get_workspace_doctypes returns for the slug.
+import { ref, onMounted } from "vue";
+import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
+import { getWorkspaceDoctypes } from "@/data/workspaceSettingApi";
+
+const props = defineProps({ workspace: { type: String, required: true } });
+
+const records = ref([]);
+onMounted(async () => {
+	try {
+		records.value = await getWorkspaceDoctypes(props.workspace);
+	} catch {
+		records.value = [];
+	}
+});
+</script>
+
+<template>
+	<div v-if="records.length" class="mb-8">
+		<h2 class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2">Records</h2>
+		<div class="border-t border-ink-200 mb-3"></div>
+		<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+			<WorkspaceShortcut
+				v-for="(d, i) in records"
+				:key="i"
+				:icon="d.icon"
+				:label="d.label"
+				:description="d.description"
+				:to="d.route"
+			>
+				<template #badge>
+					<span
+						class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 font-medium uppercase tracking-wider"
+						style="border-radius: 2px"
+						>Records</span
+					>
+				</template>
+			</WorkspaceShortcut>
+		</div>
+	</div>
+</template>

--- a/frontend/src/data/doctypeRecordApi.js
+++ b/frontend/src/data/doctypeRecordApi.js
@@ -23,3 +23,9 @@ export const insertRecord = (doc) => call("frappe.client.insert", { doc: JSON.st
 export const saveRecord = (doc) => call("frappe.client.save", { doc: JSON.stringify(doc) });
 
 export const deleteRecord = (doctype, name) => call("frappe.client.delete", { doctype, name });
+
+// Submittable lifecycle (allow-list-guarded, permission-enforced server-side).
+const M = "buildsuite_core.api.workspace_setting";
+export const submitRecord = (doctype, name) => call(`${M}.submit_record`, { doctype, name });
+export const cancelRecord = (doctype, name) => call(`${M}.cancel_record`, { doctype, name });
+export const amendRecord = (doctype, name) => call(`${M}.amend_record`, { doctype, name });

--- a/frontend/src/data/doctypeRecordApi.js
+++ b/frontend/src/data/doctypeRecordApi.js
@@ -1,0 +1,25 @@
+import { frappeRequest } from "frappe-ui-frappe-request";
+import { parseFrappeError } from "@/utils/frappeError";
+
+// Generic single-record CRUD over Frappe's standard `frappe.client.*` endpoints,
+// used by the generic /records form (DocTypeForm). Permissions are enforced
+// server-side; this is a thin, doctype-agnostic wrapper.
+
+async function call(method, params) {
+	try {
+		return await frappeRequest({ url: method, params: params || {} });
+	} catch (err) {
+		throw new Error(parseFrappeError(err).summary || "Request failed.");
+	}
+}
+
+// Full document incl. child tables.
+export const getRecord = (doctype, name) => call("frappe.client.get", { doctype, name });
+
+// Insert a new document. `doc` is a plain object with at least `doctype`.
+export const insertRecord = (doc) => call("frappe.client.insert", { doc: JSON.stringify(doc) });
+
+// Save an existing document (round-trips the full doc, so untouched child tables survive).
+export const saveRecord = (doc) => call("frappe.client.save", { doc: JSON.stringify(doc) });
+
+export const deleteRecord = (doctype, name) => call("frappe.client.delete", { doctype, name });

--- a/frontend/src/data/workspaceSettingApi.js
+++ b/frontend/src/data/workspaceSettingApi.js
@@ -24,3 +24,18 @@ export const getWorkspaceSettings = () => call("get_workspace_settings");
 // Replace one workspace's rows (order preserved). Admin only.
 export const setWorkspaceReports = (workspace, reports) =>
 	call("set_workspace_reports", { workspace, reports: JSON.stringify(reports || []) });
+
+// --- DocType shortcut tiles (the generic /records list + form) ---
+
+// Ordered, renderable DocType tiles for a workspace (any signed-in user).
+export const getWorkspaceDoctypes = (workspace) => call("get_workspace_doctypes", { workspace });
+
+// Replace one workspace's DocType rows (order preserved). Admin only.
+export const setWorkspaceDoctypes = (workspace, doctypes) =>
+	call("set_workspace_doctypes", { workspace, doctypes: JSON.stringify(doctypes || []) });
+
+// DocTypeListView props derived from a DocType's Frappe meta (allow-listed only).
+export const getDoctypeListConfig = (doctype) => call("get_doctype_list_config", { doctype });
+
+// The current user's action permissions on a DocType, for gating New / Save / Delete.
+export const getDoctypePermissions = (doctype) => call("get_doctype_permissions", { doctype });

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -364,6 +364,24 @@ const routes = [
 				component: () => import("@/views/procurement/NewMaterialRequestView.vue"),
 			},
 			{
+				path: "records/:doctype/new",
+				name: "record-new",
+				component: () => import("@/views/records/DocTypeRecordFormView.vue"),
+				props: true,
+			},
+			{
+				path: "records/:doctype/:name",
+				name: "record-edit",
+				component: () => import("@/views/records/DocTypeRecordFormView.vue"),
+				props: true,
+			},
+			{
+				path: "records/:doctype",
+				name: "records-list",
+				component: () => import("@/views/records/DocTypeRecordsListView.vue"),
+				props: true,
+			},
+			{
 				path: "procurement/purchase-orders",
 				name: "purchase-orders",
 				component: () => import("@/views/procurement/PurchaseOrdersListView.vue"),

--- a/frontend/src/views/records/DocTypeRecordFormView.vue
+++ b/frontend/src/views/records/DocTypeRecordFormView.vue
@@ -1,0 +1,46 @@
+<script setup>
+// Generic add/edit page for an admin-curated DocType — hosts DocTypeForm with the
+// page chrome. /records/:doctype/new (create) and /records/:doctype/:name (edit).
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DocTypeForm from "@/components/doctype/DocTypeForm.vue";
+
+const props = defineProps({
+	doctype: { type: String, required: true },
+	name: { type: String, default: "" },
+});
+const router = useRouter();
+
+const isEdit = computed(() => !!props.name);
+const title = computed(() => (isEdit.value ? props.name : `New ${props.doctype}`));
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: props.doctype, to: `/records/${encodeURIComponent(props.doctype)}` },
+	{ label: isEdit.value ? props.name : "New" },
+]);
+
+function toList() {
+	router.push({ name: "records-list", params: { doctype: props.doctype } });
+}
+function onSaved(doc) {
+	// After creating, move onto the saved record's edit page; after editing, back to the list.
+	if (!isEdit.value && doc?.name) {
+		router.replace({ name: "record-edit", params: { doctype: props.doctype, name: doc.name } });
+	} else {
+		toList();
+	}
+}
+</script>
+
+<template>
+	<DeskPage :title="title" :breadcrumbs="breadcrumbs">
+		<DocTypeForm
+			:key="`${doctype}:${name}`"
+			:doctype="doctype"
+			:name="name"
+			@saved="onSaved"
+			@cancelled="toList"
+		/>
+	</DeskPage>
+</template>

--- a/frontend/src/views/records/DocTypeRecordFormView.vue
+++ b/frontend/src/views/records/DocTypeRecordFormView.vue
@@ -1,8 +1,8 @@
 <script setup>
 // Generic add/edit page for an admin-curated DocType — hosts DocTypeForm with the
 // page chrome. /records/:doctype/new (create) and /records/:doctype/:name (edit).
+// DocTypeForm owns its own navigation (back to list, on to a created/amended doc).
 import { computed } from "vue";
-import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DocTypeForm from "@/components/doctype/DocTypeForm.vue";
 
@@ -10,7 +10,6 @@ const props = defineProps({
 	doctype: { type: String, required: true },
 	name: { type: String, default: "" },
 });
-const router = useRouter();
 
 const isEdit = computed(() => !!props.name);
 const title = computed(() => (isEdit.value ? props.name : `New ${props.doctype}`));
@@ -19,28 +18,10 @@ const breadcrumbs = computed(() => [
 	{ label: props.doctype, to: `/records/${encodeURIComponent(props.doctype)}` },
 	{ label: isEdit.value ? props.name : "New" },
 ]);
-
-function toList() {
-	router.push({ name: "records-list", params: { doctype: props.doctype } });
-}
-function onSaved(doc) {
-	// After creating, move onto the saved record's edit page; after editing, back to the list.
-	if (!isEdit.value && doc?.name) {
-		router.replace({ name: "record-edit", params: { doctype: props.doctype, name: doc.name } });
-	} else {
-		toList();
-	}
-}
 </script>
 
 <template>
 	<DeskPage :title="title" :breadcrumbs="breadcrumbs">
-		<DocTypeForm
-			:key="`${doctype}:${name}`"
-			:doctype="doctype"
-			:name="name"
-			@saved="onSaved"
-			@cancelled="toList"
-		/>
+		<DocTypeForm :key="`${doctype}:${name}`" :doctype="doctype" :name="name" />
 	</DeskPage>
 </template>

--- a/frontend/src/views/records/DocTypeRecordsListView.vue
+++ b/frontend/src/views/records/DocTypeRecordsListView.vue
@@ -1,0 +1,77 @@
+<script setup>
+// Generic list page for an admin-curated DocType (/records/:doctype). Pulls the
+// list config (columns/search/sort) from the backend — derived from the DocType's
+// Frappe meta — and renders it through the shared DocTypeListView. Rows open the
+// generic form; "New" opens a blank one.
+import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
+import DeskPage from "@/components/desk/DeskPage.vue";
+import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
+import { getDoctypeListConfig, getDoctypePermissions } from "@/data/workspaceSettingApi";
+
+const props = defineProps({ doctype: { type: String, required: true } });
+const router = useRouter();
+
+const config = ref(null);
+const perms = ref({ create: false });
+const error = ref("");
+const loading = ref(true);
+
+async function load() {
+	loading.value = true;
+	error.value = "";
+	config.value = null;
+	try {
+		config.value = await getDoctypeListConfig(props.doctype);
+		perms.value = await getDoctypePermissions(props.doctype).catch(() => perms.value);
+	} catch (err) {
+		error.value = err.message || "This record type isn't available here.";
+	} finally {
+		loading.value = false;
+	}
+}
+watch(() => props.doctype, load, { immediate: true });
+
+const breadcrumbs = computed(() => [
+	{ label: "BuildSuite Core", to: "/" },
+	{ label: config.value?.label || props.doctype },
+]);
+
+function onNew() {
+	router.push({ name: "record-new", params: { doctype: props.doctype } });
+}
+function onRow(row) {
+	router.push({ name: "record-edit", params: { doctype: props.doctype, name: row.name } });
+}
+</script>
+
+<template>
+	<DeskPage :title="config?.label || doctype" :breadcrumbs="breadcrumbs">
+		<template #actions>
+			<button
+				v-if="perms.create"
+				type="button"
+				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
+				style="border-radius: 6px"
+				@click="onNew"
+			>
+				+ New
+			</button>
+		</template>
+
+		<div v-if="error" class="bg-warning-50 border border-warning-200 rounded-lg px-4 py-6 text-sm text-warning-700">
+			{{ error }}
+		</div>
+		<div v-else-if="loading" class="text-sm text-ink-500 py-10 text-center">Loading…</div>
+		<DocTypeListView
+			v-else-if="config"
+			:doctype="doctype"
+			:field-order="config.fieldOrder"
+			:search-fields="config.searchFields"
+			:initial-order-by="config.initialOrderBy"
+			:cache-key="doctype"
+			:search-placeholder="`Search ${config.label}…`"
+			@row-click="onRow"
+		/>
+	</DeskPage>
+</template>

--- a/frontend/src/views/records/DocTypeRecordsListView.vue
+++ b/frontend/src/views/records/DocTypeRecordsListView.vue
@@ -81,13 +81,7 @@ function onRow(row) {
 <template>
 	<DeskPage :title="config?.label || doctype" :breadcrumbs="breadcrumbs">
 		<template #actions>
-			<button
-				v-if="perms.create"
-				type="button"
-				class="text-xs px-2.5 py-1 border border-brand-300 bg-brand-50 hover:bg-brand-100 text-brand-700 font-medium"
-				style="border-radius: 6px"
-				@click="onNew"
-			>
+			<button v-if="perms.create" type="button" class="desk-save-btn" @click="onNew">
 				+ New
 			</button>
 		</template>

--- a/frontend/src/views/records/DocTypeRecordsListView.vue
+++ b/frontend/src/views/records/DocTypeRecordsListView.vue
@@ -1,11 +1,15 @@
 <script setup>
 // Generic list page for an admin-curated DocType (/records/:doctype). Pulls the
-// list config (columns/search/sort) from the backend — derived from the DocType's
-// Frappe meta — and renders it through the shared DocTypeListView. Rows open the
-// generic form; "New" opens a blank one.
-import { computed, ref, watch } from "vue";
+// list config (columns/search/sort + filter fields) from the backend — all derived
+// from the DocType's own Frappe meta — and renders it through the shared
+// DocTypeListView. Filters are built from the meta's in_standard_filter / in_list_view
+// fields. Rows open the generic form; "New" opens a blank one.
+import { computed, reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { getDoctypeListConfig, getDoctypePermissions } from "@/data/workspaceSettingApi";
 
@@ -17,12 +21,17 @@ const perms = ref({ create: false });
 const error = ref("");
 const loading = ref(true);
 
+// Reactive filter values keyed by fieldname, fed into DocTypeListView.
+const filterState = reactive({});
+
 async function load() {
 	loading.value = true;
 	error.value = "";
 	config.value = null;
+	Object.keys(filterState).forEach((k) => delete filterState[k]);
 	try {
 		config.value = await getDoctypeListConfig(props.doctype);
+		for (const f of config.value.filters || []) filterState[f.fieldname] = "";
 		perms.value = await getDoctypePermissions(props.doctype).catch(() => perms.value);
 	} catch (err) {
 		error.value = err.message || "This record type isn't available here.";
@@ -31,6 +40,30 @@ async function load() {
 	}
 }
 watch(() => props.doctype, load, { immediate: true });
+
+const filters = computed(() => config.value?.filters || []);
+
+// Free-text fields match with a `like` contains; everything else is exact equality.
+const filterFieldMap = computed(() => {
+	const map = {};
+	for (const f of filters.value) {
+		map[f.fieldname] =
+			f.fieldtype === "Data" || f.fieldtype === "Small Text"
+				? { field: f.fieldname, op: "like", like: true }
+				: f.fieldname;
+	}
+	return map;
+});
+
+const activeFilters = computed(() =>
+	filters.value.filter((f) => filterState[f.fieldname] !== "" && filterState[f.fieldname] != null)
+);
+function clearFilters() {
+	for (const f of filters.value) filterState[f.fieldname] = "";
+}
+function selectOptions(f) {
+	return (f.options || "").split("\n").map((o) => o.trim()).filter(Boolean);
+}
 
 const breadcrumbs = computed(() => [
 	{ label: "BuildSuite Core", to: "/" },
@@ -69,9 +102,69 @@ function onRow(row) {
 			:field-order="config.fieldOrder"
 			:search-fields="config.searchFields"
 			:initial-order-by="config.initialOrderBy"
+			:filter-values="filterState"
+			:filter-field-map="filterFieldMap"
 			:cache-key="doctype"
 			:search-placeholder="`Search ${config.label}…`"
 			@row-click="onRow"
-		/>
+		>
+			<template v-if="filters.length" #filter-chips>
+				<div v-for="f in filters" :key="f.fieldname" class="flex items-center gap-1.5">
+					<span class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						{{ f.label }}
+					</span>
+					<!-- Link -->
+					<DeskLinkPicker
+						v-if="f.fieldtype === 'Link'"
+						v-model="filterState[f.fieldname]"
+						class="!w-44"
+						:doctype="f.options || 'DocType'"
+						:page-length="10"
+						:placeholder="`Any`"
+					/>
+					<!-- Select -->
+					<DeskSelect
+						v-else-if="f.fieldtype === 'Select'"
+						v-model="filterState[f.fieldname]"
+						class="!w-40"
+					>
+						<option value="">Any</option>
+						<option v-for="o in selectOptions(f)" :key="o" :value="o">{{ o }}</option>
+					</DeskSelect>
+					<!-- Check -->
+					<DeskSelect
+						v-else-if="f.fieldtype === 'Check'"
+						v-model="filterState[f.fieldname]"
+						class="!w-28"
+					>
+						<option value="">Any</option>
+						<option value="1">Yes</option>
+						<option value="0">No</option>
+					</DeskSelect>
+					<!-- Date / Datetime -->
+					<DeskInput
+						v-else-if="f.fieldtype === 'Date' || f.fieldtype === 'Datetime'"
+						v-model="filterState[f.fieldname]"
+						type="date"
+						class="!w-40"
+					/>
+					<!-- Data / Small Text -->
+					<DeskInput
+						v-else
+						v-model="filterState[f.fieldname]"
+						class="!w-40"
+						:placeholder="`Filter ${f.label.toLowerCase()}…`"
+					/>
+				</div>
+				<button
+					v-if="activeFilters.length"
+					type="button"
+					class="text-[11px] text-ink-500 hover:text-ink-800 underline"
+					@click="clearFilters"
+				>
+					Clear
+				</button>
+			</template>
+		</DocTypeListView>
 	</DeskPage>
 </template>

--- a/frontend/src/views/settings/WorkspaceSettingsView.vue
+++ b/frontend/src/views/settings/WorkspaceSettingsView.vue
@@ -8,7 +8,11 @@ import { ref, computed, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
-import { getWorkspaceSettings, setWorkspaceReports } from "@/data/workspaceSettingApi";
+import {
+	getWorkspaceSettings,
+	setWorkspaceReports,
+	setWorkspaceDoctypes,
+} from "@/data/workspaceSettingApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
 import DeskActionBar from "@/components/desk/DeskActionBar.vue";
@@ -20,23 +24,33 @@ const store = useDataStore();
 const router = useRouter();
 
 const workspaces = ref([]); // [{ slug, label }]
-const byWorkspace = ref({}); // { slug: [row, …] }
+const byWorkspace = ref({}); // { slug: [report row, …] }
+const docByWorkspace = ref({}); // { slug: [doctype row, …] }
 const activeSlug = ref("");
 const saving = ref(false);
 const loading = ref(true);
 
 const rows = computed(() => byWorkspace.value[activeSlug.value] || []);
+const docRows = computed(() => docByWorkspace.value[activeSlug.value] || []);
+
+// Rebuild the per-workspace report + doctype maps from an authoritative response.
+function hydrate(res) {
+	const rmap = {};
+	const dmap = {};
+	for (const w of workspaces.value) {
+		rmap[w.slug] = (res?.reports?.[w.slug] || []).map((r) => ({ ...r }));
+		dmap[w.slug] = (res?.doctypes?.[w.slug] || []).map((r) => ({ ...r }));
+	}
+	byWorkspace.value = rmap;
+	docByWorkspace.value = dmap;
+}
 
 async function load() {
 	loading.value = true;
 	try {
 		const res = await getWorkspaceSettings();
 		workspaces.value = res?.workspaces || [];
-		const map = {};
-		for (const w of workspaces.value) {
-			map[w.slug] = (res?.reports?.[w.slug] || []).map((r) => ({ ...r }));
-		}
-		byWorkspace.value = map;
+		hydrate(res);
 		if (!activeSlug.value && workspaces.value.length)
 			activeSlug.value = workspaces.value[0].slug;
 	} catch (err) {
@@ -46,36 +60,42 @@ async function load() {
 	}
 }
 
+function move(arr, i, delta) {
+	const j = i + delta;
+	if (j < 0 || j >= arr.length) return;
+	const [row] = arr.splice(i, 1);
+	arr.splice(j, 0, row);
+}
+
 function addReport() {
 	rows.value.push({ label: "", report: "", route: "", icon: "file-text", description: "" });
 }
 function removeReport(i) {
 	rows.value.splice(i, 1);
 }
-function move(i, delta) {
-	const j = i + delta;
-	if (j < 0 || j >= rows.value.length) return;
-	const [row] = rows.value.splice(i, 1);
-	rows.value.splice(j, 0, row);
+function addRecord() {
+	docRows.value.push({ label: "", doctype: "", icon: "file-text", description: "" });
+}
+function removeRecord(i) {
+	docRows.value.splice(i, 1);
 }
 
 async function save() {
 	if (saving.value) return;
-	const bad = rows.value.find((r) => !r.report && !(r.route || "").trim());
-	if (bad) {
-		showToast("Every row needs a report or a route.", "error");
+	if (rows.value.find((r) => !r.report && !(r.route || "").trim())) {
+		showToast("Every report row needs a report or a route.", "error");
+		return;
+	}
+	if (docRows.value.find((r) => !(r.doctype || "").trim())) {
+		showToast("Every record row needs a DocType.", "error");
 		return;
 	}
 	saving.value = true;
 	try {
-		const res = await setWorkspaceReports(activeSlug.value, rows.value);
-		// re-hydrate all workspaces from the authoritative response
-		const map = {};
-		for (const w of workspaces.value) {
-			map[w.slug] = (res?.reports?.[w.slug] || []).map((r) => ({ ...r }));
-		}
-		byWorkspace.value = map;
-		showToast(`${activeLabel.value} reports saved`);
+		await setWorkspaceReports(activeSlug.value, rows.value);
+		const res = await setWorkspaceDoctypes(activeSlug.value, docRows.value);
+		hydrate(res); // final response carries both maps
+		showToast(`${activeLabel.value} saved`);
 	} catch (err) {
 		showToast(err.message || "Failed to save", "error");
 	} finally {
@@ -111,7 +131,7 @@ onMounted(() => {
 		<DeskForm>
 			<template #action-bar>
 				<DeskActionBar
-					:save-label="saving ? 'Saving…' : `Save ${activeLabel} reports`"
+					:save-label="saving ? 'Saving…' : `Save ${activeLabel}`"
 					:saving="saving"
 					@save="save"
 					@cancel="load"
@@ -205,7 +225,7 @@ onMounted(() => {
 											class="text-ink-400 hover:text-ink-700 px-1 disabled:opacity-30"
 											:disabled="i === 0"
 											title="Move up"
-											@click="move(i, -1)"
+											@click="move(rows, i, -1)"
 										>
 											↑
 										</button>
@@ -213,7 +233,7 @@ onMounted(() => {
 											class="text-ink-400 hover:text-ink-700 px-1 disabled:opacity-30"
 											:disabled="i === rows.length - 1"
 											title="Move down"
-											@click="move(i, 1)"
+											@click="move(rows, i, 1)"
 										>
 											↓
 										</button>
@@ -236,6 +256,97 @@ onMounted(() => {
 					</div>
 					<button class="mt-2 text-sm text-brand-600 hover:underline" @click="addReport">
 						+ Add report
+					</button>
+				</DeskSection>
+
+				<DeskSection :title="`${activeLabel} records`" :cols="1">
+					<p class="text-sm text-ink-500 -mt-1">
+						DocType tiles render in the {{ activeLabel }} workspace's
+						<strong>Records</strong> group. Each opens the generic list + add/edit form
+						for that DocType (columns and filters come from the DocType's own fields).
+					</p>
+					<div class="overflow-x-auto">
+						<table class="w-full text-sm">
+							<thead>
+								<tr class="text-left text-ink-500 border-b border-ink-100">
+									<th class="py-1.5 pr-2 font-medium w-8">#</th>
+									<th class="py-1.5 pr-2 font-medium w-44">Label</th>
+									<th class="py-1.5 pr-2 font-medium w-52">DocType</th>
+									<th class="py-1.5 pr-2 font-medium w-28">Icon</th>
+									<th class="py-1.5 pr-2 font-medium">Description</th>
+									<th class="w-20"></th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr
+									v-for="(r, i) in docRows"
+									:key="i"
+									class="border-b border-ink-50 align-top"
+								>
+									<td class="py-1 pr-2 text-ink-400 tabular-nums pt-2.5">
+										{{ i + 1 }}
+									</td>
+									<td class="py-1 pr-2">
+										<DeskInput
+											v-model="r.label"
+											placeholder="Tile title (defaults to DocType)"
+										/>
+									</td>
+									<td class="py-1 pr-2">
+										<DeskLinkPicker
+											v-model="r.doctype"
+											doctype="DocType"
+											placeholder="Select DocType"
+											value-field="name"
+											:search-fields="['name']"
+											:page-length="20"
+										/>
+									</td>
+									<td class="py-1 pr-2">
+										<DeskInput v-model="r.icon" placeholder="file-text" />
+									</td>
+									<td class="py-1 pr-2">
+										<DeskInput
+											v-model="r.description"
+											placeholder="Short description"
+										/>
+									</td>
+									<td class="py-1 text-center whitespace-nowrap pt-2">
+										<button
+											class="text-ink-400 hover:text-ink-700 px-1 disabled:opacity-30"
+											:disabled="i === 0"
+											title="Move up"
+											@click="move(docRows, i, -1)"
+										>
+											↑
+										</button>
+										<button
+											class="text-ink-400 hover:text-ink-700 px-1 disabled:opacity-30"
+											:disabled="i === docRows.length - 1"
+											title="Move down"
+											@click="move(docRows, i, 1)"
+										>
+											↓
+										</button>
+										<button
+											class="text-ink-400 hover:text-danger-600 px-1"
+											title="Remove"
+											@click="removeRecord(i)"
+										>
+											×
+										</button>
+									</td>
+								</tr>
+								<tr v-if="!docRows.length">
+									<td colspan="6" class="py-3 text-center text-ink-400">
+										No records configured for {{ activeLabel }} yet.
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<button class="mt-2 text-sm text-brand-600 hover:underline" @click="addRecord">
+						+ Add record
 					</button>
 				</DeskSection>
 			</template>

--- a/frontend/src/views/workspaces/EstimationWorkspace.vue
+++ b/frontend/src/views/workspaces/EstimationWorkspace.vue
@@ -5,6 +5,7 @@
 import { computed, ref, onMounted } from "vue";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
 import { getWorkspaceReports } from "@/data/workspaceSettingApi";
+import WorkspaceRecordsSection from "@/components/workspaces/WorkspaceRecordsSection.vue";
 
 const today = computed(() =>
 	new Date().toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" }),
@@ -74,6 +75,8 @@ const SETUP = [
 					:description="sc.description"
 				/>
 			</div>
+
+			<WorkspaceRecordsSection workspace="estimation" />
 
 			<!-- Reports group — configured in Workspace Setting -->
 			<div v-if="reports.length" class="mt-8">

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -4,6 +4,7 @@ import { RouterLink } from "vue-router";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { getWorkspaceReports } from "@/data/workspaceSettingApi";
+import WorkspaceRecordsSection from "@/components/workspaces/WorkspaceRecordsSection.vue";
 
 const today = computed(() => {
 	const d = new Date();
@@ -99,6 +100,8 @@ onMounted(async () => {
 					:prevent="sc.prevent"
 				/>
 			</div>
+
+			<WorkspaceRecordsSection workspace="procurement" />
 
 			<!-- Reports group at the bottom -->
 			<div v-if="reports.length" class="mt-8">

--- a/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
+++ b/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
@@ -11,7 +11,8 @@ import { storeToRefs } from "pinia";
 import { useFinanceMock } from "@/data/financeMock";
 import { useSessionStore } from "@/stores/session";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
-import { getWorkspaceReports, getWorkspaceDoctypes } from "@/data/workspaceSettingApi";
+import { getWorkspaceReports } from "@/data/workspaceSettingApi";
+import WorkspaceRecordsSection from "@/components/workspaces/WorkspaceRecordsSection.vue";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
 import { fmtINR } from "@/utils/format";
 
@@ -76,24 +77,17 @@ const MASTERS = [
 // BuildSuite-specific Petty Cash / Expense Summary. Each tile is role-gated server-side, so
 // a persona without the Accounts roles simply gets none.
 const reports = ref([]);
-const records = ref([]);
 onMounted(async () => {
 	try {
 		reports.value = await getWorkspaceReports("project-finance");
 	} catch {
 		reports.value = [];
 	}
-	try {
-		records.value = await getWorkspaceDoctypes("project-finance");
-	} catch {
-		records.value = [];
-	}
 });
 
 const txTiles = computed(() => TRANSACTIONS.filter((t) => canSee(t.section)));
 const masterTiles = computed(() => MASTERS.filter((t) => canSee(t.section)));
 const showReports = computed(() => canSee("reports") && reports.value.length > 0);
-const showRecords = computed(() => records.value.length > 0);
 const showOverview = computed(() => canSee("overview"));
 </script>
 
@@ -205,32 +199,7 @@ const showOverview = computed(() => canSee("overview"));
 				</div>
 
 				<!-- Records (admin-curated DocTypes) -->
-				<div v-if="showRecords" class="mb-8">
-					<h2
-						class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2"
-					>
-						Records
-					</h2>
-					<div class="border-t border-ink-200 mb-3"></div>
-					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-						<WorkspaceShortcut
-							v-for="(d, i) in records"
-							:key="i"
-							:icon="d.icon"
-							:label="d.label"
-							:description="d.description"
-							:to="d.route"
-						>
-							<template #badge>
-								<span
-									class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 font-medium uppercase tracking-wider"
-									style="border-radius: 2px"
-									>Records</span
-								>
-							</template>
-						</WorkspaceShortcut>
-					</div>
-				</div>
+				<WorkspaceRecordsSection workspace="project-finance" />
 
 				<!-- Reports -->
 				<div v-if="showReports" class="mb-4">

--- a/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
+++ b/frontend/src/views/workspaces/ProjectFinanceWorkspace.vue
@@ -11,7 +11,7 @@ import { storeToRefs } from "pinia";
 import { useFinanceMock } from "@/data/financeMock";
 import { useSessionStore } from "@/stores/session";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
-import { getWorkspaceReports } from "@/data/workspaceSettingApi";
+import { getWorkspaceReports, getWorkspaceDoctypes } from "@/data/workspaceSettingApi";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
 import { fmtINR } from "@/utils/format";
 
@@ -76,17 +76,24 @@ const MASTERS = [
 // BuildSuite-specific Petty Cash / Expense Summary. Each tile is role-gated server-side, so
 // a persona without the Accounts roles simply gets none.
 const reports = ref([]);
+const records = ref([]);
 onMounted(async () => {
 	try {
 		reports.value = await getWorkspaceReports("project-finance");
 	} catch {
 		reports.value = [];
 	}
+	try {
+		records.value = await getWorkspaceDoctypes("project-finance");
+	} catch {
+		records.value = [];
+	}
 });
 
 const txTiles = computed(() => TRANSACTIONS.filter((t) => canSee(t.section)));
 const masterTiles = computed(() => MASTERS.filter((t) => canSee(t.section)));
 const showReports = computed(() => canSee("reports") && reports.value.length > 0);
+const showRecords = computed(() => records.value.length > 0);
 const showOverview = computed(() => canSee("overview"));
 </script>
 
@@ -194,6 +201,34 @@ const showOverview = computed(() => canSee("overview"));
 							:label="t.label"
 							:to="`/project-finance/${t.section}`"
 						/>
+					</div>
+				</div>
+
+				<!-- Records (admin-curated DocTypes) -->
+				<div v-if="showRecords" class="mb-8">
+					<h2
+						class="text-[11px] font-semibold uppercase tracking-wider text-ink-700 mb-2"
+					>
+						Records
+					</h2>
+					<div class="border-t border-ink-200 mb-3"></div>
+					<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+						<WorkspaceShortcut
+							v-for="(d, i) in records"
+							:key="i"
+							:icon="d.icon"
+							:label="d.label"
+							:description="d.description"
+							:to="d.route"
+						>
+							<template #badge>
+								<span
+									class="text-[9px] px-1 py-0.5 bg-ink-100 text-ink-600 font-medium uppercase tracking-wider"
+									style="border-radius: 2px"
+									>Records</span
+								>
+							</template>
+						</WorkspaceShortcut>
 					</div>
 				</div>
 

--- a/frontend/src/views/workspaces/SiteExecutionWorkspace.vue
+++ b/frontend/src/views/workspaces/SiteExecutionWorkspace.vue
@@ -30,6 +30,7 @@ import UserAvatar from "@/components/UserAvatar.vue";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { getWorkspaceReports } from "@/data/workspaceSettingApi";
+import WorkspaceRecordsSection from "@/components/workspaces/WorkspaceRecordsSection.vue";
 
 const store = useDataStore();
 
@@ -196,6 +197,8 @@ onMounted(async () => {
 					Active role: {{ store.currentRole?.name }}
 				</div>
 			</div>
+
+			<WorkspaceRecordsSection workspace="site-execution" />
 
 			<!-- Reports group — configured in Site Execution Settings (report + icon
            + description, in order). Each tile opens the report's desk route. -->

--- a/frontend/src/views/workspaces/SubcontractWorkspace.vue
+++ b/frontend/src/views/workspaces/SubcontractWorkspace.vue
@@ -11,6 +11,7 @@ import { RouterLink } from "vue-router";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
 import { getWorkspaceIconPath } from "@/utils/workspaceIcons";
 import { getWorkspaceReports } from "@/data/workspaceSettingApi";
+import WorkspaceRecordsSection from "@/components/workspaces/WorkspaceRecordsSection.vue";
 
 const today = computed(() => {
 	const d = new Date();
@@ -99,6 +100,8 @@ onMounted(async () => {
 					:to="sc.to"
 				/>
 			</div>
+
+			<WorkspaceRecordsSection workspace="subcontract" />
 
 			<!-- Reports group -->
 			<div v-if="reports.length" class="mt-8">


### PR DESCRIPTION
Adds admin-curated **DocType sections** to workspaces, mirroring the existing report tiles: an admin adds a DocType to a workspace in Workspace Settings, and it renders as a tile that opens a generic **list + add/edit form** for that DocType — no per-DocType code.

## Config
- New `Workspace Doctype` child table on the `Workspace Setting` Single (field is `document_type` — `doctype` is a reserved Frappe attribute).
- API: `get/set_workspace_doctypes`, `get_doctype_list_config` (columns/search/sort/filters derived from the DocType's own meta), `get_doctype_permissions`, and submittable lifecycle (`submit/cancel/amend_record`). All allowlist-guarded — only DocTypes an admin actually added are reachable; Frappe permissions (incl. row-level query conditions / User Permissions) still gate every record.

## Generic routes + list
- `/records/:doctype` (list), `/records/:doctype/new`, `/records/:doctype/:name` (form).
- `DocTypeRecordsListView` renders the shared `DocTypeListView` with meta-derived columns and **filter controls** (Link/Select/Check/date/text) built from `in_standard_filter`/`in_list_view`.

## The form (the missing piece)
- `DocTypeForm`: meta-driven, honours reqd/read_only/hidden/depends_on; renders **tabs** (Tab Break), sections, a 2-col field grid, and **child-table grids** (`DocTypeChildTable`) with **Dynamic Link** support and a per-row **detail modal**.
- Submittable **lifecycle by docstatus**: Draft → Save/Submit/Delete; Submitted → Cancel; Cancelled → Amend/Delete, with **Save/Submit dirty tracking** (Save primary while dirty, Submit primary once clean; Submit only for submittable DocTypes).
- Uses the app's canonical `.desk-save-btn` primary.

## Workspace wiring
- Shared `WorkspaceRecordsSection` rendered in all five workspaces; the section hides when nothing is configured.

## Verified
- All endpoints on bs.local; Journal Entry as the exercise doctype — list + filters, tabbed form, balanced accounts grid saving as a draft, and the full submit → cancel → amend chain. Frontend builds clean.