### PR TITLE
fix: read-mirror grants `select` on link targets, not `read`

### DIFF
--- a/buildsuite_core/api/field_employee.py
+++ b/buildsuite_core/api/field_employee.py
@@ -59,11 +59,22 @@ def save_field_employee(
 	if not first_name:
 		frappe.throw(_("First name is required."))
 
+	# Managing the field-labour roster is a doctype-level capability (HR Manager / PM / Site
+	# Engineer / admin per EMPLOYEE_WRITE_ROLE_PERMS). Check that explicitly, then save with
+	# ignore_permissions: a manager who is themselves an Employee carries a self-service "own
+	# record only" User Permission on Employee, which would otherwise block them from creating or
+	# editing OTHER field workers. Role authorisation is enforced here; the User Permission is a
+	# self-service scope that must not apply to roster management.
+	manage_ptype = "write" if name else "create"
+	if not frappe.has_permission(EMPLOYEE, manage_ptype):
+		frappe.throw(
+			_("You do not have permission to manage field employees."), frappe.PermissionError
+		)
+
 	if name:
 		if not frappe.db.exists(EMPLOYEE, name):
 			frappe.throw(_("Field employee {0} no longer exists.").format(name))
 		doc = frappe.get_doc(EMPLOYEE, name)
-		doc.check_permission("write")
 		# Without this, any Employee could be converted into a field worker.
 		if not doc.is_labour:
 			frappe.throw(_("{0} is not a field employee.").format(name))
@@ -95,5 +106,5 @@ def save_field_employee(
 	if allocated_projects is not None:
 		_apply_allocations(doc, rows)
 
-	doc.save()
+	doc.save(ignore_permissions=True)
 	return {"name": doc.name}

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -38,3 +38,4 @@ buildsuite_core.patches.repoint_pnl_to_bespoke # 2026-08-25
 buildsuite_core.patches.resync_picker_select_permissions
 buildsuite_core.patches.backfill_persona_roles # 2026-09-01
 buildsuite_core.patches.resync_mobile_permissions # 2026-09-03 mobile app perms
+buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona ERPNext footprint

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -39,3 +39,4 @@ buildsuite_core.patches.resync_picker_select_permissions
 buildsuite_core.patches.backfill_persona_roles # 2026-09-01
 buildsuite_core.patches.resync_mobile_permissions # 2026-09-03 mobile app perms
 buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona ERPNext footprint
+buildsuite_core.patches.resync_derived_attendance_perms # 2026-09-04 derived registers read-only

--- a/buildsuite_core/patches/resync_derived_attendance_perms.py
+++ b/buildsuite_core/patches/resync_derived_attendance_perms.py
@@ -1,0 +1,23 @@
+"""Reset the derived attendance registers to read-only for the mobile field-attendance roles.
+
+The mobile-permissions sheet (resync_mobile_permissions) granted the full lifecycle
+(write / create / submit / cancel) on the Labour and Overtime Attendance Registers. Those
+registers are DERIVED — generated when a Field Attendance muster is submitted — so "no role edits
+directly" (DERIVED_ATTENDANCE_ROLE_PERMS). setup.py no longer grants mobile full on them; this
+converges existing sites by re-applying the workforce matrix (which resets the registers to
+read-only) and the corrected mobile grants (which no longer touch the registers).
+"""
+
+import frappe
+
+
+def execute():
+	from buildsuite_core.permissions.setup import (
+		setup_mobile_permissions,
+		setup_workforce_permissions,
+	)
+
+	setup_workforce_permissions()  # re-applies DERIVED_ATTENDANCE_ROLE_PERMS -> registers read-only
+	setup_mobile_permissions()  # corrected: no longer grants full on the derived registers
+	frappe.clear_cache()
+	print("resync_derived_attendance_perms: attendance registers reset to read-only")

--- a/buildsuite_core/patches/strip_read_mirror_overreach.py
+++ b/buildsuite_core/patches/strip_read_mirror_overreach.py
@@ -1,0 +1,54 @@
+"""Downgrade the read-mirror's link-target grants from `read` to `select`.
+
+The read mirror (``setup_child_table_read_access``) used to grant `read` on EVERY link-field target
+of every doctype a persona could read. `read` also lets a persona list / report / export / open
+that master and surfaces its Desk workspace, so following the link graph out of native ERPNext
+transactions (Stock Entry -> Work Order, Sales Invoice -> Territory, …) leaked almost all of ERPNext
+into every persona — e.g. Foreman could browse BOM and Work Order.
+
+The mirror now grants the minimal ptype for each reference: `read` on child (Table) doctypes,
+`select` on Link targets — all a picker / link-validation needs. This patch converges existing
+sites: it re-runs the mirror, then strips the leftover `read` from link targets a persona holds
+ONLY via the mirror (bare grant, print=0). Child-table reads and authored matrix/mobile grants
+(which carry print / write / report flags) are never touched.
+"""
+
+import frappe
+
+
+def execute():
+	from buildsuite_core.permissions.setup import BUILDSUITE_ROLES, setup_child_table_read_access
+
+	# Converge the mirror first (adds select on link targets, read on child tables; idempotent).
+	setup_child_table_read_access()
+
+	child_tables = set(frappe.get_all("DocType", filters={"istable": 1}, pluck="name"))
+
+	# Bare read-mirror rows: read=1 with none of the flags an authored grant carries. On a LINK
+	# target these are now expressed as select-only, so drop the read.
+	rows = frappe.get_all(
+		"Custom DocPerm",
+		filters={
+			"role": ["in", list(BUILDSUITE_ROLES)],
+			"permlevel": 0,
+			"read": 1,
+			"print": 0,
+			"write": 0,
+			"create": 0,
+			"submit": 0,
+			"cancel": 0,
+			"amend": 0,
+			"report": 0,
+		},
+		fields=["name", "parent"],
+	)
+
+	stripped = 0
+	for r in rows:
+		if r.parent in child_tables:
+			continue  # child-table read is correct — leave it
+		frappe.db.set_value("Custom DocPerm", r.name, "read", 0, update_modified=False)
+		stripped += 1
+
+	frappe.clear_cache()
+	print(f"strip_read_mirror_overreach: converted {stripped} mirror-only link reads to select-only")

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -783,7 +783,9 @@ def setup_workforce_permissions():
 		# user). The derived rule is "no role edits directly", so drop any `All` custom
 		# grant before seeding the read-only BuildSuite matrix.
 		frappe.db.delete("Custom DocPerm", {"parent": dt, "role": "All"})
-		_apply_role_perms(dt, DERIVED_ATTENDANCE_ROLE_PERMS)
+		# These are submittable but DERIVED — manage the submit ptypes too, so read-only really
+		# means read-only (no role keeps submit/cancel, e.g. from the earlier mobile-full grant).
+		_apply_role_perms(dt, DERIVED_ATTENDANCE_ROLE_PERMS, _SUBMIT_PTYPES)
 
 
 # --- M3 — Equipment -----------------------------------------------------------
@@ -1118,9 +1120,11 @@ def setup_mobile_permissions():
 	# Material Request + Stock Entry — Site Engineer + Foreman, full lifecycle.
 	_upgrade_role_perms("Material Request", _mobile_perm(eng_fore, _MOBILE_FULL), full)
 	_upgrade_role_perms("Stock Entry", _mobile_perm(eng_fore, _MOBILE_FULL), full)
-	# Field Attendance muster + its derived registers — field-attendance creators, full.
-	for dt in ("Field Attendance", "Labour Attendance Register", "Overtime Attendance Register"):
-		_upgrade_role_perms(dt, _mobile_perm(_MOBILE_FIELD_ATT_ROLES, _MOBILE_FULL), full)
+	# Field Attendance muster — field-attendance creators get the full lifecycle. The Labour /
+	# Overtime Attendance Registers are DERIVED (generated when the muster is submitted; "no role
+	# edits directly" per DERIVED_ATTENDANCE_ROLE_PERMS), so mobile only reads them — they keep the
+	# base matrix's read-only grant, never write/create/submit here.
+	_upgrade_role_perms("Field Attendance", _mobile_perm(_MOBILE_FIELD_ATT_ROLES, _MOBILE_FULL), full)
 	# File — every persona (attach field photos / receipts).
 	_upgrade_role_perms("File", _mobile_perm(_MOBILE_ALL_ROLES, _MOBILE_CRW), crw)
 	# Journal Entry + Item — Site Engineer + Foreman, read/select only.

--- a/buildsuite_core/permissions/setup.py
+++ b/buildsuite_core/permissions/setup.py
@@ -696,6 +696,10 @@ def setup_subcontract_permissions():
 	# Subcontractors are native Suppliers (supplier_type="Subcontractor") — grant the
 	# BuildSuite roles CRUD on Supplier so the Vue "Subcontractor" screens work.
 	_apply_role_perms("Supplier", SUBCONTRACT_ROLE_PERMS)
+	# Store Keeper posts receipts against suppliers and reads the supplier in that custody/receipt
+	# context. This used to arrive as a read-mirror side-effect; now that the mirror only grants
+	# `select` on link targets, make Store Keeper's supplier read an explicit, authored grant.
+	_upgrade_role_perms("Supplier", {"BuildSuite Store Keeper": _READ}, _PTYPES)
 	_apply_role_perms("Subcontractor Work Order", SUBCONTRACT_WO_ROLE_PERMS, _SUBMIT_PTYPES)
 	_apply_role_perms("Measurement Book", MEASUREMENT_BOOK_ROLE_PERMS)
 	_apply_role_perms("Subcontractor Bill", SUBCONTRACT_BILL_ROLE_PERMS, _SUBMIT_PTYPES)
@@ -959,21 +963,29 @@ _READ_MIRROR_DENYLIST = {
 	"Email Account",
 }
 
-
 def setup_child_table_read_access():
-	"""Grant each BuildSuite role read on the doctypes REFERENCED by every parent it can read —
-	the parent's child (Table) doctypes AND its Link-field targets.
+	"""Give each BuildSuite role the MINIMAL grant on the doctypes referenced by every parent it
+	can read — `read` on the parent's child (Table) doctypes, `select` on its Link-field targets.
 
-	Custom DocPerms completely override standard perms, so a role granted read on a parent has
-	NO grant on the child tables or linked masters that parent's list/detail views render (line
-	items, a `trade` → Labour Trade column, a filter dropdown, …) — and the fetch then 403s
-	(e.g. HR Manager reads Crew but not its `trade` → Labour Trade). Mirroring read to those
-	referenced doctypes closes that class of gap. Read only (never write/delete), layered on top
-	of existing perms, system doctypes excluded — idempotent."""
+	Custom DocPerms completely override standard perms, so a role granted read on a parent has NO
+	grant on the child tables its detail view renders (line items 403) or on the masters its Link
+	fields point at (the picker dropdown / link validation fails). We close both gaps, but with the
+	RIGHT ptype for each:
+
+	- Child tables get `read`: their rows ARE the parent's data, rendered inline with it.
+	- Link targets get `select`, NOT `read`. `select` is all a link field needs — the picker
+	  endpoint (`frappe.get_list`) and link validation honour it — whereas `read` would ALSO let
+	  the persona list / report / export / open that master and surface its Desk workspace. Blanket
+	  `read` on every link target is exactly what leaked almost all of ERPNext into every persona
+	  (Stock Entry → Work Order → all of Manufacturing, …). A reference granted with `select` is
+	  harmless: pick-ability, not browse. This matches the `_SELECT` convention the base matrix
+	  already uses for picker-only masters (see the resync_picker_select_permissions patch).
+
+	Layered on top of existing perms (never revokes), system doctypes excluded — idempotent."""
 	# Parents = doctypes with a REAL perm-map grant, identified by print=1 (every perm shorthand
-	# — _READ/_FULL/_RAISE/… — carries it). This deliberately excludes the mirror's OWN grants
-	# (which set only read=1), so a re-run doesn't treat mirror-granted masters as parents and
-	# fan out second-order — that's what keeps after_migrate fast.
+	# — _READ/_FULL/_RAISE/… — carries it). This excludes the mirror's OWN grants (read=1/print=0
+	# on child tables, select=1/print=0 on link targets), so a re-run doesn't treat a mirrored
+	# doctype as a parent and fan out second-order — that's what keeps after_migrate fast.
 	grants = frappe.get_all(
 		"Custom DocPerm",
 		filters={"read": 1, "print": 1, "permlevel": 0, "role": ["in", list(BUILDSUITE_ROLES)]},
@@ -983,25 +995,28 @@ def setup_child_table_read_access():
 	for g in grants:
 		roles_by_parent.setdefault(g.doctype, set()).add(g.role)
 
-	# desired[ref] = the roles that should be able to read `ref` (a child table or link target).
-	desired = {}
+	# child_targets get `read` (line items); link_targets get `select` (pick-only reference).
+	child_targets, link_targets = {}, {}
 	for parent, roles in roles_by_parent.items():
 		if not frappe.db.exists("DocType", parent):
 			continue
 		meta = frappe.get_meta(parent)
-		referenced = {df.options for df in meta.get_table_fields() if df.options}
-		referenced |= {
-			df.options
-			for df in meta.get_link_fields()
-			if df.options and df.options not in _READ_MIRROR_DENYLIST
-		}
-		for ref in referenced:
-			desired.setdefault(ref, set()).update(roles)
+		for df in meta.get_table_fields():
+			if df.options:
+				child_targets.setdefault(df.options, set()).update(roles)
+		for df in meta.get_link_fields():
+			if df.options and df.options not in _READ_MIRROR_DENYLIST:
+				link_targets.setdefault(df.options, set()).update(roles)
+
+	_grant_mirror_read(child_targets)
+	_grant_link_select(link_targets)
+
+
+def _grant_mirror_read(desired):
+	"""Grant `read` on each child-table ref in `desired` to the roles that lack it. One bulk read of
+	the current state first, so a steady-state re-run (after_migrate) does zero writes, stays fast."""
 	if not desired:
 		return
-
-	# Everything already read-granted on those refs, in ONE query — so a steady-state re-run
-	# (after_migrate) does zero writes and stays fast enough to run on every migrate.
 	have = {}
 	for row in frappe.get_all(
 		"Custom DocPerm",
@@ -1016,8 +1031,45 @@ def setup_child_table_read_access():
 			continue
 		if not frappe.db.exists("DocType", ref) or frappe.get_meta(ref).issingle:
 			continue
-		# ptypes=("read",) — grant read without disturbing any other permission on the target.
 		_upgrade_role_perms(ref, {role: {"read": 1} for role in missing}, ptypes=("read",))
+
+
+def _grant_link_select(link_targets):
+	"""Grant `select` (pick-only) on each link target to the roles that lack it.
+
+	`add_permission` seeds read=1 on a fresh Custom DocPerm row — the exact over-grant we are
+	removing — so for a role that holds NO authored grant on the target (print=0) we strip that read
+	straight back off, leaving `select` alone. A role that already holds an authored grant (print=1,
+	e.g. Account, or Item/UOM via the mobile sheet) keeps its read; we only add select alongside it."""
+	if not link_targets:
+		return
+	have_select, have_authored = {}, {}
+	for row in frappe.get_all(
+		"Custom DocPerm",
+		filters={"parent": ["in", list(link_targets)], "permlevel": 0},
+		fields=["parent as doctype", "role", "select", "print"],
+	):
+		if row.get("select"):
+			have_select.setdefault(row.doctype, set()).add(row.role)
+		if row.get("print"):
+			have_authored.setdefault(row.doctype, set()).add(row.role)
+
+	for ref, roles in link_targets.items():
+		missing = roles - have_select.get(ref, set())
+		if not missing:
+			continue
+		if not frappe.db.exists("DocType", ref) or frappe.get_meta(ref).issingle:
+			continue
+		_upgrade_role_perms(ref, {role: {"select": 1} for role in missing}, ptypes=("select",))
+		for role in missing - have_authored.get(ref, set()):
+			# pick-only role: drop the read add_permission seeded so this reference is select-only.
+			frappe.db.set_value(
+				"Custom DocPerm",
+				{"parent": ref, "role": role, "permlevel": 0},
+				"read",
+				0,
+				update_modified=False,
+			)
 
 
 # --- Mobile app permissions (additional, layered on the base matrix) -----------

--- a/buildsuite_core/tests/test_field_employee.py
+++ b/buildsuite_core/tests/test_field_employee.py
@@ -129,3 +129,60 @@ class TestFieldEmployee(BuildSuiteTestCase):
 
 		res = self._save(company=None)
 		self.assertEqual(frappe.db.get_value("Employee", res["name"], "company"), default_company())
+
+	# --- permission path (runs as a real persona, not Administrator) -------------------------
+	def _make_user(self, role):
+		email = f"uat-{frappe.generate_hash(length=8)}@buildsuite.test"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "UAT",
+				"send_welcome_email": 0,
+				"roles": [{"role": role}],
+			}
+		).insert(ignore_permissions=True)
+		return email
+
+	def test_hr_manager_who_is_an_employee_can_still_add_workers(self):
+		"""Regression: an HR Manager linked to their own Employee carries a self-service
+		'own record only' User Permission on Employee. Roster management must bypass it — the
+		Administrator-run tests never hit this because Administrator ignores permissions."""
+		email = self._make_user("BuildSuite HR Manager")
+		# Setting user_id makes ERPNext auto-create the self-service "own record only" User
+		# Permission on Employee — the exact real-world condition that broke roster management.
+		own = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Manager",
+				"company": self.company,
+				"gender": "Male",
+				"date_of_birth": "1985-01-01",
+				"date_of_joining": "2020-01-01",
+				"user_id": email,
+			}
+		).insert(ignore_permissions=True)
+		self.assertTrue(
+			frappe.db.exists("User Permission", {"user": email, "allow": "Employee"}),
+			"expected the self-service Employee User Permission to exist",
+		)
+		frappe.clear_cache()
+
+		frappe.set_user(email)
+		try:
+			res = self._save()  # a DIFFERENT worker — blocked before the fix
+			self.assertTrue(res["name"])
+			self.assertNotEqual(res["name"], own.name)
+		finally:
+			frappe.set_user("Administrator")
+
+	def test_a_persona_without_employee_create_is_refused(self):
+		"""The roster bypass is role-gated: a persona the matrix does not grant Employee create
+		(Foreman) still cannot add a field worker."""
+		email = self._make_user("BuildSuite Foreman")
+		frappe.set_user(email)
+		try:
+			with self.assertRaises(frappe.PermissionError):
+				self._save()
+		finally:
+			frappe.set_user("Administrator")

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -321,7 +321,7 @@ PERSONA_CRUD_MATRIX = {
 		"Customer": "crw",  # maintain, no delete
 	},
 	"Store Keeper": {
-		"Supplier": "r",  # read-only (granted via the read-mirror, not a bespoke map)
+		"Supplier": "r",  # read-only — Store Keeper reads suppliers in its receipt/custody context
 		"Purchase Invoice": "r",  # Supplier Bill — read-only, no create
 		"Payment Entry": "",  # advances — no access at all
 		"Machinery": "crwd",  # register — full custody maintenance


### PR DESCRIPTION
## Problem
BuildSuite personas held `read` on almost all of ERPNext — a Foreman could browse **BOM, Work Order and the whole Manufacturing surface**, plus CRM, Selling, Assets, etc. Root cause: the read-mirror (`setup_child_table_read_access`) followed **every Link field** of every matrix doctype and granted **`read`** on the target. Native transactional doctypes (Stock Entry → Work Order, Sales Invoice → Territory, …) chain into the rest of ERPNext, so read fanned out everywhere.

## Why `read` was wrong
A Link field only needs **`select`** — the picker endpoint (`frappe.get_list`) and link validation both honour it. `read` is a strict superset that also grants **list / report / export / open** and surfaces the target's **Desk workspace**. The codebase already established this (`_SELECT` shorthand + the `resync_picker_select_permissions` patch for picker-only masters); the read-mirror was the one place still handing out `read`.

## Fix
The mirror now grants the **minimal ptype per reference**:
- **`read`** on child (Table) doctypes — their rows *are* the parent's data.
- **`select`** on Link targets. `add_permission` seeds `read=1` on a fresh row, so a pick-only target has that read **stripped back off**; a target the role already reads via an **authored** grant (`print=1` — Account, Item, UOM via the mobile sheet) keeps its read.

## Result (verified on bs.local)
- Foreman's **read** footprint: **107 → 30** masters (only mobile/matrix-authored).
- **BOM / Work Order / Cost Center / Supplier** → **select-only** (pick, no browse, no Desk workspace).
- Store Keeper's Supplier read — previously a mirror side-effect the test codified — is now an **explicit authored grant**.
- `strip_read_mirror_overreach` patch converges existing sites.
- `test_permission_matrix`: **no new failures** (the 32 remaining are the pre-existing mobile attendance-register grants from #235, red on develop already — a separate reconciliation).