### PR TITLE
feat: auto-save drafts on field change (Subcontractor Bill / Invoice / Supplier Bill)

### DIFF
--- a/frontend/src/composables/useAutosave.js
+++ b/frontend/src/composables/useAutosave.js
@@ -1,0 +1,77 @@
+// Debounced, quiet auto-save for draft forms.
+//
+// Mirrors the StagePlanningDetailView inline-edit pattern: while a draft exists, field changes are
+// saved in the background — no spinner, no navigation, no reload — so the focused input is never
+// disrupted mid-keystroke. Saves are coalesced (never overlap; the latest wins), and errors are
+// swallowed on purpose: the explicit Save button stays the single place validation and save errors
+// surface (per product decision — auto-save skips silently when the form isn't saveable).
+//
+// The caller owns the gate via `canAutosave`, which MUST include the same access-control the Save
+// button uses (e.g. canEdit("salesInvoice")) plus "draft exists", "form valid", and a load-ready
+// flag — auto-save must never write where the button itself would be denied.
+//
+//   const { status } = useAutosave(form, quietSave, {
+//     canAutosave: () => ready.value && isEdit.value && canManage.value && isSaveable(),
+//   });
+//
+// `status` is "idle" | "saving" | "saved" for an optional subtle indicator.
+import { ref, watch, onScopeDispose } from "vue";
+
+export function useAutosave(source, saveFn, options = {}) {
+	const { canAutosave, delay = 1000 } = options;
+	const status = ref("idle");
+	let timer = null;
+	let inFlight = false;
+	let queued = false;
+	let savedResetTimer = null;
+
+	function allowed() {
+		return !canAutosave || canAutosave();
+	}
+
+	async function flush() {
+		if (!allowed()) return;
+		if (inFlight) {
+			// A change arrived while a save was in flight — run once more when it settles.
+			queued = true;
+			return;
+		}
+		inFlight = true;
+		status.value = "saving";
+		try {
+			await saveFn();
+			status.value = "saved";
+			clearTimeout(savedResetTimer);
+			savedResetTimer = setTimeout(() => {
+				if (status.value === "saved") status.value = "idle";
+			}, 2000);
+		} catch {
+			// Quiet: the manual Save button surfaces validation / save errors.
+			status.value = "idle";
+		} finally {
+			inFlight = false;
+			if (queued) {
+				queued = false;
+				flush();
+			}
+		}
+	}
+
+	const stop = watch(
+		source,
+		() => {
+			if (!allowed()) return;
+			clearTimeout(timer);
+			timer = setTimeout(flush, delay);
+		},
+		{ deep: true }
+	);
+
+	onScopeDispose(() => {
+		clearTimeout(timer);
+		clearTimeout(savedResetTimer);
+		stop();
+	});
+
+	return { status, flush };
+}

--- a/frontend/src/views/NewSubcontractorBillView.vue
+++ b/frontend/src/views/NewSubcontractorBillView.vue
@@ -6,10 +6,11 @@
 // Taxes, TDS, discount and retention overrides are edited on the detail page
 // (Draft-editable). Pre-fills the WO from ?work_order=… on the URL.
 
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, nextTick } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import { getBill, getWoBillContext, saveBill } from "@/data/subcontractApi";
+import { useAutosave } from "@/composables/useAutosave";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskForm from "@/components/desk/DeskForm.vue";
 import DeskActionBar from "@/components/desk/DeskActionBar.vue";
