### PR TITLE
feat: paginate the bespoke Expense + Petty Cash tables

### DIFF
--- a/frontend/src/components/desk/DeskPaginationFooter.vue
+++ b/frontend/src/components/desk/DeskPaginationFooter.vue
@@ -1,0 +1,65 @@
+<!--
+  Pagination footer for bespoke tables, paired with usePagination(). Visually identical to the
+  footer DeskList renders, so paginated raw <table>s match the built-in lists.
+-->
+<script setup>
+defineProps({
+	// A reactive pager from usePagination().
+	pager: { type: Object, required: true },
+});
+</script>
+
+<template>
+	<div
+		v-if="pager.showPagination"
+		class="border-t border-ink-200 px-3 py-2 flex items-center gap-3 flex-wrap text-xs text-ink-600"
+	>
+		<div class="flex items-center gap-2">
+			<span class="text-ink-500">Rows per page</span>
+			<select
+				data-test="pager-size"
+				:value="pager.pageSize"
+				class="text-xs border border-ink-200 bg-white text-ink-700 hover:bg-ink-50 cursor-pointer"
+				style="border-radius: 6px; padding: 4px 8px"
+				@change="pager.setPageSize($event.target.value)"
+			>
+				<option v-for="opt in pager.pageSizeOptions" :key="opt" :value="opt">
+					{{ opt }}
+				</option>
+			</select>
+		</div>
+
+		<div class="text-ink-500 tabular-nums">
+			Showing
+			<span class="text-ink-800 font-medium">{{ pager.rangeStart }}–{{ pager.rangeEnd }}</span> of
+			<span class="text-ink-800 font-medium">{{ pager.totalRows }}</span>
+		</div>
+
+		<div class="ml-auto flex items-center gap-1">
+			<button
+				type="button"
+				data-test="pager-prev"
+				class="text-xs text-ink-700 hover:bg-ink-50 disabled:text-ink-300 disabled:hover:bg-transparent disabled:cursor-not-allowed border border-ink-200 bg-white"
+				style="border-radius: 6px; padding: 4px 10px"
+				:disabled="pager.page <= 1"
+				@click="pager.prev()"
+			>
+				‹ Prev
+			</button>
+			<span class="text-ink-500 tabular-nums px-2">
+				Page <span class="text-ink-800 font-medium">{{ pager.page }}</span> of
+				<span class="text-ink-800 font-medium">{{ pager.totalPages }}</span>
+			</span>
+			<button
+				type="button"
+				data-test="pager-next"
+				class="text-xs text-ink-700 hover:bg-ink-50 disabled:text-ink-300 disabled:hover:bg-transparent disabled:cursor-not-allowed border border-ink-200 bg-white"
+				style="border-radius: 6px; padding: 4px 10px"
+				:disabled="pager.page >= pager.totalPages"
+				@click="pager.next()"
+			>
+				Next ›
+			</button>
+		</div>
+	</div>
+</template>

