### PR TITLE
feat: JV expense line → BOQ cost code (feeds BOQ actual)

### DIFF
--- a/buildsuite_core/api/boq_actuals.py
+++ b/buildsuite_core/api/boq_actuals.py
@@ -19,6 +19,7 @@ Rails (all post on Submit, reverse on Cancel):
   Material Consumption   qty x valuation rate  (Stock Entry.total_outgoing_value)  -> "Material"
   Subcontractor Bill     this-period amount    (Subcontractor Bill Line)           -> "Subcontract"
   Expense Entry          expense amount        (Expense Entry Table)               -> "Overhead"
+  Journal Entry          line debit            (Journal Entry Account.debit)        -> "Overhead"
 
 Cost is recognised at consumption, not at purchase — a Purchase Receipt increases stock but
 does not touch BOQ actual. The Subcontractor Work Order (Committed) is a separate promise and
@@ -168,13 +169,76 @@ def _expense_entries(project):
 	return out
 
 
+def _journal_entries(project):
+	"""Submitted Journal Entry (JV) expense lines charged to a cost code — direct GL spend booked
+	by a Journal Voucher. The line's DEBIT is the expense; the cost code + project live on the
+	Journal Entry Account row (a credit leg carries no debit, so it self-excludes). Child-row
+	docstatus mirrors the parent, so filtering docstatus=1 selects lines of submitted JEs."""
+	rows = frappe.get_all(
+		"Journal Entry Account",
+		filters={
+			"project": project,
+			"docstatus": 1,
+			"custom_cost_code_type": ["in", ["Group", "Item"]],
+		},
+		fields=[
+			"name",
+			"parent",
+			"account",
+			"debit_in_account_currency",
+			"custom_cost_code_type",
+			"custom_cost_code_group",
+			"custom_cost_code_item",
+			"custom_cost_code_label",
+			"user_remark",
+		],
+	)
+	if not rows:
+		return []
+	parents = {
+		je.name: je
+		for je in frappe.get_all(
+			"Journal Entry",
+			filters={"name": ["in", list({r.parent for r in rows})]},
+			fields=["name", "posting_date"],
+		)
+	}
+	out = []
+	for r in rows:
+		amount = flt(r.debit_in_account_currency)
+		if not (r.custom_cost_code_group or r.custom_cost_code_item) or amount == 0:
+			continue
+		je = parents.get(r.parent)
+		out.append(
+			{
+				"cost_code_type": r.custom_cost_code_type,
+				"group_code": r.custom_cost_code_group or "",
+				"item_code": r.custom_cost_code_item or "",
+				"cost_type": "Overhead",
+				"amount": amount,
+				"source_doctype": "Journal Entry",
+				"source_name": r.parent,
+				"source_line": r.name,
+				"party": r.account or None,
+				"date": str(je.posting_date) if je and je.posting_date else None,
+				"label": r.custom_cost_code_label or r.user_remark or "",
+			}
+		)
+	return out
+
+
 def _actual_entries(project):
 	"""The full actuals log for a project — one line per contributing source line, across all
-	three rails. Derived live from submitted documents (never stored). This is the single source
+	rails. Derived live from submitted documents (never stored). This is the single source
 	the summary and the drill-down both read, so they can never disagree (R2)."""
 	if not project:
 		return []
-	return _material_entries(project) + _subcontract_entries(project) + _expense_entries(project)
+	return (
+		_material_entries(project)
+		+ _subcontract_entries(project)
+		+ _expense_entries(project)
+		+ _journal_entries(project)
+	)
 
 
 # The cost types a group row reports, in display order. A type with no source shows "— pending",

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -440,13 +440,16 @@ CUSTOM_FIELD = {
 		# Charge a JV expense line to a BOQ cost code — the same four fields as Stock Entry /
 		# Subcontractor Bill Line, so the actuals log (buildsuite_core.api.boq_actuals) folds a
 		# Journal Entry debit into BOQ actual by cost code, and CostCodePicker.vue-style logic
-		# works unchanged. `project` is native on Journal Entry Account.
+		# works unchanged. `project` is native on Journal Entry Account (surfaced in the grid via
+		# a property setter). Type + Cost Code show as grid columns so the feature is discoverable
+		# without expanding the row.
 		{
 			"fieldname": "custom_cost_code_type",
 			"fieldtype": "Select",
 			"label": "Cost Code Type",
 			"options": "\nGroup\nItem",
 			"insert_after": "project",
+			"in_list_view": 1,
 			"module": "BuildSuite Core",
 		},
 		{
@@ -473,6 +476,7 @@ CUSTOM_FIELD = {
 			"insert_after": "custom_cost_code_item",
 			"depends_on": "eval:doc.custom_cost_code_type",
 			"read_only": 1,
+			"in_list_view": 1,
 			"module": "BuildSuite Core",
 		},
 	],

--- a/buildsuite_core/custom_property_list/custom_field.py
+++ b/buildsuite_core/custom_property_list/custom_field.py
@@ -436,6 +436,46 @@ CUSTOM_FIELD = {
 			"module": "BuildSuite Core",
 		},
 	],