@@ -64,6 +65,8 @@ function costCodeFromLine(l) {
 const mode = ref("wo"); // 'wo' | 'direct'
 const saving = ref(false);
 const errors = ref({});
+// Auto-save only engages once an existing draft has finished loading into the form.
+const ready = ref(false);
 
 const form = ref({
 	work_order: route.query.work_order || "",
@@ -121,6 +124,9 @@ watch(
 						: [{ scope: "", cost_code: null, amount: 0 }],
 				};
 				if (!bill.is_direct) loadWoContext(bill.work_order);
+				// Arm auto-save after the watcher has flushed the load-population.
+				await nextTick();
+				ready.value = true;
 			} catch (err) {
 				showToast(err.message || "Failed to load bill", "error");
 			}
@@ -171,39 +177,49 @@ function validate() {
 	return Object.keys(e).length === 0;
 }
 
+// Payload shared by the explicit Save and the quiet auto-save.
+function buildPayload() {
+	return mode.value === "wo"
+		? {
+				name: editingId.value || undefined,
+				is_direct: 0,
+				work_order: form.value.work_order,
+				date: form.value.date,
+				supplier_invoice_no: form.value.supplier_invoice_no,
+				supplier_invoice_date: form.value.supplier_invoice_date || undefined,
+				retention_percent: form.value.retention_percent,
+		  }
+		: {
+				name: editingId.value || undefined,
+				is_direct: 1,
+				subcontractor: form.value.subcontractor,
+				project: form.value.project,
+				date: form.value.date,
+				supplier_invoice_no: form.value.supplier_invoice_no,
+				supplier_invoice_date: form.value.supplier_invoice_date || undefined,
+				retention_percent: form.value.retention_percent,
+				lines: form.value.lines
+					.filter((l) => (l.scope || "").trim() || Number(l.amount) > 0)
+					.map((l) => ({
+						scope: l.scope,
+						...costCodeForSave(l.cost_code),
+						amount: Number(l.amount) || 0,
+					})),
+		  };
+}
+
+// Silent validity gate for auto-save — mirrors validate() WITHOUT mutating the `errors` UI (so
+// typing never flashes errors). In edit mode the wo-mode "no fresh qty" check doesn't apply.
+function isSaveable() {
+	if (mode.value === "wo") return !!form.value.work_order;
+	return !!form.value.subcontractor && !!form.value.project && directGross.value > 0;
+}
+
 async function onSave() {
 	if (!validate()) return;
 	saving.value = true;
 	try {
-		const payload =
-			mode.value === "wo"
-				? {
-						name: editingId.value || undefined,
-						is_direct: 0,
-						work_order: form.value.work_order,
-						date: form.value.date,
-						supplier_invoice_no: form.value.supplier_invoice_no,
-						supplier_invoice_date: form.value.supplier_invoice_date || undefined,
-						retention_percent: form.value.retention_percent,
-				  }
-				: {
-						name: editingId.value || undefined,
-						is_direct: 1,
-						subcontractor: form.value.subcontractor,
-						project: form.value.project,
-						date: form.value.date,
-						supplier_invoice_no: form.value.supplier_invoice_no,
-						supplier_invoice_date: form.value.supplier_invoice_date || undefined,
-						retention_percent: form.value.retention_percent,
-						lines: form.value.lines
-							.filter((l) => (l.scope || "").trim() || Number(l.amount) > 0)
-							.map((l) => ({
-								scope: l.scope,
-								...costCodeForSave(l.cost_code),
-								amount: Number(l.amount) || 0,
-							})),
-				  };
-		const bill = await saveBill(payload);
+		const bill = await saveBill(buildPayload());
 		router.push(`/subcontractor-bills/${bill.name}`);
 	} catch (err) {
 		showToast(err.message || "Failed to save bill", "error");
@@ -211,6 +227,16 @@ async function onSave() {
 		saving.value = false;
 	}
 }
+
+// Quiet background update of the existing draft. The subcontractor-bill form has no frontend
+// permission gate on its Save button (backend-enforced), so auto-save adds none either — it
+// stays gated on draft-exists / loaded / valid, matching the button exactly.
+async function quietSave() {
+	await saveBill(buildPayload());
+}
+const { status: autosaveStatus } = useAutosave(form, quietSave, {
+	canAutosave: () => ready.value && isEdit.value && isSaveable(),
+});
 function onCancel() {
 	router.back();
 }
@@ -243,7 +269,16 @@ const breadcrumbs = computed(() => [
 					:saving="saving"
 					@save="onSave"
 					@cancel="onCancel"
-				/>
+				>
+					<template #left>
+						<span
+							v-if="isEdit && autosaveStatus !== 'idle'"
+							class="text-xs text-ink-400"
+						>
+							{{ autosaveStatus === "saving" ? "Saving…" : "Saved" }}
+						</span>
+					</template>
+				</DeskActionBar>
 			</template>
 
 			<!-- Mode toggle (create only) -->

--- a/frontend/src/views/finance/FinanceInvoiceFormView.vue
+++ b/frontend/src/views/finance/FinanceInvoiceFormView.vue
@@ -4,7 +4,7 @@
 // a non-Draft bounces to the detail page). Item lines (qty × rate), then taxes & discount
 // via templates + a live waterfall — the same pattern as the Subcontractor Bill. Saves a
 // draft Sales Invoice via api.invoice.
-import { computed, reactive, ref } from "vue";
+import { computed, reactive, ref, nextTick } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import {
@@ -23,6 +23,7 @@ import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import { activeCompanyFilter, useActiveCompany } from "@/composables/useActiveCompany";
 import { usePermissions } from "@/composables/usePermissions";
+import { useAutosave } from "@/composables/useAutosave";
 import { fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, default: "" } });
@@ -59,6 +60,9 @@ const termsOpen = ref(false);
 const errors = reactive({ customer: "", lines: "" });
 const saving = ref(false);
 const loading = ref(isEdit.value);
+// Auto-save only engages once an existing draft has finished loading into the form (so the
+// load-population itself never triggers a redundant save).
+const ready = ref(false);
 
 if (isEdit.value) {
 	getInvoice(props.id)
@@ -95,6 +99,10 @@ if (isEdit.value) {
 			});
 			if (!form.lines.length) form.lines = [blankLine()];
 			termsOpen.value = !!inv.terms;
+			// Arm auto-save after the watcher has flushed the load-population.
+			nextTick(() => {
+				ready.value = true;
+			});
 		})
 		.catch((err) => showToast(err.message || "Failed to load invoice", "error"))
 		.finally(() => (loading.value = false));
@@ -179,6 +187,44 @@ const breadcrumbs = computed(() => [
 	{ label: isEdit.value ? `Edit ${props.id}` : "New" },
 ]);
 
+// Payload shared by the explicit Save and the quiet auto-save.
+function buildPayload() {
+	const lines = form.lines.filter((l) => (l.description || "").trim() && lineAmount(l) > 0);
+	return {
+		name: isEdit.value ? props.id : undefined,
+		customer: form.customer,
+		project: form.project || undefined,
+		date: form.date,
+		due_date: form.due_date || undefined,
+		items: lines.map((l) => ({
+			description: l.description.trim(),
+			qty: Number(l.qty) || 1,
+			rate: Number(l.rate),
+		})),
+		taxes_and_charges: form.taxes_and_charges || undefined,
+		taxes: form.taxes
+			.filter((t) => t.account_head)
+			.map((t) => ({
+				charge_type: t.charge_type,
+				account_head: t.account_head,
+				description: t.description,
+				rate: Number(t.rate) || 0,
+			})),
+		additional_discount_on: form.discount_on,
+		additional_discount_percentage:
+			form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
+		discount_amount: form.discount_type === "₹" ? Number(form.discount_value) || 0 : 0,
+		tc_name: form.tc_name || undefined,
+		terms: form.terms || undefined,
+	};
+}
+
+// Silent validity gate for auto-save — mirrors save()'s checks WITHOUT mutating the `errors`
+// UI (so typing never flashes errors); the explicit Save still surfaces them.
+function isSaveable() {
+	return !!form.customer && form.lines.some((l) => (l.description || "").trim() && lineAmount(l) > 0);
+}
+
 async function save() {
 	errors.customer = "";
 	errors.lines = "";
@@ -189,33 +235,7 @@ async function save() {
 
 	saving.value = true;
 	try {
-		const res = await saveInvoice({
-			name: isEdit.value ? props.id : undefined,
-			customer: form.customer,
-			project: form.project || undefined,
-			date: form.date,
-			due_date: form.due_date || undefined,
-			items: lines.map((l) => ({
-				description: l.description.trim(),
-				qty: Number(l.qty) || 1,
-				rate: Number(l.rate),
-			})),
-			taxes_and_charges: form.taxes_and_charges || undefined,
-			taxes: form.taxes
-				.filter((t) => t.account_head)
-				.map((t) => ({
-					charge_type: t.charge_type,
-					account_head: t.account_head,
-					description: t.description,
-					rate: Number(t.rate) || 0,
-				})),
-			additional_discount_on: form.discount_on,
-			additional_discount_percentage:
-				form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
-			discount_amount: form.discount_type === "₹" ? Number(form.discount_value) || 0 : 0,
-			tc_name: form.tc_name || undefined,
-			terms: form.terms || undefined,
-		});
+		const res = await saveInvoice(buildPayload());
 		showToast(isEdit.value ? "Invoice updated." : "Invoice saved as draft.");
 		router.push(`/project-finance/invoices/${res.name}`);
 	} catch (err) {
@@ -224,6 +244,15 @@ async function save() {
 		saving.value = false;
 	}
 }
+
+// Quiet background update of the existing draft. Gated on the SAME permission the Save button
+// uses (canSaveInvoice), plus draft-exists / loaded / valid — never writes where Save is denied.
+async function quietSave() {
+	await saveInvoice(buildPayload());
+}
+const { status: autosaveStatus } = useAutosave(form, quietSave, {
+	canAutosave: () => ready.value && isEdit.value && canSaveInvoice.value && isSaveable(),
+});
 </script>
 
 <template>
@@ -246,7 +275,16 @@ async function save() {
 					:saving="saving"
 					@save="save"
 					@cancel="router.back()"
-				/>
+				>
+					<template #left>
+						<span
+							v-if="isEdit && autosaveStatus !== 'idle'"
+							class="text-xs text-ink-400"
+						>
+							{{ autosaveStatus === "saving" ? "Saving…" : "Saved" }}
+						</span>
+					</template>
+				</DeskActionBar>
 			</template>
 
 			<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Loading…</div>

--- a/frontend/src/views/finance/FinanceSupplierBillFormView.vue
+++ b/frontend/src/views/finance/FinanceSupplierBillFormView.vue
@@ -6,7 +6,7 @@
 //   · Direct — no PO: pick the supplier and enter Item-master lines manually.
 // Item lines carry a real Item (qty × rate), then taxes & discount via templates + a live
 // waterfall, and terms. Mirrors the customer-invoice form.
-import { computed, reactive, ref } from "vue";
+import { computed, reactive, ref, nextTick } from "vue";
 import { useRouter } from "vue-router";
 import { showToast } from "@/utils/appToast";
 import {
@@ -26,6 +26,7 @@ import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
 import { activeCompanyFilter } from "@/composables/useActiveCompany";
 import { usePermissions } from "@/composables/usePermissions";
+import { useAutosave } from "@/composables/useAutosave";
 import { fmtINR } from "@/utils/format";
 
 const props = defineProps({ id: { type: String, default: "" } });
@@ -80,6 +81,8 @@ const termsOpen = ref(false);
 const errors = reactive({ supplier: "", po: "", lines: "" });
 const saving = ref(false);
 const loading = ref(isEdit.value);
+// Auto-save only engages once an existing draft has finished loading into the form.
+const ready = ref(false);
 
 if (isEdit.value) {
 	getSupplierBill(props.id)
@@ -127,6 +130,10 @@ if (isEdit.value) {
 			});
 			if (!form.lines.length) form.lines = [blankLine()];
 			termsOpen.value = !!b.terms;
+			// Arm auto-save after the watcher has flushed the load-population.
+			nextTick(() => {
+				ready.value = true;
+			});
 		})
 		.catch((err) => showToast(err.message || "Failed to load bill", "error"))
 		.finally(() => (loading.value = false));
@@ -244,6 +251,53 @@ const breadcrumbs = computed(() => [
 	{ label: isEdit.value ? `Edit ${props.id}` : "New supplier bill" },
 ]);
 
+// Payload shared by the explicit Save and the quiet auto-save.
+function buildPayload() {
+	const lines = form.lines.filter((l) => (l.item_code || l.description) && lineAmount(l) > 0);
+	return {
+		name: isEdit.value ? props.id : undefined,
+		supplier: form.supplier,
+		project: form.project || undefined,
+		bill_no: form.bill_no || undefined,
+		bill_date: form.bill_date || undefined,
+		date: form.date,
+		due_date: form.due_date || undefined,
+		items: lines.map((l) => ({
+			item_code: l.item_code || undefined,
+			description: (l.description || "").trim(),
+			qty: Number(l.qty) || 1,
+			uom: l.uom || undefined,
+			rate: Number(l.rate),
+			purchase_order: l.purchase_order || undefined,
+			po_detail: l.po_detail || undefined,
+		})),
+		taxes_and_charges: form.taxes_and_charges || undefined,
+		taxes: form.taxes
+			.filter((t) => t.account_head)
+			.map((t) => ({
+				charge_type: t.charge_type,
+				account_head: t.account_head,
+				description: t.description,
+				rate: Number(t.rate) || 0,
+			})),
+		additional_discount_on: form.discount_on,
+		additional_discount_percentage:
+			form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
+		discount_amount: form.discount_type === "₹" ? Number(form.discount_value) || 0 : 0,
+		tc_name: form.tc_name || undefined,
+		terms: form.terms || undefined,
+	};
+}
+
+// Silent validity gate for auto-save — mirrors save()'s checks WITHOUT mutating the `errors` UI.
+function isSaveable() {
+	return (
+		!!form.supplier &&
+		(mode.value !== "po" || !!form.purchase_order) &&
+		form.lines.some((l) => (l.item_code || l.description) && lineAmount(l) > 0)
+	);
+}
+
 async function save() {
 	errors.supplier = "";
 	errors.po = "";
@@ -256,39 +310,7 @@ async function save() {
 
 	saving.value = true;
 	try {
-		const res = await saveSupplierBill({
-			name: isEdit.value ? props.id : undefined,
-			supplier: form.supplier,
-			project: form.project || undefined,
-			bill_no: form.bill_no || undefined,
-			bill_date: form.bill_date || undefined,
-			date: form.date,
-			due_date: form.due_date || undefined,
-			items: lines.map((l) => ({
-				item_code: l.item_code || undefined,
-				description: (l.description || "").trim(),
-				qty: Number(l.qty) || 1,
-				uom: l.uom || undefined,
-				rate: Number(l.rate),
-				purchase_order: l.purchase_order || undefined,
-				po_detail: l.po_detail || undefined,
-			})),
-			taxes_and_charges: form.taxes_and_charges || undefined,
-			taxes: form.taxes
-				.filter((t) => t.account_head)
-				.map((t) => ({
-					charge_type: t.charge_type,
-					account_head: t.account_head,
-					description: t.description,
-					rate: Number(t.rate) || 0,
-				})),
-			additional_discount_on: form.discount_on,
-			additional_discount_percentage:
-				form.discount_type === "%" ? Number(form.discount_value) || 0 : 0,
-			discount_amount: form.discount_type === "₹" ? Number(form.discount_value) || 0 : 0,
-			tc_name: form.tc_name || undefined,
-			terms: form.terms || undefined,
-		});
+		const res = await saveSupplierBill(buildPayload());
 		showToast(isEdit.value ? "Bill updated." : "Bill saved as draft.");
 		router.push(`/project-finance/supplier-bills/${res.name}`);
 	} catch (err) {
@@ -297,6 +319,15 @@ async function save() {
 		saving.value = false;
 	}
 }
+
+// Quiet background update of the existing draft. Gated on the SAME permission the Save button
+// uses (canSaveBill), plus draft-exists / loaded / valid — never writes where Save is denied.
+async function quietSave() {
+	await saveSupplierBill(buildPayload());
+}
+const { status: autosaveStatus } = useAutosave(form, quietSave, {
+	canAutosave: () => ready.value && isEdit.value && canSaveBill.value && isSaveable(),
+});
 </script>
 
 <template>
@@ -319,7 +350,16 @@ async function save() {
 					:saving="saving"
 					@save="save"
 					@cancel="router.back()"
-				/>
+				>
+					<template #left>
+						<span
+							v-if="isEdit && autosaveStatus !== 'idle'"
+							class="text-xs text-ink-400"
+						>
+							{{ autosaveStatus === "saving" ? "Saving…" : "Saved" }}
+						</span>
+					</template>
+				</DeskActionBar>
 			</template>
 
 			<div v-if="loading" class="py-16 text-center text-sm text-ink-400">Loading…</div>


### PR DESCRIPTION
## What
While editing an existing **draft**, field changes now **auto-save** in the background — no more relying solely on the Save button. Applies to **Subcontractor Bill**, **Invoice** (Sales Invoice), and **Supplier Bill** forms.

Reuses the `StagePlanningDetailView` inline-edit approach via a new **`composables/useAutosave.js`**: debounced, **quiet** (no spinner, no navigation, no reload — the focused input is never disrupted), saves **coalesced** (latest wins, never overlapping), errors swallowed.

## Scope
- **Only after the draft exists** — new forms still need the first **Create** click; from then on (and whenever you reopen a draft) edits auto-save. A load-ready flag stops the initial load-population from triggering a redundant save.
- **Skips silently when invalid** — a silent `isSaveable()` gate that never flashes the `errors` UI; the explicit **Save** button stays and remains the single place validation/save errors surface.
- **Same access-control as the Save button** — gated on `canEdit("salesInvoice")` / `canEdit("supplierBill")` for the finance forms; the subcontractor-bill form has no frontend permission gate (backend-enforced), so auto-save adds none either. Auto-save never writes where the button would be denied.

## UX
- The **Save button is unchanged** (explicit commit + fallback).
- A subtle **"Saving… / Saved"** indicator sits at the left of the action bar (edit mode only).

Frontend builds clean.