### PR TITLE
fix: Customer/Supplier lists sort by Updated + read-only detail view

### DIFF
--- a/buildsuite_core/api/customers.py
+++ b/buildsuite_core/api/customers.py
@@ -33,11 +33,12 @@ def _default_group_and_territory(doc):
 
 @frappe.whitelist()
 def list_customers():
-	"""All customers with type, tax id, primary contact and advance held, name-sorted."""
+	"""All customers with type, tax id, primary contact and advance held, most-recently-updated
+	first. `updated`/`created` are returned so the list can be re-sorted by either client-side."""
 	rows = frappe.get_all(
 		"Customer",
-		fields=["name", "customer_name", "customer_type", "tax_id"],
-		order_by="customer_name asc",
+		fields=["name", "customer_name", "customer_type", "tax_id", "modified", "creation"],
+		order_by="modified desc",
 	)
 	out = []
 	for c in rows:
@@ -52,6 +53,8 @@ def list_customers():
 				"phone": contact["phone"],
 				"email": contact["email"],
 				"advance": unallocated_advance("Customer", c.name),
+				"updated": str(c.modified or ""),
+				"created": str(c.creation or ""),
 			}
 		)
 	return out

--- a/buildsuite_core/api/suppliers.py
+++ b/buildsuite_core/api/suppliers.py
@@ -35,11 +35,12 @@ def _default_supplier_group(subcontractor=False):
 @frappe.whitelist()
 def list_suppliers():
 	"""Every supplier (incl. subcontractors) with type, trade, tax id, primary contact
-	and advance paid — name-sorted. Subcontractor rows carry is_subcontractor + trade."""
+	and advance paid — most-recently-updated first. `updated`/`created` are returned so the
+	list can be re-sorted by either client-side. Subcontractor rows carry is_subcontractor + trade."""
 	rows = frappe.get_all(
 		"Supplier",
-		fields=["name", "supplier_name", "supplier_type", "tax_id", "custom_trade"],
-		order_by="supplier_name asc",
+		fields=["name", "supplier_name", "supplier_type", "tax_id", "custom_trade", "modified", "creation"],
+		order_by="modified desc",
 	)
 	out = []
 	for s in rows:
@@ -57,6 +58,8 @@ def list_suppliers():
 				"phone": contact["phone"],
 				"email": contact["email"],
 				"advance": unallocated_advance("Supplier", s.name),
+				"updated": str(s.modified or ""),
+				"created": str(s.creation or ""),
 			}
 		)
 	return out

--- a/frontend/src/views/finance/FinanceCustomersPanel.vue
+++ b/frontend/src/views/finance/FinanceCustomersPanel.vue
@@ -17,7 +17,7 @@ import { usePermissions } from "@/composables/usePermissions";
 import { fmtINR } from "@/utils/format";
 
 const store = useDataStore();
-const { canCreate, canDelete } = usePermissions();
+const { canCreate, canDelete, canRead } = usePermissions();
 const adapter = createDataAdapter(store);
 const confirmDialog = useConfirm();
 // Customers are created AND edited from this panel; the create and write role-sets
@@ -66,6 +66,16 @@ const columns = [
 	{ key: "advance", label: "Advance held", align: "right" },
 ];
 
+// Sort by Updated (most-recently-touched first) by default; Created and Updated are always
+// offered alongside the column sorts. Rows carry `updated`/`created` from the API.
+const sortOptions = [
+	...columns.map((c) => ({ value: c.key, label: c.label })),
+	{ value: "updated", label: "Updated" },
+	{ value: "created", label: "Created" },
+];
+const sortField = ref("updated");
+const sortDirection = ref("desc");
+
 // --- create / edit modal ---
 const modalOpen = ref(false);
 const modalError = ref("");
@@ -77,7 +87,9 @@ function openCreate() {
 	modalOpen.value = true;
 }
 function onRowClick(row) {
-	if (!canManage.value) return;
+	// Read-access personas open the record read-only (view, no edit/save/delete); the modal
+	// switches to view mode via :read-only. Only block users who can't read at all.
+	if (!canRead("customer")) return;
 	editing.value = row;
 	modalError.value = "";
 	modalOpen.value = true;
@@ -133,6 +145,11 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 				:columns="columns"
 				row-key="id"
 				search-placeholder="Search name, contact, tax ID…"
+				:sort-options="sortOptions"
+				:sort-field="sortField"
+				:sort-direction="sortDirection"
+				@update:sort-field="sortField = $event"
+				@update:sort-direction="sortDirection = $event"
 				@row-click="onRowClick"
 			>
 				<template #filter-chips>
@@ -191,12 +208,13 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 
 			<PartyFormModal
 				:open="modalOpen"
-				:title="editing ? 'Edit Customer' : 'New Customer'"
+				:title="editing ? (canManage ? 'Edit Customer' : 'View Customer') : 'New Customer'"
 				type-label="Customer type"
 				:type-options="TYPE_OPTIONS"
 				:initial="editing"
 				:server-error="modalError"
 				:can-delete="canDelete('customer')"
+				:read-only="!canManage"
 				@save="onSave"
 				@delete="onDelete"
 				@close="modalOpen = false"

--- a/frontend/src/views/finance/FinanceSuppliersPanel.vue
+++ b/frontend/src/views/finance/FinanceSuppliersPanel.vue
@@ -22,7 +22,7 @@ import { fmtINR } from "@/utils/format";
 
 const router = useRouter();
 const store = useDataStore();
-const { canCreate, canDelete } = usePermissions();
+const { canCreate, canDelete, canRead } = usePermissions();
 const adapter = createDataAdapter(store);
 const confirmDialog = useConfirm();
 // Regular suppliers are created AND edited here; create and write role-sets coincide
@@ -74,6 +74,16 @@ const columns = [
 	{ key: "advance", label: "Advance paid", align: "right" },
 ];
 
+// Sort by Updated (most-recently-touched first) by default; Created and Updated are always
+// offered alongside the column sorts. Rows carry `updated`/`created` from the API.
+const sortOptions = [
+	...columns.map((c) => ({ value: c.key, label: c.label })),
+	{ value: "updated", label: "Updated" },
+	{ value: "created", label: "Created" },
+];
+const sortField = ref("updated");
+const sortDirection = ref("desc");
+
 // --- create / edit modal (regular suppliers only) ---
 const modalOpen = ref(false);
 const modalError = ref("");
@@ -89,7 +99,9 @@ function onRowClick(row) {
 		router.push(`/subcontractors/${row.id}`);
 		return;
 	}
-	if (!canManage.value) return;
+	// Read-access personas open the record read-only (view, no edit/save/delete); the modal
+	// switches to view mode via :read-only. Only block users who can't read at all.
+	if (!canRead("supplier")) return;
 	editing.value = row;
 	modalError.value = "";
 	modalOpen.value = true;
@@ -145,6 +157,11 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 				:columns="columns"
 				row-key="id"
 				search-placeholder="Search name, contact, trade, tax ID…"
+				:sort-options="sortOptions"
+				:sort-field="sortField"
+				:sort-direction="sortDirection"
+				@update:sort-field="sortField = $event"
+				@update:sort-direction="sortDirection = $event"
 				@row-click="onRowClick"
 			>
 				<template #filter-chips>
@@ -215,12 +232,13 @@ const breadcrumbs = [{ label: "Project Finance", to: "/project-finance" }, { lab
 
 			<PartyFormModal
 				:open="modalOpen"
-				:title="editing ? 'Edit Supplier' : 'New Supplier'"
+				:title="editing ? (canManage ? 'Edit Supplier' : 'View Supplier') : 'New Supplier'"
 				type-label="Supplier type"
 				:type-options="MODAL_TYPES"
 				:initial="editing"
 				:server-error="modalError"
 				:can-delete="canDelete('subcontractor')"
+				:read-only="!canManage"
 				@save="onSave"
 				@delete="onDelete"
 				@close="modalOpen = false"

--- a/frontend/src/views/finance/PartyFormModal.vue
+++ b/frontend/src/views/finance/PartyFormModal.vue
@@ -13,6 +13,7 @@ const props = defineProps({
 	initial: { type: Object, default: null }, // for edit
 	serverError: { type: String, default: "" }, // e.g. duplicate-name from the parent's save attempt
 	canDelete: { type: Boolean, default: false }, // show Delete when editing an existing record
+	readOnly: { type: Boolean, default: false }, // read-access persona: view the record, no edit/save/delete
 });
 const emit = defineEmits(["save", "close", "delete"]);
 
@@ -69,7 +70,10 @@ function onSave() {
 					</button>
 				</header>
 
-				<div class="px-4 py-4 overflow-y-auto flex-1 space-y-3">
+				<fieldset
+					:disabled="readOnly"
+					class="px-4 py-4 overflow-y-auto flex-1 space-y-3 min-w-0 border-0"
+				>
 					<div>
 						<label
 							class="block text-[11px] uppercase tracking-wider text-ink-500 font-medium mb-1"
@@ -145,14 +149,14 @@ function onSave() {
 							placeholder="29AABC…1Z5"
 						/>
 					</div>
-				</div>
+				</fieldset>
 
 				<footer
 					class="px-4 py-3 border-t border-ink-200 flex items-center gap-2 flex-shrink-0"
 				>
 					<!-- Delete only when editing an existing record and the persona may delete. -->
 					<button
-						v-if="initial && canDelete"
+						v-if="initial && canDelete && !readOnly"
 						type="button"
 						class="text-xs px-3 py-1.5 border border-danger-200 bg-white hover:bg-danger-50 text-danger-700 rounded-md"
 						@click="emit('delete')"
@@ -165,9 +169,14 @@ function onSave() {
 							class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
 							@click="emit('close')"
 						>
-							Cancel
+							{{ readOnly ? "Close" : "Cancel" }}
 						</button>
-						<button type="button" class="text-xs desk-save-btn" @click="onSave">
+						<button
+							v-if="!readOnly"
+							type="button"
+							class="text-xs desk-save-btn"
+							@click="onSave"
+						>
 							Save
 						</button>
 					</div>


### PR DESCRIPTION
## Changes

### 1. Sort by Updated by default
The Customer & Supplier master panels are bespoke `DeskList` panels (not `DocTypeListView`), so they never got the default *Updated* sort or the Created/Updated sort options. Now:
- `list_customers` / `list_suppliers` return `updated`/`created` and default to `modified desc`.
- The panels default the sort to **Updated (desc)** and always offer **Created** + **Updated** in the sort dropdown, alongside the column sorts — matching the Invoices/Bills lists (which use `DocTypeListView`, already behaving this way).

### 2. Read-only personas can view the detail
A persona with **read but not create/edit/delete** on Customer/Supplier (e.g. **Procurement Officer** on Customer) could see the list but **couldn't open a row** — the click was gated behind `canManage` (`canCreate`). Now:
- `PartyFormModal` gains a `readOnly` mode: fields disabled (wrapped in a `<fieldset :disabled>`), Save + Delete hidden, Cancel → **Close**, title **View Customer/Supplier**.
- The panels open the modal via `:read-only="!canManage"` and gate row-click on `canRead` instead of `canManage`.

Frontend builds clean; Python syntax checked.