+	"Journal Entry Account": [
+		# Charge a JV expense line to a BOQ cost code — the same four fields as Stock Entry /
+		# Subcontractor Bill Line, so the actuals log (buildsuite_core.api.boq_actuals) folds a
+		# Journal Entry debit into BOQ actual by cost code, and CostCodePicker.vue-style logic
+		# works unchanged. `project` is native on Journal Entry Account.
+		{
+			"fieldname": "custom_cost_code_type",
+			"fieldtype": "Select",
+			"label": "Cost Code Type",
+			"options": "\nGroup\nItem",
+			"insert_after": "project",
+			"module": "BuildSuite Core",
+		},
+		{
+			"fieldname": "custom_cost_code_group",
+			"fieldtype": "Data",
+			"label": "Cost Code Group",
+			"insert_after": "custom_cost_code_type",
+			"depends_on": "eval:doc.custom_cost_code_type",
+			"module": "BuildSuite Core",
+		},
+		{
+			# Only an Item pick carries one; a Group pick leaves it empty.
+			"fieldname": "custom_cost_code_item",
+			"fieldtype": "Data",
+			"label": "Cost Code Item",
+			"insert_after": "custom_cost_code_group",
+			"depends_on": 'eval:doc.custom_cost_code_type=="Item"',
+			"module": "BuildSuite Core",
+		},
+		{
+			"fieldname": "custom_cost_code_label",
+			"fieldtype": "Data",
+			"label": "Cost Code",
+			"insert_after": "custom_cost_code_item",
+			"depends_on": "eval:doc.custom_cost_code_type",
+			"read_only": 1,
+			"module": "BuildSuite Core",
+		},
+	],
 	"Purchase Order Item": [
 		{
 			"fieldname": "custom_rate_master",

--- a/buildsuite_core/custom_property_list/property_field.py
+++ b/buildsuite_core/custom_property_list/property_field.py
@@ -27,6 +27,17 @@ def get_property_setters():
 			"property_type": "Text",
 		},
 		{
+			# Show the (native) per-line Project in the Journal Entry accounts grid, so a JV
+			# expense line can be charged to a project + BOQ cost code inline — set Project, then
+			# pick a Cost Code Type (journal_entry.js opens the code picker). Feeds BOQ actual.
+			"doctype_or_field": "DocField",
+			"doctype": "Journal Entry Account",
+			"fieldname": "project",
+			"property": "in_list_view",
+			"value": "1",
+			"property_type": "Check",
+		},
+		{
 			"name": "Project-status-options",
 			"doctype_or_field": "DocField",
 			"doctype": "Project",

--- a/buildsuite_core/public/js/journal_entry.js
+++ b/buildsuite_core/public/js/journal_entry.js
@@ -40,3 +40,76 @@ frappe.ui.form.on("Journal Entry", {
 		});
 	},
 });
