### PR TITLE
fix: Billing and Collection — add Customer and Invoice filters

### DIFF
--- a/buildsuite_core/buildsuite_core/report/billing_and_collection/billing_and_collection.json
+++ b/buildsuite_core/buildsuite_core/report/billing_and_collection/billing_and_collection.json
@@ -14,6 +14,18 @@
    "options": "Project"
   },
   {
+   "fieldname": "customer",
+   "fieldtype": "Link",
+   "label": "Customer",
+   "options": "Customer"
+  },
+  {
+   "fieldname": "invoice",
+   "fieldtype": "Link",
+   "label": "Invoice",
+   "options": "Sales Invoice"
+  },
+  {
    "fieldname": "from_date",
    "fieldtype": "Date",
    "label": "From"
@@ -32,7 +44,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2026-08-20 00:00:00.000000",
+ "modified": "2026-09-09 00:00:00.000000",
  "module": "BuildSuite Core",
  "name": "Billing and Collection",
  "owner": "Administrator",

--- a/buildsuite_core/buildsuite_core/report/billing_and_collection/billing_and_collection.py
+++ b/buildsuite_core/buildsuite_core/report/billing_and_collection/billing_and_collection.py
@@ -46,6 +46,10 @@ def execute(filters=None):
 		return columns, [], None, None, []
 
 	conditions = ""
+	if filters.get("customer"):
+		conditions += " AND si.customer = %(customer)s"
+	if filters.get("invoice"):
+		conditions += " AND si.name = %(invoice)s"
 	if filters.get("from_date"):
 		conditions += " AND si.posting_date >= %(from_date)s"
 	if filters.get("to_date"):


### PR DESCRIPTION
## What
The **Billing and Collection** register showed Invoice and Customer columns but could only be narrowed by **project / date range / overdue-only**. Added the two missing filters:

- **Customer** — Link → Customer
- **Invoice** — Link → Sales Invoice

So you can drill a project down to one client, or to a single invoice.

## Details
- Both bind only when set (Script Report; empty filters stay safe on page load).
- Bumped the report's `modified` timestamp so the new filter definitions **sync on migrate** to already-provisioned sites (reload skips a report whose file isn't newer than the DB record).
- **Apply button** already uses the reusable `.desk-save-btn` (black-on-green in dark via #269) — no button change needed.

Verified on bs.local: all six filters land on the Report record; report executes and the customer filter binds. Completes **chunk F**.