### PR TITLE
fix: block usage logs against inactive machinery (ISS-180)

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/machinery_usage/machinery_usage.js
+++ b/buildsuite_core/buildsuite_core/doctype/machinery_usage/machinery_usage.js
@@ -1,8 +1,8 @@
 // Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Machinery Usage", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Machinery Usage", {
+	setup(frm) {
+		frm.set_query("machine", () => ({ filters: { status: "Active" } }));
+	},
+});

--- a/buildsuite_core/buildsuite_core/doctype/machinery_usage/machinery_usage.py
+++ b/buildsuite_core/buildsuite_core/doctype/machinery_usage/machinery_usage.py
@@ -26,9 +26,21 @@ class MachineryUsage(Document):
 	# end: auto-generated types
 
 	def validate(self):
+		self.validate_machine_active()
+
 		# The task is optional, but if set it must belong to the selected project —
 		# a usage log must never be booked against a task from another project.
 		if self.task and self.project:
 			task_project = frappe.db.get_value("Task", self.task, "project")
 			if task_project != self.project:
 				frappe.throw(_("Task {0} does not belong to project {1}.").format(self.task, self.project))
+
+	def validate_machine_active(self):
+		machine = frappe.db.get_value("Machinery", self.machine, ["status", "machinery_name"], as_dict=True)
+
+		if machine and machine.status == "Inactive":
+			frappe.throw(
+				_("Machinery {0} is Inactive. Usage cannot be logged against it.").format(
+					machine.machinery_name or self.machine
+				)
+			)

--- a/buildsuite_core/buildsuite_core/doctype/machinery_usage/test_machinery_usage.py
+++ b/buildsuite_core/buildsuite_core/doctype/machinery_usage/test_machinery_usage.py
@@ -163,3 +163,25 @@ class TestMachineryUsage(BuildSuiteTestCase):
 
 		frappe.delete_doc("Machinery Usage", usage.name, ignore_permissions=True)
 		self.assertFalse(frappe.db.exists("Machinery Usage", usage.name))
+
+	def test_inactive_machine_cannot_be_logged(self):
+		machine = self._machine()
+		frappe.db.set_value("Machinery", machine.name, "status", "Inactive")
+
+		with self.assertRaisesRegex(frappe.ValidationError, "Inactive"):
+			frappe.get_doc({"doctype": "Machinery Usage", "machine": machine.name}).insert(
+				ignore_permissions=True
+			)
+
+	def test_log_is_frozen_once_its_machine_is_retired(self):
+		# Strict rule: retiring a machine seals its existing logs, not just new ones.
+		machine = self._machine()
+		usage = frappe.get_doc({"doctype": "Machinery Usage", "machine": machine.name}).insert(
+			ignore_permissions=True
+		)
+
+		frappe.db.set_value("Machinery", machine.name, "status", "Inactive")
+
+		usage.fuel_cost = 250
+		with self.assertRaisesRegex(frappe.ValidationError, "Inactive"):
+			usage.save(ignore_permissions=True)

--- a/frontend/src/views/NewMachineryUsageView.vue
+++ b/frontend/src/views/NewMachineryUsageView.vue
@@ -25,11 +25,13 @@ const route = useRoute();
 const adapter = createDataAdapter(useDataStore());
 const { canCreate } = usePermissions();
 
+// Active only. Own cache key — the detail view's picker still lists every machine.
 const machineryRes = useDocTypeList("Machinery", {
 	fields: ["name", "machinery_name", "machinery_type", "ownership", "rate", "rate_unit"],
+	filters: [["status", "=", "Active"]],
 	orderBy: "machinery_name asc",
 	pageLength: 0,
-	cache: "buildsuite-machinery-options",
+	cache: "buildsuite-machinery-active-options",
 });
 const machineryOptions = computed(() =>
 	(machineryRes.data || []).map((m) => ({


### PR DESCRIPTION
A usage log could be recorded against a Machinery marked Inactive. The controller now rejects it, and both the Desk and Vue pickers list active machines only.

Retiring a machine also seals its existing logs. To fix an old entry, set the machine Active, edit, then retire it again.