### PR TITLE
feat: Labour Attendance Register filters + total-wages subtitle

### DIFF
--- a/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.py
+++ b/buildsuite_core/buildsuite_core/doctype/field_attendance/field_attendance.py
@@ -398,6 +398,7 @@ def create_registers(doc_name):
 				reference=doc.name,
 				comments=row.comments,
 				wage_rate=row.labour_rate,
+				task=doc.task,
 			)
 
 		if flt(row.overtime_hours) > 0 and row.employee not in existing_ot:
@@ -409,6 +410,7 @@ def create_registers(doc_name):
 				reference=doc.name,
 				comments=row.comments,
 				overtime_rate=row.overtime_rate,
+				task=doc.task,
 			)
 
 
@@ -427,7 +429,7 @@ def cancel_registers(doc_name):
 			reg.cancel()
 
 
-def create_labour_attendance(employee, date, project, status, reference, comments, wage_rate):
+def create_labour_attendance(employee, date, project, status, reference, comments, wage_rate, task=None):
 	doc = frappe.get_doc(
 		{
 			"doctype": "Labour Attendance Register",
@@ -436,6 +438,7 @@ def create_labour_attendance(employee, date, project, status, reference, comment
 			"project": project,
 			"status": status,
 			"wage_rate": wage_rate,
+			"task": task,
 			REGISTER_SOURCE_FIELD: reference,
 			"comments": comments,
 		}
@@ -445,7 +448,7 @@ def create_labour_attendance(employee, date, project, status, reference, comment
 
 
 def create_overtime_attendance(
-	employee, date, project, overtime_hours, reference, comments, overtime_rate
+	employee, date, project, overtime_hours, reference, comments, overtime_rate, task=None
 ):
 	doc = frappe.get_doc(
 		{
@@ -455,6 +458,7 @@ def create_overtime_attendance(
 			"project": project,
 			"overtime_rate": overtime_rate,
 			OT_HOURS_FIELD: overtime_hours,
+			"task": task,
 			REGISTER_SOURCE_FIELD: reference,
 			"comments": comments,
 		}

--- a/buildsuite_core/buildsuite_core/doctype/labour_attendance_register/labour_attendance_register.json
+++ b/buildsuite_core/buildsuite_core/doctype/labour_attendance_register/labour_attendance_register.json
@@ -17,6 +17,8 @@
   "company",
   "project",
   "project_name",
+  "task",
+  "task_subject",
   "comments",
   "details_section",
   "wage_rate",
@@ -117,6 +119,19 @@
    "fieldname": "project_name",
    "fieldtype": "Data",
    "label": "Project Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "task",
+   "fieldtype": "Link",
+   "label": "Task",
+   "options": "Task"
+  },
+  {
+   "fieldname": "task_subject",
+   "fieldtype": "Data",
+   "label": "Task Subject",
+   "fetch_from": "task.subject",
    "read_only": 1
   },
   {

--- a/buildsuite_core/buildsuite_core/doctype/overtime_attendance_register/overtime_attendance_register.json
+++ b/buildsuite_core/buildsuite_core/doctype/overtime_attendance_register/overtime_attendance_register.json
@@ -16,6 +16,8 @@
   "overtime_date",
   "project",
   "project_name",
+  "task",
+  "task_subject",
   "company",
   "comments",
   "wage_detail_section",
@@ -100,6 +102,19 @@
    "fieldname": "project_name",
    "fieldtype": "Data",
    "label": "Project Name",
+   "read_only": 1
+  },
+  {
+   "fieldname": "task",
+   "fieldtype": "Link",
+   "label": "Task",
+   "options": "Task"
+  },
+  {
+   "fieldname": "task_subject",
+   "fieldtype": "Data",
+   "label": "Task Subject",
+   "fetch_from": "task.subject",
    "read_only": 1
   },
   {

--- a/frontend/src/views/LabourAttendanceListView.vue
+++ b/frontend/src/views/LabourAttendanceListView.vue
@@ -1,20 +1,91 @@
 <script setup>
 // Labour Attendance Register — read-only. Rows are generated when a Field
-// Attendance sheet is submitted, never created by hand here.
+// Attendance sheet is submitted, never created by hand here. Filters (project,
+// worker, status, date range) + a total-daily-wages subtitle mirror the prototype
+// (S216). Task/Day-Type columns need source data on the register doctype.
 
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskSelect from "@/components/desk/DeskSelect.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import StatusBadge from "@/components/StatusBadge.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectOptions } from "@/composables/useProjectOptions";
+import { useFieldEmployeeOptions } from "@/composables/useFieldEmployeeOptions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const { projectOptions, projectLabel } = useProjectOptions();
+const { workerOptions } = useFieldEmployeeOptions();
+
+const STATUSES = ["Full Day", "Half Day", "Absent"];
 
 const projectFilter = ref("");
-const filterValues = computed(() => ({ project: projectFilter.value }));
+const workerFilter = ref("");
+const statusFilter = ref("");
+const fromFilter = ref("");
+const toFilter = ref("");
+
+const filterValues = computed(() => ({
+	project: projectFilter.value,
+	worker: workerFilter.value,
+	status: statusFilter.value,
+	from: fromFilter.value,
+	to: toFilter.value,
+}));
+// worker → the employee link; the date range targets attendance_date via op.
+const filterFieldMap = {
+	project: "project",
+	worker: "employee",
+	status: "status",
+	from: { field: "attendance_date", op: ">=" },
+	to: { field: "attendance_date", op: "<=" },
+};
+
+const anyFilter = computed(() =>
+	Object.values(filterValues.value).some((v) => v)
+);
+function clearFilters() {
+	projectFilter.value = "";
+	workerFilter.value = "";
+	statusFilter.value = "";
+	fromFilter.value = "";
+	toFilter.value = "";
+}
+
+// Total daily wages across the WHOLE filtered set (not just the visible page) —
+// a single SQL sum with the same filters, shown as the page subtitle.
+const totalWages = ref(0);
+function currentServerFilters() {
+	const f = [["docstatus", "<", 2]];
+	if (projectFilter.value) f.push(["project", "=", projectFilter.value]);
+	if (workerFilter.value) f.push(["employee", "=", workerFilter.value]);
+	if (statusFilter.value) f.push(["status", "=", statusFilter.value]);
+	if (fromFilter.value) f.push(["attendance_date", ">=", fromFilter.value]);
+	if (toFilter.value) f.push(["attendance_date", "<=", toFilter.value]);
+	return f;
+}
+async function loadTotal() {
+	try {
+		const params = new URLSearchParams({
+			doctype: "Labour Attendance Register",
+			fields: JSON.stringify(["sum(daily_wage_calculated) as total"]),
+			filters: JSON.stringify(currentServerFilters()),
+		});
+		const res = await fetch("/api/method/frappe.client.get_list?" + params, {
+			credentials: "include",
+			headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+		});
+		const data = await res.json();
+		totalWages.value = Number(data?.message?.[0]?.total) || 0;
+	} catch {
+		totalWages.value = 0;
+	}
+}
+watch(filterValues, loadTotal, { immediate: true, deep: true });
+
+const subtitle = computed(() => `Total daily wages ${fmtINR(totalWages.value)}`);
 
 const columns = [
 	{ key: "attendance_date", label: "Date" },
@@ -33,7 +104,7 @@ const breadcrumbs = [
 </script>
 
 <template>
-	<DeskPage title="Labour Attendance Register" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Labour Attendance Register" :subtitle="subtitle" :breadcrumbs="breadcrumbs">
 		<DocTypeListView
 			doctype="Labour Attendance Register"
 			:field-order="[
@@ -47,7 +118,7 @@ const breadcrumbs = [
 			:columns="columns"
 			:search-fields="['employee_name', 'name', 'project']"
 			:filter-values="filterValues"
-			:filter-field-map="{ project: 'project' }"
+			:filter-field-map="filterFieldMap"
 			:base-filters="[['docstatus', '<', 2]]"
 			cache-key="buildsuite-labour-attendance"
 			row-key="name"
@@ -56,14 +127,42 @@ const breadcrumbs = [
 			empty-message="No labour attendance yet — submit a Field Attendance."
 		>
 			<template #filter-chips>
-				<div class="w-56">
-					<DeskSearchableSelect
-						v-model="projectFilter"
-						:options="projectOptions"
-						placeholder="All projects"
-						search-placeholder="Search projects…"
-						allow-clear
-					/>
+				<div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+					<div class="w-48">
+						<DeskSearchableSelect
+							v-model="projectFilter"
+							:options="projectOptions"
+							placeholder="All projects"
+							search-placeholder="Search projects…"
+							allow-clear
+						/>
+					</div>
+					<div class="w-48">
+						<DeskSearchableSelect
+							v-model="workerFilter"
+							:options="workerOptions"
+							placeholder="Everyone"
+							search-placeholder="Search workers…"
+							allow-clear
+						/>
+					</div>
+					<DeskSelect v-model="statusFilter" class="!w-32">
+						<option value="">Any status</option>
+						<option v-for="s in STATUSES" :key="s" :value="s">{{ s }}</option>
+					</DeskSelect>
+					<div class="flex items-center gap-1.5">
+						<DeskInput v-model="fromFilter" type="date" class="!w-36" />
+						<span class="text-[11px] text-ink-400">to</span>
+						<DeskInput v-model="toFilter" type="date" class="!w-36" />
+					</div>
+					<button
+						v-if="anyFilter"
+						type="button"
+						class="text-[11px] text-ink-500 hover:text-ink-800 px-1"
+						@click="clearFilters"
+					>
+						Clear
+					</button>
 				</div>
 			</template>
 
@@ -72,9 +171,7 @@ const breadcrumbs = [
 			</template>
 
 			<template #cell-employee_name="{ row }">
-				<span class="text-ink-900 font-medium">{{
-					row.employee_name || row.employee
-				}}</span>
+				<span class="text-ink-900 font-medium">{{ row.employee_name || row.employee }}</span>
 			</template>
 
 			<template #cell-status="{ row }">

--- a/frontend/src/views/LabourAttendanceListView.vue
+++ b/frontend/src/views/LabourAttendanceListView.vue
@@ -91,6 +91,8 @@ const columns = [
 	{ key: "attendance_date", label: "Date" },
 	{ key: "employee_name", label: "Worker" },
 	{ key: "status", label: "Status" },
+	{ key: "day_type", label: "Day type" },
+	{ key: "task", label: "Task" },
 	{ key: "project", label: "Project" },
 	{ key: "wage_rate", label: "Wage rate", align: "right" },
 	{ key: "daily_wage_calculated", label: "Daily wage", align: "right" },
@@ -111,6 +113,8 @@ const breadcrumbs = [
 				'attendance_date',
 				'employee_name',
 				'status',
+				'task',
+				'task_subject',
 				'project',
 				'wage_rate',
 				'daily_wage_calculated',
@@ -176,6 +180,14 @@ const breadcrumbs = [
 
 			<template #cell-status="{ row }">
 				<StatusBadge :status="row.status" />
+			</template>
+
+			<template #cell-day_type="{ row }">
+				<span class="text-ink-600">{{ row.day_type || "Regular" }}</span>
+			</template>
+
+			<template #cell-task="{ row }">
+				<span class="text-ink-700">{{ row.task_subject || row.task || "—" }}</span>
 			</template>
 
 			<template #cell-project="{ row }">

--- a/frontend/src/views/OvertimeAttendanceListView.vue
+++ b/frontend/src/views/OvertimeAttendanceListView.vue
@@ -1,23 +1,90 @@
 <script setup>
 // Overtime Attendance Register — read-only. Rows are generated when a Field
-// Attendance sheet carrying overtime hours is submitted.
+// Attendance sheet carrying overtime hours is submitted. Filters (project, worker,
+// date range) + a Total-OT-hours / Total-amount subtitle mirror the prototype.
 
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import DeskPage from "@/components/desk/DeskPage.vue";
 import DeskLink from "@/components/desk/DeskLink.vue";
+import DeskInput from "@/components/desk/DeskInput.vue";
 import DeskSearchableSelect from "@/components/desk/DeskSearchableSelect.vue";
 import DocTypeListView from "@/components/doctype/DocTypeListView.vue";
 import { useProjectOptions } from "@/composables/useProjectOptions";
+import { useFieldEmployeeOptions } from "@/composables/useFieldEmployeeOptions";
 import { fmtDate, fmtINR } from "@/utils/format";
 
 const { projectOptions, projectLabel } = useProjectOptions();
+const { workerOptions } = useFieldEmployeeOptions();
 
 const projectFilter = ref("");
-const filterValues = computed(() => ({ project: projectFilter.value }));
+const workerFilter = ref("");
+const fromFilter = ref("");
+const toFilter = ref("");
+
+const filterValues = computed(() => ({
+	project: projectFilter.value,
+	worker: workerFilter.value,
+	from: fromFilter.value,
+	to: toFilter.value,
+}));
+const filterFieldMap = {
+	project: "project",
+	worker: "employee",
+	from: { field: "overtime_date", op: ">=" },
+	to: { field: "overtime_date", op: "<=" },
+};
+
+const anyFilter = computed(() => Object.values(filterValues.value).some((v) => v));
+function clearFilters() {
+	projectFilter.value = "";
+	workerFilter.value = "";
+	fromFilter.value = "";
+	toFilter.value = "";
+}
+
+// Totals across the WHOLE filtered set — a single SQL sum with the same filters.
+const totalHours = ref(0);
+const totalAmount = ref(0);
+function currentServerFilters() {
+	const f = [["docstatus", "<", 2]];
+	if (projectFilter.value) f.push(["project", "=", projectFilter.value]);
+	if (workerFilter.value) f.push(["employee", "=", workerFilter.value]);
+	if (fromFilter.value) f.push(["overtime_date", ">=", fromFilter.value]);
+	if (toFilter.value) f.push(["overtime_date", "<=", toFilter.value]);
+	return f;
+}
+async function loadTotals() {
+	try {
+		const params = new URLSearchParams({
+			doctype: "Overtime Attendance Register",
+			fields: JSON.stringify([
+				"sum(overtime_hours) as hours",
+				"sum(overtime_wage_calculated) as amount",
+			]),
+			filters: JSON.stringify(currentServerFilters()),
+		});
+		const res = await fetch("/api/method/frappe.client.get_list?" + params, {
+			credentials: "include",
+			headers: { "X-Frappe-CSRF-Token": window.csrf_token || "" },
+		});
+		const data = await res.json();
+		totalHours.value = Number(data?.message?.[0]?.hours) || 0;
+		totalAmount.value = Number(data?.message?.[0]?.amount) || 0;
+	} catch {
+		totalHours.value = 0;
+		totalAmount.value = 0;
+	}
+}
+watch(filterValues, loadTotals, { immediate: true, deep: true });
+
+const subtitle = computed(
+	() => `Total OT hours ${totalHours.value} · Total amount ${fmtINR(totalAmount.value)}`
+);
 
 const columns = [
 	{ key: "overtime_date", label: "Date" },
 	{ key: "employee_name", label: "Worker" },
+	{ key: "task", label: "Task" },
 	{ key: "project", label: "Project" },
 	{ key: "overtime_hours", label: "OT hrs", align: "right" },
 	{ key: "overtime_rate", label: "OT rate", align: "right" },
@@ -32,12 +99,14 @@ const breadcrumbs = [
 </script>
 
 <template>
-	<DeskPage title="Overtime Attendance Register" :breadcrumbs="breadcrumbs">
+	<DeskPage title="Overtime Attendance Register" :subtitle="subtitle" :breadcrumbs="breadcrumbs">
 		<DocTypeListView
 			doctype="Overtime Attendance Register"
 			:field-order="[
 				'overtime_date',
 				'employee_name',
+				'task',
+				'task_subject',
 				'project',
 				'overtime_hours',
 				'overtime_rate',
@@ -46,7 +115,7 @@ const breadcrumbs = [
 			:columns="columns"
 			:search-fields="['employee_name', 'name', 'project']"
 			:filter-values="filterValues"
-			:filter-field-map="{ project: 'project' }"
+			:filter-field-map="filterFieldMap"
 			:base-filters="[['docstatus', '<', 2]]"
 			cache-key="buildsuite-overtime-attendance"
 			row-key="name"
@@ -55,14 +124,38 @@ const breadcrumbs = [
 			empty-message="No overtime yet — submit a Field Attendance with overtime hours."
 		>
 			<template #filter-chips>
-				<div class="w-56">
-					<DeskSearchableSelect
-						v-model="projectFilter"
-						:options="projectOptions"
-						placeholder="All projects"
-						search-placeholder="Search projects…"
-						allow-clear
-					/>
+				<div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+					<div class="w-48">
+						<DeskSearchableSelect
+							v-model="projectFilter"
+							:options="projectOptions"
+							placeholder="All projects"
+							search-placeholder="Search projects…"
+							allow-clear
+						/>
+					</div>
+					<div class="w-48">
+						<DeskSearchableSelect
+							v-model="workerFilter"
+							:options="workerOptions"
+							placeholder="Everyone"
+							search-placeholder="Search workers…"
+							allow-clear
+						/>
+					</div>
+					<div class="flex items-center gap-1.5">
+						<DeskInput v-model="fromFilter" type="date" class="!w-36" />
+						<span class="text-[11px] text-ink-400">to</span>
+						<DeskInput v-model="toFilter" type="date" class="!w-36" />
+					</div>
+					<button
+						v-if="anyFilter"
+						type="button"
+						class="text-[11px] text-ink-500 hover:text-ink-800 px-1"
+						@click="clearFilters"
+					>
+						Clear
+					</button>
 				</div>
 			</template>
 
@@ -71,9 +164,11 @@ const breadcrumbs = [
 			</template>
 
 			<template #cell-employee_name="{ row }">
-				<span class="text-ink-900 font-medium">{{
-					row.employee_name || row.employee
-				}}</span>
+				<span class="text-ink-900 font-medium">{{ row.employee_name || row.employee }}</span>
+			</template>
+
+			<template #cell-task="{ row }">
+				<span class="text-ink-700">{{ row.task_subject || row.task || "—" }}</span>
 			</template>
 
 			<template #cell-project="{ row }">


### PR DESCRIPTION
Adds the prototype's (S216) filter set + totals to the Labour Attendance Register:

- **Filters**: Worker (field employee), Status (Full Day / Half Day / Absent), and a **Date from/to** range, alongside the existing Project filter.
- **Clear** action when any filter is active.
- **Total daily wages** now shown as the page subtitle — a single SQL `sum(daily_wage_calculated)` over the **whole filtered set** (not just the visible page).

### Deliberately not in this PR (flagged)
- **Task column** — the register doctype has no `task` field. Field Attendance *does* carry `task`, so it's achievable: add a `task` field to `Labour Attendance Register` + populate it in generation. Kept out of this frontend-only PR since it needs a doctype change + migration.
- **Day Type column** — there is **no `day_type` field anywhere in the live model** (mock-only in the prototype). Needs a product decision on what defines it before it can be added.

Frontend builds clean.