### PR TITLE
fix: field attendance list, task field and detail tiles (ISS-167)

### DIFF
--- a/buildsuite_core/api/field_attendance.py
+++ b/buildsuite_core/api/field_attendance.py
@@ -38,6 +38,8 @@ def _serialize(doc) -> dict:
 		"project_name": doc.project_name,
 		"date": str(doc.date) if doc.date else None,
 		"status": doc.status,
+		"task": doc.task,
+		"task_subject": frappe.db.get_value("Task", doc.task, "subject") if doc.task else None,
 		"overtime_hours": doc.overtime_hours,
 		"comments": doc.comments,
 		"docstatus": doc.docstatus,
@@ -71,6 +73,7 @@ def save_field_attendance(
 	project: str | None = None,
 	date: str | None = None,
 	status: str | None = None,
+	task: str | None = None,
 	overtime_hours: float | None = None,
 	comments: str | None = None,
 	employee_list: str | None = None,
@@ -104,6 +107,8 @@ def save_field_attendance(
 	# "Absent" header to Present or blank the hours and comments.
 	if status is not None:
 		doc.status = status
+	if task is not None:
+		doc.task = task
 	if overtime_hours is not None:
 		doc.overtime_hours = overtime_hours
 	if comments is not None:

--- a/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.json
+++ b/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "project",
+  "task",
   "column_break_o1sw",
   "date",
   "column_break_vbqw",
@@ -20,6 +21,7 @@
   "comments",
   "section_break_20su",
   "employee_list",
+  "employees_count",
   "section_break_pdmm",
   "amended_from",
   "column_break_3cdg",
@@ -70,6 +72,12 @@
    "reqd": 1
   },
   {
+   "fieldname": "task",
+   "fieldtype": "Link",
+   "label": "Task",
+   "options": "Task"
+  },
+  {
    "fieldname": "section_break_dkns",
    "fieldtype": "Section Break"
   },
@@ -117,13 +125,20 @@
   {
    "fieldname": "column_break_3cdg",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "employees_count",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Employees Count",
+   "read_only": 1
   }
  ],
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2026-07-22 18:36:38.826430",
+ "modified": "2026-09-06 21:38:31.959823",
  "modified_by": "Administrator",
  "module": "BuildSuite Core",
  "name": "Field Attendance",

--- a/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.py
+++ b/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.py
@@ -47,15 +47,20 @@ class FieldAttendance(Document):
 		comments: DF.SmallText | None
 		date: DF.Date
 		employee_list: DF.Table[FieldAttendanceEmployee]
+		employees_count: DF.Int
 		naming_series: DF.Literal["HR-FA-.YYYY.-"]
 		overtime_hours: DF.Float
 		project: DF.Link
 		project_name: DF.Data | None
 		status: DF.Literal["", "Present", "Half Day", "Absent", "Overtime Only"]
+		task: DF.Link | None
 	# end: auto-generated types
 
 	def validate(self):
 		self.validate_rows_present()
+		self.validate_task_project()
+
+		self.employees_count = len(self.employee_list)
 
 		emp_map = self.get_employee_map()
 		leave_map = self.get_leave_map()
@@ -125,6 +130,15 @@ class FieldAttendance(Document):
 	# ------------------------------------------------------------------
 	# row / list level
 	# ------------------------------------------------------------------
+
+	def validate_task_project(self):
+		if not (self.task and self.project):
+			return
+
+		if frappe.db.get_value("Task", self.task, "project") != self.project:
+			frappe.throw(
+				_("Task {0} does not belong to project {1}.").format(self.task, self.project)
+			)
 
 	def validate_rows_present(self):
 		if not self.employee_list:

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -46,3 +46,4 @@ buildsuite_core.patches.resync_persona_permission_matrix # 2026-09-05 converge s
 buildsuite_core.patches.restore_transaction_doctype_naming # 2026-09-05 bill/MB naming import override
 buildsuite_core.patches.restore_subcontractor_work_order_naming # 2026-09-05 WO naming import override
 buildsuite_core.patches.promote_persona_users_to_system_user # 2026-09-06 persona users are system users
