### PR TITLE
feat: import a project template into an existing project (⋯ menu)

### DIFF
--- a/buildsuite_core/utils/project.py
+++ b/buildsuite_core/utils/project.py
@@ -227,16 +227,38 @@ def seed_from_template_on_insert(doc, method=None):
 	if not template_name:
 		return
 	template = frappe.get_doc("Project Template", template_name)
+	_apply_template(doc, template, seed_wps, seed_stages, seed_tasks)
+
+
+def _apply_template(project_doc, template, seed_wps, seed_stages, seed_tasks):
+	"""Append a Project Template's Work Packages, Tasks and Stages onto a project — the single
+	seeding path shared by the create-time hook AND the post-creation import (⋯ menu). Existing
+	data is always kept: a Work Package whose `code` already exists on the project is reused
+	(never duplicated), and tasks/stages are appended. Tasks link to their Work Package by the
+	template's work-package code, resolving to an existing WP when one is present. Returns
+	{"work_packages", "tasks", "stages"} — the count of each NEWLY created."""
+	created = {"work_packages": 0, "tasks": 0, "stages": 0}
+
+	# Existing Work Packages by code, so a re-import reuses them (keep both, no duplicate code)
+	# and tasks can link to an existing WP even when Work Packages aren't being (re)imported.
+	wp_by_code = {
+		wp.code: wp.name
+		for wp in frappe.get_all(
+			"Work Package", filters={"project": project_doc.name}, fields=["name", "code"]
+		)
+		if wp.code
+	}
 
 	# --- Work Packages -----------------------------------------------------
-	wp_by_code = {}
 	if seed_wps:
 		for row in sorted(template.custom_work_packages, key=lambda r: r.sort_order or 0):
+			if row.code in wp_by_code:
+				continue  # keep the existing Work Package with this code
 			try:
 				wp = frappe.get_doc(
 					{
 						"doctype": "Work Package",
-						"project": doc.name,
+						"project": project_doc.name,
 						"code": row.code,
 						"work_package_name": row.work_package_name,
 						"budget": row.budget or 0,
@@ -245,15 +267,16 @@ def seed_from_template_on_insert(doc, method=None):
 					}
 				).insert(ignore_permissions=True)
 				wp_by_code[row.code] = wp.name
+				created["work_packages"] += 1
 			except Exception:
 				frappe.log_error(
 					frappe.get_traceback(),
-					f'BuildSuite: seed work package "{row.code}" for project "{doc.name}"',
+					f'BuildSuite: seed work package "{row.code}" for project "{project_doc.name}"',
 				)
 
 	# --- Tasks (undated; scheduled later on the Gantt) — linked to their WP ---
-	# Remember which seeded tasks belong to which template stage so the stages
-	# below can pick them up into their stage_planning_tasks list.
+	# Remember which seeded tasks belong to which template stage so the stages below can pick
+	# them up into their stage_planning_tasks list.
 	tasks_by_stage = {}
 	if seed_tasks:
 		for row in template.tasks:
@@ -262,7 +285,7 @@ def seed_from_template_on_insert(doc, method=None):
 				task = frappe.get_doc(
 					{
 						"doctype": "Task",
-						"project": doc.name,
+						"project": project_doc.name,
 						"subject": tt.subject,
 						"priority": tt.priority or "Medium",
 						"expected_time": tt.expected_time or 0,
@@ -270,21 +293,53 @@ def seed_from_template_on_insert(doc, method=None):
 						"task_status": "Yet To Start",
 					}
 				).insert(ignore_permissions=True)
+				created["tasks"] += 1
 				stage = row.get("custom_stage")
 				if stage:
 					tasks_by_stage.setdefault(stage, []).append(task.name)
 			except Exception:
 				frappe.log_error(
 					frappe.get_traceback(),
-					f'BuildSuite: seed task "{row.task}" for project "{doc.name}"',
+					f'BuildSuite: seed task "{row.task}" for project "{project_doc.name}"',
 				)
 
 	# --- Stages (planned dates from the template offsets, clamped to bounds) ---
 	if seed_stages:
 		try:
