### PR TITLE
fix: personas created without their roles (manual role entry needed after install)

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -36,3 +36,4 @@ buildsuite_core.patches.grant_child_table_read_access # 2026-08-21
 buildsuite_core.patches.resync_director_permission_matrix # 2026-08-24
 buildsuite_core.patches.repoint_pnl_to_bespoke # 2026-08-25
 buildsuite_core.patches.resync_picker_select_permissions
+buildsuite_core.patches.backfill_persona_roles # 2026-09-01

--- a/buildsuite_core/patches/backfill_persona_roles.py
+++ b/buildsuite_core/patches/backfill_persona_roles.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Backfill default roles onto personas that were created empty.
+
+The persona-creation patches (repair_default_personas / enforce_persona_backend_only) run
+BEFORE the BuildSuite roles exist — the roles are created later, by setup_record_permissions
+via the resync_* patches — so personas were inserted with empty role tables. seed_personas
+then skipped them (it only attaches roles to personas it creates itself, never to existing
+ones), so those personas stayed role-less and their users were locked out of the app until an
+admin added the roles by hand. The roles exist by now, so re-run repair_default_personas to
+add the missing default roles. Idempotent; never removes an admin's extra roles."""
+
+
+def execute():
+	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import (
+		repair_default_personas,
+	)
+
+	repair_default_personas()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -1022,7 +1022,7 @@ def setup_child_table_read_access():
 
 def setup_record_permissions():
 	"""Seed roles + DocPerms for every BuildSuite-scoped doctype."""
-	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import seed_personas
+	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import repair_default_personas
 	from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import (
 		seed_workspace_reports,
 	)
@@ -1049,7 +1049,10 @@ def setup_record_permissions():
 	# Mirror read to child tables of everything the BuildSuite roles can read (must run AFTER
 	# all the parent grants above are in place).
 	setup_child_table_read_access()
-	# Personas map to the roles ensured above — seed them once the roles exist.
-	seed_personas()
+	# Personas map to the roles ensured above. Use repair (not plain seed) so an existing
+	# persona that was created empty — the persona-creation patches run BEFORE the roles
+	# exist, and plain seed_personas skips already-created personas — gets its missing
+	# default roles backfilled now that the roles are in place.
+	repair_default_personas()
 	# Per-workspace report tiles (Query Reports + the Workspace Setting table).
 	seed_workspace_reports()


### PR DESCRIPTION
## Symptom
After install/migrate, the default Personas exist but with **empty role tables**, so their users get no BuildSuite role and are locked out of the app — until someone adds the roles to each Persona by hand.

## Root cause — a patch-ordering bug
The BuildSuite **roles** are created only inside `setup_record_permissions()`, which runs via patches **36/38** (`resync_director_permission_matrix`, `resync_picker_select_permissions`). But the **personas** are created earlier, by patches **15/16** (`repair_default_personas`, `enforce_persona_backend_only`) — *before those roles exist*:

- Persona creation guards each role with `if frappe.db.exists("Role", role)`, so at patch 15 the roles aren't there yet → personas are inserted with **empty** role tables.
- At patch 36, `setup_record_permissions` creates the roles and calls `seed_personas()` — but `seed_personas` does `if frappe.db.exists("Persona", …): continue`. It **skips personas that already exist** and only attaches roles to ones it creates itself. So the empty personas never get their roles.

## Fix
1. **`setup_record_permissions` now calls `repair_default_personas()`** instead of `seed_personas()`. `repair` backfills missing default roles onto *existing* personas (roles are already ensured earlier in the same function), so it's self-healing on every run — and never removes an admin's extra roles.
2. **New `backfill_persona_roles` patch** re-runs `repair_default_personas()` on sites that already applied the old seed path (their roles exist; only the persona role tables are empty), added at the end of `patches.txt` so it runs after the roles are in place.

## Verification
On bs.local: emptied the "Director / Owner" persona's roles (`[]`), ran the repair, and its default role was restored (`['BuildSuite Director']`). Idempotent and additive-only.