### PR TITLE
fix: subcontract registers — hide drafts + status badges (shared renderer)

### DIFF
--- a/buildsuite_core/buildsuite_core/report/measurement_book_register/measurement_book_register.py
+++ b/buildsuite_core/buildsuite_core/report/measurement_book_register/measurement_book_register.py
@@ -51,7 +51,7 @@ def execute(filters=None):
 			(SELECT COUNT(*) FROM `tabMeasurement Book Entry` e WHERE e.parent = mb.name) AS entries,
 			mb.measured_total AS measured, mb.status
 		FROM `tabMeasurement Book` mb
-		WHERE mb.docstatus < 2 """ + conditions + """
+		WHERE mb.docstatus = 1 """ + conditions + """
 		ORDER BY mb.date DESC, mb.name DESC
 		""",
 		filters,

--- a/buildsuite_core/buildsuite_core/report/subcontractor_bill_register/subcontractor_bill_register.py
+++ b/buildsuite_core/buildsuite_core/report/subcontractor_bill_register/subcontractor_bill_register.py
@@ -51,7 +51,7 @@ def execute(filters=None):
 		SELECT sb.name AS bill, sb.subcontractor, sb.project, sb.date,
 			sb.gross, sb.retention_amount AS retention, sb.net_payable, sb.status
 		FROM `tabSubcontractor Bill` sb
-		WHERE sb.docstatus < 2 """ + conditions + """
+		WHERE sb.docstatus = 1 """ + conditions + """
 		ORDER BY sb.date DESC, sb.name DESC
 		""",
 		filters,

--- a/buildsuite_core/buildsuite_core/report/subcontractor_work_order_register/subcontractor_work_order_register.py
+++ b/buildsuite_core/buildsuite_core/report/subcontractor_work_order_register/subcontractor_work_order_register.py
@@ -52,10 +52,10 @@ def execute(filters=None):
 			wo.delivery_type, wo.total_value, wo.status,
 			LEAST(100, ROUND(IFNULL(
 				(SELECT SUM(sb.gross) FROM `tabSubcontractor Bill` sb
-					WHERE sb.work_order = wo.name AND sb.docstatus < 2), 0)
+					WHERE sb.work_order = wo.name AND sb.docstatus = 1), 0)
 				/ NULLIF(wo.total_value, 0) * 100, 1)) AS percent_billed
 		FROM `tabSubcontractor Work Order` wo
-		WHERE wo.docstatus < 2 """ + conditions + """
+		WHERE wo.docstatus = 1 """ + conditions + """
 		ORDER BY wo.date DESC, wo.name DESC
 		""",
 		filters,

--- a/frontend/src/components/FrappeReport.vue
+++ b/frontend/src/components/FrappeReport.vue
@@ -16,6 +16,7 @@ import { evalReportFilters } from "@/utils/reportFilters";
 import { useActiveCompany } from "@/composables/useActiveCompany";
 import { fmtINR, fmtDate } from "@/utils/format";
 import DeskLinkPicker from "@/components/desk/DeskLinkPicker.vue";
+import StatusBadge from "@/components/StatusBadge.vue";
 import DeskSelect from "@/components/desk/DeskSelect.vue";
 import ReportChart from "@/components/ReportChart.vue";
 
@@ -53,6 +54,12 @@ const urlFilters = computed(() => {
 const filterDefs = ref([]);
 const filterValues = reactive({});
 const NUMERIC = new Set(["Currency", "Float", "Int", "Percent"]);
+// A status column renders as a StatusBadge (one place → every report's status column gets badges:
+// WO / MB / Bill registers, Requests-waiting, etc.).
+function isStatusCol(col) {
+	const f = (col.fieldname || "").toLowerCase();
+	return f === "status" || f.endsWith("_status");
+}
 
 function seedFilters(defs) {
 	for (const k of Object.keys(filterValues)) delete filterValues[k];
@@ -522,6 +529,10 @@ const inputClass =
 										cellText(item.row, col)
 									}}</span>
 								</span>
+								<StatusBadge
+									v-else-if="isStatusCol(col) && cellText(item.row, col)"
+									:status="cellText(item.row, col)"
+								/>
 								<template v-else>{{ cellText(item.row, col) }}</template>
 							</td>
 						</tr>


### PR DESCRIPTION
## What
Two fixes across the Subcontract-workspace registers (Query Reports):

### Hide drafts
The **Work Order**, **Measurement Book**, and **Subcontractor Bill** registers filtered `docstatus < 2`, which includes **Draft**. Changed to `docstatus = 1` (submitted only). The WO register's billed-amount subquery got the same treatment, so **draft bills don't count** toward billed.

### Status badges — one place, every report
`FrappeReport.vue` (the shared Query-Report renderer) now renders any `status` / `*_status` column as a **StatusBadge**. So every report's status column gets a badge in one edit — the three subcontract registers **and** Procurement's "Requests waiting to be ordered".

## Apply button
Already the reusable **`.desk-save-btn`** (FrappeReport's Apply button), which #269 flipped to black-on-green in dark mode — so no per-report button change is needed (your "one place" model).

## Still to come in this area (noted)
MB-specific cell colours (id green / measured blue), the Bill **payment status** column (computed from outstanding), and the report-level **add-filter** link — plus the three new subcontract reports (Client Bill Register, Subcontract Ledger, Cost Code Variance).

Reports execute; frontend builds clean.