### PR TITLE
refactor: seed Workforce report tiles to Workspace Setting (drop the hardcoded array)

### DIFF
--- a/buildsuite_core/api/workspace_setting.py
+++ b/buildsuite_core/api/workspace_setting.py
@@ -28,6 +28,7 @@ WORKSPACES = (
 	{"slug": "procurement", "label": "Procurement"},
 	{"slug": "subcontract", "label": "Subcontract"},
 	{"slug": "project-finance", "label": "Project Finance"},
+	{"slug": "workforce", "label": "Workforce"},
 )
 _SLUGS = {w["slug"] for w in WORKSPACES}
 

--- a/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
+++ b/buildsuite_core/buildsuite_core/doctype/workspace_setting/seed_workspace_reports.py
@@ -74,6 +74,26 @@ _SEED = {
 			"description": "Planned vs Committed vs Actual per BOQ cost code, for a project.",
 		},
 	),
+	"workforce": (
+		{
+			"label": "Labour Attendance Register",
+			"icon": "clipboard-list",
+			"route": "/labour-attendance",
+			"description": "Per-worker daily wages — Full Day / Half Day / Absent.",
+		},
+		{
+			"label": "Overtime Attendance Register",
+			"icon": "chart-line",
+			"route": "/overtime-attendance",
+			"description": "Per-worker overtime hours × overtime rate.",
+		},
+		{
+			"label": "Site Attendance Summary",
+			"icon": "hard-hat",
+			"route": "/workforce/attendance-summary",
+			"description": "Days worked, overtime and labour cost per site — the HR roll-up.",
+		},
+	),
 	"procurement": (
 		{
 			"label": "Requests waiting to be ordered",

--- a/buildsuite_core/patches.txt
+++ b/buildsuite_core/patches.txt
@@ -48,3 +48,4 @@ buildsuite_core.patches.restore_subcontractor_work_order_naming # 2026-09-05 WO 
 buildsuite_core.patches.promote_persona_users_to_system_user # 2026-09-06 persona users are system users
 buildsuite_core.patches.backfill_field_attendance_employees_count # 2026-09-06 ISS-167 list count
 buildsuite_core.patches.add_subcontract_client_ledger_variance_reports # 2026-09-09 client bill / sub ledger / cost code variance tiles
+buildsuite_core.patches.seed_workforce_report_tiles # 2026-09-09 workforce report tiles to Workspace Setting

--- a/buildsuite_core/patches/seed_workforce_report_tiles.py
+++ b/buildsuite_core/patches/seed_workforce_report_tiles.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026, Infraholic Innovations Pvt. Ltd and contributors
+# For license information, please see license.txt
+
+"""The Workforce workspace's report tiles were hardcoded in the SPA landing view while every other
+workspace draws its tiles from Workspace Setting. Workforce has now joined the WORKSPACES allowlist
+and its tiles (Labour Attendance Register, Overtime Attendance Register, Site Attendance Summary)
+are seeded like the rest. The workspace seeder is install-only, so this patch seeds the workforce
+tiles on already-provisioned sites. Idempotent — it no-ops if any workforce row already exists."""
+
+import frappe
+
+from buildsuite_core.buildsuite_core.doctype.workspace_setting.seed_workspace_reports import _SEED
+
+
+def execute():
+	settings = frappe.get_single("Workspace Setting")
+	if any(r.workspace == "workforce" for r in settings.reports):
+		return
+	for row in _SEED["workforce"]:
+		settings.append("reports", {"workspace": "workforce", **row})
+	settings.flags.ignore_permissions = True
+	settings.save()

--- a/frontend/src/views/workspaces/WorkforceWorkspace.vue
+++ b/frontend/src/views/workspaces/WorkforceWorkspace.vue
@@ -1,9 +1,9 @@
 <script setup>
-// Workforce landing. Reports stay hardcoded until "workforce" joins the
-// WORKSPACES allowlist in buildsuite_core/api/workspace_setting.py.
+// Workforce landing — greeting, a DocType shortcuts grid, and a Reports group.
 
-import { computed } from "vue";
+import { computed, ref, onMounted } from "vue";
 import WorkspaceShortcut from "@/components/WorkspaceShortcut.vue";
+import { getWorkspaceReports } from "@/data/workspaceSettingApi";
 
 const today = computed(() => {
 	const d = new Date();
@@ -16,26 +16,15 @@ const shortcuts = [
 	{ label: "Field Attendance", icon: "clipboard-list", to: "/field-attendance", cap: "fieldAttendance" },
 ];
 
-const reports = [
-	{
-		label: "Labour Attendance Register",
-		icon: "clipboard-list",
-		description: "Per-worker daily wages — Full Day / Half Day / Absent.",
-		to: "/labour-attendance",
-	},
-	{
-		label: "Overtime Attendance Register",
-		icon: "chart-line",
-		description: "Per-worker overtime hours × overtime rate.",
-		to: "/overtime-attendance",
-	},
-	{
-		label: "Site Attendance Summary",
-		icon: "hard-hat",
-		description: "Days worked, overtime and labour cost per site — the HR roll-up.",
-		to: "/workforce/attendance-summary",
-	},
-];
+// Report tiles are configured per workspace in Workspace Setting.
+const reports = ref([]);
+onMounted(async () => {
+	try {
+		reports.value = await getWorkspaceReports("workforce");
+	} catch {
+		reports.value = [];
+	}
+});
 </script>
 
 <template>
@@ -66,12 +55,13 @@ const reports = [
 				<div class="border-t border-ink-200 mb-3"></div>
 				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
 					<WorkspaceShortcut
-						v-for="r in reports"
-						:key="r.label"
+						v-for="(r, i) in reports"
+						:key="i"
 						:icon="r.icon"
 						:label="r.label"
 						:description="r.description"
-						:to="r.to"
+						:to="r.external ? null : r.route"
+						:href="r.external ? r.route : null"
 					>
 						<template #badge>
 							<span


### PR DESCRIPTION
## Why
Workforce was the **last workspace** whose report tiles were **hardcoded** in the SPA landing view (`WorkforceWorkspace.vue`) instead of coming from **Workspace Setting** like every other workspace (subcontract, procurement, site-execution, project-finance). This makes it consistent — so the Site Attendance Summary (and the two registers) are seeded, not hardcoded.

## Change
- **Allowlist** — added `workforce` to `WORKSPACES` (`api/workspace_setting.py`) so `get_workspace_reports` serves its tiles.
- **Seed** — the three tiles in `_SEED["workforce"]`: **Labour Attendance Register**, **Overtime Attendance Register**, **Site Attendance Summary**. Route tiles (they navigate to SPA routes, not Query Reports).
- **View** — `WorkforceWorkspace.vue` now fetches via `getWorkspaceReports("workforce")` and renders exactly like the Subcontract workspace (route/external handling + Report badge). The hardcoded `reports` array is gone, along with its "stays hardcoded until…" comment.
- **Patch** — the seeder is install-only, so `seed_workforce_report_tiles` seeds the tiles on already-provisioned sites; **idempotent** (no-ops if any workforce row exists).

## Verified on bs.local
The three tiles seed; `get_workspace_reports("workforce")` returns them (route-resolved, `external=false`); the Workforce landing renders them from the setting with the Report badge. Frontend builds clean.

## Answers the question
Every report tile is now seeded to Workspace Setting — none are hardcoded. Admins can also reorder/relabel the Workforce tiles from the settings screen, same as the other workspaces.