### PR TITLE
fix: roster-managing users see the whole employee roster

### DIFF
--- a/buildsuite_core/hooks.py
+++ b/buildsuite_core/hooks.py
@@ -182,6 +182,12 @@ doc_events = {
 	"Payment Entry": {
 		"before_validate": "buildsuite_core.utils.payment.default_bank_reference"
 	},
+	# ERPNext auto-creates a self-service User Permission (own Employee only) when a user is linked
+	# to their Employee. For a roster-managing persona that wrongly hides every OTHER employee
+	# (empty field-employee list, 403 on any other worker) — drop it so access matches the matrix.
+	"User Permission": {
+		"after_insert": "buildsuite_core.utils.employee_permissions.drop_self_service_for_managers"
+	},
 	"Project": {
 		"before_insert": "buildsuite_core.utils.project.set_company_on_insert",
 		"validate": [

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -40,3 +40,4 @@ buildsuite_core.patches.backfill_persona_roles # 2026-09-01
 buildsuite_core.patches.resync_mobile_permissions # 2026-09-03 mobile app perms
 buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona ERPNext footprint
 buildsuite_core.patches.resync_derived_attendance_perms # 2026-09-04 derived registers read-only
+buildsuite_core.patches.drop_manager_employee_user_permissions # 2026-09-04 roster mgrs see all employees

--- a/buildsuite_core/patches/drop_manager_employee_user_permissions.py
+++ b/buildsuite_core/patches/drop_manager_employee_user_permissions.py
@@ -1,0 +1,25 @@
+"""Remove the self-service Employee User Permission from roster-managing users.
+
+ERPNext auto-creates a User Permission (allow=Employee, own record) when a user is linked to their
+Employee. For a user who manages the roster (an Employee-write BuildSuite role) that restriction
+contradicts the permission matrix — it hides every OTHER employee (empty field-employee list, 403
+on read). Going forward the User Permission after_insert hook drops it; this converges existing
+sites by removing the ones already there.
+"""
+
+import frappe
+
+
+def execute():
+	from buildsuite_core.utils.employee_permissions import is_roster_manager
+
+	rows = frappe.get_all("User Permission", filters={"allow": "Employee"}, fields=["name", "user"])
+	removed = 0
+	for r in rows:
+		if is_roster_manager(r.user):
+			frappe.db.delete("User Permission", {"name": r.name})
+			removed += 1
+
+	if removed:
+		frappe.clear_cache()
+	print(f"drop_manager_employee_user_permissions: removed {removed} self-service Employee perms")

--- a/buildsuite_core/tests/test_field_employee.py
+++ b/buildsuite_core/tests/test_field_employee.py
@@ -144,13 +144,27 @@ class TestFieldEmployee(BuildSuiteTestCase):
 		).insert(ignore_permissions=True)
 		return email
 
-	def test_hr_manager_who_is_an_employee_can_still_add_workers(self):
-		"""Regression: an HR Manager linked to their own Employee carries a self-service
-		'own record only' User Permission on Employee. Roster management must bypass it — the
-		Administrator-run tests never hit this because Administrator ignores permissions."""
+	def test_hr_manager_who_is_an_employee_manages_the_whole_roster(self):
+		"""An HR Manager linked to their own Employee carries ERPNext's auto-created self-service
+		'own record only' User Permission. For a roster-managing role that contradicts the matrix,
+		so the after_insert hook drops it — the manager then READS / LISTS / ADDS every worker. The
+		matrix tests never caught this: they run as freshly-made users who aren't Employees (no User
+		Permission) and check doctype-level has_permission, which never applies User Permissions."""
 		email = self._make_user("BuildSuite HR Manager")
-		# Setting user_id makes ERPNext auto-create the self-service "own record only" User
-		# Permission on Employee — the exact real-world condition that broke roster management.
+		# Another worker that already exists — the one the manager must be able to see.
+		other = frappe.get_doc(
+			{
+				"doctype": "Employee",
+				"first_name": "Other",
+				"company": self.company,
+				"gender": "Male",
+				"date_of_birth": "1990-01-01",
+				"date_of_joining": "2021-01-01",
+				"is_labour": 1,
+			}
+		).insert(ignore_permissions=True)
+		# Linking the manager to their OWN Employee makes ERPNext auto-create the self-service User
+		# Permission — which the hook immediately drops for a roster manager.
 		own = frappe.get_doc(
 			{
 				"doctype": "Employee",
@@ -162,15 +176,21 @@ class TestFieldEmployee(BuildSuiteTestCase):
 				"user_id": email,
 			}
 		).insert(ignore_permissions=True)
-		self.assertTrue(
+		self.assertFalse(
 			frappe.db.exists("User Permission", {"user": email, "allow": "Employee"}),
-			"expected the self-service Employee User Permission to exist",
+			"the self-service Employee User Permission must be dropped for a roster manager",
 		)
 		frappe.clear_cache()
 
 		frappe.set_user(email)
 		try:
-			res = self._save()  # a DIFFERENT worker — blocked before the fix
+			# READ another worker — 403'd before the fix.
+			self.assertTrue(frappe.has_permission("Employee", "read", doc=other.name))
+			# LIST returns other workers, not just their own — empty before the fix.
+			names = {e.name for e in frappe.get_list("Employee", limit_page_length=0)}
+			self.assertIn(other.name, names)
+			# CREATE a new worker.
+			res = self._save()
 			self.assertTrue(res["name"])
 			self.assertNotEqual(res["name"], own.name)
 		finally:

--- a/buildsuite_core/tests/test_field_employee.py
+++ b/buildsuite_core/tests/test_field_employee.py
@@ -144,14 +144,18 @@ class TestFieldEmployee(BuildSuiteTestCase):
 		).insert(ignore_permissions=True)
 		return email
 
-	def test_hr_manager_who_is_an_employee_manages_the_whole_roster(self):
-		"""An HR Manager linked to their own Employee carries ERPNext's auto-created self-service
-		'own record only' User Permission. For a roster-managing role that contradicts the matrix,
-		so the after_insert hook drops it — the manager then READS / LISTS / ADDS every worker. The
-		matrix tests never caught this: they run as freshly-made users who aren't Employees (no User
-		Permission) and check doctype-level has_permission, which never applies User Permissions."""
-		email = self._make_user("BuildSuite HR Manager")
-		# Another worker that already exists — the one the manager must be able to see.
+	def test_every_roster_manager_who_is_an_employee_sees_the_whole_roster(self):
+		"""EVERY Employee-write role (HR Manager / PM / Site Engineer / Administrator) — not just
+		HR Manager — when linked to their own Employee carries ERPNext's auto-created self-service
+		'own record only' User Permission. That contradicts the matrix, so the after_insert hook
+		drops it and the manager READS / LISTS / ADDS every worker. Asserted via GENERIC Employee
+		read + list (not a field-employee endpoint), so it covers every screen that touches
+		Employee. The matrix tests never caught this: they run as freshly-made users who aren't
+		Employees (no User Permission) and check doctype-level has_permission, which never applies
+		document-level User Permissions."""
+		from buildsuite_core.utils.employee_permissions import ROSTER_ROLES
+
+		# A worker that already exists — the record each manager must be able to see / list.
 		other = frappe.get_doc(
 			{
 				"doctype": "Employee",
@@ -163,38 +167,44 @@ class TestFieldEmployee(BuildSuiteTestCase):
 				"is_labour": 1,
 			}
 		).insert(ignore_permissions=True)
-		# Linking the manager to their OWN Employee makes ERPNext auto-create the self-service User
-		# Permission — which the hook immediately drops for a roster manager.
-		own = frappe.get_doc(
-			{
-				"doctype": "Employee",
-				"first_name": "Manager",
-				"company": self.company,
-				"gender": "Male",
-				"date_of_birth": "1985-01-01",
-				"date_of_joining": "2020-01-01",
-				"user_id": email,
-			}
-		).insert(ignore_permissions=True)
-		self.assertFalse(
-			frappe.db.exists("User Permission", {"user": email, "allow": "Employee"}),
-			"the self-service Employee User Permission must be dropped for a roster manager",
-		)
-		frappe.clear_cache()
 
-		frappe.set_user(email)
-		try:
-			# READ another worker — 403'd before the fix.
-			self.assertTrue(frappe.has_permission("Employee", "read", doc=other.name))
-			# LIST returns other workers, not just their own — empty before the fix.
-			names = {e.name for e in frappe.get_list("Employee", limit_page_length=0)}
-			self.assertIn(other.name, names)
-			# CREATE a new worker.
-			res = self._save()
-			self.assertTrue(res["name"])
-			self.assertNotEqual(res["name"], own.name)
-		finally:
-			frappe.set_user("Administrator")
+		for role in sorted(ROSTER_ROLES):
+			with self.subTest(role=role):
+				email = self._make_user(role)
+				# Linking the manager to their OWN Employee makes ERPNext auto-create the
+				# self-service User Permission — which the hook drops for a roster manager.
+				own = frappe.get_doc(
+					{
+						"doctype": "Employee",
+						"first_name": "Manager",
+						"company": self.company,
+						"gender": "Male",
+						"date_of_birth": "1985-01-01",
+						"date_of_joining": "2020-01-01",
+						"user_id": email,
+					}
+				).insert(ignore_permissions=True)
+				self.assertFalse(
+					frappe.db.exists("User Permission", {"user": email, "allow": "Employee"}),
+					f"the self-service Employee User Permission must be dropped for {role}",
+				)
+				frappe.clear_cache()
+
+				frappe.set_user(email)
+				try:
+					# READ another worker — 403'd before the fix.
+					self.assertTrue(
+						frappe.has_permission("Employee", "read", doc=other.name), f"{role} read"
+					)
+					# LIST returns other workers, not just their own — empty before the fix.
+					names = {e.name for e in frappe.get_list("Employee", limit_page_length=0)}
+					self.assertIn(other.name, names, f"{role} should list other workers")
+					# CREATE a new worker.
+					res = self._save()
+					self.assertTrue(res["name"])
+					self.assertNotEqual(res["name"], own.name)
+				finally:
+					frappe.set_user("Administrator")
 
 	def test_a_persona_without_employee_create_is_refused(self):
 		"""The roster bypass is role-gated: a persona the matrix does not grant Employee create

--- a/buildsuite_core/utils/employee_permissions.py
+++ b/buildsuite_core/utils/employee_permissions.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Keep roster-managing users out of ERPNext's self-service Employee restriction.
+
+When a User is linked to an Employee (``user_id`` set), ERPNext auto-creates a User Permission
+(``allow=Employee``, ``for_value=<that employee>``) so a regular employee only ever sees their OWN
+record — leave, payslip, and so on. For a user who MANAGES the roster (holds a BuildSuite
+Employee-write role: HR Manager / PM / Site Engineer / Administrator), that restriction directly
+contradicts the permission matrix — it stops them reading or LISTING other employees, so the
+field-employee list comes back empty and opening any other worker 403s.
+
+We drop the restriction for those users, so their Employee access matches the matrix (full CRUD).
+ERPNext re-creates the permission whenever the Employee is saved, so the ``after_insert`` hook fires
+each time and keeps it gone. It only ever touches the auto-created self-service Employee permission;
+Company (and any other) user permissions are left untouched.
+"""
+
+import frappe
+
+from buildsuite_core.permissions.setup import EMPLOYEE_WRITE_ROLE_PERMS
+
+# Holders of these roles manage the employee roster — the self-service restriction must not apply.
+ROSTER_ROLES = frozenset(EMPLOYEE_WRITE_ROLE_PERMS)
+
+
+def is_roster_manager(user: str) -> bool:
+	return bool(user and ROSTER_ROLES & set(frappe.get_roles(user)))
+
+
+def drop_self_service_for_managers(doc, method=None):
+	"""User Permission ``after_insert`` hook — remove a self-service Employee permission the moment
+	it is created for a roster-managing user."""
+	if doc.allow != "Employee" or not doc.user:
+		return
+	if is_roster_manager(doc.user):
+		frappe.db.delete("User Permission", {"name": doc.name})
+		frappe.clear_cache(user=doc.user)


### PR DESCRIPTION
## Problem
An HR Manager (or PM / Site Engineer) who is **also an Employee** couldn't read or list *other* employees — the Field Employees list came back **empty** and opening any worker **403'd** (`You need the 'read' permission on Employee …`).

**Root cause:** ERPNext auto-creates a self-service User Permission (`allow=Employee`, own record) whenever a user is linked to their Employee, restricting them to **only their own** record. For a roster-managing role that directly contradicts the permission matrix (HR Manager = full Employee). It bites **every** path — read (`frappe.client.get`), list (`get_list`), delete, and Employee-linking flows (crew, attendance) — not just create (which had a custom-API bypass). The DocPerm `ignore_user_permissions` flag doesn't help: `has_user_permission` has no role-based bypass for reading the doctype itself.

## Fix
A `User Permission` **after_insert hook** drops the self-service Employee permission for a roster-managing user (Employee-write roles: HR Manager / PM / Site Engineer / Administrator). ERPNext re-creates it on every Employee save, so the hook keeps it gone. A **patch** clears the ones already there. This fixes list + read + delete + create + all Employee-linking flows in one place — no per-endpoint bypasses, and the user's Employee access now matches the matrix.

Verified on bs.local: the affected user now reads any employee (`True`), lists all workers, and has 0 self-service Employee permissions; the hook re-drops it on save.

## Why the tests missed it (and now don't)
`TestPersonaCrudMatrix` runs as freshly-made users who **aren't Employees** (so no self-service User Permission) and checks **doctype-level** `has_permission`, which never applies User Permissions. The field-employee regression test only covered **create**. It now runs as a real HR-Manager-who-is-an-Employee and asserts **read + list** of *other* workers too.