+
+// --- BOQ cost code on a JV expense line ------------------------------------------------------
+// Charge an expense line to a BOQ cost code so its debit lands in BOQ actual
+// (buildsuite_core.api.boq_actuals). Set the line's Project, then pick a Cost Code Type — a
+// picker lists that project's Approved-BOQ codes (buildsuite_core.api.subcontract
+// .get_project_cost_codes) and stamps the group / item / read-only label.
+frappe.ui.form.on("Journal Entry Account", {
+	custom_cost_code_type(frm, cdt, cdn) {
+		const row = locals[cdt][cdn];
+		if (!row.custom_cost_code_type) {
+			set_cost_code(cdt, cdn, {});
+			return;
+		}
+		if (!row.project) {
+			frappe.msgprint(__("Set the Project on this line first, then pick a cost code."));
+			frappe.model.set_value(cdt, cdn, "custom_cost_code_type", "");
+			return;
+		}
+		pick_cost_code(cdt, cdn, row.project, row.custom_cost_code_type);
+	},
+
+	project(frm, cdt, cdn) {
+		// A code set against the old project is now stale — clear it.
+		const row = locals[cdt][cdn];
+		if (row.custom_cost_code_label) set_cost_code(cdt, cdn, {});
+	},
+});
+
+function set_cost_code(cdt, cdn, c) {
+	frappe.model.set_value(cdt, cdn, "custom_cost_code_group", c.group_code || "");
+	frappe.model.set_value(cdt, cdn, "custom_cost_code_item", c.item_code || "");
+	frappe.model.set_value(cdt, cdn, "custom_cost_code_label", c.label || "");
+}
+
+function pick_cost_code(cdt, cdn, project, type) {
+	frappe.call({
+		method: "buildsuite_core.api.subcontract.get_project_cost_codes",
+		args: { project },
+		callback: ({ message }) => {
+			const codes = (message || []).filter((c) => c.type === type);
+			if (!codes.length) {
+				frappe.msgprint(__("No {0} cost codes on this project's Approved BOQ.", [type]));
+				frappe.model.set_value(cdt, cdn, "custom_cost_code_type", "");
+				return;
+			}
+			const d = new frappe.ui.Dialog({
+				title: __("Pick Cost Code"),
+				fields: [
+					{
+						fieldname: "code",
+						fieldtype: "Select",
+						label: __("Cost Code"),
+						reqd: 1,
+						options: codes.map((c) => c.label),
+					},
+				],
+				primary_action_label: __("Select"),
+				primary_action(values) {
+					const c = codes.find((x) => x.label === values.code);
+					if (c) set_cost_code(cdt, cdn, c);
+					d.hide();
+				},
+			});
+			// Abandoning the picker clears the half-set type.
+			d.onhide = () => {
+				if (!locals[cdt][cdn].custom_cost_code_label) {
+					frappe.model.set_value(cdt, cdn, "custom_cost_code_type", "");
+				}
+			};
+			d.show();
+		},
+	});
+}

--- a/buildsuite_core/tests/test_cost_report.py
+++ b/buildsuite_core/tests/test_cost_report.py
@@ -89,3 +89,67 @@ class TestCostVsBudget(BuildSuiteTestCase):
 		res = cost_vs_budget_by_cost_code(p.name)
 		self.assertEqual(len(res["rows"]), 1)
 		self.assertEqual(res["rows"][0]["costType"], "Unclassified")
+
+	# --- Journal Entry (JV) actuals rail -----------------------------------------------------
+	def _account(self, root_type, account_type=None):
+		filters = {"company": self.company, "root_type": root_type, "is_group": 0}
+		if account_type:
+			filters["account_type"] = account_type
+		names = frappe.get_all("Account", filters=filters, limit=1, pluck="name")
+		return names[0] if names else None
+
+	def test_journal_entry_actual_by_cost_code(self):
+		"""A submitted JV expense line charged to a cost code books its debit into BOQ actual
+		(Overhead), and cancelling reverses it — same derived-getter behaviour as the other rails."""
+		from buildsuite_core.api.boq_actuals import get_actuals_summary
+
+		p = self._make_project(company=self.company)
+		b = self._boq(p.name)
+		g = self._group(b.name, code="A", name="Civil")
+		self._item(b.name, g.name, qty=10, rate=100, cost_head="Material")
+		boq_api.approve_boq(b.name)
+
+		expense_account = self._account("Expense")
+		cash_account = self._account("Asset", "Cash") or self._account("Asset")
+		cost_center = frappe.db.get_value("Company", self.company, "cost_center")
+
+		je = frappe.new_doc("Journal Entry")
+		je.company = self.company
+		je.posting_date = "2026-07-20"
+		je.append(
+			"accounts",
+			{
+				"account": expense_account,
+				"debit_in_account_currency": 5000,
+				"cost_center": cost_center,
+				"project": p.name,
+				"custom_cost_code_type": "Group",
+				"custom_cost_code_group": "A",
+				"custom_cost_code_label": "A · Civil",
+			},
+		)
+		je.append(
+			"accounts",
+			{"account": cash_account, "credit_in_account_currency": 5000, "cost_center": cost_center},
+		)
+		je.flags.ignore_permissions = True
+		je.insert()
+
+		# Draft JV contributes nothing (reads only submitted docs).
+		self.assertEqual(get_actuals_summary(p.name)["by_group"].get("A", {}).get("actual", 0), 0)
+
+		je.submit()
+		summary = get_actuals_summary(p.name)
+		self.assertAlmostEqual(summary["by_group"]["A"]["actual"], 5000, places=2)
+		self.assertAlmostEqual(summary["by_group"]["A"]["by_cost_type"]["Overhead"], 5000, places=2)
+
+		# The drill-down entry references the JV (its "BOQ actual hyperlink").
+		from buildsuite_core.api.boq_actuals import get_actuals_for_code
+
+		entries = get_actuals_for_code(p.name, group_code="A")["entries"]
+		je_entry = next(e for e in entries if e["source_doctype"] == "Journal Entry")
+		self.assertEqual(je_entry["source_name"], je.name)
+
+		# Cancelling reverses the contribution.
+		je.cancel()
+		self.assertEqual(get_actuals_summary(p.name)["by_group"].get("A", {}).get("actual", 0), 0)