-			_seed_stages_from_template(doc, template, tasks_by_stage)
+			created["stages"] = _seed_stages_from_template(project_doc, template, tasks_by_stage)
 		except Exception:
-			frappe.log_error(frappe.get_traceback(), f'BuildSuite: seed stages for project "{doc.name}"')
+			frappe.log_error(
+				frappe.get_traceback(), f'BuildSuite: seed stages for project "{project_doc.name}"'
+			)
+
+	return created
+
+
+@frappe.whitelist()
+def import_project_template(project: str, work_packages=0, stages=0, tasks=0, project_category: str | None = None):
+	"""Import a Project Template into an EXISTING project (⋯ menu → Import project template).
+	Appends the chosen layers — the project's existing Work Packages / Tasks / Stages are kept.
+	Defaults to the project's own Project Category template; pass `project_category` to import a
+	different category's template. Returns {ok, category, work_packages, tasks, stages}."""
+	from frappe.utils import cint
+
+	doc = frappe.get_doc("Project", project)
+	doc.check_permission("write")
+
+	category = project_category or doc.get("project_category")
+	if not category:
+		frappe.throw(_("This project has no Project Category, so there is no template to import."))
+	template_name = frappe.db.get_value("Project Template", {"project_category": category}, "name")
+	if not template_name:
+		frappe.throw(_("No template is configured for category {0}.").format(category))
+
+	seed_wps, seed_stages, seed_tasks = cint(work_packages), cint(stages), cint(tasks)
+	if not (seed_wps or seed_stages or seed_tasks):
+		frappe.throw(_("Choose at least one of Work Packages, Stages or Tasks to import."))
+
+	template = frappe.get_doc("Project Template", template_name)
+	created = _apply_template(doc, template, bool(seed_wps), bool(seed_stages), bool(seed_tasks))
+	return {"ok": True, "category": category, **created}
 
 
 @frappe.whitelist()

--- a/frontend/src/data/projectTemplateApi.js
+++ b/frontend/src/data/projectTemplateApi.js
@@ -1,0 +1,43 @@
+// Thin wrapper over the buildsuite_core.utils.project template methods — the category-template
+// preview and the post-creation import (⋯ menu → Import project template).
+function serverMessage(data, status) {
+	if (data?._server_messages) {
+		try {
+			const first = JSON.parse(data._server_messages)[0];
+			const parsed = JSON.parse(first);
+			if (parsed?.message) return String(parsed.message).replace(/<[^>]*>/g, "");
+		} catch {
+			/* fall through */
+		}
+	}
+	return data?.exception || data?.exc_type || `Request failed (${status})`;
+}
+
+async function call(method, args) {
+	const res = await fetch(`/api/method/buildsuite_core.utils.project.${method}`, {
+		method: "POST",
+		credentials: "include",
+		headers: {
+			"Content-Type": "application/json",
+			"X-Frappe-CSRF-Token": window.csrf_token || "",
+		},
+		body: JSON.stringify(args || {}),
+	});
+	const data = await res.json().catch(() => ({}));
+	if (!res.ok) throw new Error(serverMessage(data, res.status));
+	return data.message;
+}
+
+// Preview of a category's template: { exists, stage_names, stage_count, work_package_count, task_count }.
+export const getProjectTemplateSummary = (projectCategory) =>
+	call("get_project_template_summary", { project_category: projectCategory });
+
+// Import the category template into an existing project, appending the chosen layers (existing
+// data is kept). `opts` = { workPackages, stages, tasks } booleans. Returns counts created.
+export const importProjectTemplate = (project, { workPackages, stages, tasks } = {}) =>
+	call("import_project_template", {
+		project,
+		work_packages: workPackages ? 1 : 0,
+		stages: stages ? 1 : 0,
+		tasks: tasks ? 1 : 0,
+	});

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -18,6 +18,7 @@ import { fetchProjectBounds } from "@/utils/projectBounds";
 import StatusBadge from "@/components/StatusBadge.vue";
 import UserAvatar from "@/components/UserAvatar.vue";
 import ConfirmDialog from "@/components/ConfirmDialog.vue";
