### PR TITLE
feat: Open Schedule link on the project detail view

### DIFF
--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -1083,6 +1083,14 @@ usePageTitle(() => project.value?.name);
 	>
 		<!-- Edit + Delete buttons share the title row (DeskPage #actions slot) -->
 		<template #actions>
+			<!-- Jump to this project's Gantt (mirrors the Task detail's "Open Gantt" link). -->
+			<RouterLink
+				:to="`/schedule?project=${resolvedProjectId}`"
+				class="text-xs px-2.5 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 inline-flex items-center gap-1"
+				style="border-radius: 6px"
+			>
+				Open Schedule →
+			</RouterLink>
 			<button
 				v-if="canEdit('project')"
 				type="button"


### PR DESCRIPTION
Adds an **Open Schedule →** action in the project detail header, opening that project's Gantt (`/schedule?project=<id>`) — mirroring the existing "Open Gantt" link on the Task detail view. Build passes.