### PR TITLE
feat: mobile-app permission layer

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -37,3 +37,4 @@ buildsuite_core.patches.resync_director_permission_matrix # 2026-08-24
 buildsuite_core.patches.repoint_pnl_to_bespoke # 2026-08-25
 buildsuite_core.patches.resync_picker_select_permissions
 buildsuite_core.patches.backfill_persona_roles # 2026-09-01
+buildsuite_core.patches.resync_mobile_permissions # 2026-09-03 mobile app perms

--- a/buildsuite_core/patches/resync_mobile_permissions.py
+++ b/buildsuite_core/patches/resync_mobile_permissions.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Apply the companion mobile app's extra DocPerms to existing sites.
+
+Record permissions are seeded on install only, so a new perm set (here setup_mobile_permissions)
+doesn't reach existing sites without a patch. setup_record_permissions() is idempotent, so this
+re-runs the whole authoritative seed safely."""
+
+from buildsuite_core.permissions.setup import setup_record_permissions
+
+
+def execute():
+	setup_record_permissions()

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -1020,6 +1020,68 @@ def setup_child_table_read_access():
 		_upgrade_role_perms(ref, {role: {"read": 1} for role in missing}, ptypes=("read",))
 
 
+# --- Mobile app permissions (additional, layered on the base matrix) -----------
+# A companion mobile app (a separate app) authenticates as BuildSuite users and needs extra
+# DocPerms on top of the base matrix, per the mobile-permissions sheet. Applied with
+# _upgrade_role_perms so it only RAISES perms, never revokes a base grant; each call passes only
+# the ptypes it grants, so unlisted ptypes (e.g. delete) keep their base value.
+_MOBILE_FULL = {"select": 1, "read": 1, "write": 1, "create": 1, "submit": 1, "cancel": 1, "print": 1}
+_MOBILE_CRW = {"select": 1, "read": 1, "write": 1, "create": 1, "print": 1}  # Select/Read/Write/Create
+_MOBILE_SR = {"select": 1, "read": 1, "print": 1}  # Select, Read
+
+_M_PM = "BuildSuite PM"
+_M_ENGINEER = "BuildSuite Site Engineer"
+_M_FOREMAN = "BuildSuite Foreman"
+# Roles that may create a Field Attendance muster (from FIELD_ATTENDANCE_ROLE_PERMS).
+_MOBILE_FIELD_ATT_ROLES = (_M_PM, _M_ENGINEER, _M_FOREMAN, "BuildSuite HR Manager")
+# Every BuildSuite persona — an Expense Entry can be raised by all of them (→ Account read), and
+# File is available to all in the mobile app.
+_MOBILE_ALL_ROLES = (
+	"BuildSuite Director",
+	_M_PM,
+	"BuildSuite QS",
+	"BuildSuite Estimator",
+	_M_ENGINEER,
+	_M_FOREMAN,
+	"BuildSuite Procurement Officer",
+	"BuildSuite Store Keeper",
+	"BuildSuite Accountant",
+	"BuildSuite HR Manager",
+)
+
+
+def _mobile_perm(roles, perm):
+	return {role: perm for role in roles}
+
+
+def setup_mobile_permissions():
+	"""Extra DocPerms for the companion mobile app, layered on the base matrix (never revokes).
+	Source: the mobile-permissions sheet — Select/Read/Write/Create/Submit/Cancel per doctype."""
+	full, crw, sr = tuple(_MOBILE_FULL), tuple(_MOBILE_CRW), tuple(_MOBILE_SR)
+	eng_fore = (_M_ENGINEER, _M_FOREMAN)
+	eng_fore_pm = (_M_ENGINEER, _M_FOREMAN, _M_PM)
+
+	# Account — anyone who can raise an expense reads/selects accounts in the mobile form.
+	_upgrade_role_perms("Account", _mobile_perm(_MOBILE_ALL_ROLES, _MOBILE_SR), sr)
+	# Material Request + Stock Entry — Site Engineer + Foreman, full lifecycle.
+	_upgrade_role_perms("Material Request", _mobile_perm(eng_fore, _MOBILE_FULL), full)
+	_upgrade_role_perms("Stock Entry", _mobile_perm(eng_fore, _MOBILE_FULL), full)
+	# Field Attendance muster + its derived registers — field-attendance creators, full.
+	for dt in ("Field Attendance", "Labour Attendance Register", "Overtime Attendance Register"):
+		_upgrade_role_perms(dt, _mobile_perm(_MOBILE_FIELD_ATT_ROLES, _MOBILE_FULL), full)
+	# File — every persona (attach field photos / receipts).
+	_upgrade_role_perms("File", _mobile_perm(_MOBILE_ALL_ROLES, _MOBILE_CRW), crw)
+	# Journal Entry + Item — Site Engineer + Foreman, read/select only.
+	_upgrade_role_perms("Journal Entry", _mobile_perm(eng_fore, _MOBILE_SR), sr)
+	_upgrade_role_perms("Item", _mobile_perm(eng_fore, _MOBILE_SR), sr)
+	# Task Progress Entry — Site Engineer + Foreman + PM, create/edit.
+	_upgrade_role_perms("Task Progress Entry", _mobile_perm(eng_fore_pm, _MOBILE_CRW), crw)
+	# Purchase Receipt — Site Engineer + Foreman + PM, full lifecycle.
+	_upgrade_role_perms("Purchase Receipt", _mobile_perm(eng_fore_pm, _MOBILE_FULL), full)
+	# UOM — Site Engineer + Foreman + PM, read/select.
+	_upgrade_role_perms("UOM", _mobile_perm(eng_fore_pm, _MOBILE_SR), sr)
+
+
 def setup_record_permissions():
 	"""Seed roles + DocPerms for every BuildSuite-scoped doctype."""
 	from buildsuite_core.buildsuite_core.doctype.persona.seed_personas import repair_default_personas
@@ -1043,6 +1105,7 @@ def setup_record_permissions():
 	setup_workforce_permissions()
 	setup_equipment_permissions()
 	setup_project_finance_permissions()
+	setup_mobile_permissions()  # extra DocPerms for the companion mobile app (layered)
 	_ensure_role(WORKFLOW_EDITOR_ROLE)
 	setup_stage_planning_workflow()
 	setup_subcontractor_wo_workflow()

--- a/buildsuite_core/tests/test_mobile_permissions.py
+++ b/buildsuite_core/tests/test_mobile_permissions.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+"""The companion mobile app's extra DocPerms (setup_mobile_permissions) — layered on the base
+matrix without revoking it. Source: the mobile-permissions sheet."""
+
+import frappe
+
+from buildsuite_core.tests.base import BuildSuiteTestCase
+
+
+class TestMobilePermissions(BuildSuiteTestCase):
+	@classmethod
+	def setUpClass(cls):
+		super().setUpClass()
+		# Seed just the mobile layer (fast). The base matrix is already present on any migrated
+		# site; setup_mobile only upgrades, so it's enough to assert the mobile grants + that the
+		# base Field Attendance grant survives the layering.
+		from buildsuite_core.permissions.setup import setup_mobile_permissions
+
+		setup_mobile_permissions()
+		frappe.db.commit()  # noqa: bs-manual-commit — seed once for the whole class
+
+	def _perm(self, doctype, role, ptype):
+		return frappe.db.get_value(
+			"Custom DocPerm", {"parent": doctype, "role": role, "permlevel": 0}, ptype
+		)
+
+	def test_site_engineer_full_material_request(self):
+		for p in ("select", "read", "write", "create", "submit", "cancel"):
+			self.assertTrue(self._perm("Material Request", "BuildSuite Site Engineer", p), p)
+
+	def test_foreman_full_stock_entry(self):
+		for p in ("read", "write", "create", "submit", "cancel"):
+			self.assertTrue(self._perm("Stock Entry", "BuildSuite Foreman", p), p)
+
+	def test_pm_full_purchase_receipt(self):
+		for p in ("read", "write", "create", "submit", "cancel"):
+			self.assertTrue(self._perm("Purchase Receipt", "BuildSuite PM", p), p)
+
+	def test_engineer_task_progress_entry_crw(self):
+		for p in ("read", "write", "create"):
+			self.assertTrue(self._perm("Task Progress Entry", "BuildSuite Site Engineer", p), p)
+
+	def test_read_only_grants(self):
+		# Journal Entry / Item / UOM are read+select only for the mobile roles.
+		self.assertTrue(self._perm("Journal Entry", "BuildSuite Site Engineer", "read"))
+		self.assertFalse(self._perm("Journal Entry", "BuildSuite Site Engineer", "write"))
+		self.assertTrue(self._perm("UOM", "BuildSuite Foreman", "select"))
+
+	def test_field_attendance_registers_full_for_creators(self):
+		for dt in ("Field Attendance", "Labour Attendance Register", "Overtime Attendance Register"):
+			self.assertTrue(self._perm(dt, "BuildSuite HR Manager", "create"), dt)
+
+	def test_layering_does_not_revoke_base(self):
+		# The base matrix grants the Foreman create on Field Attendance — the mobile layer must
+		# keep it (upgrade-only), never zero it out.
+		self.assertTrue(self._perm("Field Attendance", "BuildSuite Foreman", "create"))


### PR DESCRIPTION
Seeds the **companion mobile app's** extra DocPerms on top of the base BuildSuite matrix. The mobile app signs in as BuildSuite users, so this only needs additional permissions layered onto existing roles.

## Approach
`setup_mobile_permissions()` (in `permissions/setup.py`) applies the grants via `_upgrade_role_perms` — **upgrade-only, never revokes** a base grant. Each call passes only the ptypes it grants, so unlisted ptypes (e.g. `delete`) keep their base value. Called from `setup_record_permissions()`; a `resync_mobile_permissions` patch applies it to existing sites (perm setup is install-only).

## Grants (from the mobile-permissions sheet)
| Doctype | Perms | Roles |
|---|---|---|
| Material Request, Stock Entry | Select/Read/Write/Create/Submit/Cancel | Site Engineer, Foreman |
| Field Attendance + Labour/Overtime registers | full lifecycle | field-attendance creators (PM/SE/Foreman/HR) |
| Purchase Receipt | full lifecycle | Site Engineer, Foreman, PM |
| Task Progress Entry, File | Select/Read/Write/Create | SE/Foreman/PM (File: all) |
| Account | Select/Read | expense-entry creators (all personas) |
| Journal Entry, Item | Select/Read | Site Engineer, Foreman |
| UOM | Select/Read | Site Engineer, Foreman, PM |

Role mapping: Engineer → **Site Engineer**, Foreman → **Foreman**, PM → **PM**; "All" / "creators" resolved to the persona set that already creates that doctype.

## Verified
- `tests/test_mobile_permissions.py` — 7 tests green (full grants applied; read-only grants stay read-only; base Field Attendance grant survives the layering).
- Applied on bs.local + spot-checked DocPerms.
- Access-control artifact updated with a **Mobile app permissions** section.

Separate from the SPA fixes (PR #231) and multi-company (`feat/multi-company-support`), off `develop`.