### PR TITLE
fix: reseed_site_execution_reports patch fails migrate on freshly-migrated sites

### DIFF
--- a/buildsuite_core/patches/reseed_site_execution_reports.py
+++ b/buildsuite_core/patches/reseed_site_execution_reports.py
@@ -1,18 +1,23 @@
 # Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
 # For license information, please see license.txt
 
-"""The Site Execution report set was reworked to match the prototype's Overview reports:
-Delay Analysis, Billing and Collection, Subcontractor Position, Material Status. This
-replaces the old set (Project Status Summary, Completed Tasks, Pending Progress Entries,
-Stage Plan vs Actual, Progress Entries) on sites seeded before the change — creates the
-new Query Reports, repoints the Site Execution workspace tiles, and removes the retired
-reports."""
+"""The Site Execution report set was reworked to match the prototype's Overview reports
+(Delay Analysis, Billing and Collection, Subcontractor Position, Material Status), replacing the
+old set (Project Status Summary, Completed Tasks, Pending Progress Entries, Stage Plan vs Actual,
+Progress Entries). This resets the Site Execution workspace tiles to the new set and removes the
+retired reports on sites seeded before the change.
+
+The report definitions now live as app-owned Script Reports (created on migrate), so this patch no
+longer creates Query Reports itself — it was originally written against a since-removed
+`_ensure_report` + 7-tuple `REPORTS`, which broke `bench migrate` on sites that migrate in later.
+Rewritten to the current API: `REPORTS` is now `(name, icon, desc)` and Delay Analysis is a
+bespoke in-app route."""
 
 import frappe
 
 from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import (
+	DELAY_ANALYSIS_ROUTE,
 	REPORTS,
-	_ensure_report,
 )
 
 RETIRED = (
@@ -25,11 +30,7 @@ RETIRED = (
 
 
 def execute():
-	# 1) Ensure the four new reports exist (query + filters + roles reconciled).
-	for report_name, ref_doctype, _icon, _desc, query, filters, roles in REPORTS:
-		_ensure_report(report_name, ref_doctype, query, filters, roles)
-
-	# 2) Reset the Site Execution workspace tiles to the new report set (keep other workspaces).
+	# Reset the Site Execution tiles to the current report set, keeping every other workspace's.
 	settings = frappe.get_single("Workspace Setting")
 	kept = [
 		{
@@ -46,15 +47,18 @@ def execute():
 	settings.set("reports", [])
 	for row in kept:
 		settings.append("reports", row)
-	for name, _ref, icon, desc, _q, _f, _r in REPORTS:
-		settings.append(
-			"reports",
-			{"workspace": "site-execution", "report": name, "icon": icon, "description": desc},
+	for name, icon, desc in REPORTS:
+		# Delay Analysis is a bespoke in-app view (a plain route); the rest reference Reports.
+		row = (
+			{"label": name, "route": DELAY_ANALYSIS_ROUTE, "icon": icon, "description": desc}
+			if name == "Delay Analysis"
+			else {"report": name, "icon": icon, "description": desc}
 		)
+		settings.append("reports", {"workspace": "site-execution", **row})
 	settings.flags.ignore_permissions = True
 	settings.save()
 
-	# 3) Remove the retired reports (app-owned, now superseded).
+	# Remove the retired reports (app-owned, now superseded).
 	for name in RETIRED:
 		if frappe.db.exists("Report", name):
 			frappe.delete_doc("Report", name, ignore_permissions=True, force=True)


### PR DESCRIPTION
## Symptom
`bench migrate` on a site the data was freshly migrated into dies with:
```
ImportError: cannot import name '_ensure_report' from
  buildsuite_core...workspace_setting.seed_workspace_reports
  (patches/reseed_site_execution_reports.py line 13)
```

## Cause
`reseed_site_execution_reports` imported `_ensure_report` and unpacked `REPORTS` as a **7-tuple**. A later rework (`8f71762`, reports became app-owned **Script Reports**) removed `_ensure_report` and changed `REPORTS` to `(name, icon, desc)` — the patch was never updated.

- Sites that ran it **before** the rework have it recorded as done → migrate **skips** it.
- A **freshly-migrated** site runs it for the first time → ImportError, aborting the patch phase. On Frappe Cloud that fails/rolls back the whole deploy, so merged fixes never go live.

## Fix
Rewritten to the current API (no `_ensure_report`): reset the Site Execution tiles to the current `REPORTS` set (Delay Analysis as an in-app route, the rest Report refs), keep other workspaces, and drop the retired reports. Verified clean on bs.local → [Delay Analysis, Billing and Collection, Subcontractor Position, Material Status]. Idempotent; py-compiles.