### PR TITLE
feat: delete action for Customer & Supplier (finance panels)

### DIFF
--- a/frontend/src/views/finance/FinanceCustomersPanel.vue
+++ b/frontend/src/views/finance/FinanceCustomersPanel.vue
@@ -6,6 +6,8 @@ import { ref, computed, onMounted } from "vue";
 import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { listCustomers, addCustomer, updateCustomer } from "@/data/customersApi";
+import { createDataAdapter } from "@/data/adapters";
+import { useConfirm } from "@/composables/useConfirm";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
@@ -15,7 +17,9 @@ import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const store = useDataStore();
-const { canCreate } = usePermissions();
+const { canCreate, canDelete } = usePermissions();
+const adapter = createDataAdapter(store);
+const confirmDialog = useConfirm();
 // Customers are created AND edited from this panel; the create and write role-sets
 // coincide (Director / PM / Accountant / admin tier), so one capability gates both.
 const canManage = computed(() => canCreate("customer"));
@@ -87,6 +91,27 @@ async function onSave(payload) {
 		await load();
 	} catch (err) {
 		modalError.value = err.message || "Save failed.";
+	}
+}
+async function onDelete() {
+	if (!editing.value) return;
+	const ok = await confirmDialog({
+		title: `Delete ${editing.value.name}?`,
+		message:
+			"This customer master record will be removed permanently. Deletion is blocked if it has linked transactions (invoices, payments).",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	modalError.value = "";
+	try {
+		await adapter.remove("Customer", editing.value.id);
+		modalOpen.value = false;
+		await load();
+		showToast("Customer deleted.");
+	} catch (err) {
+		modalError.value =
+			err.message || "Delete failed — the customer may have linked transactions.";
 	}
 }
 
@@ -171,7 +196,9 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 				:type-options="TYPE_OPTIONS"
 				:initial="editing"
 				:server-error="modalError"
+				:can-delete="canDelete('customer')"
 				@save="onSave"
+				@delete="onDelete"
 				@close="modalOpen = false"
 			/>
 		</div>

--- a/frontend/src/views/finance/FinanceSuppliersPanel.vue
+++ b/frontend/src/views/finance/FinanceSuppliersPanel.vue
@@ -10,6 +10,8 @@ import { useRouter } from "vue-router";
 import { useDataStore } from "@/stores";
 import { showToast } from "@/utils/appToast";
 import { listSuppliers, addSupplier, updateSupplier } from "@/data/suppliersApi";
+import { createDataAdapter } from "@/data/adapters";
+import { useConfirm } from "@/composables/useConfirm";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
@@ -20,7 +22,9 @@ import { fmtINR } from "@/utils/format";
 
 const router = useRouter();
 const store = useDataStore();
-const { canCreate } = usePermissions();
+const { canCreate, canDelete } = usePermissions();
+const adapter = createDataAdapter(store);
+const confirmDialog = useConfirm();
 // Regular suppliers are created AND edited here; create and write role-sets coincide
 // (Procurement / PM / Director / admin tier), so one capability gates both.
 const canManage = computed(() => canCreate("supplier"));
@@ -99,6 +103,27 @@ async function onSave(payload) {
 		await load();
 	} catch (err) {
 		modalError.value = err.message || "Save failed.";
+	}
+}
+async function onDelete() {
+	if (!editing.value) return;
+	const ok = await confirmDialog({
+		title: `Delete ${editing.value.name}?`,
+		message:
+			"This supplier master record will be removed permanently. Deletion is blocked if it has linked transactions (bills, payments, work orders).",
+		confirmLabel: "Delete",
+		destructive: true,
+	});
+	if (!ok) return;
+	modalError.value = "";
+	try {
+		await adapter.remove("Supplier", editing.value.id);
+		modalOpen.value = false;
+		await load();
+		showToast("Supplier deleted.");
+	} catch (err) {
+		modalError.value =
+			err.message || "Delete failed — the supplier may have linked transactions.";
 	}
 }
 
@@ -195,7 +220,9 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 				:type-options="MODAL_TYPES"
 				:initial="editing"
 				:server-error="modalError"
+				:can-delete="canDelete('subcontractor')"
 				@save="onSave"
+				@delete="onDelete"
 				@close="modalOpen = false"
 			/>
 		</div>

--- a/frontend/src/views/finance/PartyFormModal.vue
+++ b/frontend/src/views/finance/PartyFormModal.vue
@@ -12,8 +12,9 @@ const props = defineProps({
 	typeOptions: { type: Array, default: () => [] }, // string[]
 	initial: { type: Object, default: null }, // for edit
 	serverError: { type: String, default: "" }, // e.g. duplicate-name from the parent's save attempt
+	canDelete: { type: Boolean, default: false }, // show Delete when editing an existing record
 });
-const emit = defineEmits(["save", "close"]);
+const emit = defineEmits(["save", "close", "delete"]);
 
 const form = ref(blank());
 const error = ref("");
@@ -147,18 +148,29 @@ function onSave() {
 				</div>
 
 				<footer
-					class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2 flex-shrink-0"
+					class="px-4 py-3 border-t border-ink-200 flex items-center gap-2 flex-shrink-0"
 				>
+					<!-- Delete only when editing an existing record and the persona may delete. -->
 					<button
+						v-if="initial && canDelete"
 						type="button"
-						class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
-						@click="emit('close')"
+						class="text-xs px-3 py-1.5 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700 rounded-md"
+						@click="emit('delete')"
 					>
-						Cancel
+						Delete
 					</button>
-					<button type="button" class="text-xs desk-save-btn" @click="onSave">
-						Save
-					</button>
+					<div class="ml-auto flex items-center gap-2">
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+							@click="emit('close')"
+						>
+							Cancel
+						</button>
+						<button type="button" class="text-xs desk-save-btn" @click="onSave">
+							Save
+						</button>
+					</div>
 				</footer>
 			</div>
 		</div>


### PR DESCRIPTION
The Project Finance **Customers** and **Suppliers** panels were create/edit only — no delete button ever rendered, even though delete is already granted at both layers (backend `_FULL` for Director/Accountant/Admin on Customer, +QS/Procurement on Supplier; caps `customer.del` / `subcontractor.del`). This adds a **Delete** button to the shared `PartyFormModal`, shown only when **editing an existing record** and the persona **may delete** (`canDelete('customer')` / `canDelete('subcontractor')`). Uses `adapter.remove` and surfaces ERPNext's "linked transactions exist" error in the modal. Build passes.