--- a/docs/jv-cost-code-actuals.md
+++ b/docs/jv-cost-code-actuals.md
@@ -1,0 +1,95 @@
+# JV Expense → BOQ Cost Code → Actual
+
+Charge a **Journal Entry (JV)** expense line to a **BOQ cost code**, so direct GL spend posted by a
+Journal Voucher lands in **BOQ actual** — with a hyperlink from the BOQ drill-down back to the JV.
+
+Before this, only three rails produced BOQ actual (Material Consumption, Subcontractor Bill,
+Expense Entry). The Journal Entry is the fourth.
+
+---
+
+## Where a user does it (Desk Journal Entry)
+
+The JV is the standard **Desk** Journal Entry form (`/app/journal-entry`). The cost code lives on
+each **accounts line** (the `Journal Entry Account` child row), which is where an expense is
+recognised.
+
+On each line, three columns are shown in the accounts grid:
+
+| Column | Field | Notes |
+|---|---|---|
+| **Project** | `project` (native) | Set this first — cost codes are resolved per project. |
+| **Cost Code Type** | `custom_cost_code_type` | `Group` or `Item`. Picking it opens the code picker. |
+| **Cost Code** | `custom_cost_code_label` | Read-only result, e.g. `A · Civil`. |
+
+**Flow:** on an expense (debit) line, set **Project** → set **Cost Code Type** → a dialog lists that
+project's **Approved-BOQ** cost codes → pick one. The line's group/item/label are stamped. Only the
+line's **debit** books to actual, so the balancing credit leg needs no code.
+
+> If nothing appears, hard-refresh the form (`Ctrl/Cmd+Shift+R`). The fields are custom fields +
+> a property setter applied on migrate; the picker is a client script served from the built assets.
+
+---
+
+## The actuals rails (what feeds BOQ actual)
+
+BOQ actual is a **derived getter** (`buildsuite_core/api/boq_actuals.py`) — computed live from
+**submitted** source documents, never stored. Cost is recognised **at consumption**, not at
+request/order/receipt. Each rail carries a cost code and emits a source reference for the
+drill-down.
+
+| Source document | Amount used | Cost type | Feeds actual? |
+|---|---|---|---|
+| **Material Consumption** — Stock Entry / *Material Issue* | outgoing value | Material | ✅ |
+| **Subcontractor Bill** | this-period certified amount | Subcontract | ✅ |
+| **Expense Entry** | line amount | Overhead | ✅ |
+| **Journal Entry** *(this feature)* | line **debit** | Overhead | ✅ |
+| **Material Request (MR)** | — | — | ❌ a request is not spend |
+| **Purchase Order / Purchase Receipt** | — | — | ❌ cost recognised at consumption, not receipt |
+| **Subcontractor Work Order** | commitment | — | ❌ *Committed*, a separate column — not actual |
+
+So **Expense Entry and Subcontractor Bill already populate actual**, as does **Material
+Consumption** (the *Material Issue*, not the Material Request). This change adds **Journal Entry**.
+An **MR does not** feed actual, by design.
+
+---
+
+## The BOQ actual hyperlink (drill-down)
+
+Every rail emits `{source_doctype, source_name, source_line}`. The BOQ detail view
+(`frontend/src/views/BoqDetailView.vue`, `openActualSource`) turns that into a link to the source
+document:
+
+- Subcontractor Bill → in-app `/subcontractor-bills/<name>`
+- Stock Entry / Expense Entry / **Journal Entry** → Desk form in a new tab
+  (`/app/journal-entry/<name>`)
+
+---
+
+## Behaviour
+
+- **Submit** posts the contribution; **Cancel** removes it — the getter reads only submitted docs,
+  so reversal is automatic (no stored ledger to unwind).
+- Only the **debit** on a line contributes (a credit leg has debit = 0 and self-excludes).
+- JV expense is classed as **Overhead** (matching Expense Entry). If a JV should count as
+  Material/Labour/Plant, that would be a follow-up (derive from the expense account, or add a field).
+
+---
+
+## Implementation map
+
+| Area | File | Change |
+|---|---|---|
+| Line fields | `buildsuite_core/custom_property_list/custom_field.py` | 4 `custom_cost_code_*` fields on `Journal Entry Account` (type + label `in_list_view`) |
+| Grid Project | `buildsuite_core/custom_property_list/property_field.py` | property setter: `Journal Entry Account.project` `in_list_view` |
+| Desk picker | `buildsuite_core/public/js/journal_entry.js` | line-level cost-code picker (`get_project_cost_codes`) |
+| Actuals rail | `buildsuite_core/api/boq_actuals.py` | `_journal_entries` feeder, wired into `_actual_entries` |
+| Drill-down link | `frontend/src/views/BoqDetailView.vue` | Journal Entry → Desk hyperlink |
+| Test | `buildsuite_core/tests/test_cost_report.py` | `test_journal_entry_actual_by_cost_code` |
+
+## Deployment
+
+Fields + property setter apply automatically on **`bench migrate`** (`after_migrate` →
+`create_custom_fields` + `make_property_setters`). No separate patch. The client-script picker is
+served from the built app assets — run `bench build --app buildsuite_core` on deploy (part of the
+normal build). Cost codes come from the project's **Approved** BOQ only.

