### PR TITLE
feat: dynamic filters on DocTypeListView (Frappe-style)

### DIFF
--- a/frontend/src/components/desk/DeskFilterChip.vue
+++ b/frontend/src/components/desk/DeskFilterChip.vue
@@ -30,7 +30,7 @@ defineEmits(["remove"]);
 			class="text-brand-700 hover:text-brand-800 leading-none"
 			style="font-size: 14px"
 			aria-label="Remove filter"
-			@click="$emit('remove')"
+			@click.stop="$emit('remove')"
 		>
 			×
 		</button>

--- a/frontend/src/components/desk/DeskFilterEditor.vue
+++ b/frontend/src/components/desk/DeskFilterEditor.vue
@@ -1,0 +1,281 @@
+<script setup>
+// Dynamic filter editor — a field + condition + value builder, modelled on Frappe's
+// `frappe.ui.Filter` (apps/frappe/frappe/public/js/frappe/ui/filters/filter.js):
+//   • the same condition list and per-fieldtype `invalid_condition_map`, so only the
+//     operators Frappe allows for a fieldtype are offered;
+//   • the value control switches by fieldtype/condition (Link picker, Select, date,
+//     Between = two dates, Timespan list, "is" = set/not set, "in" = comma list).
+// Emits `apply` with { fieldname, label, fieldtype, options, condition, value } or `cancel`.
+import { ref, computed, watch } from "vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+
+const props = defineProps({
+	// [{ fieldname, label, fieldtype, options }]
+	fields: { type: Array, default: () => [] },
+	// existing filter to edit, or null to add a new one
+	initial: { type: Object, default: null },
+});
+const emit = defineEmits(["apply", "cancel"]);
+
+// --- Frappe condition model (verbatim from filter.js) ---------------------------
+const ALL_CONDITIONS = [
+	["=", "Equals"],
+	["!=", "Not Equals"],
+	["like", "Like"],
+	["not like", "Not Like"],
+	["in", "In"],
+	["not in", "Not In"],
+	["is", "Is"],
+	[">", "Greater Than"],
+	["<", "Less Than"],
+	[">=", "Greater Than Or Equal To"],
+	["<=", "Less Than Or Equal To"],
+	["Between", "Between"],
+	["Timespan", "Timespan"],
+];
+const CHECK_INVALID = ALL_CONDITIONS.map((c) => c[0]).filter((c) => c !== "=");
+const INVALID_CONDITION_MAP = {
+	Date: ["like", "not like"],
+	Datetime: ["like", "not like", "in", "not in", "=", "!="],
+	Data: ["Between", "Timespan"],
+	Time: ["Between", "Timespan"],
+	Select: ["like", "not like", "Between", "Timespan"],
+	Link: ["Between", "Timespan", ">", "<", ">=", "<="],
+	Currency: ["Between", "Timespan"],
+	Color: ["Between", "Timespan"],
+	Check: CHECK_INVALID,
+	Code: ["Between", "Timespan", ">", "<", ">=", "<=", "in", "not in"],
+	"HTML Editor": ["Between", "Timespan", ">", "<", ">=", "<=", "in", "not in"],
+	"Markdown Editor": ["Between", "Timespan", ">", "<", ">=", "<=", "in", "not in"],
+	Password: ["Between", "Timespan", ">", "<", ">=", "<=", "in", "not in"],
+	Rating: ["like", "not like", "Between", "in", "not in", "Timespan"],
+	Int: ["like", "not like", "Between", "in", "not in", "Timespan"],
+	Float: ["like", "not like", "Between", "in", "not in", "Timespan"],
+	Percent: ["like", "not like", "Between", "in", "not in", "Timespan"],
+};
+// Frappe's special_condition_labels for date-like fields.
+const DATE_LABELS = { "<": "Before", ">": "After", "<=": "On or Before", ">=": "On or After" };
+
+const TIMESPANS = [
+	"last week",
+	"last month",
+	"last quarter",
+	"last 6 months",
+	"last year",
+	"yesterday",
+	"today",
+	"tomorrow",
+	"this week",
+	"this month",
+	"this quarter",
+	"this year",
+	"next week",
+	"next month",
+	"next quarter",
+	"next 6 months",
+	"next year",
+];
+
+const sortedFields = computed(() =>
+	[...props.fields].sort((a, b) => String(a.label).localeCompare(String(b.label)))
+);
+
+const fieldname = ref(props.initial?.fieldname || sortedFields.value[0]?.fieldname || "");
+const condition = ref(props.initial?.condition || "");
+const value = ref(props.initial?.value ?? "");
+
+const selectedField = computed(
+	() => props.fields.find((f) => f.fieldname === fieldname.value) || null
+);
+const fieldtype = computed(() => selectedField.value?.fieldtype || "Data");
+
+const conditions = computed(() => {
+	const invalid = INVALID_CONDITION_MAP[fieldtype.value] || [];
+	return ALL_CONDITIONS.filter((c) => !invalid.includes(c[0])).map(([op, label]) => [
+		op,
+		(["Date", "Datetime"].includes(fieldtype.value) && DATE_LABELS[op]) || label,
+	]);
+});
+
+// The value control to render for the current fieldtype + condition.
+const valueKind = computed(() => {
+	if (condition.value === "is") return "isset";
+	if (condition.value === "in" || condition.value === "not in") return "multi";
+	if (condition.value === "Timespan") return "timespan";
+	if (condition.value === "Between") return "between";
+	switch (fieldtype.value) {
+		case "Link":
+		case "Dynamic Link":
+			return "link";
+		case "Select":
+			return "select";
+		case "Check":
+			return "check";
+		case "Date":
+			return "date";
+		case "Datetime":
+			return "datetime";
+		case "Int":
+		case "Float":
+		case "Currency":
+		case "Percent":
+			return "number";
+		default:
+			return "text";
+	}
+});
+
+const selectOptions = computed(() =>
+	String(selectedField.value?.options || "")
+		.split("\n")
+		.map((o) => o.trim())
+		.filter((o) => o.length)
+);
+
+function resetValueForKind() {
+	if (valueKind.value === "between") value.value = ["", ""];
+	else if (valueKind.value === "isset") value.value = "set";
+	else if (valueKind.value === "check") value.value = "1";
+	else value.value = "";
+}
+
+// Keep condition valid when the field changes; reset value when the control shape changes.
+watch(fieldname, () => {
+	if (!conditions.value.some((c) => c[0] === condition.value)) {
+		condition.value = conditions.value[0]?.[0] || "=";
+	}
+	resetValueForKind();
+});
+watch(condition, () => resetValueForKind());
+
+// Initialise a valid condition on first render.
+if (!condition.value || !conditions.value.some((c) => c[0] === condition.value)) {
+	condition.value = conditions.value[0]?.[0] || "=";
+	if (props.initial == null) resetValueForKind();
+}
+
+const canApply = computed(() => {
+	if (!fieldname.value || !condition.value) return false;
+	if (valueKind.value === "isset") return true;
+	if (valueKind.value === "between") return value.value?.[0] && value.value?.[1];
+	return value.value !== "" && value.value != null;
+});
+
+function apply() {
+	if (!canApply.value) return;
+	emit("apply", {
+		fieldname: fieldname.value,
+		label: selectedField.value?.label || fieldname.value,
+		fieldtype: fieldtype.value,
+		options: selectedField.value?.options || "",
+		condition: condition.value,
+		value: Array.isArray(value.value) ? [...value.value] : value.value,
+	});
+}
+</script>
+
+<template>
+	<div
+		class="bg-white border border-ink-200 shadow-lg p-3 w-[30rem] max-w-full"
+		style="border-radius: 10px"
+	>
+		<div class="flex items-start gap-2">
+			<!-- Field -->
+			<DeskSelect v-model="fieldname" class="!w-40 flex-shrink-0">
+				<option v-for="f in sortedFields" :key="f.fieldname" :value="f.fieldname">
+					{{ f.label }}
+				</option>
+			</DeskSelect>
+
+			<!-- Condition -->
+			<DeskSelect v-model="condition" class="!w-32 flex-shrink-0">
+				<option v-for="[op, label] in conditions" :key="op" :value="op">{{ label }}</option>
+			</DeskSelect>
+
+			<!-- Value -->
+			<div class="flex-1 min-w-0">
+				<DeskLinkPicker
+					v-if="valueKind === 'link'"
+					v-model="value"
+					:doctype="selectedField?.options || 'DocType'"
+					placeholder="Select…"
+				/>
+				<DeskSelect v-else-if="valueKind === 'select'" v-model="value">
+					<option value="">—</option>
+					<option v-for="o in selectOptions" :key="o" :value="o">{{ o }}</option>
+				</DeskSelect>
+				<DeskSelect v-else-if="valueKind === 'check'" v-model="value">
+					<option value="1">Yes</option>
+					<option value="0">No</option>
+				</DeskSelect>
+				<DeskSelect v-else-if="valueKind === 'isset'" v-model="value">
+					<option value="set">Set</option>
+					<option value="not set">Not Set</option>
+				</DeskSelect>
+				<DeskSelect v-else-if="valueKind === 'timespan'" v-model="value">
+					<option value="">—</option>
+					<option v-for="t in TIMESPANS" :key="t" :value="t">{{ t }}</option>
+				</DeskSelect>
+				<div v-else-if="valueKind === 'between'" class="flex items-center gap-1">
+					<input v-model="value[0]" type="date" class="desk-input flex-1" />
+					<span class="text-ink-400 text-xs">–</span>
+					<input v-model="value[1]" type="date" class="desk-input flex-1" />
+				</div>
+				<input
+					v-else-if="valueKind === 'date'"
+					v-model="value"
+					type="date"
+					class="desk-input w-full"
+				/>
+				<input
+					v-else-if="valueKind === 'datetime'"
+					v-model="value"
+					type="datetime-local"
+					class="desk-input w-full"
+				/>
+				<input
+					v-else-if="valueKind === 'number'"
+					v-model="value"
+					type="number"
+					class="desk-input w-full"
+					placeholder="Value"
+				/>
+				<input
+					v-else-if="valueKind === 'multi'"
+					v-model="value"
+					type="text"
+					class="desk-input w-full"
+					placeholder="Comma-separated values"
+				/>
+				<input
+					v-else
+					v-model="value"
+					type="text"
+					class="desk-input w-full"
+					placeholder="Value"
+					@keyup.enter="apply"
+				/>
+			</div>
+		</div>
+
+		<div class="flex items-center justify-end gap-2 mt-3">
+			<button
+				type="button"
+				class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+				@click="emit('cancel')"
+			>
+				Cancel
+			</button>
+			<button
+				type="button"
+				class="text-xs desk-save-btn"
+				:disabled="!canApply"
+				:class="{ 'opacity-50 cursor-not-allowed': !canApply }"
+				@click="apply"
+			>
+				Apply
+			</button>
+		</div>
+	</div>
+</template>