+buildsuite_core.patches.backfill_field_attendance_employees_count # 2026-09-06 ISS-167 list count

--- a/buildsuite_core/patches/backfill_field_attendance_employees_count.py
+++ b/buildsuite_core/patches/backfill_field_attendance_employees_count.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""Backfill employees_count on existing Field Attendance sheets.
+
+The field is new, so every existing sheet reads 0 until it is next saved — and most are
+already Submitted or Cancelled and can never be saved again. One grouped count fills
+them all. Idempotent."""
+
+import frappe
+
+
+def execute():
+	if not frappe.db.has_column("Field Attendance", "employees_count"):
+		return
+
+	for name, count in frappe.db.sql(
+		"""
+		SELECT parent, COUNT(*)
+		FROM `tabField Attendance Employee`
+		WHERE parenttype = 'Field Attendance'
+		GROUP BY parent
+		"""
+	):
+		frappe.db.set_value("Field Attendance", name, "employees_count", count, update_modified=False)

--- a/frontend/src/components/AttendanceFormFields.vue
+++ b/frontend/src/components/AttendanceFormFields.vue
@@ -7,6 +7,7 @@ import DeskField from "@/components/desk/DeskField.vue";
 import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import { useProjectOptions } from "@/composables/useProjectOptions";
 import { ATTENDANCE_STATUSES } from "@/utils/workforceForms";
 
@@ -39,6 +40,16 @@ const { projectOptions } = useProjectOptions();
 			<DeskSelect :model-value="form.status" @update:model-value="(v) => emit('status', v)">
 				<option v-for="s in ATTENDANCE_STATUSES" :key="s">{{ s }}</option>
 			</DeskSelect>
+		</DeskField>
+		<DeskField label="Task (optional)" hint="Books the whole sheet to one task.">
+			<DeskLinkPicker
+				v-model="form.task"
+				doctype="Task"
+				label-field="subject"
+				value-field="name"
+				:filters="form.project ? [['project', '=', form.project]] : []"
+				placeholder="Deploy to task…"
+			/>
 		</DeskField>
 		<DeskField label="Overtime hours" hint="Applies to all rows.">
 			<DeskInput

--- a/frontend/src/components/AttendanceFormFields.vue
+++ b/frontend/src/components/AttendanceFormFields.vue
@@ -18,7 +18,7 @@ defineProps({
 // The three "applies to all rows" controls report upward instead of writing the
 // header directly — useAttendanceSheet owns both the header value and the rows,
 // so the two can never disagree.
-const emit = defineEmits(["status", "overtime", "comments"]);
+const emit = defineEmits(["status", "overtime", "comments", "project"]);
 
 const { projectOptions } = useProjectOptions();
 </script>
@@ -27,10 +27,11 @@ const { projectOptions } = useProjectOptions();
 	<DeskSection title="Header" :cols="3">
 		<DeskField label="Project" required :error="errors.project">
 			<DeskSearchableSelect
-				v-model="form.project"
+				:model-value="form.project"
 				:options="projectOptions"
 				placeholder="Pick a project…"
 				search-placeholder="Search projects…"
+				@update:model-value="(v) => emit('project', v)"
 			/>
 		</DeskField>
 		<DeskField label="Date" required :error="errors.date">

--- a/frontend/src/composables/useAttendanceSheet.js
+++ b/frontend/src/composables/useAttendanceSheet.js
@@ -43,6 +43,13 @@ export function useAttendanceSheet(getForm) {
 		eachRow((r) => (r.comments = v));
 	}
 
+	// Task is scoped to the project, so a project change drops it. A handler, not a
+	// watcher, for the reason above: Edit swaps the whole form in.
+	function setHeaderProject(v) {
+		form.value.project = v;
+		form.value.task = "";
+	}
+
 	const inTable = computed(
 		() => new Set((form.value?.employee_list || []).map((r) => r.employee).filter(Boolean))
 	);
@@ -118,6 +125,7 @@ export function useAttendanceSheet(getForm) {
 		setHeaderStatus,
 		setHeaderOvertime,
 		setHeaderComments,
+		setHeaderProject,
 		rosterToAdd,
 		rosterTitle,
 		addProjectRoster,

--- a/frontend/src/views/FieldAttendanceDetailView.vue
+++ b/frontend/src/views/FieldAttendanceDetailView.vue
@@ -126,6 +126,7 @@ const {
 	setHeaderStatus,
 	setHeaderOvertime,
 	setHeaderComments,
+	setHeaderProject,
 	rosterToAdd,
 	rosterTitle,
 	addProjectRoster,
@@ -153,14 +154,6 @@ function snapshot() {
 		})),
 	};
 }
-
-// Task is scoped to the project — the server rejects a stale cross-project one.
-watch(
-	() => form.value.project,
-	() => {
-		if (editing.value) form.value.task = "";
-	},
-);
 
 function startEdit() {
 	form.value = snapshot();
@@ -410,6 +403,7 @@ const breadcrumbs = computed(() => [
 				@status="setHeaderStatus"
 				@overtime="setHeaderOvertime"
 				@comments="setHeaderComments"
+				@project="setHeaderProject"
 			/>
 
 			<AttendanceEmployeeTable

--- a/frontend/src/views/FieldAttendanceDetailView.vue
+++ b/frontend/src/views/FieldAttendanceDetailView.vue
@@ -28,8 +28,7 @@ import {
 import { fmtDate } from "@/utils/format";
 import { isPermissionDenied } from "@/utils/frappeError";
 import DeskPage from "@/components/desk/DeskPage.vue";
-import DeskSection from "@/components/desk/DeskSection.vue";
-import DeskField from "@/components/desk/DeskField.vue";
+import DeskLink from "@/components/desk/DeskLink.vue";
 import AccessDenied from "@/components/AccessDenied.vue";
 import AttendanceFormFields from "@/components/AttendanceFormFields.vue";
 import AttendanceTableActions from "@/components/AttendanceTableActions.vue";
@@ -94,6 +93,32 @@ const docStatusLabel = computed(() =>
 );
 const rows = computed(() => doc.value?.employee_list || []);
 
+// Crew and labour cost show "—" until their data lands.
+const cards = computed(() => {
+	const d = doc.value;
+	if (!d) return [];
+
+	const present = rows.value.filter(
+		(r) => r.status === "Present" || r.status === "Half Day",
+	).length;
+
+	return [
+		{ label: "Project", value: d.project_name || projectLabel(d.project) || "—" },
+		{ label: "Crew", value: "—" },
+		{
+			label: "Task",
+			value: d.task_subject || d.task || "—",
+			to: d.task ? `/tasks/${d.task}` : null,
+		},
+		{
+			label: "Present",
+			value: `${present} / ${rows.value.length}`,
+			cls: "font-medium tabular-nums",
+		},
+		{ label: "Labour cost", value: "—", cls: "font-medium tabular-nums" },
+	];
+});
+
 const {
 	inTable,
 	addRow,
@@ -113,6 +138,7 @@ function snapshot() {
 		project: d.project || "",
 		date: d.date || "",
 		status: d.status || "Present",
+		task: d.task || "",
 		overtime_hours: d.overtime_hours ?? 0,
 		comments: d.comments || "",
 		employee_list: (d.employee_list || []).map((r) => ({
@@ -127,6 +153,14 @@ function snapshot() {
 		})),
 	};
 }
+
+// Task is scoped to the project — the server rejects a stale cross-project one.
+watch(
+	() => form.value.project,
+	() => {
+		if (editing.value) form.value.task = "";
+	},
+);
 
 function startEdit() {
 	form.value = snapshot();
@@ -343,30 +377,23 @@ const breadcrumbs = computed(() => [
 				This sheet is {{ docStatusLabel.toLowerCase() }} and can no longer be edited here.
 			</div>
 
-			<DeskSection title="Header" :cols="3">
-				<DeskField label="Project">
-					<div class="text-sm text-ink-900">
-						{{ doc.project_name || projectLabel(doc.project) || "—" }}
+			<!-- Headline strip — project / crew / task / present / labour cost -->
+			<div class="grid grid-cols-2 md:grid-cols-5 gap-2 mb-4">
+				<div
+					v-for="c in cards"
+					:key="c.label"
+					class="bg-white border border-ink-200 px-3 py-2"
+					style="border-radius: 6px"
+				>
+					<div class="text-[10px] uppercase tracking-wider text-ink-500 font-medium">
+						{{ c.label }}
 					</div>
-				</DeskField>
-				<DeskField label="Date">
-					<div class="text-sm text-ink-700">{{ fmtDate(doc.date) || "—" }}</div>
-				</DeskField>
-				<DeskField label="Status">
-					<div class="text-sm text-ink-700">{{ doc.status || "—" }}</div>
-				</DeskField>
-
-				<DeskField label="Overtime hours">
-					<div class="text-sm tabular-nums text-ink-700">
-						{{ doc.overtime_hours || 0 }}
+					<div class="text-sm text-ink-900 mt-0.5 truncate" :class="c.cls">
+						<DeskLink v-if="c.to" :to="c.to">{{ c.value }}</DeskLink>
+						<template v-else>{{ c.value }}</template>
 					</div>
-				</DeskField>
-				<div class="md:col-span-3">
-					<DeskField label="Comments">
-						<div class="text-sm text-ink-700">{{ doc.comments || "—" }}</div>
-					</DeskField>
 				</div>
-			</DeskSection>
+			</div>
 
 			<AttendanceEmployeeTable :rows="rows" :statuses="ATTENDANCE_STATUSES" />
 

--- a/frontend/src/views/FieldAttendanceListView.vue
+++ b/frontend/src/views/FieldAttendanceListView.vue
@@ -1,16 +1,16 @@
 <script setup>
 // Field Attendance — one sheet per project per day. Submitting a sheet (from
 // Desk for now) generates the Labour and Overtime Attendance registers.
-//
-// The employee count is not shown: child tables don't come back from the list
-// API, and Field Attendance has no denormalised count field.
 
 import { computed, ref } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
+import { useFieldEmployeeOptions } from "@/composables/useFieldEmployeeOptions";
 import { useProjectOptions } from "@/composables/useProjectOptions";
 import { usePermissions } from "@/composables/usePermissions";
 import { DOCSTATUS_LABELS } from "@/utils/workforceForms";
@@ -18,10 +18,25 @@ import { fmtDate } from "@/utils/format";
 
 const router = useRouter();
 const { projectOptions, projectLabel } = useProjectOptions();
+const { workerOptions } = useFieldEmployeeOptions();
 const { canCreate } = usePermissions();
 
 const projectFilter = ref("");
-const filterValues = computed(() => ({ project: projectFilter.value }));
+const employeeFilter = ref("");
+// String, not number: the filter builder drops falsy values, so 0 (Draft) would never apply.
+const statusFilter = ref("");
+
+const filterValues = computed(() => ({
+	project: projectFilter.value,
+	docstatus: statusFilter.value,
+}));
+
+// Child-table filter — filterFieldMap only builds 3-part ones, so it goes via baseFilters.
+const baseFilters = computed(() =>
+	employeeFilter.value
+		? [["Field Attendance Employee", "employee", "=", employeeFilter.value]]
+		: [],
+);
 
 function onRowClick(row) {
 	router.push(`/field-attendance/${row.name}`);
@@ -31,8 +46,8 @@ const columns = [
 	{ key: "name", label: "ID" },
 	{ key: "project", label: "Project" },
 	{ key: "date", label: "Date" },
-	{ key: "status", label: "Day status" },
-	{ key: "docstatus", label: "State" },
+	{ key: "employees_count", label: "Employees", align: "right" },
+	{ key: "docstatus", label: "Status" },
 ];
 
 const breadcrumbs = [
@@ -56,11 +71,12 @@ const breadcrumbs = [
 
 		<DocTypeListView
 			doctype="Field Attendance"
-			:field-order="['name', 'project', 'date', 'status', 'docstatus']"
+			:field-order="['name', 'project', 'date', 'employees_count', 'docstatus']"
 			:columns="columns"
 			:search-fields="['name', 'project']"
+			:base-filters="baseFilters"
 			:filter-values="filterValues"
-			:filter-field-map="{ project: 'project' }"
+			:filter-field-map="{ project: 'project', docstatus: 'docstatus' }"
 			cache-key="buildsuite-field-attendance"
 			row-key="name"
 			initial-order-by="date desc"
@@ -77,6 +93,23 @@ const breadcrumbs = [
 						allow-clear
 					/>
 				</div>
+
+				<div class="w-56">
+					<DeskSearchableSelect
+						v-model="employeeFilter"
+						:options="workerOptions"
+						placeholder="All employees"
+						search-placeholder="Search employees…"
+						allow-clear
+					/>
+				</div>
+
+				<DeskSelect v-model="statusFilter" class="!w-36">
+					<option value="">All statuses</option>
+					<option value="0">Draft</option>
+					<option value="1">Submitted</option>
+					<option value="2">Cancelled</option>
+				</DeskSelect>
 			</template>
 
 			<template #cell-name="{ row }">
@@ -97,12 +130,12 @@ const breadcrumbs = [
 				<span class="text-ink-700">{{ fmtDate(row.date) || "—" }}</span>
 			</template>
 
-			<template #cell-status="{ row }">
-				<span class="text-ink-700">{{ row.status || "—" }}</span>
+			<template #cell-employees_count="{ row }">
+				<span class="tabular-nums text-ink-700">{{ row.employees_count || 0 }}</span>
 			</template>
 
 			<template #cell-docstatus="{ row }">
-				<span class="text-ink-600">{{ DOCSTATUS_LABELS[row.docstatus] || "Draft" }}</span>
+				<StatusBadge :status="DOCSTATUS_LABELS[row.docstatus] || 'Draft'" />
 			</template>
 		</DocTypeListView>
 	</DeskPage>

--- a/frontend/src/views/NewFieldAttendanceView.vue
+++ b/frontend/src/views/NewFieldAttendanceView.vue
@@ -3,7 +3,7 @@
 // from Desk. The header block and roster helpers are shared with the detail view
 // via AttendanceFormFields / useAttendanceSheet.
 
-import { reactive, ref, watch } from "vue";
+import { reactive, ref } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
@@ -34,14 +34,6 @@ const form = reactive({
 	employee_list: [],
 });
 
-// Task is scoped to the project — the server rejects a stale cross-project one.
-watch(
-	() => form.project,
-	() => {
-		form.task = "";
-	},
-);
-
 const {
 	inTable,
 	addRow,
@@ -49,6 +41,7 @@ const {
 	setHeaderStatus,
 	setHeaderOvertime,
 	setHeaderComments,
+	setHeaderProject,
 	rosterToAdd,
 	rosterTitle,
 	addProjectRoster,
@@ -119,6 +112,7 @@ const breadcrumbs = [
 				@status="setHeaderStatus"
 				@overtime="setHeaderOvertime"
 				@comments="setHeaderComments"
+				@project="setHeaderProject"
 			/>
 
 			<AttendanceEmployeeTable

--- a/frontend/src/views/NewFieldAttendanceView.vue
+++ b/frontend/src/views/NewFieldAttendanceView.vue
@@ -3,7 +3,7 @@
 // from Desk. The header block and roster helpers are shared with the detail view
 // via AttendanceFormFields / useAttendanceSheet.
 
-import { reactive, ref } from "vue";
+import { reactive, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import { useFormErrors } from "@/composables/useFormErrors";
@@ -28,10 +28,19 @@ const form = reactive({
 	project: "",
 	date: new Date().toISOString().slice(0, 10),
 	status: "Present",
+	task: "",
 	overtime_hours: 0,
 	comments: "",
 	employee_list: [],
 });
+
+// Task is scoped to the project — the server rejects a stale cross-project one.
+watch(
+	() => form.project,
+	() => {
+		form.task = "";
+	},
+);
 
 const {
 	inTable,


### PR DESCRIPTION
Fixes part of ISS-167.

List now shows an employee count and a status badge, plus filters for employee and status.

New and edit forms get a Task field, scoped to the project.

The detail page shows a 5 tile strip, replacing the old header block.

Includes a patch to backfill the employee count on existing sheets - most are submitted or cancelled and can never be re-saved.

Crew and labour cost tiles show "-" for now.