### PR TITLE
fix: restore Subcontractor Bill + Measurement Book naming (imported sites)

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -42,3 +42,4 @@ buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona E
 buildsuite_core.patches.resync_derived_attendance_perms # 2026-09-04 derived registers read-only
 buildsuite_core.patches.drop_manager_employee_user_permissions # 2026-09-04 roster mgrs see all employees
 buildsuite_core.patches.fix_stage_planning_name_column # 2026-09-04 stage planning name column int->varchar
+buildsuite_core.patches.restore_transaction_doctype_naming # 2026-09-05 bill/MB naming import override

--- a/buildsuite_core/patches/restore_transaction_doctype_naming.py
+++ b/buildsuite_core/patches/restore_transaction_doctype_naming.py
@@ -1,0 +1,43 @@
+"""Restore Subcontractor Bill / Measurement Book to the app's Expression naming.
+
+Same class as restore_subcontractor_work_order_naming (#252), extended to the other transaction
+doctypes an import can break. These name by Expression and have NO `naming_series` field, but an
+imported/live-data site carried a naming override (a Property Setter or stale DocType row) that
+names them via a Naming Series — so creating one fails with:
+
+    AttributeError: '<Doctype>' object has no attribute 'naming_series'
+
+Remove the stray naming Property Setters and restore the app's Expression rule. Existing records
+keep their names; new ones follow the app series. No-op on already-correct sites.
+"""
+
+import frappe
+
+# doctype -> the app's autoname (Expression rule, no naming_series field)
+AUTONAMES = {
+	"Subcontractor Work Order": "SWO-.YYYY.-.#####",
+	"Subcontractor Bill": "SB-.YYYY.-.#####",
+	"Measurement Book": "MB-.YYYY.-.#####",
+}
+
+
+def execute():
+	for dt, autoname in AUTONAMES.items():
+		if not frappe.db.exists("DocType", dt):
+			continue
+		stray = frappe.get_all(
+			"Property Setter",
+			filters={"doc_type": dt, "property": ["in", ["autoname", "naming_rule", "naming_series"]]},
+			pluck="name",
+		)
+		for ps in stray:
+			frappe.delete_doc("Property Setter", ps, ignore_permissions=True, force=True)
+
+		current = frappe.db.get_value("DocType", dt, ["autoname", "naming_rule"], as_dict=True)
+		if not current or current.autoname != autoname:
+			frappe.db.set_value(
+				"DocType", dt, {"autoname": autoname, "naming_rule": "Expression"}, update_modified=False
+			)
+		if stray or (current and current.autoname != autoname):
+			frappe.clear_cache(doctype=dt)
+			print(f"restore_transaction_doctype_naming: {dt} — removed {len(stray)} PS; restored {autoname}")


### PR DESCRIPTION
Extends #252 to the sibling transaction doctypes. **Subcontractor Bill** and **Measurement Book** have the identical shape to Work Order — Expression naming, no `naming_series` field — so the imported site's stray naming-series override makes creating one 500 with `object has no attribute naming_series`. #252 only covered Work Order; this covers all three. Removes the stray naming Property Setters and restores the app Expression rule. Guarded no-op on clean sites (verified on bs.local).