--- a/frontend/src/components/desk/DeskFilterEditor.vue
+++ b/frontend/src/components/desk/DeskFilterEditor.vue
@@ -83,7 +83,11 @@ const sortedFields = computed(() =>
 
 const fieldname = ref(props.initial?.fieldname || sortedFields.value[0]?.fieldname || "");
 const condition = ref(props.initial?.condition || "");
-const value = ref(props.initial?.value ?? "");
+// Copy array values (multi / between) so editing chips before Apply — or cancelling —
+// never mutates the live filter still held in the list.
+const value = ref(
+	Array.isArray(props.initial?.value) ? [...props.initial.value] : (props.initial?.value ?? "")
+);
 
 const selectedField = computed(
 	() => props.fields.find((f) => f.fieldname === fieldname.value) || null
@@ -135,9 +139,27 @@ const selectOptions = computed(() =>
 
 function resetValueForKind() {
 	if (valueKind.value === "between") value.value = ["", ""];
+	else if (valueKind.value === "multi") value.value = [];
 	else if (valueKind.value === "isset") value.value = "set";
 	else if (valueKind.value === "check") value.value = "1";
 	else value.value = "";
+}
+
+// --- multi-value (`in` / `not in`) helpers ---------------------------------------
+const multiPickerKey = ref(0); // bump to remount the Link "add" picker so it clears
+function addMultiItem(v) {
+	const val = String(v ?? "").trim();
+	if (!val) return;
+	if (!Array.isArray(value.value)) value.value = [];
+	if (!value.value.includes(val)) value.value.push(val);
+	multiPickerKey.value += 1;
+}
+function addMultiFromInput(e) {
+	addMultiItem(e.target.value);
+	e.target.value = "";
+}
+function removeMultiItem(i) {
+	value.value.splice(i, 1);
 }
 
 // Keep condition valid when the field changes; reset value when the control shape changes.
@@ -159,6 +181,7 @@ const canApply = computed(() => {
 	if (!fieldname.value || !condition.value) return false;
 	if (valueKind.value === "isset") return true;
 	if (valueKind.value === "between") return value.value?.[0] && value.value?.[1];
+	if (valueKind.value === "multi") return Array.isArray(value.value) && value.value.length > 0;
 	return value.value !== "" && value.value != null;
 });
 
@@ -250,13 +273,50 @@ function apply() {
 					class="desk-input w-full"
 					placeholder="Value"
 				/>
-				<input
-					v-else-if="valueKind === 'multi'"
-					v-model="value"
-					type="text"
-					class="desk-input w-full"
-					placeholder="Comma-separated values"
-				/>
+				<div v-else-if="valueKind === 'multi'" class="space-y-1">
+					<div v-if="value.length" class="flex flex-wrap gap-1">
+						<span
+							v-for="(item, i) in value"
+							:key="i"
+							class="inline-flex items-center gap-1 text-[11px] px-2 py-0.5 bg-ink-100 text-ink-700"
+							style="border-radius: 9999px"
+						>
+							{{ item }}
+							<button
+								type="button"
+								class="text-ink-500 hover:text-ink-800 leading-none"
+								aria-label="Remove"
+								@click="removeMultiItem(i)"
+							>
+								×
+							</button>
+						</span>
+					</div>
+					<!-- Add control: link picker for Link fields, option list for Select, else a tag input. -->
+					<DeskLinkPicker
+						v-if="fieldtype === 'Link' && selectedField?.options"
+						:key="`multi-${selectedField.options}-${multiPickerKey}`"
+						:model-value="''"
+						:doctype="selectedField.options"
+						placeholder="Add…"
+						@update:model-value="addMultiItem"
+					/>
+					<DeskSelect
+						v-else-if="fieldtype === 'Select'"
+						:model-value="''"
+						@update:model-value="addMultiItem"
+					>
+						<option value="">Add…</option>
+						<option v-for="o in selectOptions" :key="o" :value="o">{{ o }}</option>
+					</DeskSelect>
+					<input
+						v-else
+						type="text"
+						class="desk-input w-full"
+						placeholder="Type a value and press Enter"
+						@keyup.enter="addMultiFromInput"
+					/>
+				</div>
 				<input
 					v-else
 					v-model="value"

--- a/frontend/src/components/desk/DeskFilterEditor.vue
+++ b/frontend/src/components/desk/DeskFilterEditor.vue
@@ -8,6 +8,7 @@
 // Emits `apply` with { fieldname, label, fieldtype, options, condition, value } or `cancel`.
 import { ref, computed, watch } from "vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 
 const props = defineProps({
@@ -79,6 +80,11 @@ const TIMESPANS = [
 
 const sortedFields = computed(() =>
 	[...props.fields].sort((a, b) => String(a.label).localeCompare(String(b.label)))
+);
+// Options for the searchable field picker — the fieldname shows as a hint so
+// same-labelled fields stay distinguishable.
+const fieldOptions = computed(() =>
+	sortedFields.value.map((f) => ({ value: f.fieldname, label: f.label, hint: f.fieldname }))
 );
 
 const fieldname = ref(props.initial?.fieldname || sortedFields.value[0]?.fieldname || "");
@@ -204,12 +210,14 @@ function apply() {
 		style="border-radius: 10px"
 	>
 		<div class="flex items-start gap-2">
-			<!-- Field -->
-			<DeskSelect v-model="fieldname" class="!w-40 flex-shrink-0">
-				<option v-for="f in sortedFields" :key="f.fieldname" :value="f.fieldname">
-					{{ f.label }}
-				</option>
-			</DeskSelect>
+			<!-- Field (searchable — doctypes can have many fields) -->
+			<DeskSearchableSelect
+				v-model="fieldname"
+				:options="fieldOptions"
+				placeholder="Field"
+				search-placeholder="Search fields…"
+				class="w-44 flex-shrink-0"
+			/>
 
 			<!-- Condition -->
 			<DeskSelect v-model="condition" class="!w-32 flex-shrink-0">

--- a/frontend/src/components/desk/DeskFilterEditor.vue
+++ b/frontend/src/components/desk/DeskFilterEditor.vue
@@ -196,10 +196,19 @@ function apply() {
 			<!-- Value -->
 			<div class="flex-1 min-w-0">
 				<DeskLinkPicker
-					v-if="valueKind === 'link'"
+					v-if="valueKind === 'link' && selectedField?.options"
+					:key="selectedField.options"
 					v-model="value"
-					:doctype="selectedField?.options || 'DocType'"
+					:doctype="selectedField.options"
 					placeholder="Select…"
+				/>
+				<!-- Link field without a resolvable target doctype (e.g. Dynamic Link): fall back to text. -->
+				<input
+					v-else-if="valueKind === 'link'"
+					v-model="value"
+					type="text"
+					class="desk-input w-full"
+					placeholder="Value"
 				/>
 				<DeskSelect v-else-if="valueKind === 'select'" v-model="value">
 					<option value="">—</option>

--- a/frontend/src/components/doctype/DocTypeListView.vue
+++ b/frontend/src/components/doctype/DocTypeListView.vue
@@ -226,7 +226,9 @@ function toServerFilter(f) {
 			return v === "" || v == null ? null : [field, f.condition, `%${v}%`];
 		case "in":
 		case "not in": {
-			const list = String(v ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+			const list = Array.isArray(v)
+				? v.filter(Boolean)
+				: String(v ?? "").split(",").map((s) => s.trim()).filter(Boolean);
 			return list.length ? [field, f.condition, list] : null;
 		}
 		case "is":
@@ -244,6 +246,10 @@ function toServerFilter(f) {
 
 function openFilterEditor() {
 	editingFilterIndex.value = -1;
+	filterEditorOpen.value = true;
+}
+function editFilter(i) {
+	editingFilterIndex.value = i;
 	filterEditorOpen.value = true;
 }
 function onFilterApply(filter) {
@@ -268,10 +274,12 @@ const CONDITION_SYMBOL = {
 	is: "is", ">": ">", "<": "<", ">=": "≥", "<=": "≤", Between: "between", Timespan: "in",
 };
 function chipLabel(f) {
-	let text = String(f.value ?? "");
+	let text;
 	if (f.condition === "is") text = f.value === "not set" ? "Not Set" : "Set";
 	else if (f.condition === "Between" && Array.isArray(f.value)) text = `${f.value[0]} – ${f.value[1]}`;
+	else if (Array.isArray(f.value)) text = f.value.join(", ");
 	else if (f.fieldtype === "Check") text = f.value === "0" || f.value === 0 ? "No" : "Yes";
+	else text = String(f.value ?? "");
 	return `${f.label} ${CONDITION_SYMBOL[f.condition] || f.condition} ${text}`.trim();
 }
 
@@ -716,12 +724,15 @@ function onPageSizeChange(value) {
 					:meta-loading="metaLoading"
 					:fields="resolvedFields"
 				/>
-				<DeskFilterChip
+				<span
 					v-for="(f, i) in dynamicFilters"
 					:key="i"
-					:label="chipLabel(f)"
-					@remove="removeFilter(i)"
-				/>
+					class="cursor-pointer"
+					title="Click to edit"
+					@click="editFilter(i)"
+				>
+					<DeskFilterChip :label="chipLabel(f)" @remove="removeFilter(i)" />
+				</span>
 				<button
 					v-if="dynamicFilters.length"
 					type="button"

--- a/frontend/src/components/doctype/DocTypeListView.vue
+++ b/frontend/src/components/doctype/DocTypeListView.vue
@@ -1,6 +1,8 @@
 <script setup>
 import { computed, ref, watch } from "vue";
 import DeskList from "@/components/desk/DeskList.vue";
+import DeskFilterChip from "@/components/desk/DeskFilterChip.vue";
+import DeskFilterEditor from "@/components/desk/DeskFilterEditor.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import { fmtDate } from "@/utils/format";
 import { useDocTypeList } from "@/composables/useDocTypeList";
@@ -176,6 +178,103 @@ const resolvedColumns = computed(() => {
 	});
 });
 
+// --- Dynamic (ad-hoc) filters — Frappe-style field/condition/value builder ---------
+// Layout / no-value fieldtypes can't be filtered on, so they're excluded from the picker.
+const NO_VALUE_FIELDTYPES = new Set([
+	"Section Break", "Column Break", "Tab Break", "HTML", "Table", "Table MultiSelect",
+	"Button", "Image", "Fold", "Heading", "Signature", "Geolocation",
+]);
+const STANDARD_FILTER_FIELDS = [
+	{ fieldname: "name", label: "ID", fieldtype: "Data" },
+	{ fieldname: "owner", label: "Created By", fieldtype: "Link", options: "User" },
+	{ fieldname: "creation", label: "Created On", fieldtype: "Datetime" },
+	{ fieldname: "modified", label: "Last Updated On", fieldtype: "Datetime" },
+	{ fieldname: "modified_by", label: "Last Updated By", fieldtype: "Link", options: "User" },
+	{ fieldname: "_assign", label: "Assigned To", fieldtype: "Data" },
+	{ fieldname: "idx", label: "Index", fieldtype: "Int" },
+];
+// Fields offered in the filter editor: standard metadata + the doctype's own
+// value-bearing fields, mirroring Frappe's list filter field list.
+const filterableFields = computed(() => {
+	const out = [...STANDARD_FILTER_FIELDS];
+	const seen = new Set(out.map((f) => f.fieldname));
+	for (const f of meta.value?.fields || []) {
+		if (!f?.fieldname || NO_VALUE_FIELDTYPES.has(f.fieldtype) || seen.has(f.fieldname)) continue;
+		out.push({
+			fieldname: f.fieldname,
+			label: f.label || f.fieldname,
+			fieldtype: f.fieldtype,
+			options: f.options,
+		});
+		seen.add(f.fieldname);
+	}
+	return out;
+});
+
+const dynamicFilters = ref([]); // [{ fieldname, label, fieldtype, options, condition, value }]
+const filterEditorOpen = ref(false);
+const editingFilterIndex = ref(-1);
+
+// One dynamic filter -> a [field, operator, value] tuple the backend understands
+// (frappe.client.get_list / reportview). Returns null when the value is empty.
+function toServerFilter(f) {
+	const field = f.fieldname;
+	const v = f.value;
+	switch (f.condition) {
+		case "like":
+		case "not like":
+			return v === "" || v == null ? null : [field, f.condition, `%${v}%`];
+		case "in":
+		case "not in": {
+			const list = String(v ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+			return list.length ? [field, f.condition, list] : null;
+		}
+		case "is":
+			return [field, "is", v || "set"];
+		case "Between": {
+			const [a, b] = Array.isArray(v) ? v : [];
+			return a && b ? [field, "between", [a, b]] : null;
+		}
+		case "Timespan":
+			return v ? [field, "timespan", v] : null;
+		default:
+			return v === "" || v == null ? null : [field, f.condition, v];
+	}
+}
+
+function openFilterEditor() {
+	editingFilterIndex.value = -1;
+	filterEditorOpen.value = true;
+}
+function onFilterApply(filter) {
+	if (editingFilterIndex.value >= 0) {
+		dynamicFilters.value.splice(editingFilterIndex.value, 1, filter);
+	} else {
+		dynamicFilters.value.push(filter);
+	}
+	filterEditorOpen.value = false;
+	editingFilterIndex.value = -1;
+}
+function removeFilter(i) {
+	dynamicFilters.value.splice(i, 1);
+}
+function clearFilters() {
+	dynamicFilters.value = [];
+}
+
+// Chip text: "Label operator value".
+const CONDITION_SYMBOL = {
+	"=": "=", "!=": "≠", like: "like", "not like": "not like", in: "in", "not in": "not in",
+	is: "is", ">": ">", "<": "<", ">=": "≥", "<=": "≤", Between: "between", Timespan: "in",
+};
+function chipLabel(f) {
+	let text = String(f.value ?? "");
+	if (f.condition === "is") text = f.value === "not set" ? "Not Set" : "Set";
+	else if (f.condition === "Between" && Array.isArray(f.value)) text = `${f.value[0]} – ${f.value[1]}`;
+	else if (f.fieldtype === "Check") text = f.value === "0" || f.value === 0 ? "No" : "Yes";
+	return `${f.label} ${CONDITION_SYMBOL[f.condition] || f.condition} ${text}`.trim();
+}
+
 const serverFilters = computed(() => {
 	const filters = [...props.baseFilters];
 	for (const [key, value] of Object.entries(props.filterValues || {})) {
@@ -189,6 +288,10 @@ const serverFilters = computed(() => {
 		} else if (spec.field) {
 			filters.push([spec.field, spec.op || "=", spec.like ? `%${value}%` : value]);
 		}
+	}
+	for (const f of dynamicFilters.value) {
+		const sf = toServerFilter(f);
+		if (sf) filters.push(sf);
 	}
 	return filters;
 });
@@ -564,10 +667,23 @@ function onPageSizeChange(value) {
 </script>
 
 <template>
-	<div>
+	<div class="relative">
 		<div v-if="metaError" class="mb-2 text-xs text-danger-600">
 			Failed to load {{ doctype }} metadata.
 		</div>
+
+		<!-- Dynamic filter editor (Frappe-style field/condition/value builder) -->
+		<template v-if="filterEditorOpen">
+			<div class="fixed inset-0 z-30" @click="filterEditorOpen = false"></div>
+			<div class="absolute left-0 top-12 z-40">
+				<DeskFilterEditor
+					:fields="filterableFields"
+					:initial="editingFilterIndex >= 0 ? dynamicFilters[editingFilterIndex] : null"
+					@apply="onFilterApply"
+					@cancel="filterEditorOpen = false"
+				/>
+			</div>
+		</template>
 
 		<DeskList
 			v-model="search"
@@ -590,6 +706,7 @@ function onPageSizeChange(value) {
 			@update:sort-direction="sortDirection = $event"
 			@page-change="onPageChange"
 			@page-size-change="onPageSizeChange"
+			@add-filter="openFilterEditor"
 		>
 			<template #filter-chips>
 				<slot
@@ -599,6 +716,20 @@ function onPageSizeChange(value) {
 					:meta-loading="metaLoading"
 					:fields="resolvedFields"
 				/>
+				<DeskFilterChip
+					v-for="(f, i) in dynamicFilters"
+					:key="i"
+					:label="chipLabel(f)"
+					@remove="removeFilter(i)"
+				/>
+				<button
+					v-if="dynamicFilters.length"
+					type="button"
+					class="text-[11px] text-ink-500 hover:text-ink-800 px-1"
+					@click="clearFilters"
+				>
+					Clear
+				</button>
 			</template>
 
 			<template #actions>


### PR DESCRIPTION
## What
Implements a generic **field + condition + value** filter builder on `DocTypeListView`, modelled on Frappe's `frappe.ui.Filter`.

### `DeskFilterEditor.vue` (new)
A popover with three controls:
- **Field** — the doctype's value-bearing fields + standard metadata (`name`, `owner`, `creation`, `modified`, `modified_by`, `_assign`, `idx`).
- **Condition** — Frappe's exact condition list, filtered by the per-fieldtype `invalid_condition_map` (e.g. `Between`/`Timespan` hidden for `Data`/`Link`; `Check` → only `=`; numeric fields drop `like`; `Date`/`Datetime` get Before/After labels).
- **Value** — control chosen by fieldtype/condition: **Link picker**, **Select**, **date** (two inputs for `Between`), **Timespan** list, **is** → set/not set, **in/not in** → comma list, number, or text.

### `DocTypeListView.vue`
- Dynamic filters merge into the existing `serverFilters` as `[field, op, value]` tuples — `like → %v%`, `in → [...]`, `Between → between`, `Timespan → timespan`, `is → set/not set` — so the existing refetch + count wiring just works.
- Active filters render as removable chips with a **Clear**; the existing **+ Add filter** button now opens the editor.

## Scope
- **On by default** for every `DocTypeListView` (coexists with the predefined `filter-chips` slot views already use).
- Filters are **in-memory** — they reset when you leave the list (no persistence), per the agreed scope.

Frontend builds clean.