### PR TITLE
fix: encode work-order names in SPA links (slashed IDs still redirected)

### DIFF
--- a/frontend/src/views/MeasurementBookDetailView.vue
+++ b/frontend/src/views/MeasurementBookDetailView.vue
@@ -202,7 +202,7 @@ const breadcrumbs = computed(() => [
 					Work order
 				</div>
 				<div class="text-sm mt-0.5">
-					<DeskLink :to="`/subcontractor-work-orders/${mb.work_order}`">{{
+					<DeskLink :to="`/subcontractor-work-orders/${encodeURIComponent(mb.work_order)}`">{{
 						mb.work_order
 					}}</DeskLink>
 				</div>

--- a/frontend/src/views/MeasurementBooksListView.vue
+++ b/frontend/src/views/MeasurementBooksListView.vue
@@ -86,7 +86,7 @@ function onRowClick(row) {
 			</template>
 			<template #cell-work_order="{ row }">
 				<DeskLink
-					:to="`/subcontractor-work-orders/${row.work_order}`"
+					:to="`/subcontractor-work-orders/${encodeURIComponent(row.work_order)}`"
 					class="font-mono text-xs"
 					@click.stop
 					>{{ row.work_order }}</DeskLink

--- a/frontend/src/views/NewSubcontractorWorkOrderView.vue
+++ b/frontend/src/views/NewSubcontractorWorkOrderView.vue
@@ -177,7 +177,7 @@ async function onSave() {
 			lines: form.value.lines.map(lineForSave),
 		};
 		const wo = await saveWorkOrder(payload);
-		router.push(`/subcontractor-work-orders/${wo.name}`);
+		router.push(`/subcontractor-work-orders/${encodeURIComponent(wo.name)}`);
 	} catch (err) {
 		showToast(err.message || "Failed to save work order", "error");
 	} finally {
@@ -193,7 +193,7 @@ const breadcrumbs = computed(() => [
 	{ label: "Subcontract", to: "/subcontract" },
 	{ label: "Work Orders", to: "/subcontractor-work-orders" },
 	isEdit.value
-		? { label: editingId.value, to: `/subcontractor-work-orders/${editingId.value}` }
+		? { label: editingId.value, to: `/subcontractor-work-orders/${encodeURIComponent(editingId.value)}` }
 		: { label: "New" },
 	...(isEdit.value ? [{ label: "Edit" }] : []),
 ]);

--- a/frontend/src/views/SubcontractorBillDetailView.vue
+++ b/frontend/src/views/SubcontractorBillDetailView.vue
@@ -762,7 +762,7 @@ const accountFilters = computed(() =>
 				</div>
 				<DeskLink
 					v-if="!bill.is_direct"
-					:to="`/subcontractor-work-orders/${bill.work_order}`"
+					:to="`/subcontractor-work-orders/${encodeURIComponent(bill.work_order)}`"
 					class="text-sm mt-0.5 block"
 					>{{ bill.work_order }}</DeskLink
 				>

--- a/frontend/src/views/SubcontractorDetailView.vue
+++ b/frontend/src/views/SubcontractorDetailView.vue
@@ -294,11 +294,11 @@ const breadcrumbs = computed(() => [
 								v-for="wo in linkedWOs"
 								:key="wo.name"
 								class="border-t border-ink-100 hover:bg-brand-50/30 cursor-pointer"
-								@click="router.push(`/subcontractor-work-orders/${wo.name}`)"
+								@click="router.push(`/subcontractor-work-orders/${encodeURIComponent(wo.name)}`)"
 							>
 								<td class="px-3 py-2">
 									<DeskLink
-										:to="`/subcontractor-work-orders/${wo.name}`"
+										:to="`/subcontractor-work-orders/${encodeURIComponent(wo.name)}`"
 										@click.stop
 										>{{ wo.name }}</DeskLink
 									>

--- a/frontend/src/views/SubcontractorWorkOrderDetailView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderDetailView.vue
@@ -109,7 +109,7 @@ function onRaiseBill() {
 // In-app print: routes to the Vue print view, which renders the work order as a
 // printable document and exports via the browser print dialog (Save as PDF).
 function onPrint() {
-	router.push(`/subcontractor-work-orders/${wo.value.name}/print`);
+	router.push(`/subcontractor-work-orders/${encodeURIComponent(wo.value.name)}/print`);
 }
 
 async function onSubmit() {
@@ -162,7 +162,7 @@ async function onAmend() {
 	try {
 		const res = await amendWorkOrder(wo.value.name);
 		showToast("Amended — a fresh draft was created.");
-		router.push(`/subcontractor-work-orders/${res.name}`);
+		router.push(`/subcontractor-work-orders/${encodeURIComponent(res.name)}`);
 	} catch (err) {
 		showToast(err.message || "Amend failed", "error");
 	} finally {
@@ -171,7 +171,7 @@ async function onAmend() {
 }
 
 function onEdit() {
-	router.push(`/subcontractor-work-orders/${wo.value.name}/edit`);
+	router.push(`/subcontractor-work-orders/${encodeURIComponent(wo.value.name)}/edit`);
 }
 
 async function onDelete() {

--- a/frontend/src/views/SubcontractorWorkOrderPrintView.vue
+++ b/frontend/src/views/SubcontractorWorkOrderPrintView.vue
@@ -44,7 +44,7 @@ function printDoc() {
 	window.print();
 }
 function backToWO() {
-	router.push(`/subcontractor-work-orders/${props.id}`);
+	router.push(`/subcontractor-work-orders/${encodeURIComponent(props.id)}`);
 }
 
 async function load() {

--- a/frontend/src/views/SubcontractorWorkOrdersListView.vue
+++ b/frontend/src/views/SubcontractorWorkOrdersListView.vue
@@ -83,7 +83,7 @@ const breadcrumbs = [
 ];
 
 function onRowClick(row) {
-	router.push(`/subcontractor-work-orders/${row.name}`);
+	router.push(`/subcontractor-work-orders/${encodeURIComponent(row.name)}`);
 }
 </script>
 
@@ -111,7 +111,7 @@ function onRowClick(row) {
 		>
 			<template #cell-name="{ row }">
 				<DeskLink
-					:to="`/subcontractor-work-orders/${row.name}`"
+					:to="`/subcontractor-work-orders/${encodeURIComponent(row.name)}`"
 					class="font-mono text-xs"
 					@click.stop
 					>{{ row.name }}</DeskLink

--- a/frontend/src/views/workspaces/SubcontractorDashboardView.vue
+++ b/frontend/src/views/workspaces/SubcontractorDashboardView.vue
@@ -203,7 +203,7 @@ function woPercent(wo) {
 						<li v-for="wo in recentWorkOrders" :key="wo.name" class="px-4 py-3">
 							<div class="flex items-baseline justify-between gap-2">
 								<RouterLink
-									:to="`/subcontractor-work-orders/${wo.name}`"
+									:to="`/subcontractor-work-orders/${encodeURIComponent(wo.name)}`"
 									class="text-sm text-ink-900 font-medium hover:text-brand-700 truncate"
 								>
 									{{ wo.subcontractor_name || wo.name }}
@@ -340,7 +340,7 @@ function woPercent(wo) {
 							<div class="text-[11px] text-ink-500 mt-0.5 truncate">
 								{{ projectName(mb.project) }} ·
 								<RouterLink
-									:to="`/subcontractor-work-orders/${mb.work_order}`"
+									:to="`/subcontractor-work-orders/${encodeURIComponent(mb.work_order)}`"
 									class="text-brand-700 hover:underline"
 									>{{ mb.work_order }}</RouterLink
 								>


### PR DESCRIPTION
Follow-up to #247. That PR made the route `:id(.*)` match slashed names **client-side** (verified against the real vue-router: it resolves `/subcontractor-work-orders/CNBC/1069/24/07/2026` to the detail route). But the **links still emitted the raw name**, so a refresh / direct-load sends Frappe a multi-slash path it won't serve for the `/core` SPA → falls through to the `/home` redirect.

**Fix:** encode the name in every work-order link with `encodeURIComponent`, producing a single-segment `%2F` URL — the exact shape the Frappe **desk** already uses (`/desk/subcontractor-work-order/CNBC%2F1066%2F...`), which Frappe serves. vue-router matches the encoded path and decodes `props.id` back to the raw name, so the detail/edit/print views are unchanged. The `new?subcontractor=` link is untouched. Build passes.