### PR TITLE
fix: restore Subcontractor Work Order naming on imported sites

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -42,3 +42,4 @@ buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona E
 buildsuite_core.patches.resync_derived_attendance_perms # 2026-09-04 derived registers read-only
 buildsuite_core.patches.drop_manager_employee_user_permissions # 2026-09-04 roster mgrs see all employees
 buildsuite_core.patches.fix_stage_planning_name_column # 2026-09-04 stage planning name column int->varchar
+buildsuite_core.patches.restore_subcontractor_work_order_naming # 2026-09-05 WO naming import override

--- a/buildsuite_core/patches/restore_subcontractor_work_order_naming.py
+++ b/buildsuite_core/patches/restore_subcontractor_work_order_naming.py
@@ -1,0 +1,47 @@
+"""Restore Subcontractor Work Order to the app's Expression naming.
+
+Imported / live-data sites carried a naming override — a Property Setter, or a stale DocType row —
+that names the Work Order via a **Naming Series**. But the doctype has no `naming_series` field and
+the app names it by Expression (`SWO-.YYYY.-.#####`), so creating a WO on those sites fails with:
+
+    AttributeError: 'SubcontractorWorkOrder' object has no attribute 'naming_series'
+
+Remove the stray naming Property Setters and force the DocType row back to the app's Expression
+rule. Existing (imported) records keep their names; new ones get SWO-YYYY-#####. No-op on sites that
+were never overridden (e.g. a freshly-created one).
+"""
+
+import frappe
+
+DOCTYPE = "Subcontractor Work Order"
+APP_AUTONAME = "SWO-.YYYY.-.#####"
+
+
+def execute():
+	if not frappe.db.exists("DocType", DOCTYPE):
+		return
+
+	stray = frappe.get_all(
+		"Property Setter",
+		filters={"doc_type": DOCTYPE, "property": ["in", ["autoname", "naming_rule", "naming_series"]]},
+		pluck="name",
+	)
+	for ps in stray:
+		frappe.delete_doc("Property Setter", ps, ignore_permissions=True, force=True)
+
+	# Force the DocType row back to the app's naming, in case a stale row survived schema sync.
+	current = frappe.db.get_value("DocType", DOCTYPE, ["autoname", "naming_rule"], as_dict=True)
+	if not current or current.autoname != APP_AUTONAME or current.naming_rule != "Expression":
+		frappe.db.set_value(
+			"DocType",
+			DOCTYPE,
+			{"autoname": APP_AUTONAME, "naming_rule": "Expression"},
+			update_modified=False,
+		)
+
+	if stray or (current and current.autoname != APP_AUTONAME):
+		frappe.clear_cache(doctype=DOCTYPE)
+		print(
+			f"restore_subcontractor_work_order_naming: removed {len(stray)} naming Property Setter(s); "
+			f"restored {APP_AUTONAME}"
+		)


### PR DESCRIPTION
## Symptom (imported/live-data sites only)
Creating a Subcontractor Work Order 500s with:
```
AttributeError: 'SubcontractorWorkOrder' object has no attribute 'naming_series'
```

## Cause
The app names WOs by **Expression** (`autoname = SWO-.YYYY.-.#####`) and has **no `naming_series` field**. The imported data carried a **naming override** (a Property Setter, or a stale DocType row) that names the WO via a **Naming Series** → Frappe calls `set_name_by_naming_series` → `doc.naming_series` doesn't exist. It only lives in that site's DB, so only that site breaks (bs.local names WOs fine).

## Fix
A patch removes the stray naming Property Setters (`autoname`/`naming_rule`/`naming_series`) and forces the DocType row back to the app's Expression rule. Existing imported WOs keep their names; new ones get `SWO-YYYY-#####`. Guarded — a no-op on already-correct sites (verified on bs.local).