--- a/frontend/src/views/BoqDetailView.vue
+++ b/frontend/src/views/BoqDetailView.vue
@@ -476,6 +476,12 @@ function openActualSource(e) {
 			"_blank",
 			"noopener"
 		);
+	} else if (e.source_doctype === "Journal Entry") {
+		window.open(
+			`/app/journal-entry/${encodeURIComponent(e.source_name)}`,
+			"_blank",
+			"noopener"
+		);
 	}
 }
 const COST_TYPE_TONE = {


### PR DESCRIPTION
## What
A **Journal Entry (JV)** expense line can now carry a **Project + Cost Code**, so direct GL spend posted by a Journal Voucher books against a **BOQ cost code** and shows up in **BOQ actual** — previously only Material Consumption, Subcontractor Bill, and Expense Entry fed actual.

## Acceptance
- ✅ **Add Project + Cost Code on a JV expense line.** `Journal Entry Account` gets the four `custom_cost_code_*` fields (same set as Stock Entry / Subcontractor Bill Line); `project` is native on the line. A Desk picker (in `journal_entry.js`) lists the project's Approved-BOQ codes (`subcontract.get_project_cost_codes`) and stamps group/item/label.
- ✅ **BOQ reflects the right actual, referenced by the drill-down hyperlink.** A new `_journal_entries` rail in `boq_actuals.py` folds each submitted JV line's **debit** into BOQ actual by cost code (cost type *Overhead*), emitting `{source_doctype: "Journal Entry", source_name, source_line}`. `BoqDetailView.vue`'s actuals drill-down links a *Journal Entry* source to `/app/journal-entry/<name>` — the BOQ actual hyperlink.

## How it behaves
- Cost is recognised only on **submit** and reverses on **cancel** (the actuals log reads only submitted docs — same derived-getter model as the other rails).
- Only the **debit** contributes (a credit leg has no debit, so it self-excludes).

## Changes
| File | Change |
|---|---|
| `custom_property_list/custom_field.py` | 4 cost-code fields on `Journal Entry Account` (apply on migrate) |
| `public/js/journal_entry.js` | Desk line-level cost-code picker |
| `api/boq_actuals.py` | `_journal_entries` rail + wired into `_actual_entries` |
| `frontend/src/views/BoqDetailView.vue` | drill-down hyperlink for Journal Entry |
| `tests/test_cost_report.py` | JV actuals test (draft→0, submit→books, cancel→reverses) |

Test passes; frontend builds; `journal_entry.js` lints. Fields reach existing sites via `bench migrate` (`after_migrate`), no separate patch needed.