### PR TITLE
fix: Stage Planning name column (int→varchar) + numeric retention_percent

### DIFF
--- a/buildsuite_core/api/subcontract.py
+++ b/buildsuite_core/api/subcontract.py
@@ -141,7 +141,7 @@ def save_work_order(
 	project: str | None = None,
 	date: str | None = None,
 	delivery_type: str | None = None,
-	retention_percent: str | None = None,
+	retention_percent: str | float | None = None,
 	terms_template: str | None = None,
 	terms: str | None = None,
 	lines: str | None = None,

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -41,3 +41,4 @@ buildsuite_core.patches.resync_mobile_permissions # 2026-09-03 mobile app perms
 buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona ERPNext footprint
 buildsuite_core.patches.resync_derived_attendance_perms # 2026-09-04 derived registers read-only
 buildsuite_core.patches.drop_manager_employee_user_permissions # 2026-09-04 roster mgrs see all employees
+buildsuite_core.patches.fix_stage_planning_name_column # 2026-09-04 stage planning name column int->varchar

--- a/buildsuite_core/patches/fix_stage_planning_name_column.py
+++ b/buildsuite_core/patches/fix_stage_planning_name_column.py
@@ -1,0 +1,39 @@
+"""Convert tabStage Planning.name from an integer column to varchar.
+
+Stage Planning names records with the `STG-.YYYY.-.###` series (a string). On sites first created
+when the doctype used an Autoincrement name, the `name` column is still an INTEGER column — so
+inserting a string name fails with:
+
+    MySQLdb.OperationalError: (1366, "Incorrect integer value: 'STG-2026-001' for column ... name")
+
+Frappe does not auto-convert the `name` column when a doctype's naming changes, so migrate left the
+old integer column in place. Convert it to varchar(140) to match the naming. No-op on sites where
+the column is already varchar (freshly created ones).
+"""
+
+import frappe
+
+DOCTYPE = "Stage Planning"
+TABLE = f"tab{DOCTYPE}"
+_INT_TYPES = {"bigint", "int", "integer", "mediumint", "smallint", "tinyint"}
+
+
+def execute():
+	if not frappe.db.table_exists(DOCTYPE):
+		return
+
+	rows = frappe.db.sql(
+		"""
+		select lower(data_type)
+		from information_schema.columns
+		where table_schema = %s and table_name = %s and column_name = 'name'
+		""",
+		(frappe.conf.db_name, TABLE),
+	)
+	if not rows or rows[0][0] not in _INT_TYPES:
+		return  # already varchar — nothing to do
+
+	# MODIFY to varchar drops any AUTO_INCREMENT attribute the old naming left behind.
+	frappe.db.sql_ddl(f"ALTER TABLE `{TABLE}` MODIFY `name` VARCHAR(140)")
+	frappe.db.commit()
+	print(f"fix_stage_planning_name_column: converted {TABLE}.name to varchar(140)")


### PR DESCRIPTION
Two errors reported on a production/imported site.

## 1. Creating a Stage Planning → 500 `Incorrect integer value: 'STG-2026-001'`
Stage Planning names records with the string series `STG-.YYYY.-.###`. On a site first created when the doctype used an **Autoincrement** name, `tabStage Planning.name` is still an **integer** column, and Frappe never converts the `name` column when naming changes — so inserting the string name fails at the DB. **Fix:** a guarded patch converts `name` to `varchar(140)` where it's still integer (no-op on correctly-typed sites — verified it skips on our dev site).

## 2. Creating a Work Order → 417 `retention_percent should be 'str | None' but got int`
`save_work_order` annotated `retention_percent` as `str | None`, but the form sends a number (`5`). Frappe's pydantic argument validation rejects the int. **Fix:** widen to `str | float | None` (same class as the payment `amount` fixes; the body coerces the value).

Both backend-only.