### PR TITLE
fix: a persona makes the user a System User

### DIFF
--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -45,3 +45,4 @@ buildsuite_core.patches.fix_stage_planning_name_column # 2026-09-04 stage planni
 buildsuite_core.patches.resync_persona_permission_matrix # 2026-09-05 converge stale imported-site perms
 buildsuite_core.patches.restore_transaction_doctype_naming # 2026-09-05 bill/MB naming import override
 buildsuite_core.patches.restore_subcontractor_work_order_naming # 2026-09-05 WO naming import override
+buildsuite_core.patches.promote_persona_users_to_system_user # 2026-09-06 persona users are system users

--- a/buildsuite_core/patches/promote_persona_users_to_system_user.py
+++ b/buildsuite_core/patches/promote_persona_users_to_system_user.py
@@ -1,0 +1,22 @@
+"""Promote existing persona users to System User.
+
+A BuildSuite persona user works in the Desk / SPA, which needs user_type="System User". A persona
+user created as a Website User can't log in — and the workaround (adding System Manager) over-grants
+(System Manager unlocks the full Project Finance workspace, etc.). The User validate hook now
+promotes on save; this converges existing sites.
+"""
+
+import frappe
+
+
+def execute():
+	users = frappe.get_all(
+		"User",
+		filters={"persona": ["is", "set"], "user_type": "Website User", "name": ["not in", ("Guest",)]},
+		pluck="name",
+	)
+	for u in users:
+		frappe.db.set_value("User", u, "user_type", "System User", update_modified=False)
+	if users:
+		frappe.clear_cache()
+		print(f"promote_persona_users_to_system_user: promoted {len(users)} persona user(s)")

--- a/buildsuite_core/tests/test_permission_matrix.py
+++ b/buildsuite_core/tests/test_permission_matrix.py
@@ -82,6 +82,24 @@ class TestPersonaRoleSync(_PersonaBase):
 				stray = (MANAGED_ROLES - {role}) & roles
 				self.assertFalse(stray, f"{persona} leaked other personas' roles: {stray}")
 
+	# --- a persona user is a System User (can log in without System Manager) --
+	def test_persona_makes_the_user_a_system_user(self):
+		"""A persona user works in the Desk/SPA, so setting a persona must make them a System
+		User — otherwise login needs a System Manager role added on top, which over-grants (e.g.
+		System Manager unlocks the full Project Finance workspace)."""
+		email = f"su-{self._n}-{frappe.generate_hash(length=4)}@example.com"
+		frappe.get_doc(
+			{
+				"doctype": "User",
+				"email": email,
+				"first_name": "SysUser",
+				"user_type": "Website User",  # deliberately NOT a system user
+				"send_welcome_email": 0,
+				"persona": "Site Engineer",
+			}
+		).insert(ignore_permissions=True)
+		self.assertEqual(frappe.db.get_value("User", email, "user_type"), "System User")
+
 	# --- switching between field personas ------------------------------------
 	def test_switch_chain_keeps_only_current_field_persona_role(self):
 		"""Switch one user through every ordinary persona in turn. At each step it must

--- a/buildsuite_core/utils/user.py
+++ b/buildsuite_core/utils/user.py
@@ -63,6 +63,13 @@ def sync_persona_roles(doc, method=None):
 	if doc.persona and not frappe.db.exists("Persona", doc.persona):
 		return
 
+	# A persona user works in the Desk / SPA, so make them a System User. Otherwise they can't log
+	# in and an admin has to add the System Manager role just to enable login — which over-grants
+	# (e.g. System Manager unlocks the FULL Project Finance workspace). Promotion only: clearing a
+	# persona never demotes an existing System User.
+	if doc.persona and doc.user_type != "System User":
+		doc.user_type = "System User"
+
 	grant = _persona_roles(doc.persona)
 
 	# On a persona SWITCH, strip only the roles the previous persona granted that the


### PR DESCRIPTION
## Problem
A BuildSuite persona user works in the Desk/SPA, which requires `user_type="System User"`. A persona user created as a **Website User** couldn't log in — so the workaround was to add the **System Manager** role, which **over-grants** (System Manager unlocks the *full* Project Finance workspace, among other things). That's the actual reason SE appeared to have full finance access.

## Fix
The `User` validate hook (`sync_persona_roles`) now promotes any user with a persona to **System User** (promotion only — clearing a persona never demotes an existing System User). A **patch** converges existing persona users created as Website Users. A **regression test** asserts a Website User + persona becomes a System User.

Verified on bs.local: inserting a Website User with a persona yields `user_type = System User`.