### PR TITLE
fix: white text on the expenses Submit button (ISS-181)

### DIFF
--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -335,7 +335,7 @@ const expenseAccountFilters = computed(() => [
 							<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
 							<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 							<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
-							<td class="px-4 py-2.5 text-right"><button type="button" class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-ink-900 rounded-md" @click.stop="onSubmit(e)">Submit</button></td>
+							<td class="px-4 py-2.5 text-right"><button type="button" class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-white rounded-md" @click.stop="onSubmit(e)">Submit</button></td>
 						</tr>
 					</tbody>
 				</table>


### PR DESCRIPTION
The Submit button in Expenses had dark text on green and was hard to read. Restores text-white, matching the prototype.