### PR TITLE
feat: workspace shortcuts hide entities the persona can't access

### DIFF
--- a/frontend/src/components/WorkspaceShortcut.vue
+++ b/frontend/src/components/WorkspaceShortcut.vue
@@ -21,6 +21,7 @@
 import { computed } from "vue";
 import { RouterLink } from "vue-router";
 import { getWorkspaceIconPath, resolveWorkspaceIconSlug } from "@/utils/workspaceIcons";
+import { usePermissions } from "@/composables/usePermissions";
 
 const props = defineProps({
 	to: { type: [String, Object], default: null },
@@ -31,7 +32,15 @@ const props = defineProps({
 	// Set true when the click should NOT navigate (stub tiles, e.g.
 	// AccountingWorkspace's illustrative shortcuts).
 	prevent: { type: Boolean, default: false },
+	// Persona-caps entity this tile opens (e.g. "materialRequest"). When set, the tile is only
+	// rendered for personas that can READ it — so a workspace never shows a shortcut to something
+	// the persona has no access to. Omitted (reports, dashboards) → always shown.
+	cap: { type: String, default: "" },
 });
+
+const { canRead } = usePermissions();
+// Hidden when a cap is declared and the persona can't read that entity.
+const visible = computed(() => !props.cap || canRead(props.cap));
 
 const tag = computed(() => {
 	if (props.prevent) return "a";
@@ -53,6 +62,7 @@ function onClick(e) {
 <template>
 	<component
 		:is="tag"
+		v-if="visible"
 		v-bind="bindings"
 		class="bg-white border border-ink-200 hover:border-brand-400 hover:shadow-sm p-4 transition-all group block"
 		style="border-radius: 8px"

--- a/frontend/src/views/workspaces/EquipmentWorkspace.vue
+++ b/frontend/src/views/workspaces/EquipmentWorkspace.vue
@@ -13,8 +13,8 @@ const today = computed(() => {
 });
 
 const shortcuts = [
-	{ label: "Machinery Register", icon: "wrench", to: "/machinery" },
-	{ label: "Machinery Usage", icon: "clipboard-list", to: "/machinery-usage" },
+	{ label: "Machinery Register", icon: "wrench", to: "/machinery", cap: "machinery" },
+	{ label: "Machinery Usage", icon: "clipboard-list", to: "/machinery-usage", cap: "machineryUsage" },
 ];
 
 // Fuel & running cost was dropped (prototype S314): fuel is captured per usage entry and
@@ -97,6 +97,7 @@ const reports = [
 					:icon="sc.icon"
 					:label="sc.label"
 					:to="sc.to"
+					:cap="sc.cap"
 				/>
 			</div>
 

--- a/frontend/src/views/workspaces/EstimationWorkspace.vue
+++ b/frontend/src/views/workspaces/EstimationWorkspace.vue
@@ -21,25 +21,28 @@ onMounted(async () => {
 	}
 });
 
-const ESTIMATES = [{ to: "/boq", icon: "chart-bar", label: "BOQ" }];
+const ESTIMATES = [{ to: "/boq", icon: "chart-bar", label: "BOQ", cap: "boq" }];
 const SETUP = [
 	{
 		to: "/rate-master",
 		icon: "tag",
 		label: "Rate Master",
 		description: "Price book for materials, labour, and equipment.",
+		cap: "rateMaster",
 	},
 	{
 		to: "/assembly",
 		icon: "layout-grid",
 		label: "Assembly",
 		description: "Rate-analysis recipes built from rate-master resources.",
+		cap: "assembly",
 	},
 	{
 		to: "/estimate-template",
 		icon: "file-text",
 		label: "Estimate Template",
 		description: "Reusable BOQ skeletons of assemblies and resources.",
+		cap: "estimateTemplate",
 	},
 ];
 </script>
@@ -59,6 +62,7 @@ const SETUP = [
 					:to="sc.to"
 					:icon="sc.icon"
 					:label="sc.label"
+					:cap="sc.cap"
 				/>
 			</div>
 
@@ -73,6 +77,7 @@ const SETUP = [
 					:icon="sc.icon"
 					:label="sc.label"
 					:description="sc.description"
+					:cap="sc.cap"
 				/>
 			</div>
 

--- a/frontend/src/views/workspaces/ProcurementWorkspace.vue
+++ b/frontend/src/views/workspaces/ProcurementWorkspace.vue
@@ -12,15 +12,15 @@ const today = computed(() => {
 });
 
 const shortcuts = [
-	{ label: "Material Requests", icon: "clipboard-list", to: "/procurement/material-requests" },
-	{ label: "Purchase Orders", icon: "file-text", to: "/procurement/purchase-orders" },
-	{ label: "Purchase Receipts", icon: "check-circle", to: "/procurement/receipts" },
+	{ label: "Material Requests", icon: "clipboard-list", to: "/procurement/material-requests", cap: "materialRequest" },
+	{ label: "Purchase Orders", icon: "file-text", to: "/procurement/purchase-orders", cap: "purchaseOrder" },
+	{ label: "Purchase Receipts", icon: "check-circle", to: "/procurement/receipts", cap: "purchaseReceipt" },
 	// Supplier bills (money out) — opens the Bills register, where direct supplier bills
 	// are listed and a new one can be raised. Matches the prototype's "Supplier Bills" tile.
-	{ label: "Supplier Bills", icon: "wallet", to: "/project-finance/bills" },
-	{ label: "Material Consumption", icon: "stock", to: "/material-consumption" },
-	{ label: "Suppliers", icon: "building-2", href: "/app/supplier" },
-	{ label: "Items", icon: "tag", to: "/items" },
+	{ label: "Supplier Bills", icon: "wallet", to: "/project-finance/bills", cap: "supplierBill" },
+	{ label: "Material Consumption", icon: "stock", to: "/material-consumption", cap: "materialConsumption" },
+	{ label: "Suppliers", icon: "building-2", href: "/app/supplier", cap: "supplier" },
+	{ label: "Items", icon: "tag", to: "/items", cap: "item" },
 ];
 
 // Report tiles are configured per workspace in Workspace Setting.
@@ -98,6 +98,7 @@ onMounted(async () => {
 					:to="sc.to"
 					:href="sc.href"
 					:prevent="sc.prevent"
+					:cap="sc.cap"
 				/>
 			</div>
 

--- a/frontend/src/views/workspaces/SubcontractWorkspace.vue
+++ b/frontend/src/views/workspaces/SubcontractWorkspace.vue
@@ -19,10 +19,10 @@ const today = computed(() => {
 });
 
 const shortcuts = [
-	{ label: "Subcontractors", icon: "users-2", to: "/subcontractors" },
-	{ label: "Work Orders", icon: "clipboard-list", to: "/subcontractor-work-orders" },
-	{ label: "Measurement Books", icon: "chart-bar", to: "/measurement-books" },
-	{ label: "Subcontractor Bills", icon: "file-text", to: "/subcontractor-bills" },
+	{ label: "Subcontractors", icon: "users-2", to: "/subcontractors", cap: "subcontractor" },
+	{ label: "Work Orders", icon: "clipboard-list", to: "/subcontractor-work-orders", cap: "subcontractorWorkOrder" },
+	{ label: "Measurement Books", icon: "chart-bar", to: "/measurement-books", cap: "measurementBook" },
+	{ label: "Subcontractor Bills", icon: "file-text", to: "/subcontractor-bills", cap: "subcontractorBill" },
 ];
 
 // Report tiles are configured per workspace in Workspace Setting.
@@ -98,6 +98,7 @@ onMounted(async () => {
 					:icon="sc.icon"
 					:label="sc.label"
 					:to="sc.to"
+					:cap="sc.cap"
 				/>
 			</div>
 

--- a/frontend/src/views/workspaces/WorkforceWorkspace.vue
+++ b/frontend/src/views/workspaces/WorkforceWorkspace.vue
@@ -11,9 +11,9 @@ const today = computed(() => {
 });
 
 const shortcuts = [
-	{ label: "Field Employees", icon: "hard-hat", to: "/field-employees" },
-	{ label: "Crews", icon: "users-2", to: "/crews" },
-	{ label: "Field Attendance", icon: "clipboard-list", to: "/field-attendance" },
+	{ label: "Field Employees", icon: "hard-hat", to: "/field-employees", cap: "fieldEmployee" },
+	{ label: "Crews", icon: "users-2", to: "/crews", cap: "crew" },
+	{ label: "Field Attendance", icon: "clipboard-list", to: "/field-attendance", cap: "fieldAttendance" },
 ];
 
 const reports = [
@@ -48,6 +48,7 @@ const reports = [
 					:icon="sc.icon"
 					:label="sc.label"
 					:to="sc.to"
+					:cap="sc.cap"
 				/>
 			</div>
 


### PR DESCRIPTION
## Problem
The hardcoded workspace landings showed **every** entity shortcut to **every** persona. A Site Engineer opening **Procurement** saw Purchase Orders, Purchase Receipts, Supplier Bills and Items — none of which they have permission for.

## Fix
`WorkspaceShortcut` now accepts a **`cap`** prop (the persona-caps entity the tile opens) and renders **only when `canRead(cap)`**. Each entity tile in the five **hardcoded** workspaces (Procurement, Subcontract, Workforce, Equipment, Estimation) declares its cap; report/dashboard tiles pass no cap and always show. Permission drives visibility from the existing caps (single source of truth) — no per-workspace role logic.

**Already gated, so untouched:** Site Execution (`store.visibleShortcutsFor`, per-role/customizable) and Project Finance (`visibleSections`).

## Result (Site Engineer → Procurement)
Shows **Material Requests + Material Consumption** (and Suppliers — SE genuinely has `supplier` read); hides **Purchase Orders / Receipts / Supplier Bills / Items**. Build passes.