### PR TITLE
fix: advance/payment Reference No optional + expenses CTA colour

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -520,9 +520,10 @@ def record_advance(customer: str, amount: str, date: str | None = None, deposit_
 	pe.received_amount = amount
 	if mode_of_payment:
 		pe.mode_of_payment = mode_of_payment
-	if reference_no:
-		pe.reference_no = reference_no
-		pe.reference_date = date or nowdate()
+	# ERPNext makes Reference No + Date mandatory for a Bank Mode of Payment; we keep them
+	# OPTIONAL for the user by defaulting them when none was supplied (harmless for cash).
+	pe.reference_no = reference_no or "Advance"
+	pe.reference_date = date or nowdate()
 	pe.custom_is_bs_advance = 1  # durable marker — a fully-consumed advance must never read as a receipt
 	pe.flags.ignore_permissions = True
 	pe.set_missing_values()

--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -622,9 +622,10 @@ def record_payment(
 			pe.references[0].allocated_amount = flt(amount)
 	if mode_of_payment:
 		pe.mode_of_payment = mode_of_payment
-	if reference_no:
-		pe.reference_no = reference_no
-		pe.reference_date = date or nowdate()
+	# ERPNext makes Reference No + Date mandatory for a Bank Mode of Payment; we keep them
+	# OPTIONAL for the user by defaulting them when none was supplied (harmless for cash).
+	pe.reference_no = reference_no or "Payment"
+	pe.reference_date = date or nowdate()
 	pe.flags.ignore_permissions = True
 	pe.insert()
 	pe.submit()

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -335,7 +335,7 @@ const expenseAccountFilters = computed(() => [
 							<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
 							<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 							<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
-							<td class="px-4 py-2.5 text-right"><button type="button" class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-white rounded-md" @click.stop="onSubmit(e)">Submit</button></td>
+							<td class="px-4 py-2.5 text-right"><button type="button" class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-ink-900 rounded-md" @click.stop="onSubmit(e)">Submit</button></td>
 						</tr>
 					</tbody>
 				</table>
@@ -511,3 +511,11 @@ const expenseAccountFilters = computed(() => [
 		</div>
 	</DeskPage>
 </template>
+
+<style scoped>
+/* CTA buttons read black-on-green in dark mode (prototype). The shared .desk-save-btn is
+   green-bg/white-text in dark; scope the black text to this view for now. */
+html.dark .desk-save-btn {
+	color: #0f172a;
+}
+</style>


### PR DESCRIPTION
Two small, independent fixes (split off from the multi-company work, which is pended on its own branch).

## 1. Reference No optional when recording an advance / payment
ERPNext makes **Reference No + Date mandatory for a Bank Mode of Payment**, which blocked recording a customer advance or a bill payment from a bank account (`Reference No and Reference Date is mandatory for Bank transaction`). Now defaulted when the user doesn't supply one (harmless for cash), so the field is optional in the UI.
- `api/invoice.py` `record_advance` (customer advance)
- `api/supplier_bill.py` `record_payment` (bill payment)

## 2. Expenses CTA buttons — black-on-green in dark mode
The shared `.desk-save-btn` is green-bg/white-text in dark mode, and the row **Submit** button hardcoded `bg-brand-600 text-white` — both read white-on-green. The prototype uses **black-on-green**. Fixed the Submit button (`text-ink-900`) and scoped a black-text override onto `.desk-save-btn` for the Expenses view.
- `frontend/src/views/finance/FinanceExpensesPanel.vue`

## Verified
- Reference-no "mandatory" error no longer fires on advance/payment.
- `yarn build` passes.

## Not included (tracked separately)
- Salary Slip print button / sidebar — that screen is Frappe HR (hrms), not this app.
- Default Print Format in the SPA print view — comes with the server-print work pended on `feat/multi-company-support`.
- One pre-existing `test_subcontractor_bill` type-hint error (`amount` on `subcontractor_bill.record_payment`) from the earlier semgrep pass — separate.