### PR TITLE
fix: WO bill context 500 (AttributeError: no 'status') on migrated sites

### DIFF
--- a/buildsuite_core/api/subcontractor_bill.py
+++ b/buildsuite_core/api/subcontractor_bill.py
@@ -233,7 +233,7 @@ def list_bills(project: str | None = None):
 def get_wo_bill_context(work_order: str):
 	"""Everything the New (Work Order) bill screen needs: WO header, the derived this-period
 	lines (measured − previously billed), and the next RA number."""
-	from buildsuite_core.api.subcontract import get_wo_measurements
+	from buildsuite_core.api.subcontract import _wo_state, get_wo_measurements
 	from buildsuite_core.buildsuite_core.doctype.subcontractor_bill.subcontractor_bill import (
 		previously_billed_by_line,
 	)
@@ -270,7 +270,9 @@ def get_wo_bill_context(work_order: str):
 		"project_name": frappe.db.get_value("Project", wo.project, "project_name"),
 		"company": wo.company,
 		"retention_percent": wo.retention_percent,
-		"status": wo.status,
+		# Work Order state is derived from docstatus (Phase 2 dropped the stored `status` field);
+		# reading wo.status raised AttributeError on migrated sites that never had that field.
+		"status": _wo_state(wo),
 		"total_value": wo.total_value,
 		"next_ra_no": max([r for r in existing if r] or [0]) + 1,
 		"lines": lines,


### PR DESCRIPTION
## Symptom
Selecting a Work Order for a new Subcontractor Bill returned **500** on the migrated remote (fine locally):
```
AttributeError: 'SubcontractorWorkOrder' object has no attribute 'status'
  api/subcontractor_bill.py:273 in get_wo_bill_context  ->  "status": wo.status
```

## Cause
Phase 2 (`6efef5c`, *Work Order is natively submittable*) **dropped the stored `status` field** — WO state is now derived from `docstatus` via `_wo_state(doc)`. But `get_wo_bill_context` still read the raw `wo.status`.

- **Locally** it worked by accident: bs.local's `tabSubcontractor Work Order` still has a **leftover `status` column** from before the field was removed (Frappe doesn't drop columns), and `get_doc` loads every column — so `wo.status` returned the stale value.
- **On the remote**, the table was created fresh when the data was migrated into buildsuite_core, from the *current* doctype (no `status` field) → **no `status` column** → `AttributeError`.

Creating a bill *without* a WO worked because that path never calls `get_wo_bill_context`.

## Fix
Derive status from `docstatus` using the module's canonical `_wo_state(wo)` (`{0: Draft, 1: Submitted, 2: Cancelled}`) instead of the removed field — correct on every site regardless of leftover columns.

One line; py-checks. No schema/patch needed.