+import { importProjectTemplate } from "@/data/projectTemplateApi";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskList from "@/components/desk/DeskList.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
@@ -871,6 +872,42 @@ async function confirmDelete() {
 	}
 }
 
+// --- Import project template (⋯ menu) — append the category template's Work Packages / Stages
+//     / Tasks onto this EXISTING project. Existing data is kept (see import_project_template).
+//     Reuses `templateSummary` (already loaded from the project's category via loadTemplateSummary).
+const importOpen = ref(false);
+const importSaving = ref(false);
+const importOpts = ref({ workPackages: true, stages: true, tasks: true });
+
+function openImportTemplate() {
+	importOpts.value = { workPackages: true, stages: true, tasks: true };
+	importOpen.value = true;
+}
+const importDisabled = computed(
+	() =>
+		importSaving.value ||
+		!(importOpts.value.workPackages || importOpts.value.stages || importOpts.value.tasks)
+);
+async function runImportTemplate() {
+	importSaving.value = true;
+	try {
+		const r = await importProjectTemplate(resolvedProjectId.value, importOpts.value);
+		importOpen.value = false;
+		showToast(
+			`Imported ${r.work_packages} work packages, ${r.tasks} tasks and ${r.stages} stages.`
+		);
+		// Refresh the affected lists so the imported records appear straight away.
+		workPackagesResource.value?.reload?.();
+		tasksResource.value?.reload?.();
+		stageListRef.value?.reload?.();
+		projectResource.value?.reload?.();
+	} catch (err) {
+		showToast(parseFrappeError(err).summary || "Failed to import template", "error");
+	} finally {
+		importSaving.value = false;
+	}
+}
+
 function addSubproject() {
 	// Nested subprojects are not allowed — guard the action even though the
 	// entry button is hidden by `isSubproject`.
@@ -1114,7 +1151,7 @@ usePageTitle(() => project.value?.name);
 			>
 				Edit
 			</button>
-			<div v-if="canDelete('project')" class="relative">
+			<div v-if="canEdit('project') || canDelete('project')" class="relative">
 				<button
 					type="button"
 					class="text-xs px-2 py-1 border border-ink-200 bg-white hover:bg-ink-50 text-ink-600 flex items-center"
@@ -1138,6 +1175,23 @@ usePageTitle(() => project.value?.name);
 					role="menu"
 				>
 					<button
+						v-if="canEdit('project')"
+						type="button"
+						role="menuitem"
+						class="w-full text-left px-3 py-1.5 text-xs text-ink-700 hover:bg-ink-50"
+						@click="
+							menuOpen = false;
+							openImportTemplate();
+						"
+					>
+						Import project template
+					</button>
+					<div
+						v-if="canEdit('project') && canDelete('project')"
+						class="my-1 border-t border-ink-100"
+					></div>
+					<button
+						v-if="canDelete('project')"
 						type="button"
 						role="menuitem"
 						class="w-full text-left px-3 py-1.5 text-xs text-danger-700 hover:bg-danger-50"
@@ -1854,6 +1908,91 @@ usePageTitle(() => project.value?.name);
 			:loading="deleteLoading"
 			@confirm="confirmDelete"
 		/>
+
+		<!-- Import project template — append the category template's layers onto this project -->
+		<Teleport to="body">
+			<div
+				v-if="importOpen"
+				class="fixed inset-0 bg-ink-900/40 z-[60] flex items-start justify-center p-6"
+				@click.self="importOpen = false"
+			>
+				<div
+					class="bg-white border border-ink-200 w-full max-w-md shadow-xl flex flex-col"
+					style="border-radius: 12px"
+					@click.stop
+				>
+					<header
+						class="px-4 py-3 border-b border-ink-200 flex items-center justify-between"
+					>
+						<h2 class="text-sm font-semibold text-ink-900">Import project template</h2>
+						<button
+							type="button"
+							class="text-ink-400 hover:text-ink-900"
+							aria-label="Close"
+							@click="importOpen = false"
+						>
+							✕
+						</button>
+					</header>
+
+					<div class="px-4 py-4 space-y-3">
+						<template v-if="templateSummary">
+							<p class="text-xs text-ink-600">
+								From the <strong>{{ project.type }}</strong> template. Your existing
+								tasks, stages and work packages are kept — the template is added on
+								top.
+							</p>
+							<label class="flex items-center gap-2 text-sm text-ink-800">
+								<input v-model="importOpts.workPackages" type="checkbox" />
+								Work Packages
+								<span class="text-ink-400"
+									>({{ templateSummary.work_package_count }})</span
+								>
+							</label>
+							<label class="flex items-center gap-2 text-sm text-ink-800">
+								<input v-model="importOpts.stages" type="checkbox" />
+								Stages
+								<span class="text-ink-400">({{ templateSummary.stage_count }})</span>
+							</label>
+							<label class="flex items-center gap-2 text-sm text-ink-800">
+								<input v-model="importOpts.tasks" type="checkbox" />
+								Tasks
+								<span class="text-ink-400">({{ templateSummary.task_count }})</span>
+							</label>
+						</template>
+						<p v-else class="text-sm text-ink-500">
+							No template is configured for this project's category<template
+								v-if="project?.type"
+							>
+								("{{ project.type }}")</template
+							>.
+						</p>
+					</div>
+
+					<footer
+						class="px-4 py-3 border-t border-ink-200 flex items-center justify-end gap-2"
+					>
+						<button
+							type="button"
+							class="text-xs px-3 py-1.5 border border-ink-200 bg-white hover:bg-ink-50 text-ink-700 rounded-md"
+							@click="importOpen = false"
+						>
+							Cancel
+						</button>
+						<button
+							v-if="templateSummary"
+							type="button"
+							class="text-xs desk-save-btn"
+							:disabled="importDisabled"
+							:class="{ 'opacity-50 cursor-not-allowed': importDisabled }"
+							@click="runImportTemplate"
+						>
+							{{ importSaving ? "Importing…" : "Import" }}
+						</button>
+					</footer>
+				</div>
+			</div>
+		</Teleport>
 	</DeskPage>
 
 	<AccessDenied


### PR DESCRIPTION
## What
Adds **Import project template** to the project **⋯ menu** (next to Delete), so a project can pull in its category template's **Work Packages / Stages / Tasks** *after* it's been created — not just at creation.

A dialog shows the template's counts with per-layer checkboxes and a note that **your existing data is kept** (the template is added on top).

## Keep-both semantics
The seeding is append-only. A **Work Package whose `code` already exists is reused, never duplicated**, so re-importing doesn't create dup codes; **tasks and stages append**. Imported tasks link to the existing WP of the same code.

Verified on bs.local: first import → **4 WP / 9 tasks / 4 stages**; re-import → **0 WP / +9 tasks / +4 stages**.

## Backend
- Extracted the create-time seeding into a shared **`_apply_template(project, template, wps, stages, tasks)`** — returns counts created.
- `seed_from_template_on_insert` now calls it (behaviour unchanged on new projects, which have no existing WPs).
- New whitelisted **`import_project_template(project, work_packages, stages, tasks[, project_category])`** — gated on project **write**; defaults to the project's own category template.

## Frontend
- `data/projectTemplateApi.js` wrapper.
- The ⋯ menu now shows for **editors** too (Import gated on `canEdit('project')`, Delete on `canDelete('project')`) — auto-save-style: never exposes an action the user lacks permission for.
- Reuses the view's existing `templateSummary`; reloads the Work Package / Task / Stage lists after import so the new records appear immediately.

Frontend builds clean; backend py-checks + functionally tested.