--- a/frontend/src/composables/usePagination.js
+++ b/frontend/src/composables/usePagination.js
@@ -1,0 +1,61 @@
+import { computed, reactive, ref, unref, watch } from "vue";
+
+/**
+ * Client-side pager for BESPOKE tables — the finance/expense/petty-cash panels render raw
+ * <table>s rather than <DeskList>, so they don't get DeskList's built-in pagination. Feed this
+ * the full (already filtered/sorted) row array; render `pager.pagedRows` and drop a
+ * <DeskPaginationFooter :pager="pager" /> under the table.
+ *
+ * @param {import('vue').Ref<Array>|Function|Array} rowsRef  ref, getter, or array of all rows.
+ * @param {{pageSize?: number, pageSizeOptions?: number[]}} opts
+ * @returns reactive pager: { page, pageSize, pageSizeOptions, pagedRows, totalRows, totalPages,
+ *          rangeStart, rangeEnd, showPagination, prev(), next(), setPageSize(v) }
+ */
+export function usePagination(rowsRef, opts = {}) {
+	const initialSize = opts.pageSize || 10;
+	const pageSizeOptions = opts.pageSizeOptions || [10, 20, 50, 100];
+
+	const page = ref(1);
+	const size = ref(initialSize);
+	const rows = computed(() => unref(rowsRef) || []);
+	const totalRows = computed(() => rows.value.length);
+	const totalPages = computed(() => Math.max(1, Math.ceil(totalRows.value / size.value)));
+	const pagedRows = computed(() => {
+		const start = (page.value - 1) * size.value;
+		return rows.value.slice(start, start + size.value);
+	});
+	const rangeStart = computed(() => (totalRows.value === 0 ? 0 : (page.value - 1) * size.value + 1));
+	const rangeEnd = computed(() =>
+		Math.min(rangeStart.value + pagedRows.value.length - 1, totalRows.value),
+	);
+	// Only worth showing once there's more than the smallest page size worth of rows.
+	const showPagination = computed(() => totalRows.value > Math.min(...pageSizeOptions));
+
+	// When the row set shrinks (filter / search / tab switch), never leave the view stranded
+	// past the last page.
+	watch(totalPages, (tp) => {
+		if (page.value > tp) page.value = tp;
+	});
+
+	return reactive({
+		page,
+		pageSize: size,
+		pageSizeOptions,
+		pagedRows,
+		totalRows,
+		totalPages,
+		rangeStart,
+		rangeEnd,
+		showPagination,
+		prev() {
+			if (page.value > 1) page.value -= 1;
+		},
+		next() {
+			if (page.value < totalPages.value) page.value += 1;
+		},
+		setPageSize(v) {
+			size.value = Number(v) || initialSize;
+			page.value = 1;
+		},
+	});
+}

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -342,7 +342,7 @@ const expenseAccountFilters = computed(() => [
 							<td class="px-4 py-2.5"><span class="text-[10px] px-1.5 py-0.5 rounded-full whitespace-nowrap" :class="sourceChipClass(e.source)">{{ e.source }}</span></td>
 							<td class="px-4 py-2.5 text-ink-600">{{ e.expense_account || e.cost_code || "—" }}</td>
 							<td class="px-4 py-2.5 text-right tabular-nums font-medium text-ink-900">{{ fmtINR(e.amount) }}</td>
-							<td class="px-4 py-2.5 text-right"><button type="button" class="text-[11px] px-2 py-1 bg-brand-600 hover:bg-brand-700 text-white rounded-md" @click.stop="onSubmit(e)">Submit</button></td>
+							<td class="px-4 py-2.5 text-right"><button type="button" class="desk-save-btn" @click.stop="onSubmit(e)">Submit</button></td>
 						</tr>
 					</tbody>
 				</table>

--- a/frontend/src/views/finance/FinanceExpensesPanel.vue
+++ b/frontend/src/views/finance/FinanceExpensesPanel.vue
@@ -26,6 +26,8 @@ import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { usePermissions } from "@/composables/usePermissions";
+import { usePagination } from "@/composables/usePagination";
+import DeskPaginationFooter from "@/components/desk/DeskPaginationFooter.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const { canCreate, canEdit, canDelete } = usePermissions();
@@ -122,6 +124,11 @@ const allExpenses = computed(() => {
 	);
 });
 const myExpenses = computed(() => myExpensesAll.value.filter((e) => inPeriod(e.date)));
+
+// Client-side pagers for the three bespoke expense tables (they render raw <table>s, not DeskList).
+const toSubmitPager = usePagination(toSubmit);
+const allExpensesPager = usePagination(allExpenses);
+const myExpensesPager = usePagination(myExpenses);
 
 // --- detail modal ---
 const detail = ref(null);
@@ -328,7 +335,7 @@ const expenseAccountFilters = computed(() => [
 						<tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Description</th><th class="text-left px-4 py-2">By</th><th class="text-left px-4 py-2">Source</th><th class="text-left px-4 py-2">Account</th><th class="text-right px-4 py-2">Amount</th><th class="px-4 py-2"></th></tr>
 					</thead>
 					<tbody>
-						<tr v-for="e in toSubmit" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/40 cursor-pointer" @click="openDetail(e)">
+						<tr v-for="e in toSubmitPager.pagedRows" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/40 cursor-pointer" @click="openDetail(e)">
 							<td class="px-4 py-2.5 text-ink-500">{{ fmtDate(e.date) }}</td>
 							<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span><div class="text-[10px] text-ink-400">{{ projectName(e) }}</div></td>
 							<td class="px-4 py-2.5 text-ink-700"><div class="flex items-center gap-1.5"><UserAvatar :name="holderName(e)" size="xs" /><span>{{ holderName(e) }}</span></div></td>
@@ -340,6 +347,7 @@ const expenseAccountFilters = computed(() => [
 					</tbody>
 				</table>
 				<div v-else class="px-4 py-10 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "No draft expenses awaiting submission." }}</div>
+				<DeskPaginationFooter :pager="toSubmitPager" />
 			</section>
 
 			<!-- All Expenses -->
@@ -367,7 +375,7 @@ const expenseAccountFilters = computed(() => [
 							<tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Description</th><th class="text-left px-4 py-2">By</th><th class="text-left px-4 py-2">Source</th><th class="text-left px-4 py-2">Account</th><th class="text-right px-4 py-2">Amount</th><th class="text-left px-4 py-2">Status</th></tr>
 						</thead>
 						<tbody>
-							<tr v-for="e in allExpenses" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30 cursor-pointer" @click="openDetail(e)">
+							<tr v-for="e in allExpensesPager.pagedRows" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30 cursor-pointer" @click="openDetail(e)">
 								<td class="px-4 py-2.5 text-ink-500">{{ fmtDate(e.date) }}</td>
 								<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span><div class="text-[10px] text-ink-400">{{ projectName(e) }}</div></td>
 								<td class="px-4 py-2.5 text-ink-700"><div class="flex items-center gap-1.5"><UserAvatar :name="holderName(e)" size="xs" /><span>{{ holderName(e) }}</span></div></td>
@@ -379,6 +387,7 @@ const expenseAccountFilters = computed(() => [
 						</tbody>
 					</table>
 					<div v-else class="px-4 py-10 text-center text-xs text-ink-400 italic">No expenses match.</div>
+					<DeskPaginationFooter :pager="allExpensesPager" />
 				</section>
 			</template>
 
@@ -400,7 +409,7 @@ const expenseAccountFilters = computed(() => [
 							<tr><th class="text-left px-4 py-2">Date</th><th class="text-left px-4 py-2">Description</th><th class="text-left px-4 py-2">Project</th><th class="text-left px-4 py-2">Source</th><th class="text-left px-4 py-2">Account</th><th class="text-right px-4 py-2">Amount</th><th class="text-left px-4 py-2">Status</th></tr>
 						</thead>
 						<tbody>
-							<tr v-for="e in myExpenses" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30 cursor-pointer" @click="openDetail(e)">
+							<tr v-for="e in myExpensesPager.pagedRows" :key="e.name" class="border-b border-ink-100 last:border-0 hover:bg-brand-50/30 cursor-pointer" @click="openDetail(e)">
 								<td class="px-4 py-2.5 text-ink-500">{{ fmtDate(e.date) }}</td>
 								<td class="px-4 py-2.5 text-ink-900">{{ e.description }}<span v-if="e.attachment" class="ml-1 text-ink-400">📎</span></td>
 								<td class="px-4 py-2.5 text-ink-500">{{ projectName(e) }}</td>
@@ -412,6 +421,7 @@ const expenseAccountFilters = computed(() => [
 						</tbody>
 					</table>
 					<div v-else class="px-4 py-10 text-center text-xs text-ink-400 italic">{{ loading ? "Loading…" : "You haven't logged any expenses." }}</div>
+					<DeskPaginationFooter :pager="myExpensesPager" />
 				</section>
 			</template>
 

--- a/frontend/src/views/finance/FinancePettyCashPanel.vue
+++ b/frontend/src/views/finance/FinancePettyCashPanel.vue
@@ -29,6 +29,8 @@ import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import { useUserNames } from "@/composables/useUserNames";
 import { usePermissions } from "@/composables/usePermissions";
+import { usePagination } from "@/composables/usePagination";
+import DeskPaginationFooter from "@/components/desk/DeskPaginationFooter.vue";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const session = useSessionStore();
@@ -130,6 +132,8 @@ const columns = computed(() => {
 
 // --- balances ---
 const balances = ref([]);
+// Balances is a bespoke table (the requests list uses DeskList) — give it a client-side pager too.
+const balancesPager = usePagination(balances);
 async function loadBalances() {
 	try {
 		balances.value = await pettyCashHolderBalances();
@@ -369,7 +373,7 @@ const rowsForTab = computed(() => {
 				</thead>
 				<tbody>
 					<tr
-						v-for="b in balances"
+						v-for="b in balancesPager.pagedRows"
 						:key="b.employee || b.holder"
 						class="border-t border-ink-100 hover:bg-brand-50/40 cursor-pointer"
 						:title="`Open ${b.holder}'s petty-cash report`"
@@ -408,6 +412,7 @@ const rowsForTab = computed(() => {
 					</tr>
 				</tbody>
 			</table>
+			<DeskPaginationFooter :pager="balancesPager" />
 			<p class="px-3 py-2 text-[11px] text-ink-400 border-t border-ink-100">
 				Balance in hand = disbursed float − approved expenses (from the Expenses tab). A
 				negative balance means the holder fronted their own money — it's owed back to them


### PR DESCRIPTION
## Problem
The Project Finance **Expense** tabs (To Submit / All / My Expenses) and the **Petty Cash Balances** tab render raw `<table>`s instead of `<DeskList>`, so they never got DeskList's built-in pagination — long lists scrolled forever.

## Fix
- New reusable **`usePagination()`** composable — a client-side pager for bespoke tables (page / pageSize / pagedRows / range / prev / next), clamps the page when the row set shrinks.
- New **`DeskPaginationFooter.vue`** — visually identical to the footer `DeskList` renders (rows-per-page, "Showing X–Y of N", Prev/Next), so paginated raw tables match the built-in lists.
- Wired a pager into each of the four bespoke tables. Footer only shows past one page's worth of rows (>10), same threshold as DeskList.

The Petty Cash **requests** list already paginates (it uses `DeskList`, `paginated` defaults to true); this covers the remaining custom tables. Build passes.