### PR TITLE
fix: payment/advance APIs accept a numeric `amount` argument

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -418,7 +418,7 @@ def delete_invoice(name: str):
 # Receive payment (Payment Entry against the SI)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
-def record_receipt(name: str, amount: str | None = None, date: str | None = None, mode_of_payment: str | None = None, deposit_to: str | None = None, reference_no: str | None = None):
+def record_receipt(name: str, amount: float | int | str | None = None, date: str | None = None, mode_of_payment: str | None = None, deposit_to: str | None = None, reference_no: str | None = None):
 	"""Create + submit a Payment Entry receiving against the invoice, into a Bank/Cash account."""
 	from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 
@@ -487,7 +487,7 @@ def list_receipts(name: str):
 # Customer advances (on-account receipts, no invoice yet)
 # --------------------------------------------------------------------------- #
 @frappe.whitelist()
-def record_advance(customer: str, amount: str, date: str | None = None, deposit_to: str | None = None, mode_of_payment: str | None = None, reference_no: str | None = None):
+def record_advance(customer: str, amount: float | int | str, date: str | None = None, deposit_to: str | None = None, mode_of_payment: str | None = None, reference_no: str | None = None):
 	"""Receive money from a customer BEFORE (or without) an invoice — a submitted on-account
 	Payment Entry whose full amount stays unallocated until a later invoice draws it down."""
 	from erpnext.accounts.party import get_party_account
@@ -630,7 +630,7 @@ def _reconcile_advance(si, pe, amount):
 
 
 @frappe.whitelist()
-def link_advance(name: str, payment_entry: str, amount: str):
+def link_advance(name: str, payment_entry: str, amount: float | int | str):
 	"""Adjust `amount` of a customer advance against this invoice, reducing its outstanding."""
 	si = frappe.get_doc(SI, name)
 	si.check_permission("write")

--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -476,7 +476,7 @@ def make_payment_entry(name: str):
 
 
 @frappe.whitelist()
-def record_payment(name: str, amount: str | None = None, date: str | None = None, mode_of_payment: str | None = None, paid_from: str | None = None, reference_no: str | None = None):
+def record_payment(name: str, amount: float | int | str | None = None, date: str | None = None, mode_of_payment: str | None = None, paid_from: str | None = None, reference_no: str | None = None):
 	"""Create + submit a Payment Entry against the bill's Purchase Invoice (used by tests / API)."""
 	from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 
@@ -564,7 +564,7 @@ def available_advances(name: str):
 
 
 @frappe.whitelist()
-def link_advance(name: str, payment_entry: str, amount: str):
+def link_advance(name: str, payment_entry: str, amount: float | int | str):
 	"""Adjust `amount` of a subcontractor advance against this bill, reducing its outstanding."""
 	from buildsuite_core.api import supplier_bill as _sb
 

--- a/buildsuite_core/api/supplier_bill.py
+++ b/buildsuite_core/api/supplier_bill.py
@@ -593,7 +593,7 @@ def delete_bill(name: str):
 @frappe.whitelist()
 def record_payment(
 	name: str,
-	amount: str | None = None,
+	amount: float | int | str | None = None,
 	date: str | None = None,
 	mode_of_payment: str | None = None,
 	pay_from: str | None = None,
@@ -667,7 +667,7 @@ def list_payments(name: str):
 @frappe.whitelist()
 def record_advance(
 	supplier: str,
-	amount: str,
+	amount: float | int | str,
 	date: str | None = None,
 	pay_from: str | None = None,
 	mode_of_payment: str | None = None,
@@ -812,7 +812,7 @@ def _reconcile_advance(pi, pe, amount):
 
 
 @frappe.whitelist()
-def link_advance(name: str, payment_entry: str, amount: str):
+def link_advance(name: str, payment_entry: str, amount: float | int | str):
 	"""Adjust `amount` of a supplier advance against this bill, reducing its outstanding."""
 	pi = frappe.get_doc(PI, name)
 	pi.check_permission("write")


### PR DESCRIPTION
## Problem
Recording a payment from a subcontractor bill fails with **417 EXPECTATION FAILED**:
```
FrappeTypeError: Argument 'amount' in '…record_payment' should be of type 'str | None' but got 'int'
```
The Vue forms send `amount` as a JSON number (`16100`), but the endpoint annotated it `str | None`, so Frappe's pydantic argument validation rejects the int before the body runs.

## Fix
Widen the `amount` annotation to `float | int | str | None` on the payment/advance endpoints (`record_payment`, `record_receipt`, `record_advance`, `link_advance`) across **subcontractor_bill.py**, **invoice.py**, and **supplier_bill.py**. The bodies already coerce via `flt(amount)`, so accepting a number is safe.

Verified against the exact validator Frappe uses: `float | int | str | None` accepts `16100` (int), `"16100"` (str), `16100.5` (float) and `None`; the old `str | None` rejects the int.