### PR TITLE
fix: resync persona permission matrix (converge stale imported-site perms)

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -42,3 +42,4 @@ buildsuite_core.patches.strip_read_mirror_overreach # 2026-09-03 scope persona E
 buildsuite_core.patches.resync_derived_attendance_perms # 2026-09-04 derived registers read-only
 buildsuite_core.patches.drop_manager_employee_user_permissions # 2026-09-04 roster mgrs see all employees
 buildsuite_core.patches.fix_stage_planning_name_column # 2026-09-04 stage planning name column int->varchar
+buildsuite_core.patches.resync_persona_permission_matrix # 2026-09-05 converge stale imported-site perms

--- a/buildsuite_core/patches/resync_persona_permission_matrix.py
+++ b/buildsuite_core/patches/resync_persona_permission_matrix.py
@@ -1,0 +1,18 @@
+"""Re-apply the full persona permission matrix so imported/existing sites converge.
+
+setup_record_permissions() is install-only, so imported / live-data sites carry STALE DocPerms:
+personas hit "no permission" / "insufficient permission" on entities the CURRENT matrix grants
+(Task create, Material Consumption via Stock Entry, Supplier/Customer read, ...), even though a
+freshly-installed site is correct. Re-run the authoritative setup to refresh every persona's
+DocPerms in one pass. Idempotent — a no-op where the matrix is already current.
+"""
+
+import frappe
+
+
+def execute():
+	from buildsuite_core.permissions.setup import setup_record_permissions
+
+	setup_record_permissions()
+	frappe.clear_cache()
+	print("resync_persona_permission_matrix: re-applied the persona DocPerm matrix")


### PR DESCRIPTION
Several "no permission / insufficient permission" rows from testing (Task create for SE/Foreman, Material Consumption for BS Admin/Procurement, Supplier/Customer read for SE, …) are **not** code gaps — the backend matrix grants them (verified on bs.local). They fail on the imported remote because `setup_record_permissions()` is **install-only**, so that site's DocPerms are stale.

This patch re-runs the authoritative setup on migrate, refreshing every persona's DocPerms in one pass. Idempotent — a no-op where the matrix is already current. Deploy this and the whole stale-perm bucket should clear at once.