### PR TITLE
fix: primary button no longer underlines on hover (.desk-save-btn)

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -118,7 +118,14 @@
     background-color: #0F172A;
     border-radius: 6px;
     transition: background-color 0.1s;
+    text-decoration: none;
   }
+  /* Never underline. The primary button is frequently a DeskLink (which carries .desk-link,
+     and .desk-link:hover underlines) — this keeps it a button, not a link, on hover/focus/active
+     in both themes. Defined after .desk-link so it wins the specificity tie. */
+  .desk-save-btn:hover,
+  .desk-save-btn:focus,
+  .desk-save-btn:active { text-decoration: none; }
   .desk-save-btn:hover:not(:disabled) { background-color: #1E293B; }
   .desk-save-btn:disabled {
     @apply bg-ink-200 text-ink-500 cursor-not-allowed;


### PR DESCRIPTION
## What
The primary button — e.g. **+ New Category** on Settings › Project Categories — underlined on hover in both light and dark.

## Why
It's rendered as a **`DeskLink`** styled with `desk-save-btn`, so it carries both classes (`desk-link desk-save-btn`). `.desk-link:hover` sets `text-decoration: underline`, which bled through because `.desk-save-btn` never reset it.

## Fix (one place)
Added `text-decoration: none` to `.desk-save-btn` on base + `:hover`/`:focus`/`:active` (defined after `.desk-link` so it wins the specificity tie). Fixes **every** `desk-save-btn` that happens to be a link — the reusable-button, one-place approach.

Verified: computed `text-decoration` on hover is `none` in both themes; button renders with no underline. Frontend builds clean.