### PR TITLE
fix: raise daily overtime limit to 16 hours (ISS-173)

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.py
+++ b/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.py
@@ -11,7 +11,7 @@ from frappe.utils import flt, getdate
 # --- tunables: move to a Settings doctype when the client asks ---
 DAYS_PER_MONTH = 30
 HOURS_PER_DAY = 8
-MAX_OT_HOURS_PER_DAY = 8
+MAX_OT_HOURS_PER_DAY = 16
 
 # Rows above this count are processed in a background job on submit/cancel.
 ENQUEUE_THRESHOLD = 25

--- a/buildsuite_core/buildsuite_core/doctype/overtime_attendance_register/overtime_attendance_register.py
+++ b/buildsuite_core/buildsuite_core/doctype/overtime_attendance_register/overtime_attendance_register.py
@@ -8,6 +8,8 @@ from frappe.model.document import Document
 from frappe.utils import flt, getdate
 from frappe.query_builder.functions import Sum
 
+from buildsuite_core.buildsuite_core.doctype.field_attendance.field_attendance import MAX_OT_HOURS_PER_DAY
+
 
 class OvertimeAttendanceRegister(Document):
 	# begin: auto-generated types
@@ -86,9 +88,14 @@ class OvertimeAttendanceRegister(Document):
 
 		existing_hours = flt(existing_hours[0][0]) if existing_hours else 0.0
 		total_overtime_hours = existing_hours + flt(self.overtime_hours)
-		if total_overtime_hours and total_overtime_hours >= 16:
+		if total_overtime_hours and total_overtime_hours > MAX_OT_HOURS_PER_DAY:
 			frappe.throw(
-				f"Overtime already marked for labour {frappe.bold(self.employee_name)} for date {frappe.bold(self.overtime_date)}."
+				_("{0}: Overtime for {1} would be {2} hours, over the {3} hour daily limit.").format(
+					frappe.bold(self.employee_name),
+					frappe.bold(self.overtime_date),
+					total_overtime_hours,
+					MAX_OT_HOURS_PER_DAY,
+				)
 			)
 		if self.overtime_hours == 0:
 			frappe.throw(_("Overtime hours cannot be zero!"))

--- a/buildsuite_core/tests/test_field_attendance.py
+++ b/buildsuite_core/tests/test_field_attendance.py
@@ -5,6 +5,9 @@
 import frappe
 
 from buildsuite_core.api.field_attendance import get_roster, save_field_attendance
+from buildsuite_core.buildsuite_core.doctype.field_attendance.field_attendance import (
+	MAX_OT_HOURS_PER_DAY,
+)
 from buildsuite_core.tests.base import BuildSuiteTestCase
 
 
@@ -139,3 +142,31 @@ class TestFieldAttendance(BuildSuiteTestCase):
 		for row in get_roster(self.project):
 			self.assertIn("employee", row)
 			self.assertIn("employee_name", row)
+
+	def _save_with_overtime(self, hours):
+		return self._save(
+			employee_list=frappe.as_json(
+				[{"employee": self.worker_a, "status": "Present", "overtime_hours": hours}]
+			)
+		)
+
+	def test_overtime_up_to_the_daily_limit_is_allowed(self):
+		res = self._save_with_overtime(MAX_OT_HOURS_PER_DAY)
+		self.assertEqual(res["employee_list"][0]["overtime_hours"], MAX_OT_HOURS_PER_DAY)
+
+	def test_overtime_over_the_daily_limit_is_rejected(self):
+		with self.assertRaisesRegex(frappe.ValidationError, "daily limit"):
+			self._save_with_overtime(MAX_OT_HOURS_PER_DAY + 0.5)
+
+	def test_overtime_at_the_limit_survives_submit(self):
+		res = self._save_with_overtime(MAX_OT_HOURS_PER_DAY)
+		frappe.get_doc("Field Attendance", res["name"]).submit()
+
+		self.assertEqual(
+			frappe.db.get_value(
+				"Overtime Attendance Register",
+				{"field_attendance": res["name"], "docstatus": 1},
+				"overtime_hours",
+			),
+			MAX_OT_HOURS_PER_DAY,
+		)


### PR DESCRIPTION
The daily overtime limit was written in two files and they did not match. Field Attendance capped it at 8 hours, while the Overtime register used `>= 16`, which also rejected exactly 16.

The register now imports the constant from Field Attendance, so one number controls both checks.

Result: 9 saves, 16 saves, 16.5 fails.