### PR TITLE
fix: allow deleting a cancelled invoice (not only draft)

### DIFF
--- a/buildsuite_core/api/invoice.py
+++ b/buildsuite_core/api/invoice.py
@@ -408,8 +408,9 @@ def cancel_invoice(name: str):
 def delete_invoice(name: str):
 	si = frappe.get_doc(SI, name)
 	si.check_permission("delete")
-	if si.docstatus != 0:
-		frappe.throw(_("Only a draft invoice can be deleted."))
+	# Draft (0) and Cancelled (2) can be deleted; a Submitted (1) invoice must be cancelled first.
+	if si.docstatus == 1:
+		frappe.throw(_("A submitted invoice must be cancelled before it can be deleted."))
 	frappe.delete_doc(SI, name)
 	return {"name": name, "deleted": True}
 

--- a/frontend/src/views/finance/FinanceInvoiceDetailView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceDetailView.vue
@@ -155,7 +155,7 @@ async function onWorkflowAction(action) {
 }
 async function onDelete() {
 	const ok = await confirmDialog({
-		title: "Delete draft?",
+		title: "Delete invoice?",
 		message: `Permanently delete ${inv.value.name}?`,
 		confirmLabel: "Delete",
 		destructive: true,
@@ -350,7 +350,7 @@ async function unlinkAdvance(row) {
 					Print / PDF
 				</button>
 				<button
-					v-if="isDraft && canDelete('salesInvoice')"
+					v-if="(isDraft || isCancelled) && canDelete('salesInvoice')"
 					type="button"
 					class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-danger-600 rounded-md"
 					:disabled="busy"


### PR DESCRIPTION
## Problem
BS Admin couldn't delete a **cancelled** Sales Invoice. Two gates blocked it:
- **Backend** `delete_invoice` threw *"Only a draft invoice can be deleted"* for anything not `docstatus 0` — so a cancelled invoice (docstatus 2) could never be removed, regardless of role.
- **Frontend** the Delete button was gated `v-if="isDraft && …"`, so it never appeared on a cancelled invoice.

BS Admin already holds delete permission (`SALES_INVOICE_ROLE_PERMS` = `_FULL_SUB`), so this was never a role/perm gap.

## Fix
ERPNext semantics: **draft (0)** and **cancelled (2)** are deletable; only a **submitted (1)** invoice must be cancelled first.
- Backend now blocks only `docstatus == 1` (*"A submitted invoice must be cancelled before it can be deleted"*). `check_permission("delete")` still gates by role.
- The detail-view Delete button shows for cancelled invoices too (`(isDraft || isCancelled) && canDelete('salesInvoice')`).

Py-checks; frontend builds.